### PR TITLE
ISS-019: execution-backed runtime plus bounded tcp/file health slices

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -19,11 +19,14 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-009` | `done` | Add runnable fixture-based verification for the core runtime slice | `SPEC-002`, `AC-4` | Landed with direct route/runtime tests and local verification evidence. |
 | `ISS-010` | `done` | Add minimum viable build and release plumbing for the core repo | `SPEC-002`, `AC-5` | Landed with build/typecheck/test/dev package plumbing. |
 | `ISS-011` | `done` | Reconcile canonical docs with implemented core runtime behavior | `SPEC-002`, `AC-6` | Landed through core runtime layout + migration/state/logging/storage doc updates. |
-| `ISS-012` | `todo` | Harden API error semantics and response contracts | `SPEC-002` | Normalize 4xx/5xx behavior and error payload shape across routes/actions. |
-| `ISS-013` | `todo` | Add runtime startup config loading for `servicesRoot` and `workspaceRoot` | `SPEC-002` | Move from hardcoded defaults to explicit runtime-loaded config with validation. |
-| `ISS-014` | `todo` | Rehydrate runtime and lifecycle state on startup | `SPEC-002` | Ensure persisted state survives restart and is reflected in runtime/detail endpoints. |
-| `ISS-015` | `todo` | Add real process execution and supervision slice | `SPEC-002` | Replace provider planning-only behavior with first bounded execution supervision path. |
+| `ISS-012` | `done` | Harden API error semantics and response contracts | `SPEC-002` | Landed with deterministic typed API error bodies plus explicit 400/404/409/500 behavior. |
+| `ISS-013` | `done` | Add runtime startup config loading for `servicesRoot` and `workspaceRoot` | `SPEC-002` | Landed with validated startup config resolution, explicit `workspaceRoot`, and invalid-root rejection. |
+| `ISS-014` | `done` | Rehydrate runtime and lifecycle state on startup | `SPEC-002` | Landed with startup rehydration from persisted `.state` records into runtime/detail summaries. |
+| `ISS-015` | `done` | Add real process execution and supervision slice | `SPEC-002`, `AC-4B` | Landed with the first bounded execution supervisor, persisted runtime metadata, and released Echo Service artifact proof through the core runtime. |
 | `ISS-016` | `todo` | Demo-instance hardening and regression verification | `SPEC-002` | Validate demo-readiness loop from startup through multi-service runtime operations. |
+| `ISS-017` | `todo` | Establish package boundaries for core + reference apps | `SPEC-002` | Define and scaffold `packages/core`, `packages/app-electron`, and `packages/app-node` with explicit core/no-UI-framework boundary. |
+| `ISS-018` | `done` | Turn `echo-service` into a runnable Go harness fixture | `SPEC-002`, `AC-4A` | Landed with a Go-based sample service exposing UI and API actions plus log/state/SQLite persistence surfaces. |
+| `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -39,11 +42,14 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-009` | `done` | `ISS-009` | Add fixture/sample services and direct runtime smoke verification | `SPEC-002`, `AC-4` | Direct runnable proof exists for discovery/parsing behavior |
 | `TASK-010` | `done` | `ISS-010` | Add minimum viable build/validation/release workflows for core runtime | `SPEC-002`, `AC-5` | Build/validation/release plumbing exists and runs |
 | `TASK-011` | `done` | `ISS-011` | Update canonical docs to reflect implemented runtime behavior | `SPEC-002`, `AC-6` | Docs clearly separate implemented behavior from donor/reference notes |
-| `TASK-012` | `todo` | `ISS-012` | Normalize API error/status handling and shared error DTO | `SPEC-002` | Failing and invalid flows return deterministic typed errors |
-| `TASK-013` | `todo` | `ISS-013` | Implement runtime config loading + validation (`servicesRoot`, `workspaceRoot`) | `SPEC-002` | Runtime boots from explicit config and rejects invalid root settings |
-| `TASK-014` | `todo` | `ISS-014` | Implement startup rehydration from persisted runtime/lifecycle state | `SPEC-002` | Restart restores prior known service state consistently |
-| `TASK-015` | `todo` | `ISS-015` | Add first bounded execution supervisor for one provider path | `SPEC-002` | Real process launch/stop supervision works with persisted runtime state updates |
+| `TASK-012` | `done` | `ISS-012` | Normalize API error/status handling and shared error DTO | `SPEC-002` | Invalid lifecycle/action flows now return deterministic typed 400/409 API errors with shared error payload shape |
+| `TASK-013` | `done` | `ISS-013` | Implement runtime config loading + validation (`servicesRoot`, `workspaceRoot`) | `SPEC-002` | Runtime boots from explicit validated roots, surfaces `workspaceRoot`, and rejects missing `servicesRoot` |
+| `TASK-014` | `done` | `ISS-014` | Implement startup rehydration from persisted runtime/lifecycle state | `SPEC-002` | Startup restores persisted lifecycle state and runtime summaries/detail endpoints reflect the rehydrated state |
+| `TASK-015` | `done` | `ISS-015` | Add first bounded execution supervisor for one provider path | `SPEC-002`, `AC-4B` | Real process launch/stop supervision works with persisted runtime state updates and released Echo Service artifacts can be run through the core runtime |
 | `TASK-016` | `todo` | `ISS-016` | Run demo-instance hardening checklist and regression suite | `SPEC-002` | Demo-instance plan checkpoints are met with repeatable validation evidence |
+| `TASK-017` | `todo` | `ISS-017` | Scaffold package split (`core`, `app-electron`, `app-node`) and baseline build wiring | `SPEC-002` | Monorepo package map exists with core exports/CLI target and reference app placeholders consuming core |
+| `TASK-018` | `done` | `ISS-018` | Implement the `echo-service` Go harness fixture with UI, API, and persistence behaviors | `SPEC-002`, `AC-4A` | `echo-service` now builds and runs as a Go harness with action endpoints, browser UI, logs, state snapshots, and SQLite writes |
+| `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
 
 ## Next Recommended Item
-`TASK-012` is the next best item: lock API error semantics before layering startup config and rehydration, so follow-on behavior lands on a stable contract surface.
+The next best item is the next broader donor-health slice after `TASK-019`: add bounded `file` or `variable` manifest-health support plus readiness-oriented verification against the Echo Service harness.

--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -27,6 +27,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-017` | `todo` | Establish package boundaries for core + reference apps | `SPEC-002` | Define and scaffold `packages/core`, `packages/app-electron`, and `packages/app-node` with explicit core/no-UI-framework boundary. |
 | `ISS-018` | `done` | Turn `echo-service` into a runnable Go harness fixture | `SPEC-002`, `AC-4A` | Landed with a Go-based sample service exposing UI and API actions plus log/state/SQLite persistence surfaces. |
 | `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
+| `ISS-020` | `done` | Add bounded `file` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded file-based readiness checks with automated tests and released Echo Service file proof. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -50,6 +51,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-017` | `todo` | `ISS-017` | Scaffold package split (`core`, `app-electron`, `app-node`) and baseline build wiring | `SPEC-002` | Monorepo package map exists with core exports/CLI target and reference app placeholders consuming core |
 | `TASK-018` | `done` | `ISS-018` | Implement the `echo-service` Go harness fixture with UI, API, and persistence behaviors | `SPEC-002`, `AC-4A` | `echo-service` now builds and runs as a Go harness with action endpoints, browser UI, logs, state snapshots, and SQLite writes |
 | `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
+| `TASK-020` | `done` | `ISS-020` | Implement bounded `file` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = file`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service file proof |
 
 ## Next Recommended Item
-The next best item is the next broader donor-health slice after `TASK-019`: add bounded `file` or `variable` manifest-health support plus readiness-oriented verification against the Echo Service harness.
+The next best item is the next bounded donor-health slice after `TASK-020`: add `variable` manifest-health support with deterministic evaluation and direct Echo Service-backed verification.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -1,7 +1,7 @@
 # Core Standalone Runtime
 
 ## Intent
-Create the first real product spec for `service-lasso` by moving from bootstrap-only governance into an executable core runtime slice. This matters because the repository currently has strong governance and reference documentation, but no tracked runtime implementation yet. The first core milestone should prove that Service Lasso can run as a standalone manager and consume canonical service manifests directly.
+Create the first real product spec for `service-lasso` by moving from bootstrap-only governance into an executable core runtime slice. This matters because the repository now has a tracked bounded runtime implementation and needs governed traceability as it widens toward donor parity. The first core milestone proved that Service Lasso can run as a standalone manager and consume canonical service manifests directly; the current work under this spec is widening that bounded slice carefully with direct verification.
 
 ## Scope
 Included in this spec:
@@ -10,6 +10,7 @@ Included in this spec:
 - implement a runnable entrypoint for the core runtime/server
 - support canonical `service.json` manifest discovery/parsing for the first runtime slice
 - provide direct runnable verification against fixture/sample service definitions
+- maintain at least one tracked runnable harness service fixture that can exercise runtime/demo behavior through both API and UI surfaces
 - add the minimum build/validation/release plumbing needed to make the core repo behave like a real product repo
 - update canonical docs/traceability so the implemented behavior is distinguished from donor/reference-only notes
 
@@ -26,6 +27,9 @@ Explicitly out of scope for this spec:
 - `AC-2`: A standalone runtime entrypoint can be executed locally and start successfully in a bounded development mode.
 - `AC-3`: The runtime can discover and parse canonical `service.json` manifests from a defined service root and report the discovered services reliably.
 - `AC-4`: The first runtime slice has direct runnable verification evidence using fixture/sample service definitions, not surrogate-only documentation proof.
+- `AC-4A`: The tracked fixture set includes a runnable harness-style sample service that can be started independently and used to exercise API/UI, persistence, and behavior-simulation flows for later runtime supervision work.
+- `AC-4B`: The runtime includes one bounded real execution/supervision path that can start, observe, stop, and persist runtime state for a directly executable service definition.
+- `AC-4C`: The runtime broadens bounded health support beyond `process` and `http` by directly accepting and evaluating at least one additional donor-aligned manifest health type with runnable verification evidence.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -33,6 +37,9 @@ Explicitly out of scope for this spec:
 Required evidence for this spec:
 - local execution proof that the standalone runtime entrypoint starts
 - direct proof of manifest discovery/parsing against one or more fixture/sample service definitions
+- direct proof that the tracked harness fixture can start locally and expose its documented API/UI surface
+- direct proof that the bounded execution supervisor can start and stop a real process while persisting runtime state updates
+- direct proof that at least one additional donor-aligned manifest health type can be parsed and evaluated successfully by the runtime
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented
@@ -64,3 +71,4 @@ Classify verification honestly as direct proof, partial proof, or surrogate-only
 - This spec is the explicit transition point from bootstrap-only repo setup into real `service-lasso` product implementation.
 - The first runtime slice should stay intentionally bounded: prove a runnable standalone core before widening into full donor parity or broad manifest redesign.
 - Donor material under `ref/` remains useful evidence and reference input, but implemented behavior must now move into tracked repo source with direct verification.
+- The tracked fixture set may evolve from static manifest-only samples into runnable harness services when that improves direct verification for runtime hardening and later supervision work.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This slice now establishes the first real API spine, the first canonical manifes
 Note on repo split:
 - the canonical Echo Service implementation now lives in the sibling repo `C:\projects\service-lasso\lasso-echoservice`
 - `service-lasso/services/echo-service/` remains a thin local fixture manifest so the core repo stays self-contained for discovery/runtime tests
-- the sibling Echo Service repo now includes harness-only HTTP and TCP health simulation endpoints for runtime testing, and `service-lasso` itself now evaluates bounded manifest health types `process`, `http`, and `tcp`
+- the sibling Echo Service repo now includes harness-only HTTP and TCP health simulation endpoints for runtime testing, and `service-lasso` itself now evaluates bounded manifest health types `process`, `http`, `tcp`, and `file`
 
 For the detailed layout note, see:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ What this slice means:
 - tracked sample manifests now live under `services/*/service.json`
 - `tests/api-spine.test.js`, `tests/manifest-discovery.test.js`, `tests/registry-runtime-state.test.js`, `tests/lifecycle-actions.test.js`, `tests/health-state.test.js`, `tests/operator-data.test.js`, and `tests/provider-execution.test.js` provide direct proof for the API spine, discovery/parsing behavior, runtime state read APIs, lifecycle action path, health/state persistence, operator data surfaces, and provider execution planning
 
-This slice now establishes the first real API spine, the first canonical manifest discovery/parsing path, the first in-memory runtime state model, the first bounded lifecycle actions, the first health + `.state` persistence layer, the first operator data surfaces, and the first provider execution boundary. Full real process execution and broader provider catalog expansion are still future work.
+This slice now establishes the first real API spine, the first canonical manifest discovery/parsing path, the first in-memory runtime state model, the first bounded lifecycle actions, the first health + `.state` persistence layer, the first operator data surfaces, the first provider execution boundary, and a runnable tracked harness fixture under `services/echo-service/` for later execution/demo hardening. Full real process execution and broader provider catalog expansion are still future work.
+
+Note on repo split:
+- the canonical Echo Service implementation now lives in the sibling repo `C:\projects\service-lasso\lasso-echoservice`
+- `service-lasso/services/echo-service/` remains a thin local fixture manifest so the core repo stays self-contained for discovery/runtime tests
+- the sibling Echo Service repo now includes harness-only HTTP and TCP health simulation endpoints for runtime testing, and `service-lasso` itself now evaluates bounded manifest health types `process`, `http`, and `tcp`
 
 For the detailed layout note, see:
 

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -66,6 +66,26 @@ Important scope clarification:
 - donor inline HTML/admin UI behavior is **not** the migration target for the core runtime
 - only the main runtime/service-manager code is in scope for the donor-core migration
 
+Post-core validation note:
+- once the core runtime is execution-capable and Echo Service proves the runtime path, `lasso-@serviceadmin` should be used as the first real consumer repo for integration validation
+- that validation should prove the admin UI can consume the current API/runtime behavior cleanly before broader reference app/template rollout
+
+## Reference app templates after core
+
+Once the core runtime is built and stable, Service Lasso should also provide reference app packages that showcase integration and give other teams a template starting point.
+
+These reference apps are not the core runtime.
+They are example consumers of the core runtime/API that prove the integration story and make adoption easier.
+
+Planned reference app/template packages include:
+- `@service-lasso/service-lasso-app-web`
+- `@service-lasso/service-lasso-packager-node`
+- `@service-lasso/service-lasso-app-tauri`
+- `@service-lasso/service-lasso-bundled`
+
+These should all consume the same canonical runtime model based on:
+- `servicesRoot`
+- `workspaceRoot`
 ## Runtime root model
 
 The preferred runtime root model is now:
@@ -225,6 +245,11 @@ Major donor runtime behavior still remains to be migrated more fully, including:
 - broader health types and readiness flow
 - manager-level orchestration like reload/startAll/stopAll/autostart
 - fuller runtime logging implementation
+
+Important current boundary:
+- the sibling `lasso-echoservice` harness can already simulate HTTP and TCP health targets for testing and demo hardening
+- `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, and `tcp`
+- broader donor-health migration work still remains for types such as `file` and `variable` plus readiness-loop behavior
 
 Again, that is why the repo should be read as:
 

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -248,8 +248,8 @@ Major donor runtime behavior still remains to be migrated more fully, including:
 
 Important current boundary:
 - the sibling `lasso-echoservice` harness can already simulate HTTP and TCP health targets for testing and demo hardening
-- `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, and `tcp`
-- broader donor-health migration work still remains for types such as `file` and `variable` plus readiness-loop behavior
+- `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, `tcp`, and `file`
+- broader donor-health migration work still remains for types such as `variable` plus readiness-loop behavior
 
 Again, that is why the repo should be read as:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,9 @@ Current preferred runtime-root model:
 - `docs/development/core-runtime-dev-plan.md` - recommended full core repo structure, API shape, and implementation order
 - `docs/development/core-runtime-demo-instance-plan.md` - phased plan for turning the current bounded core runtime into a reviewable demo instance
 - `docs/development/core-runtime-migration-plan.md` - donor service-manager migration status, gap map, and recommended next migration order
+- `docs/development/core-runtime-comprehensive-review.md` - consolidated review of docs, donor/spec/code coverage, assumptions, and test evidence
+- `docs/development/core-runtime-donor-coverage-audit.md` - donor/spec/code coverage audit with current test evidence and remaining runtime gaps
+- `docs/development/core-runtime-working-application-plan.md` - staged next-steps plan for turning the bounded core slice into a genuinely working application
 - `docs/development/core-runtime-state-model-audit.md` - agreed vs provisional audit of the current `.state/` model and its implementation gaps
 - `docs/development/core-runtime-logging-model.md` - canonical logging and archival model using `workspaceRoot/logs/runs/<runId>` for traceability
 - `docs/development/core-runtime-storage-model.md` - preferred split between `servicesRoot` and `workspaceRoot` for multi-config and multi-instance operation

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Current preferred runtime-root model:
 - `docs/development/core-runtime-comprehensive-review.md` - consolidated review of docs, donor/spec/code coverage, assumptions, and test evidence
 - `docs/development/core-runtime-donor-coverage-audit.md` - donor/spec/code coverage audit with current test evidence and remaining runtime gaps
 - `docs/development/core-runtime-working-application-plan.md` - staged next-steps plan for turning the bounded core slice into a genuinely working application
+- `docs/development/core-runtime-autonomous-task-list.md` - comprehensive ordered execution list for finishing donor migration slices, consumer validation, and post-core rollout
 - `docs/development/core-runtime-state-model-audit.md` - agreed vs provisional audit of the current `.state/` model and its implementation gaps
 - `docs/development/core-runtime-logging-model.md` - canonical logging and archival model using `workspaceRoot/logs/runs/<runId>` for traceability
 - `docs/development/core-runtime-storage-model.md` - preferred split between `servicesRoot` and `workspaceRoot` for multi-config and multi-instance operation

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -1,0 +1,203 @@
+# Core runtime autonomous task list
+
+This document is the working execution list for finishing the `service-lasso` core runtime and closing the remaining donor capability gaps in a controlled order.
+
+It is based on:
+- `.governance/project/BACKLOG.md`
+- `.governance/specs/SPEC-002-core-standalone-runtime.md`
+- `docs/development/core-runtime-working-application-plan.md`
+- `docs/development/core-runtime-donor-coverage-audit.md`
+- `docs/development/core-runtime-comprehensive-review.md`
+
+It is meant to answer:
+
+**what is left, in what order should it be done, and what should be proven before moving to the next major slice**
+
+## Current completion baseline
+
+Already done:
+- core runtime entrypoint and API spine
+- manifest discovery and validation
+- registry and dependency graph basics
+- deterministic API error handling
+- runtime config loading for `servicesRoot` and `workspaceRoot`
+- startup rehydration from persisted `.state`
+- first bounded real execution/supervision path
+- bounded health support for:
+  - `process`
+  - `http`
+  - `tcp`
+  - `file`
+- Echo Service harness repo and released-artifact proof through the runtime
+
+Current honest label:
+
+**bounded working core runtime exists; donor parity is not complete yet**
+
+## Execution rules for this list
+
+- complete one bounded vertical slice at a time
+- every slice must map to a governed backlog item before code starts
+- every completed slice must end with:
+  - automated proof
+  - docs/spec/backlog updates
+  - released Echo Service artifact proof when relevant
+- do not claim donor parity for an area until the capability is implemented, tested, and documented
+
+## Active execution order
+
+### Wave 1: Finish bounded health parity
+
+1. bounded `file` health support
+   status: done
+   proof:
+   - manifest parsing accepts `healthcheck.type = file`
+   - runtime reports healthy when the file exists
+   - runtime reports unhealthy without throwing when the file is absent
+   - released Echo Service artifact can be checked against a real file target
+
+2. bounded `variable` health support
+   status: next
+   proof:
+   - manifest parsing accepts `healthcheck.type = variable`
+   - runtime can evaluate a bounded variable source deterministically
+   - tests prove healthy and unhealthy cases
+
+3. readiness and wait-loop behavior
+   status: queued
+   proof:
+   - start flow can wait for configured health readiness within bounded timeout/retry rules
+   - tests prove success, timeout, and failure behavior
+
+### Wave 2: Shared environment and runtime negotiation
+
+4. `globalenv` propagation model
+   status: queued
+   proof:
+   - runtime can read emitted shared env data
+   - runtime can surface merged shared env to dependent services or operator API
+   - Echo Service and at least one dependent fixture prove the flow
+
+5. runtime-owned port negotiation
+   status: queued
+   proof:
+   - runtime can reserve or resolve service ports
+   - collisions are detected deterministically
+   - resolved port data is visible through runtime/operator surfaces
+
+### Wave 3: Setup and lifecycle depth
+
+6. bounded setup/install mechanics
+   status: queued
+   proof:
+   - setup/install is more than state recording
+   - at least one real setup path executes and records outcome
+
+7. provider-backed execution parity
+   status: queued
+   proof:
+   - at least one provider-backed service is actually executed through its provider path
+   - provider-backed state and health are visible through the API
+
+8. lifecycle depth hardening
+   status: queued
+   proof:
+   - restart behavior is deterministic
+   - intentional stop, crash exit, and restart evidence remain consistent in persisted state
+
+### Wave 4: Orchestration parity
+
+9. dependency-aware startup ordering
+   status: queued
+   proof:
+   - runtime can start services in dependency order
+   - readiness-aware dependency startup is covered by tests
+
+10. manager-level orchestration
+    status: queued
+    scope:
+    - `startAll`
+    - `stopAll`
+    - `reload`
+    - `autostart`
+    proof:
+    - orchestration behavior is deterministic and test-covered
+
+### Wave 5: Runtime observability parity
+
+11. stdout/stderr capture and runtime log ownership
+    status: queued
+    proof:
+    - managed process output is captured
+    - runtime log locations are stable and documented
+
+12. archival and retention model
+    status: queued
+    proof:
+    - run/log retention rules exist and are enforced
+
+13. process/runtime metrics
+    status: queued
+    proof:
+    - runtime exposes bounded process evidence beyond pid/running state
+
+### Wave 6: Demo and consumer validation
+
+14. demo-instance hardening
+    status: queued
+    proof:
+    - demo path proves real execution-backed behavior
+    - demo cannot be satisfied by state flips alone
+
+15. `lasso-@serviceadmin` integration validation
+    status: queued
+    proof:
+    - admin UI consumes the current runtime/API without special-case hacks
+    - released Echo Service artifact is used as the backing service target
+
+### Wave 7: Package and template rollout
+
+16. core package boundary scaffolding
+    status: queued
+    proof:
+    - package split exists and remains aligned with the runtime-root model
+
+17. reference app/template rollout
+    status: queued
+    scope:
+    - `@service-lasso/service-lasso-app-web`
+    - `@service-lasso/service-lasso-packager-node`
+    - `@service-lasso/service-lasso-app-tauri`
+    - `@service-lasso/service-lasso-bundled`
+    proof:
+    - each stays outside core
+    - each consumes the canonical runtime/API cleanly
+
+### Wave 8: Documentation truth pass
+
+18. canonical manifest/reference cleanup
+    status: queued
+    proof:
+    - canonical docs no longer overstate unsupported contract fields
+
+19. stale planning/spec cleanup
+    status: queued
+    proof:
+    - README, spec, plan, and migration docs agree with current implementation
+
+20. final donor parity review
+    status: queued
+    proof:
+    - every donor capability is marked:
+      - done
+      - partial
+      - intentionally dropped
+    - remaining gaps are explicit and justified
+
+## Immediate next item
+
+The next implementation slice from this list is:
+
+**bounded `variable` health support**
+
+That is the next smallest clean donor-parity step after bounded `file`, and it keeps the health migration moving with strong Echo Service-backed verification.

--- a/docs/development/core-runtime-comprehensive-review.md
+++ b/docs/development/core-runtime-comprehensive-review.md
@@ -32,7 +32,7 @@ These assumptions were used consistently throughout the review:
 Automated verification was run during the review:
 
 - command: `npm test`
-- result: `37 passed, 0 failed`
+- result: `40 passed, 0 failed`
 
 What that test run directly proves:
 - API startup
@@ -41,7 +41,7 @@ What that test run directly proves:
 - registry/dependency graph basics
 - lifecycle ordering and guardrails
 - state writes
-- bounded `process`, `http`, and `tcp` health behavior
+- bounded `process`, `http`, `tcp`, and `file` health behavior
 - runtime summary behavior
 - operator logs/variables/network surfaces
 - provider resolution and provider-backed response payloads
@@ -314,7 +314,7 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - in-memory service registry and dependency graph basics
 - bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
 - one bounded real execution/supervision path for directly executable services
-- bounded health handling for `process`, `http`, and `tcp`
+- bounded health handling for `process`, `http`, `tcp`, and `file`
 - structured per-service `.state` writes
 - operator data surfaces for logs, variables, and network
 - provider relationship resolution/planning for direct, `@node`, and `@python`
@@ -333,9 +333,9 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - donor code performs execution-backed lifecycle work
 
 - health model
-  - current code supports `process`, `http`, and bounded `tcp`
-  - donor code also supports `file`, `variable`, and readiness waiting loops
-  - the sibling `lasso-echoservice` harness provides direct integration proof for that bounded `tcp` slice
+  - current code supports `process`, `http`, bounded `tcp`, and bounded `file`
+  - donor code also supports `variable` and readiness waiting loops
+  - the sibling `lasso-echoservice` harness provides direct integration proof for the bounded `tcp` and `file` slices
 
 - provider/runtime behavior
   - current code resolves provider relationships and command previews
@@ -363,7 +363,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - port collision handling
 - dynamic port reassignment
 - shared `globalenv` propagation
-- broader health types beyond `process`, `http`, and `tcp`
+- broader health types beyond `process`, `http`, `tcp`, and `file`
 - dependency readiness loops and start-chain orchestration
 - manager-level `reload`
 - manager-level `startAll`
@@ -446,10 +446,12 @@ Current implementation covers:
 - `process`
 - `http`
 - bounded `tcp`
+- bounded `file`
 
 Related current harness capability:
 - the released `lasso-echoservice` binary already exposes TCP health simulation endpoints and controls
-- `service-lasso` can use that harness today as an integration target and now evaluates bounded manifest `healthcheck.type = tcp`
+- released Echo Service artifacts also provide a real file target through the harness state file
+- `service-lasso` can use that harness today as an integration target and now evaluates bounded manifest `healthcheck.type = tcp` and `healthcheck.type = file`
 - broader donor health parity still remains open beyond that bounded slice
 
 ## 6. Setup and install mechanics

--- a/docs/development/core-runtime-comprehensive-review.md
+++ b/docs/development/core-runtime-comprehensive-review.md
@@ -1,0 +1,607 @@
+# Core runtime comprehensive review
+
+This document consolidates the findings and analysis produced so far across:
+- comprehensive repo documentation review
+- donor runtime to current spec/code coverage analysis
+- current automated verification evidence
+
+It is intended to be the single place to answer:
+
+**what is implemented, what is not, where the docs are accurate, where they drift, and what the current test evidence actually proves**
+
+## Review basis
+
+The analysis in this document was based on:
+- current tracked code under `src/`
+- current automated tests under `tests/`
+- current docs under `docs/`
+- current governance/spec files under `.governance/`
+- donor/reference runtime code under `ref/typerefinery-service-manager-donor/runtime/`
+
+## Review assumptions
+
+These assumptions were used consistently throughout the review:
+
+- current code is the source of truth for implemented behavior
+- `docs/INTRODUCTION.md` plus the active spec define intended direction
+- donor material under `ref/` is valid reference evidence, but not product code
+- `README.md`, `docs/`, and the active governance/spec files all count as project documentation and source-of-truth material
+
+## Verification evidence
+
+Automated verification was run during the review:
+
+- command: `npm test`
+- result: `37 passed, 0 failed`
+
+What that test run directly proves:
+- API startup
+- manifest discovery
+- manifest validation failure handling
+- registry/dependency graph basics
+- lifecycle ordering and guardrails
+- state writes
+- bounded `process`, `http`, and `tcp` health behavior
+- runtime summary behavior
+- operator logs/variables/network surfaces
+- provider resolution and provider-backed response payloads
+
+What that test run does **not** prove:
+- full donor-depth process supervision parity
+- archive/setup mechanics
+- runtime-owned port negotiation
+- shared `globalenv` propagation
+- broader donor parity
+
+## Executive summary
+
+The current `service-lasso` repo is no longer bootstrap-only. It has a real bounded core runtime slice with direct test coverage.
+
+That bounded slice is real and meaningful:
+- standalone runtime entrypoint
+- manifest discovery and validation
+- service registry and dependency graph basics
+- bounded lifecycle actions
+- bounded health handling
+- per-service `.state` writes
+- operator data surfaces
+- provider planning/resolution
+- first API server layer
+
+But the project is **not** at donor runtime parity.
+
+The largest remaining gaps are:
+- real process spawning and supervision
+- setup/install execution mechanics
+- broader health/readiness behavior
+- shared `globalenv`
+- runtime-owned port negotiation
+- orchestration such as `reload`, `startAll`, `stopAll`, and `autostart`
+- fuller runtime logging/archival implementation
+
+Separately, the documentation set has important drift issues:
+- canonical manifest docs are broader than the runtime really supports
+- some core planning/spec docs still describe a pre-implementation phase
+- `workspaceRoot` direction is presented too much like current reality
+- the package-architecture plan presents future package/CLI targets too much like current repo shape
+- several reference docs point to missing companion docs
+- the demo-instance plan can overclaim credibility without real execution proof
+
+## Comprehensive findings
+
+## 1. Canonical `service.json` docs overstate the implemented contract
+
+Severity:
+- High
+
+Summary:
+- the repo’s canonical `service.json` docs define a contract far larger than the runtime actually accepts today
+
+Why this matters:
+- contributors following the canonical docs can author manifests the current runtime cannot parse
+- that creates source-of-truth confusion in the area the repo says is canonical
+
+Key evidence:
+- `docs/README.md` names the reference set as source of truth for the general manifest contract
+- `docs/reference/service-json-reference.md` presents `actions` and `execconfig` as current canonical direction
+- the implemented manifest type and validator only support a much smaller top-level schema
+
+Relevant files:
+- `docs/README.md`
+- `docs/reference/service-json-reference.md`
+- `docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md`
+- `src/contracts/service.ts`
+- `src/runtime/discovery/validateManifest.ts`
+
+Current reality:
+- current runtime accepts a bounded manifest shape with top-level fields such as:
+  - `id`
+  - `name`
+  - `description`
+  - `version`
+  - `enabled`
+  - `depend_on`
+  - `healthcheck`
+  - `env`
+  - `urls`
+  - `execservice`
+  - `executable`
+  - `args`
+
+Not currently accepted by the runtime as documented in canonical reference docs:
+- `actions`
+- `execconfig`
+- `logoutput`
+- `servicetype`
+- `servicelocation`
+- `globalenv`
+- `commandline`
+- `setuparchive`
+- many broader donor-derived fields
+
+Judgment:
+- the current canonical manifest docs are ahead of the implementation and should be described as future/reference direction, not current supported contract
+
+## 2. Several governing/current-state docs are stale about the project phase
+
+Severity:
+- High
+
+Summary:
+- several core planning/spec docs still read like the repo has not yet implemented the bounded runtime slice
+
+Why this matters:
+- it weakens governance traceability
+- it makes it harder to tell what is already done versus what is still planned
+- it creates confusion when a contributor tries to pick the next real task
+
+Key evidence:
+- the active spec still says the repo has no tracked runtime implementation yet
+- the development plan still frames `src/server/index.ts` and the first API routes as future work
+- the top-level README layout summary is also stale
+
+Relevant files:
+- `.governance/specs/SPEC-002-core-standalone-runtime.md`
+- `docs/development/core-runtime-dev-plan.md`
+- `README.md`
+- `src/server/index.ts`
+
+Judgment:
+- the implementation is ahead of the spec/dev-plan wording
+- these docs need a current-state refresh so they describe the bounded slice honestly
+
+## 3. `workspaceRoot` direction is not clearly separated from current implementation
+
+Severity:
+- Medium
+
+Summary:
+- the newer storage/logging docs present `workspaceRoot` as the current preferred runtime-root model, but the current runtime has not adopted that model yet
+
+Why this matters:
+- the future direction itself is reasonable
+- the problem is that the docs do not consistently separate:
+  - current implemented model
+  - target model
+
+Key evidence:
+- `docs/INTRODUCTION.md` says the preferred runtime root model is now `servicesRoot` plus `workspaceRoot`
+- `docs/README.md` repeats that as the current preferred model
+- actual runtime root types still expose `dataRoot` and `stateRoot`
+- operator log paths are still service-local in current code and tests
+
+Relevant files:
+- `docs/INTRODUCTION.md`
+- `docs/README.md`
+- `docs/development/core-runtime-storage-model.md`
+- `docs/development/core-runtime-logging-model.md`
+- `src/contracts/service-root.ts`
+- `src/runtime/layout.ts`
+- `src/runtime/operator/logs.ts`
+- `tests/operator-data.test.js`
+
+Judgment:
+- this should be documented explicitly as target architecture rather than current implemented runtime behavior
+
+## 4. The package-architecture plan overstates future package shape as near-current reality
+
+Severity:
+- Medium
+
+Summary:
+- the package-architecture doc is directionally useful, but it presents target package/CLI entrypoints and package API examples without clearly marking them as not yet implemented
+
+Why this matters:
+- it can mislead contributors about what package boundaries, entrypoints, and CLI surfaces already exist
+- it also introduces a package API shape that does not line up cleanly with the currently documented `servicesRoot` and `workspaceRoot` direction
+
+Key evidence:
+- the doc refers to built/runtime entrypoints such as `node dist/runtime/server.js`
+- it defines a package bin at `./dist/cli.js`
+- it gives a `createRuntime({ root, servicesPath, port })` example and a monorepo `packages/*` split
+- none of those paths or entrypoints exist in the current repo
+- the current package still runs through `dist/index.js`
+
+Relevant files:
+- `docs/development/core-runtime-package-architecture.md`
+- `package.json`
+- `src/index.ts`
+- `docs/INTRODUCTION.md`
+- `docs/development/core-runtime-storage-model.md`
+- `.governance/project/BACKLOG.md`
+
+Judgment:
+- this doc should be framed explicitly as target architecture and should state how it relates to the current `servicesRoot`/`workspaceRoot` direction before it is treated as planning source of truth
+
+## 5. The reference set has broken or missing companion-doc links
+
+Severity:
+- Medium
+
+Summary:
+- several reference docs point to companion docs/files that are not present in this repository
+
+Why this matters:
+- it makes the reference section harder to trust
+- it breaks the reading trail in the area the repo calls canonical documentation
+
+Examples:
+- `docs/reference/service-json-reference.md` points to missing broader template docs
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md` lists related docs that do not exist in this checkout
+- `docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md` claims value-catalog companions that are not present
+
+Relevant files:
+- `docs/reference/service-json-reference.md`
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+- `docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md`
+
+Judgment:
+- these links should either be removed, rewritten, or replaced with existing local docs
+
+## 6. The demo-instance plan still needs a clearer execution-backed success bar
+
+Severity:
+- Medium
+
+Summary:
+- the demo-instance plan still needs to distinguish bounded execution-backed proof from broader donor-parity claims
+
+Why this matters:
+- the runtime now has a bounded real execution path, so the demo should explicitly use that stronger proof
+- without a clearer bar, contributors can still confuse “bounded working demo” with “broader donor-runtime parity”
+
+Key evidence:
+- the demo success bar only requires lifecycle/state/health proof
+- the runtime now includes a bounded execution supervisor and persisted runtime metadata
+- broader donor runtime gaps still remain outside the demo slice
+
+Relevant files:
+- `docs/development/core-runtime-demo-instance-plan.md`
+- `docs/development/core-runtime-migration-plan.md`
+- `src/runtime/lifecycle/actions.ts`
+- `src/runtime/health/evaluateHealth.ts`
+
+Judgment:
+- the demo plan should explicitly distinguish:
+  - bounded state-model demo
+  - execution-backed demo
+
+## 7. Current code covers the bounded first runtime slice, not the full donor runtime
+
+Severity:
+- High
+
+Summary:
+- current code and tests do cover the bounded first runtime slice
+- current code does not cover the full donor runtime behavior
+
+Why this matters:
+- this is the main reality check for planning and claims of progress
+
+Judgment:
+- bounded first-slice coverage: mostly yes
+- full donor runtime coverage: no
+
+## Donor to spec to code analysis
+
+## What is covered in the current bounded slice
+
+These donor/runtime concerns are meaningfully represented in the current code and tests:
+
+- standalone runtime entrypoint and bounded API server
+- manifest discovery from `services/*/service.json`
+- manifest parsing/validation for the current bounded schema
+- in-memory service registry and dependency graph basics
+- bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
+- one bounded real execution/supervision path for directly executable services
+- bounded health handling for `process`, `http`, and `tcp`
+- structured per-service `.state` writes
+- operator data surfaces for logs, variables, and network
+- provider relationship resolution/planning for direct, `@node`, and `@python`
+- direct automated verification for the implemented slice
+
+## What is partially covered
+
+These donor/runtime concerns are represented directionally, but not at donor depth:
+
+- dependency behavior
+  - current code models dependencies and exposes them via API
+  - donor code also performs dependency startup and wait orchestration
+
+- lifecycle behavior
+  - current code proves lifecycle state transitions
+  - donor code performs execution-backed lifecycle work
+
+- health model
+  - current code supports `process`, `http`, and bounded `tcp`
+  - donor code also supports `file`, `variable`, and readiness waiting loops
+  - the sibling `lasso-echoservice` harness provides direct integration proof for that bounded `tcp` slice
+
+- provider/runtime behavior
+  - current code resolves provider relationships and command previews
+  - donor code actually executes through provider/runtime services
+
+- logging
+  - current code exposes bounded operator log payloads
+  - donor code writes real runtime and service logs with archival behavior
+
+- state model
+  - current code writes the first structured `.state/` slice
+  - donor code includes PID/runtime/process evidence and startup recovery concerns not yet implemented here
+
+## What is not covered yet
+
+These major donor/runtime behaviors are not implemented in the current code:
+
+- full donor-depth stop/kill/restart control over managed processes
+- exit handling and `ignoreexiterror`
+- PID file management as a real runtime concern
+- process-tree tracking and runtime metrics
+- archive extraction via `setuparchive`
+- command-driven setup/install pipeline
+- runtime-owned port reservation
+- port collision handling
+- dynamic port reassignment
+- shared `globalenv` propagation
+- broader health types beyond `process`, `http`, and `tcp`
+- dependency readiness loops and start-chain orchestration
+- manager-level `reload`
+- manager-level `startAll`
+- manager-level `stopAll`
+- `autostart`
+- fuller runtime logging, archival, and retention implementation
+
+## Major donor behavior areas
+
+## 1. Discovery and manifest loading
+
+Donor behavior:
+- `ServiceManager` scans for `*/service.json`
+- parses configs
+- builds service objects
+
+Current status:
+- covered in the bounded slice
+
+## 2. Standalone runtime entrypoint
+
+Donor behavior:
+- `Services.ts` starts the standalone manager process
+- sets up runtime logging
+- optionally triggers `startAll`
+- exposes a server/UI surface
+
+Current status:
+- partially covered
+
+Current implementation covers:
+- standalone runtime entrypoint
+- bounded API server startup
+
+Current implementation does not yet cover:
+- donor manager orchestration depth
+- donor admin/UI surface
+- autostart behavior
+
+## 3. Registry and dependency graph
+
+Donor behavior:
+- discovery becomes a managed runtime registry
+- dependency relationships influence startup
+- `execservice` also acts as a dependency edge
+
+Current status:
+- partially covered
+
+## 4. Lifecycle actions
+
+Donor behavior:
+- lifecycle is execution-backed
+- install/setup/start/stop/restart interact with real runtime state
+
+Current status:
+- partially covered
+
+Current implementation covers:
+- bounded lifecycle state transitions
+- sequencing guardrails
+
+Current implementation does not yet cover:
+- execution-backed lifecycle behavior
+- broader actions such as uninstall/update/rollback/reset
+
+## 5. Health behavior
+
+Donor behavior:
+- `http`
+- `tcp`
+- `file`
+- `variable`
+- readiness participation in startup
+
+Current status:
+- partially covered
+
+Current implementation covers:
+- `process`
+- `http`
+- bounded `tcp`
+
+Related current harness capability:
+- the released `lasso-echoservice` binary already exposes TCP health simulation endpoints and controls
+- `service-lasso` can use that harness today as an integration target and now evaluates bounded manifest `healthcheck.type = tcp`
+- broader donor health parity still remains open beyond that bounded slice
+
+## 6. Setup and install mechanics
+
+Donor behavior:
+- archive extraction
+- setup-state markers
+- setup command execution
+- provider-aware setup behavior
+
+Current status:
+- not covered beyond bounded state semantics
+
+## 7. Process supervision
+
+Donor behavior:
+- process spawn
+- PID tracking
+- stop/kill behavior
+- process completion handling
+- process-tree stats
+
+Current status:
+- not covered
+
+## 8. Port negotiation
+
+Donor behavior:
+- service ports are reserved and resolved at runtime
+- collisions are handled
+- replacement ports can be assigned
+
+Current status:
+- not covered
+
+## 9. Shared environment model
+
+Donor behavior:
+- services can emit `globalenv`
+- manager merges global env
+- merged env is pushed back into services
+
+Current status:
+- not covered
+
+## 10. Logging and archival
+
+Donor behavior:
+- manager and service log files
+- per-run logging directories
+- log archival
+- old-log cleanup
+
+Current status:
+- partially covered in docs only, not implementation
+
+Current implementation covers:
+- bounded operator log surfaces
+
+Current docs define a preferred future model:
+- `docs/development/core-runtime-logging-model.md`
+
+Current implementation does not yet realize that model.
+
+## SPEC-002 coverage judgment
+
+`SPEC-002` is a bounded first-runtime spec, not a donor-parity spec.
+
+Against that bounded intent, the current code is mostly aligned with the core scope:
+- tracked source tree exists
+- a runnable runtime entrypoint exists
+- manifest discovery/parsing exists
+- direct automated verification exists
+- docs broadly distinguish implemented behavior from donor/reference-only behavior
+
+However, `SPEC-002` itself is stale in wording.
+
+Examples:
+- it still says the repo had no tracked runtime implementation yet
+- it still reads like pre-implementation planning rather than post-slice reality
+
+So:
+- the implementation is ahead of the spec wording
+- the spec should be refreshed
+
+## Documentation health summary
+
+## Healthy and directionally useful docs
+
+These docs are still broadly useful and aligned directionally:
+- `docs/INTRODUCTION.md`
+- `docs/development/core-runtime-layout.md`
+- `docs/development/core-runtime-migration-plan.md`
+- `docs/development/core-runtime-state-model-audit.md`
+- `docs/development/core-runtime-storage-model.md`
+- `docs/development/core-runtime-logging-model.md`
+
+## Docs needing the highest-priority cleanup
+
+Highest priority:
+- `.governance/specs/SPEC-002-core-standalone-runtime.md`
+- `docs/development/core-runtime-dev-plan.md`
+- `docs/development/core-runtime-package-architecture.md`
+- `README.md`
+- `docs/reference/service-json-reference.md`
+- `docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md`
+- `docs/README.md`
+- `docs/development/core-runtime-demo-instance-plan.md`
+
+## Current trustworthy project label
+
+The most accurate current project label is:
+
+**bounded core runtime slice implemented, donor parity not yet complete**
+
+That label is supported by:
+- current code
+- current tests
+- current migration analysis
+
+## Recommended next actions
+
+## Documentation actions
+
+1. Refresh `SPEC-002` so it reflects the implemented bounded slice honestly.
+2. Refresh `core-runtime-dev-plan.md` so completed steps are no longer framed as future work.
+3. Refresh the top-level `README.md` current-layout section.
+4. Reclassify the larger `service.json` reference docs as future/reference direction unless and until the runtime supports that broader contract.
+5. Fix or remove broken companion-doc links in `docs/reference`.
+6. Clarify `workspaceRoot` as target architecture unless and until the runtime adopts it.
+7. Rework `core-runtime-package-architecture.md` so it clearly distinguishes current repo shape from target package architecture and aligns with the current runtime-root direction.
+8. Tighten the demo-instance success bar so it cannot overclaim execution credibility.
+
+## Runtime/product actions
+
+1. Choose the next bounded major migration unit explicitly.
+2. Prefer one of these as the next execution item:
+   - execution-backed demo path
+   - setup/install mechanics
+   - process supervision
+   - runtime-owned port negotiation
+
+## Final judgment
+
+The current answer to "where are we really up to?" is:
+
+- the repo has a real bounded implementation
+- the tests give direct proof for that bounded slice
+- the donor runtime remains much broader than current code
+- several docs still blur current reality and future direction
+
+So the key discipline going forward should be:
+
+- keep claims of current behavior tied to current code and tests
+- keep donor-derived and future-direction material clearly labeled as future or provisional

--- a/docs/development/core-runtime-demo-instance-plan.md
+++ b/docs/development/core-runtime-demo-instance-plan.md
@@ -81,7 +81,7 @@ Preferred first step:
 The first demo set should stay small and explicit:
 - `@node`
 - `@python`
-- one simple runnable sample service such as `echo-service`
+- one runnable harness service such as `echo-service`, with API + UI surfaces that can simulate lifecycle-adjacent behavior for demo and supervision hardening
 - optionally one HTTP-health demo service if it materially improves the review flow
 
 The demo services should be designed for clarity, not realism overload.

--- a/docs/development/core-runtime-donor-coverage-audit.md
+++ b/docs/development/core-runtime-donor-coverage-audit.md
@@ -1,0 +1,360 @@
+# Core runtime donor/spec/code coverage audit
+
+This document records the findings from a focused coverage audit across:
+- donor runtime code under `ref/typerefinery-service-manager-donor/runtime/`
+- the active bounded product spec in `.governance/specs/SPEC-002-core-standalone-runtime.md`
+- the current tracked implementation under `src/`
+- the current automated test suite under `tests/`
+
+It exists to answer a practical question clearly:
+
+**how much of the donor runtime is actually covered by the current spec and code, and what still remains outside the current bounded slice?**
+
+## Evidence used
+
+Primary donor inputs reviewed:
+- `ref/typerefinery-service-manager-donor/runtime/ServiceManager.ts`
+- `ref/typerefinery-service-manager-donor/runtime/Service.ts`
+- `ref/typerefinery-service-manager-donor/runtime/Services.ts`
+
+Primary current-repo inputs reviewed:
+- `.governance/specs/SPEC-002-core-standalone-runtime.md`
+- `src/`
+- `tests/`
+- relevant runtime/design docs under `docs/development/`
+
+Verification run used for this audit:
+- `npm test`
+- result: `37 passed, 0 failed`
+
+## Bottom line
+
+The current `service-lasso` codebase **does cover the bounded first runtime slice** that `SPEC-002` was intended to establish.
+
+It does **not** cover the full donor runtime behavior.
+
+The donor runtime is substantially broader in the following areas:
+- real process spawning and supervision
+- setup/archive extraction mechanics
+- runtime-owned port negotiation
+- shared `globalenv` propagation
+- broader health/readiness models
+- manager-level orchestration such as `reload`, `startAll`, `stopAll`, and `autostart`
+- richer logging, archival, and runtime metrics
+
+So the honest project label remains:
+
+**bounded core runtime slice implemented; donor parity not yet complete**
+
+## Coverage summary
+
+### Covered in the current bounded slice
+
+These donor/runtime concerns are meaningfully represented in the current code and tests:
+
+- standalone runtime entrypoint and bounded API server
+- manifest discovery from `services/*/service.json`
+- manifest parsing/validation for the current bounded schema
+- in-memory service registry and dependency graph basics
+- bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
+- one bounded real execution/supervision path for directly executable services
+- bounded health handling for `process`, `http`, and `tcp`
+- structured per-service `.state/` writes
+- operator data surfaces for logs, variables, and network
+- provider relationship resolution/planning for direct, `@node`, and `@python`
+- direct automated verification for the implemented slice
+
+### Partially covered
+
+These donor/runtime concerns are represented directionally, but not at donor depth:
+
+- dependency behavior
+  - current code models dependencies and exposes them via API
+  - donor code also performs dependency startup/wait orchestration
+- lifecycle behavior
+  - current code proves lifecycle state transitions
+  - donor code performs execution-backed lifecycle work
+- health model
+  - current code supports `process`, `http`, and bounded `tcp`
+  - donor code also supports `file`, `variable`, and readiness waiting loops
+- provider/runtime behavior
+  - current code resolves provider relationships and command previews
+  - donor code actually executes through provider/runtime services
+- logging
+  - current code exposes bounded operator log payloads
+  - donor code writes real runtime/service logs with archival behavior
+- state model
+  - current code writes the first structured `.state/` slice
+  - donor code includes PID/runtime/process evidence and startup recovery concerns not yet implemented here
+
+### Not covered yet
+
+These major donor/runtime behaviors are not implemented in the current code:
+
+- full donor-depth stop/kill/restart control over managed processes
+- exit handling and `ignoreexiterror` behavior
+- PID file management as a real runtime contract
+- process-tree tracking and memory/process metrics
+- archive extraction via `setuparchive`
+- command-driven setup/install pipeline
+- runtime-owned port reservation, collision handling, and reassignment
+- `globalenv` export/import propagation across services
+- broader health types beyond `process`, `http`, and `tcp`
+- dependency readiness loops and start-chain orchestration
+- manager-level `reload`
+- manager-level `startAll`
+- manager-level `stopAll`
+- `autostart`
+- fuller runtime logging, archival, and retention implementation
+
+## Donor-to-current mapping
+
+## 1. Discovery and manifest loading
+
+### Donor behavior
+- `ServiceManager` scans for `*/service.json`
+- parses configs
+- builds service objects from those configs
+
+### Current status
+- covered in the current bounded slice
+
+Current implementation covers:
+- discovery from a configured services root
+- manifest validation
+- loading discovered services into registry/graph models
+
+## 2. Standalone runtime entrypoint
+
+### Donor behavior
+- `Services.ts` starts the standalone service-manager process
+- sets up runtime logging
+- optionally triggers `startAll`
+- exposes a server/UI surface
+
+### Current status
+- partially covered
+
+Current implementation covers:
+- standalone runtime entrypoint
+- bounded API server startup
+
+Current implementation does not yet cover:
+- donor-style standalone manager orchestration
+- signal-driven managed shutdown behavior for running child services
+- donor admin/UI surface
+
+## 3. Registry and dependency graph
+
+### Donor behavior
+- service discovery becomes a managed runtime registry
+- dependency relationships influence startup flow
+- `execservice` also acts as a dependency edge
+
+### Current status
+- partially covered
+
+Current implementation covers:
+- service registry
+- dependency graph modeling
+- API exposure of dependencies/dependents
+
+Current implementation does not yet cover:
+- dependency wait loops
+- dependency-driven service startup orchestration
+- recursive start-chain handling
+
+## 4. Lifecycle actions
+
+### Donor behavior
+- lifecycle is execution-backed
+- install/setup/start/stop/restart interact with real process/runtime state
+
+### Current status
+- partially covered
+
+Current implementation covers:
+- bounded lifecycle state transitions
+- explicit action ordering
+- action error handling for invalid sequencing
+- one bounded real execution/supervision path for directly executable services
+
+Current implementation does not yet cover:
+- execution-backed lifecycle behavior
+- uninstall/update/rollback/reset semantics
+- donor-style setup/install completion semantics
+
+## 5. Health behavior
+
+### Donor behavior
+- health checks support multiple types
+- health participates in startup readiness
+
+### Current status
+- partially covered
+
+Current implementation covers:
+- default `process` health
+- bounded `http` health checks
+- bounded `tcp` health checks
+
+Current implementation does not yet cover:
+- `file`
+- `variable`
+- readiness wait loops tied to actual startup
+
+Related current test-harness note:
+- the sibling `lasso-echoservice` repo already exposes TCP health simulation endpoints and controls for integration testing
+- that harness capability is now paired with bounded `service-lasso` runtime support for manifest `healthcheck.type = tcp`
+- broader donor health parity still remains open beyond that bounded slice
+
+## 6. Setup and install mechanics
+
+### Donor behavior
+- archive extraction
+- setup-state markers
+- setup command execution
+- provider/runtime-aware setup behavior
+
+### Current status
+- not covered beyond bounded state semantics
+
+Current implementation only proves:
+- the conceptual split between `install` and `config`
+- bounded action-state recording
+
+## 7. Process supervision
+
+### Donor behavior
+- process spawn
+- PID tracking
+- stop/kill behavior
+- process completion handling
+- process-tree statistics
+
+### Current status
+- partially covered
+
+Current implementation covers:
+- one bounded child-process supervision path
+- PID/runtime metadata persistence
+- stop handling and exit observation for directly executable services
+
+Current implementation does not yet cover:
+- broader provider-backed supervision parity
+- process-tree statistics
+- fuller donor runtime supervision depth
+
+## 8. Port negotiation
+
+### Donor behavior
+- service ports are reserved and resolved at runtime
+- collisions are handled
+- replacement ports can be assigned
+
+### Current status
+- not covered
+
+Current code surfaces network/operator data from manifests but does not own port negotiation.
+
+## 9. Shared environment model
+
+### Donor behavior
+- services can emit `globalenv`
+- manager merges shared env
+- merged env is pushed back into services
+
+### Current status
+- not covered
+
+Current code only exposes bounded manifest env plus a few derived variables.
+
+## 10. Logging and archival
+
+### Donor behavior
+- manager and service log files
+- per-run logging directories
+- log archival
+- old-log cleanup
+
+### Current status
+- partially covered in docs only, not implementation
+
+Current code covers:
+- bounded operator log surfaces
+
+Current docs define a preferred future model:
+- `docs/development/core-runtime-logging-model.md`
+
+Current implementation does not yet realize that model.
+
+## SPEC-002 coverage judgment
+
+`SPEC-002` is a bounded first-runtime spec, not a donor-parity spec.
+
+Against that bounded intent, the current code is **mostly aligned** with the core scope:
+- tracked source tree exists
+- a runnable runtime entrypoint exists
+- manifest discovery/parsing exists
+- direct automated verification exists
+- docs distinguish implemented behavior from donor/reference-only behavior in broad terms
+
+However, the spec document itself is now stale in wording.
+
+Examples:
+- it still says the repo had no tracked runtime implementation yet
+- it still reads like pre-implementation planning rather than post-slice reality
+
+So the implementation is ahead of the spec wording.
+
+## Test evidence
+
+Current automated verification status for the bounded core slice:
+
+- command run: `npm test`
+- result: `37 passed, 0 failed`
+
+The passing suite directly verifies:
+- API startup
+- service discovery
+- manifest validation failure handling
+- registry/dependency graph basics
+- lifecycle ordering and guardrails
+- state writes
+- `process` and `http` health behavior
+- runtime summary behavior
+- operator logs/variables/network surfaces
+- provider resolution and provider-backed response payloads
+
+This is strong evidence for the currently implemented slice.
+
+It is **not** evidence for the unmigrated donor behaviors listed above.
+
+## Findings
+
+1. The current codebase is no longer bootstrap-only and does satisfy the main bounded intent of the first standalone runtime slice.
+2. The donor runtime remains substantially broader than the current implementation.
+3. The largest missing donor areas are execution, setup, supervision, shared env, ports, and orchestration.
+4. The migration docs are directionally correct about those missing areas.
+5. `SPEC-002` should be refreshed so its wording reflects the implemented slice rather than the pre-implementation state.
+6. The passing test suite gives strong direct proof for the bounded slice, but should not be used to imply donor parity.
+
+## Recommended next actions
+
+1. Update `SPEC-002` so it describes the implemented bounded slice honestly.
+2. Keep using `docs/development/core-runtime-migration-plan.md` as the main donor-gap tracker.
+3. Choose the next major migration unit explicitly rather than mixing several donor gaps at once.
+4. Prefer one of these as the next bounded execution item:
+   - execution-backed demo path
+   - setup/install mechanics
+   - process supervision
+   - runtime-owned port negotiation
+
+## Final judgment
+
+The current answer to "is the donor behavior covered by our spec and code?" is:
+
+- **bounded first-slice spec coverage:** mostly yes
+- **full donor runtime coverage:** no
+- **current automated proof for implemented slice:** yes
+- **current automated proof for donor parity:** no

--- a/docs/development/core-runtime-donor-coverage-audit.md
+++ b/docs/development/core-runtime-donor-coverage-audit.md
@@ -25,7 +25,7 @@ Primary current-repo inputs reviewed:
 
 Verification run used for this audit:
 - `npm test`
-- result: `37 passed, 0 failed`
+- result: `40 passed, 0 failed`
 
 ## Bottom line
 
@@ -58,7 +58,7 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - in-memory service registry and dependency graph basics
 - bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
 - one bounded real execution/supervision path for directly executable services
-- bounded health handling for `process`, `http`, and `tcp`
+- bounded health handling for `process`, `http`, `tcp`, and `file`
 - structured per-service `.state/` writes
 - operator data surfaces for logs, variables, and network
 - provider relationship resolution/planning for direct, `@node`, and `@python`
@@ -75,8 +75,8 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - current code proves lifecycle state transitions
   - donor code performs execution-backed lifecycle work
 - health model
-  - current code supports `process`, `http`, and bounded `tcp`
-  - donor code also supports `file`, `variable`, and readiness waiting loops
+  - current code supports `process`, `http`, bounded `tcp`, and bounded `file`
+  - donor code also supports `variable` and readiness waiting loops
 - provider/runtime behavior
   - current code resolves provider relationships and command previews
   - donor code actually executes through provider/runtime services
@@ -99,7 +99,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - command-driven setup/install pipeline
 - runtime-owned port reservation, collision handling, and reassignment
 - `globalenv` export/import propagation across services
-- broader health types beyond `process`, `http`, and `tcp`
+- broader health types beyond `process`, `http`, `tcp`, and `file`
 - dependency readiness loops and start-chain orchestration
 - manager-level `reload`
 - manager-level `startAll`
@@ -197,15 +197,16 @@ Current implementation covers:
 - default `process` health
 - bounded `http` health checks
 - bounded `tcp` health checks
+- bounded `file` health checks
 
 Current implementation does not yet cover:
-- `file`
 - `variable`
 - readiness wait loops tied to actual startup
 
 Related current test-harness note:
 - the sibling `lasso-echoservice` repo already exposes TCP health simulation endpoints and controls for integration testing
 - that harness capability is now paired with bounded `service-lasso` runtime support for manifest `healthcheck.type = tcp`
+- released Echo Service artifacts now also provide direct proof for bounded `service-lasso` runtime support for manifest `healthcheck.type = file`
 - broader donor health parity still remains open beyond that bounded slice
 
 ## 6. Setup and install mechanics
@@ -312,7 +313,7 @@ So the implementation is ahead of the spec wording.
 Current automated verification status for the bounded core slice:
 
 - command run: `npm test`
-- result: `37 passed, 0 failed`
+- result: `40 passed, 0 failed`
 
 The passing suite directly verifies:
 - API startup

--- a/docs/development/core-runtime-package-architecture.md
+++ b/docs/development/core-runtime-package-architecture.md
@@ -1,0 +1,249 @@
+# Core runtime package architecture
+
+This document captures the intended package boundaries for the next Service Lasso architecture step.
+
+## Core product boundary
+
+The core runtime should be a publishable Node library + CLI.
+
+Suggested package name:
+- `@service-lasso/service-lasso`
+
+### Core should contain
+
+- `Service`
+- `ServiceManager`
+- `InstanceManager`
+- `ManifestLoader`
+- `PortRegistry`
+- `HealthChecker`
+- `ProcessSupervisor`
+- `Logger`
+- shared path helpers
+- API server bootstrap
+- CLI bootstrap
+
+### Core should not contain
+
+- Electron runtime code
+- Tauri runtime code
+- UI framework lock-in
+- desktop app-window lifecycle logic
+- desktop installer packaging config
+
+## Release targets
+
+### 1) Core npm package
+
+Published via npm (`npm publish`) as the canonical reusable runtime package.
+
+### 2) Built Node runtime
+
+Runnable directly from build output:
+
+```bash
+node dist/runtime/server.js
+```
+
+### 3) CLI
+
+Runnable via package bin:
+
+```bash
+npx service-lasso
+# or global install
+```
+
+### 4) Reference apps packages (separate from core)
+
+Once the core runtime is built and stable, additional reference app packages should be created to showcase integration patterns.
+
+These reference apps are required because they should act as:
+- working examples of how to consume the core runtime
+- template starting points that teams can clone or adapt for their own apps
+- proof that the runtime integrates cleanly across multiple host/distribution styles
+
+These packages remain outside core.
+They consume the canonical runtime package and should use the same runtime-root model:
+- `servicesRoot`
+- `workspaceRoot`
+
+They should never redefine the core contract or replace the core runtime boundary.
+
+Before broad reference-template rollout, the existing sibling consumer repo `lasso-@serviceadmin` should be used as the first post-core integration check against the real runtime/API, ideally backed by released `lasso-echoservice` artifacts.
+
+#### A) Web reference app template
+
+Suggested package:
+- `@service-lasso/service-lasso-app-web`
+
+Purpose:
+- demonstrate browser-facing or web-hosted integration around the core runtime/API
+- provide a template repo/package that others can start their own web integration from
+- showcase how a UI-facing app should consume the runtime rather than replace it
+
+Dependency direction:
+- `@service-lasso/service-lasso-app-web` -> `@service-lasso/service-lasso`
+- never the reverse
+
+#### B) Node packager/reference template
+
+Suggested package:
+- `@service-lasso/service-lasso-packager-node`
+
+Purpose:
+- demonstrate a plain Node packaging/distribution path for Service Lasso
+- provide a template for teams who want a non-Electron, non-Tauri starting point
+- stay close to real runtime behavior while packaging for practical use
+
+Likely packaging styles:
+- `pkg`
+- `nexe`
+- tar/zip distribution with Node runtime expectation
+
+Dependency direction:
+- `@service-lasso/service-lasso-packager-node` -> `@service-lasso/service-lasso`
+- never the reverse
+
+#### C) Tauri desktop alternative template
+
+Suggested package:
+- `@service-lasso/service-lasso-app-tauri`
+
+Purpose:
+- provide an explicit desktop alternative to Electron
+- demonstrate how the runtime can be embedded behind a Tauri shell
+- act as a template for teams that want a desktop app starting point without Electron
+
+Dependency direction:
+- `@service-lasso/service-lasso-app-tauri` -> `@service-lasso/service-lasso`
+- never the reverse
+
+#### D) Bundled standalone distribution template
+
+Suggested package:
+- `@service-lasso/service-lasso-bundled`
+
+Purpose:
+- demonstrate a packaged standalone distribution path
+- provide a template for building a more turnkey bundled delivery of Service Lasso
+- showcase how to distribute the runtime as a packaged product without pushing packaging logic into core
+
+Dependency direction:
+- `@service-lasso/service-lasso-bundled` -> `@service-lasso/service-lasso`
+- never the reverse
+
+Recommended rollout order:
+1. core npm module
+2. `@service-lasso/service-lasso-app-web`
+3. `@service-lasso/service-lasso-packager-node`
+4. `@service-lasso/service-lasso-app-tauri`
+5. `@service-lasso/service-lasso-bundled`
+
+## Initial package map
+
+Preferred initial split:
+
+1. `packages/core`
+2. `packages/app-web`
+3. `packages/packager-node`
+
+Optional later split:
+
+4. `packages/app-tauri`
+5. `packages/bundled`
+
+This keeps runtime as the source of truth while validating reference wrappers without polluting core.
+
+## Build approach for core
+
+Use a minimal Node-oriented build:
+- `tsup` (or equivalent esbuild-based build)
+- Node target (Node 20+)
+- type declarations emitted
+- `src/` -> `dist/`
+
+Keep build/release boring and predictable.
+
+## Core package shape target
+
+```json
+{
+  "name": "@service-lasso/service-lasso",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "service-lasso": "./dist/cli.js"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./cli": "./dist/cli.js",
+    "./runtime": "./dist/runtime/index.js"
+  }
+}
+```
+
+## Runtime/UI strategy
+
+### Phase 1
+Core can include a minimal built-in admin surface for basic status/control if needed.
+
+### Phase 2
+A richer UI can evolve as a separate package, e.g. `@service-lasso/service-lasso-ui`.
+
+This preserves a self-contained runtime without coupling core to one UI framework.
+
+## Naming direction
+
+- Core: `@service-lasso/service-lasso`
+- Web reference: `@service-lasso/service-lasso-app-web`
+- Node packager reference: `@service-lasso/service-lasso-packager-node`
+- Tauri reference: `@service-lasso/service-lasso-app-tauri`
+- Bundled reference: `@service-lasso/service-lasso-bundled`
+
+Optional later:
+- `@service-lasso/service-lasso-ui`
+- `@service-lasso/service-lasso-manifests`
+- `@service-lasso/service-lasso-examples`
+
+## Target behavior (core)
+
+Programmatic:
+
+```ts
+import { createRuntime } from "@service-lasso/service-lasso";
+
+const runtime = await createRuntime({
+  servicesRoot: "./services",
+  workspaceRoot: "./workspace",
+  port: 19001,
+});
+
+await runtime.start();
+```
+
+CLI:
+
+```bash
+service-lasso dev
+service-lasso start
+service-lasso ui --port 19001
+service-lasso instance start demo
+```
+
+Built runtime:
+
+```bash
+node dist/cli.js dev
+```
+
+## Post-core implementation move
+
+After the core runtime is built and stable, move cleaned runtime code toward `packages/core/src`, then bring up the reference app/template packages as thin consumers of the core package:
+- `packages/app-web`
+- `packages/packager-node`
+- `packages/app-tauri`
+- `packages/bundled`
+
+These should be maintained as starter templates for downstream teams, not just one-off internal demos.

--- a/docs/development/core-runtime-working-application-plan.md
+++ b/docs/development/core-runtime-working-application-plan.md
@@ -169,8 +169,8 @@ Why this order:
 
 Current harness note:
 - the sibling `lasso-echoservice` repo already provides HTTP and TCP health simulation targets for testing
-- that gives us a strong migration harness, and Service Lasso runtime now has bounded `tcp` manifest-health support proven against that harness
-- broader donor health parity still requires additional types such as `file` and `variable` plus readiness-loop behavior
+- that gives us a strong migration harness, and Service Lasso runtime now has bounded `tcp` and `file` manifest-health support proven against that harness
+- broader donor health parity still requires additional types such as `variable` plus readiness-loop behavior
 
 ## Phase 5A: Validate the first real consumer repo
 

--- a/docs/development/core-runtime-working-application-plan.md
+++ b/docs/development/core-runtime-working-application-plan.md
@@ -1,0 +1,258 @@
+# Core runtime working-application plan
+
+This document turns the current review and audit findings into a practical plan for getting `service-lasso` from the current bounded core slice to a genuinely working application.
+
+It is based on:
+- `docs/development/core-runtime-comprehensive-review.md`
+- `docs/development/core-runtime-donor-coverage-audit.md`
+- `.governance/project/BACKLOG.md`
+
+## Current starting point
+
+What is already true:
+- the repo has a real bounded runtime slice
+- `npm test` passes for that bounded slice
+- discovery, validation, registry, lifecycle state, bounded health, operator surfaces, and API startup all exist
+
+What is not true yet:
+- the runtime does not yet launch and supervise real managed processes
+- the docs still blur current behavior and future direction in several places
+- the current demo plan can overstate readiness without proving real execution
+
+The honest current label remains:
+
+**bounded core runtime slice implemented; working application not complete yet**
+
+## Goal
+
+Reach a state where Service Lasso can be honestly described as:
+
+**a working local service runtime that can discover services, load explicit roots/config, launch at least one real managed service path, persist and rehydrate runtime state, expose stable API behavior, and support a credible demo flow**
+
+## Delivery strategy
+
+The best path is not donor-parity-all-at-once.
+
+The best path is:
+1. stabilize contracts and runtime boot behavior
+2. add one real execution-backed supervision slice
+3. prove a credible demo instance end to end
+4. validate the first real consumer repo against that core runtime
+5. then expand into broader donor parity and reference app templates
+
+## Phase 1: Stabilize the current bounded slice
+
+Objective:
+- make the current runtime slice trustworthy and easier to build on
+
+Why first:
+- this reduces churn before real execution lands
+- it keeps future work grounded on a stable API and startup model
+
+Recommended steps:
+1. Normalize API error/status handling and shared error DTO.
+2. Implement explicit runtime config loading and validation for:
+   - `servicesRoot`
+   - `workspaceRoot`
+3. Implement startup rehydration from persisted runtime/lifecycle state.
+
+Primary backlog alignment:
+- `TASK-012`
+- `TASK-013`
+- `TASK-014`
+
+Exit criteria:
+- invalid requests return deterministic typed API errors
+- runtime no longer depends on hardcoded roots
+- runtime restart restores known service/runtime state consistently
+
+## Phase 2: Land the first real execution-backed runtime slice
+
+Objective:
+- move from state-only lifecycle behavior to real managed execution
+
+Why this is the critical milestone:
+- this is the single biggest gap between current code and a working application
+- it also removes the biggest source of demo ambiguity
+
+Recommended scope:
+- implement one bounded process-supervision path first
+- prefer one provider/runtime path only for the first slice
+- keep the first execution path intentionally narrow and testable
+
+The first execution slice should include:
+- real child-process launch
+- PID/runtime tracking
+- stop/kill handling
+- exit detection
+- persisted runtime-state updates tied to real execution
+- health behavior connected to actual running state
+
+Primary backlog alignment:
+- `TASK-015`
+
+Exit criteria:
+- at least one manifest-backed service can be started and stopped for real
+- runtime state reflects actual process status rather than only action flags
+- tests directly prove execution-backed lifecycle behavior
+
+## Phase 3: Make the demo path honest and repeatable
+
+Objective:
+- turn the bounded runtime plus first execution slice into a credible working demo application
+
+Why now:
+- once real execution exists, the demo can become a meaningful proof point instead of a state-model walkthrough
+
+Recommended steps:
+1. Tighten `core-runtime-demo-instance-plan.md` so it clearly distinguishes:
+   - bounded state-model demo
+   - execution-backed demo
+2. Run the demo-instance hardening checklist against real managed execution.
+3. Add regression verification around the demo flow.
+
+Primary backlog alignment:
+- `TASK-016`
+
+Exit criteria:
+- a demo service can be discovered, configured, started, health-checked, and stopped with real process evidence
+- demo verification is repeatable and documented
+- the demo plan can no longer be satisfied by state flips alone
+
+## Phase 4: Clean up docs and source-of-truth drift
+
+Objective:
+- make the repo safe to navigate and trustworthy for contributors
+
+Why this should happen in parallel with Phases 1 to 3:
+- current doc drift is already causing planning confusion
+- runtime work will be harder to maintain if the docs keep overstating or lagging reality
+
+Highest-priority docs work:
+1. Refresh `SPEC-002` to describe the implemented bounded slice honestly.
+2. Refresh `core-runtime-dev-plan.md` so completed work is no longer framed as future work.
+3. Refresh the top-level `README.md` current-layout and status wording.
+4. Reclassify the larger `service.json` reference docs as future/reference direction unless and until runtime support exists.
+5. Fix or remove broken companion-doc links in `docs/reference`.
+6. Clarify `workspaceRoot` as target direction until runtime adoption is complete.
+7. Keep package-architecture docs aligned with the canonical:
+   - `servicesRoot`
+   - `workspaceRoot`
+
+Exit criteria:
+- docs clearly separate:
+  - implemented behavior
+  - target architecture
+  - donor/reference evidence
+
+## Phase 5: Expand from working application to broader runtime capability
+
+Objective:
+- close the highest-value donor/runtime gaps after the first working application milestone is real
+
+Recommended next migration order after Phase 3:
+1. setup/install mechanics
+2. runtime-owned port negotiation
+3. broader health model (`tcp`, `file`, `variable`, readiness loops)
+4. shared `globalenv` propagation
+5. manager-level orchestration:
+   - `reload`
+   - `startAll`
+   - `stopAll`
+   - `autostart`
+6. fuller runtime logging and archival
+
+Why this order:
+- setup/install and ports are core to real service operation
+- broader health becomes more valuable once real execution exists
+- orchestration should come after the first supervised process path is stable
+
+Current harness note:
+- the sibling `lasso-echoservice` repo already provides HTTP and TCP health simulation targets for testing
+- that gives us a strong migration harness, and Service Lasso runtime now has bounded `tcp` manifest-health support proven against that harness
+- broader donor health parity still requires additional types such as `file` and `variable` plus readiness-loop behavior
+
+## Phase 5A: Validate the first real consumer repo
+
+Objective:
+- prove that the core runtime works for an actual consumer, not only for harness fixtures
+
+Why this comes after Echo Service proof:
+- `lasso-echoservice` is the best controllable runtime harness for migration and supervision testing
+- `lasso-@serviceadmin` is the best first proof that a real UI consumer can use the runtime/API as intended
+
+Recommended steps:
+1. keep using released `lasso-echoservice` artifacts as the runtime-backed service under test
+2. connect `lasso-@serviceadmin` to the current Service Lasso API/runtime
+3. verify core admin surfaces end to end:
+   - health
+   - services list/detail
+   - lifecycle actions
+   - dependency/runtime summaries
+   - logs, variables, and network/operator surfaces where supported
+4. record any API contract gaps discovered through that UI integration before broader template rollout
+
+Exit criteria:
+- `lasso-@serviceadmin` can run against the current core runtime without special-case hacks
+- the Echo Service release remains the primary integration target behind that UI validation
+- any missing API or contract behavior is turned into tracked migration work before calling the core integration-ready
+
+## Phase 6: Create post-core reference app templates
+
+Objective:
+- prove integration patterns and give other teams a ready starting point
+
+These should be created once the core runtime is working and stable, not before.
+
+Required post-core reference app/template packages:
+- `@service-lasso/service-lasso-app-web`
+- `@service-lasso/service-lasso-packager-node`
+- `@service-lasso/service-lasso-app-tauri`
+- `@service-lasso/service-lasso-bundled`
+
+These should act as:
+- integration showcases
+- starter templates for downstream teams
+- proof that the runtime can be consumed cleanly in different host/distribution styles
+
+All reference apps should consume the same canonical runtime-root model:
+- `servicesRoot`
+- `workspaceRoot`
+
+They should remain outside core and never redefine the core runtime contract.
+
+## Recommended immediate order
+
+If we are choosing the next best steps right now, the recommended order is:
+
+1. `TASK-012` - normalize API error semantics
+2. `TASK-013` - add explicit runtime config loading for `servicesRoot` and `workspaceRoot`
+3. `TASK-014` - add startup rehydration
+4. `TASK-015` - land the first real execution/supervision slice
+5. tighten the demo-instance plan and run `TASK-016`
+6. refresh the highest-drift docs alongside that work
+
+## What "working application" means in this repo
+
+For this repo, "working application" should mean all of the following are true:
+- runtime boots from explicit validated config
+- runtime discovers real services from `servicesRoot`
+- runtime stores managed working data under `workspaceRoot`
+- runtime can launch and stop at least one real managed service path
+- runtime persists and rehydrates enough state to survive restart meaningfully
+- runtime exposes stable API responses and error contracts
+- runtime can support a credible demo flow with execution evidence
+
+It does **not** need to mean full donor parity yet.
+
+## Final recommendation
+
+The single best strategic move is:
+
+**finish the transition from state-only lifecycle modeling to one real execution-backed runtime slice**
+
+But the best tactical order is:
+
+**stabilize API/config/rehydration first, then land execution, then prove it through a hardened demo**
+
+That path gives Service Lasso the fastest route to becoming a genuinely working application without overclaiming parity too early.

--- a/services/echo-service/.gitignore
+++ b/services/echo-service/.gitignore
@@ -1,0 +1,4 @@
+runtime/
+.state/
+echo-service
+echo-service.exe

--- a/services/echo-service/.state/config.json
+++ b/services/echo-service/.state/config.json
@@ -1,4 +1,0 @@
-{
-  "configured": true,
-  "lastAction": "start"
-}

--- a/services/echo-service/.state/install.json
+++ b/services/echo-service/.state/install.json
@@ -1,4 +1,0 @@
-{
-  "installed": true,
-  "lastAction": "start"
-}

--- a/services/echo-service/.state/runtime.json
+++ b/services/echo-service/.state/runtime.json
@@ -1,9 +1,0 @@
-{
-  "running": true,
-  "lastAction": "start",
-  "actionHistory": [
-    "install",
-    "config",
-    "start"
-  ]
-}

--- a/services/echo-service/.state/service.json
+++ b/services/echo-service/.state/service.json
@@ -1,7 +1,0 @@
-{
-  "id": "echo-service",
-  "name": "Echo Service",
-  "description": "Tracked sample service used for the first discovery-backed API slices.",
-  "enabled": true,
-  "version": "0.1.0"
-}

--- a/services/echo-service/README.md
+++ b/services/echo-service/README.md
@@ -1,0 +1,19 @@
+# Echo Service Fixture Note
+
+The canonical Echo Service implementation now lives in the sibling repo:
+
+- `C:\projects\service-lasso\lasso-echoservice`
+
+This folder remains in `service-lasso` only as a thin local fixture surface so the core runtime repo can keep self-contained discovery and operator-data tests.
+
+What should live here:
+- the local fixture manifest
+- tiny fixture-only runtime files needed for self-contained core-runtime tests
+- fixture-only notes if needed
+
+What should not live here anymore:
+- the real Go service implementation
+- service-repo-owned build files
+- the canonical service-repo documentation
+
+If you want to run the real Echo Service harness, use the `lasso-echoservice` repo directly.

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -1,20 +1,27 @@
 {
   "id": "echo-service",
   "name": "Echo Service",
-  "description": "Tracked sample service used for the first discovery-backed API slices.",
-  "version": "0.1.0",
+  "description": "Local fixture manifest mirroring the canonical echo-service repo for core runtime tests and operator-surface coverage.",
+  "version": "0.3.0",
   "enabled": true,
-  "depend_on": ["@node"],
-  "execservice": "@node",
   "executable": "node",
-  "args": ["runtime/server.js"],
+  "args": ["runtime/fixture-harness.mjs"],
   "env": {
-    "ECHO_MESSAGE": "hello from operator data surfaces"
+    "ECHO_MESSAGE": "hello from echo-service harness",
+    "ECHO_PORT": "4010",
+    "ECHO_LOG_PATH": "./runtime/echo.log",
+    "ECHO_STATE_PATH": "./runtime/state.json",
+    "ECHO_DB_PATH": "./runtime/echo.sqlite"
   },
   "urls": [
     {
+      "label": "ui",
+      "url": "http://127.0.0.1:4010/",
+      "kind": "local"
+    },
+    {
       "label": "service",
-      "url": "http://127.0.0.1:4010",
+      "url": "http://127.0.0.1:4010/health",
       "kind": "local"
     }
   ],

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -1,0 +1,21 @@
+{
+  "id": "node-sample-service",
+  "name": "Node Sample Service",
+  "description": "Tracked provider-backed sample service used to preserve @node execution-plan coverage.",
+  "version": "0.1.0",
+  "enabled": true,
+  "depend_on": ["@node"],
+  "execservice": "@node",
+  "executable": "node",
+  "args": ["runtime/server.js"],
+  "urls": [
+    {
+      "label": "service",
+      "url": "http://127.0.0.1:4020",
+      "kind": "local"
+    }
+  ],
+  "healthcheck": {
+    "type": "process"
+  }
+}

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -13,6 +13,12 @@ export interface HealthResponse {
   };
 }
 
+export interface ApiErrorResponse {
+  error: string;
+  message: string;
+  statusCode: number;
+}
+
 export interface ServiceSummary {
   id: string;
   name: string;
@@ -47,6 +53,7 @@ export interface ServiceDetailResponse {
 export interface RuntimeSummaryResponse {
   runtime: {
     servicesRoot: string;
+    workspaceRoot?: string;
     totalServices: number;
     enabledServices: number;
     dependencyEdges: number;

--- a/src/contracts/service-root.ts
+++ b/src/contracts/service-root.ts
@@ -1,7 +1,6 @@
 export interface ServiceRootConfig {
   servicesRoot: string;
-  dataRoot: string;
-  stateRoot: string;
+  workspaceRoot: string;
 }
 
 export interface RuntimeBoundarySummary {
@@ -13,5 +12,4 @@ export interface RuntimeBoundarySummary {
 }
 
 export const DEFAULT_SERVICES_ROOT = "./services";
-export const DEFAULT_DATA_ROOT = "./.local/data";
-export const DEFAULT_STATE_ROOT = "./.state";
+export const DEFAULT_WORKSPACE_ROOT = "./workspace";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ async function main(): Promise<void> {
   console.log("[service-lasso] core API spine started");
   console.log(`- api: ${app.apiServer.url}`);
   console.log(`- servicesRoot: ${app.serviceRoot.servicesRoot}`);
-  console.log(`- stateRoot: ${app.serviceRoot.stateRoot}`);
+  console.log(`- workspaceRoot: ${app.serviceRoot.workspaceRoot}`);
 }
 
 main().catch((error: unknown) => {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,5 +1,6 @@
 import { createDefaultServiceRootConfig, describeRuntimeBoundary } from "./layout.js";
 import { startApiServer, type ApiServerOptions, type RunningApiServer } from "../server/index.js";
+import { ensureRuntimeConfig, resolveRuntimeConfig } from "./config.js";
 
 export interface RuntimeApp {
   mode: "development";
@@ -9,11 +10,19 @@ export interface RuntimeApp {
 }
 
 export async function startRuntimeApp(options: ApiServerOptions = {}): Promise<RuntimeApp> {
-  const serviceRoot = createDefaultServiceRootConfig();
+  const defaults = createDefaultServiceRootConfig();
+  const serviceRoot = await ensureRuntimeConfig(
+    resolveRuntimeConfig({
+      servicesRoot: options.servicesRoot ?? defaults.servicesRoot,
+      workspaceRoot: options.workspaceRoot ?? defaults.workspaceRoot,
+      version: options.version,
+    }),
+  );
   const apiServer = await startApiServer({
-    servicesRoot: options.servicesRoot ?? serviceRoot.servicesRoot,
+    servicesRoot: serviceRoot.servicesRoot,
+    workspaceRoot: serviceRoot.workspaceRoot,
     port: options.port,
-    version: options.version,
+    version: serviceRoot.version,
   });
 
   return {

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { mkdir, stat } from "node:fs/promises";
+import { DEFAULT_SERVICES_ROOT, DEFAULT_WORKSPACE_ROOT, type ServiceRootConfig } from "../contracts/service-root.js";
+
+export interface RuntimeConfigOptions {
+  servicesRoot?: string;
+  workspaceRoot?: string;
+  version?: string;
+}
+
+export interface RuntimeConfig extends ServiceRootConfig {
+  version: string;
+}
+
+export class RuntimeConfigError extends Error {
+  readonly code = "invalid_runtime_config";
+  readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeConfigError";
+  }
+}
+
+function resolveRequiredPath(label: "servicesRoot" | "workspaceRoot", value: string | undefined, fallback: string): string {
+  const candidate = value?.trim() || fallback;
+
+  if (!candidate.trim()) {
+    throw new RuntimeConfigError(`Runtime config requires a non-empty "${label}" value.`);
+  }
+
+  return path.resolve(candidate);
+}
+
+export function resolveRuntimeConfig(options: RuntimeConfigOptions = {}): RuntimeConfig {
+  return {
+    servicesRoot: resolveRequiredPath("servicesRoot", options.servicesRoot ?? process.env.SERVICE_LASSO_SERVICES_ROOT, DEFAULT_SERVICES_ROOT),
+    workspaceRoot: resolveRequiredPath(
+      "workspaceRoot",
+      options.workspaceRoot ?? process.env.SERVICE_LASSO_WORKSPACE_ROOT,
+      DEFAULT_WORKSPACE_ROOT,
+    ),
+    version: options.version ?? "0.1.0",
+  };
+}
+
+export async function ensureRuntimeConfig(config: RuntimeConfig): Promise<RuntimeConfig> {
+  let servicesRootStats;
+  try {
+    servicesRootStats = await stat(config.servicesRoot);
+  } catch {
+    throw new RuntimeConfigError(`Configured servicesRoot does not exist: ${config.servicesRoot}`);
+  }
+
+  if (!servicesRootStats.isDirectory()) {
+    throw new RuntimeConfigError(`Configured servicesRoot is not a directory: ${config.servicesRoot}`);
+  }
+
+  await mkdir(config.workspaceRoot, { recursive: true });
+
+  return config;
+}

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -47,6 +47,11 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
         type: "tcp",
         address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath),
       };
+    } else if (healthRecord.type === "file") {
+      healthcheck = {
+        type: "file",
+        file: expectNonEmptyString(healthRecord.file, "healthcheck.file", manifestPath),
+      };
     } else {
       throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);
     }

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -42,6 +42,11 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
         expected_status:
           typeof healthRecord.expected_status === "number" ? healthRecord.expected_status : undefined,
       };
+    } else if (healthRecord.type === "tcp") {
+      healthcheck = {
+        type: "tcp",
+        address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath),
+      };
     } else {
       throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);
     }

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -1,0 +1,170 @@
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import type { DiscoveredService } from "../../contracts/service.js";
+
+export interface ManagedProcessHandle {
+  pid: number;
+  startedAt: string;
+  command: string;
+}
+
+interface ManagedProcessRecord {
+  child: ChildProcess;
+  service: DiscoveredService;
+  startedAt: string;
+  command: string;
+  stopping: boolean;
+  exitCode: number | null;
+  exitSignal: NodeJS.Signals | null;
+  exitPromise: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
+}
+
+interface StartProcessOptions {
+  service: DiscoveredService;
+  onExit?: (payload: {
+    service: DiscoveredService;
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+    wasStopping: boolean;
+  }) => Promise<void> | void;
+}
+
+const managedProcesses = new Map<string, ManagedProcessRecord>();
+
+function resolveExecutable(service: DiscoveredService): string {
+  const executable = service.manifest.executable;
+  if (!executable) {
+    throw new Error(`Service "${service.manifest.id}" has no executable configured.`);
+  }
+
+  if (path.isAbsolute(executable) || executable.startsWith(".") || executable.includes("/") || executable.includes("\\")) {
+    return path.resolve(service.serviceRoot, executable);
+  }
+
+  return executable;
+}
+
+function buildCommandString(executable: string, args: string[]): string {
+  return [executable, ...args].join(" ");
+}
+
+function buildProcessEnvironment(service: DiscoveredService): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...service.manifest.env,
+    SERVICE_ID: service.manifest.id,
+    SERVICE_ROOT: service.serviceRoot,
+    SERVICE_STATE_ROOT: path.join(service.serviceRoot, ".state"),
+  };
+}
+
+export function hasManagedProcess(serviceId: string): boolean {
+  return managedProcesses.has(serviceId);
+}
+
+export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
+  const { service, onExit } = options;
+  const serviceId = service.manifest.id;
+
+  if (managedProcesses.has(serviceId)) {
+    throw new Error(`Service "${serviceId}" already has a managed process.`);
+  }
+
+  const executable = resolveExecutable(service);
+  const args = service.manifest.args ?? [];
+  const command = buildCommandString(executable, args);
+  const startedAt = new Date().toISOString();
+
+  const child = spawn(executable, args, {
+    cwd: service.serviceRoot,
+    env: buildProcessEnvironment(service),
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  const exitPromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    child.once("exit", (exitCode, signal) => {
+      resolve({
+        exitCode: typeof exitCode === "number" ? exitCode : null,
+        signal,
+      });
+    });
+  });
+
+  const spawnPromise = new Promise<void>((resolve, reject) => {
+    child.once("spawn", () => resolve());
+    child.once("error", reject);
+  });
+
+  await spawnPromise;
+
+  const record: ManagedProcessRecord = {
+    child,
+    service,
+    startedAt,
+    command,
+    stopping: false,
+    exitCode: null,
+    exitSignal: null,
+    exitPromise,
+  };
+
+  managedProcesses.set(serviceId, record);
+
+  void exitPromise.then(async ({ exitCode, signal }) => {
+    const current = managedProcesses.get(serviceId);
+    if (current?.child === child) {
+      managedProcesses.delete(serviceId);
+    }
+
+    record.exitCode = exitCode;
+    record.exitSignal = signal;
+
+    if (onExit) {
+      await onExit({
+        service,
+        exitCode,
+        signal,
+        wasStopping: record.stopping,
+      });
+    }
+  });
+
+  return {
+    pid: child.pid ?? 0,
+    startedAt,
+    command,
+  };
+}
+
+export async function stopManagedProcess(
+  serviceId: string,
+  timeoutMs = 5_000,
+): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null } | null> {
+  const record = managedProcesses.get(serviceId);
+  if (!record) {
+    return null;
+  }
+
+  record.stopping = true;
+
+  if (!record.child.killed) {
+    record.child.kill();
+  }
+
+  const timeoutPromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    setTimeout(() => {
+      if (!record.child.killed) {
+        record.child.kill("SIGKILL");
+      }
+      resolve({ exitCode: null, signal: "SIGKILL" });
+    }, timeoutMs).unref?.();
+  });
+
+  return Promise.race([record.exitPromise, timeoutPromise]);
+}
+
+export async function stopAllManagedProcesses(): Promise<void> {
+  const serviceIds = [...managedProcesses.keys()];
+  await Promise.all(serviceIds.map((serviceId) => stopManagedProcess(serviceId).catch(() => null)));
+}

--- a/src/runtime/health/checkFile.ts
+++ b/src/runtime/health/checkFile.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { access } from "node:fs/promises";
+import type { FileHealthcheck, ServiceHealthResult } from "./types.js";
+
+export async function checkFileHealth(
+  healthcheck: FileHealthcheck,
+  serviceRoot?: string,
+): Promise<ServiceHealthResult> {
+  const configuredFile = healthcheck.file.trim();
+  const targetPath =
+    serviceRoot && !path.isAbsolute(configuredFile) ? path.resolve(serviceRoot, configuredFile) : configuredFile;
+
+  try {
+    await access(targetPath);
+    return {
+      type: "file",
+      healthy: true,
+      detail: `File healthcheck found expected file: ${targetPath}`,
+    };
+  } catch {
+    return {
+      type: "file",
+      healthy: false,
+      detail: `File healthcheck did not find expected file: ${targetPath}`,
+    };
+  }
+}

--- a/src/runtime/health/checkHttp.ts
+++ b/src/runtime/health/checkHttp.ts
@@ -1,15 +1,25 @@
 import type { HttpHealthcheck, ServiceHealthResult } from "./types.js";
 
 export async function checkHttpHealth(healthcheck: HttpHealthcheck): Promise<ServiceHealthResult> {
-  const response = await fetch(healthcheck.url);
   const expectedStatus = healthcheck.expected_status ?? 200;
+  try {
+    const response = await fetch(healthcheck.url);
 
-  return {
-    type: "http",
-    healthy: response.status === expectedStatus,
-    detail:
-      response.status === expectedStatus
-        ? `HTTP healthcheck returned expected status ${expectedStatus}.`
-        : `HTTP healthcheck returned ${response.status}, expected ${expectedStatus}.`,
-  };
+    return {
+      type: "http",
+      healthy: response.status === expectedStatus,
+      detail:
+        response.status === expectedStatus
+          ? `HTTP healthcheck returned expected status ${expectedStatus}.`
+          : `HTTP healthcheck returned ${response.status}, expected ${expectedStatus}.`,
+    };
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : "HTTP healthcheck request failed.";
+
+    return {
+      type: "http",
+      healthy: false,
+      detail: `HTTP healthcheck failed: ${detail}`,
+    };
+  }
 }

--- a/src/runtime/health/checkProcess.ts
+++ b/src/runtime/health/checkProcess.ts
@@ -1,9 +1,17 @@
+import type { ServiceLifecycleState } from "../lifecycle/types.js";
 import type { ServiceHealthResult } from "./types.js";
 
-export function checkProcessHealth(isRunning: boolean): ServiceHealthResult {
+export function checkProcessHealth(lifecycle: ServiceLifecycleState): ServiceHealthResult {
+  const isRunning = lifecycle.running;
   return {
     type: "process",
     healthy: isRunning,
-    detail: isRunning ? "Service is marked running." : "Service is not running.",
+    detail: isRunning
+      ? lifecycle.runtime.pid
+        ? `Service is running with pid ${lifecycle.runtime.pid}.`
+        : "Service is marked running."
+      : lifecycle.runtime.exitCode !== null
+        ? `Service is not running. Last exit code: ${lifecycle.runtime.exitCode}.`
+        : "Service is not running.",
   };
 }

--- a/src/runtime/health/checkTcp.ts
+++ b/src/runtime/health/checkTcp.ts
@@ -1,0 +1,67 @@
+import net from "node:net";
+import type { ServiceHealthResult, TcpHealthcheck } from "./types.js";
+
+export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<ServiceHealthResult> {
+  const address = healthcheck.address.trim();
+  const separator = address.lastIndexOf(":");
+
+  if (separator <= 0 || separator === address.length - 1) {
+    return {
+      type: "tcp",
+      healthy: false,
+      detail: `TCP healthcheck address is invalid: ${address}`,
+    };
+  }
+
+  const host = address.slice(0, separator);
+  const port = Number(address.slice(separator + 1));
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return {
+      type: "tcp",
+      healthy: false,
+      detail: `TCP healthcheck port is invalid: ${address}`,
+    };
+  }
+
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+
+    const finish = (payload: ServiceHealthResult) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve(payload);
+    };
+
+    socket.once("connect", () => {
+      socket.end();
+      finish({
+        type: "tcp",
+        healthy: true,
+        detail: `TCP healthcheck connected successfully to ${address}.`,
+      });
+    });
+
+    socket.once("error", (error: Error) => {
+      socket.destroy();
+      finish({
+        type: "tcp",
+        healthy: false,
+        detail: `TCP healthcheck failed: ${error.message}`,
+      });
+    });
+
+    socket.setTimeout(2_000, () => {
+      socket.destroy();
+      finish({
+        type: "tcp",
+        healthy: false,
+        detail: `TCP healthcheck timed out: ${address}`,
+      });
+    });
+  });
+}

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -1,5 +1,6 @@
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ServiceLifecycleState } from "../lifecycle/types.js";
+import { checkFileHealth } from "./checkFile.js";
 import { checkHttpHealth } from "./checkHttp.js";
 import { checkProcessHealth } from "./checkProcess.js";
 import { checkTcpHealth } from "./checkTcp.js";
@@ -8,6 +9,7 @@ import type { ServiceHealthResult } from "./types.js";
 export async function evaluateServiceHealth(
   manifest: ServiceManifest,
   lifecycle: ServiceLifecycleState,
+  serviceRoot?: string,
 ): Promise<ServiceHealthResult> {
   const healthcheck = manifest.healthcheck;
 
@@ -21,6 +23,10 @@ export async function evaluateServiceHealth(
 
   if (healthcheck.type === "tcp") {
     return checkTcpHealth(healthcheck);
+  }
+
+  if (healthcheck.type === "file") {
+    return checkFileHealth(healthcheck, serviceRoot);
   }
 
   return {

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -2,6 +2,7 @@ import type { ServiceManifest } from "../../contracts/service.js";
 import type { ServiceLifecycleState } from "../lifecycle/types.js";
 import { checkHttpHealth } from "./checkHttp.js";
 import { checkProcessHealth } from "./checkProcess.js";
+import { checkTcpHealth } from "./checkTcp.js";
 import type { ServiceHealthResult } from "./types.js";
 
 export async function evaluateServiceHealth(
@@ -11,11 +12,15 @@ export async function evaluateServiceHealth(
   const healthcheck = manifest.healthcheck;
 
   if (!healthcheck || healthcheck.type === "process") {
-    return checkProcessHealth(lifecycle.running);
+    return checkProcessHealth(lifecycle);
   }
 
   if (healthcheck.type === "http") {
     return checkHttpHealth(healthcheck);
+  }
+
+  if (healthcheck.type === "tcp") {
+    return checkTcpHealth(healthcheck);
   }
 
   return {

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -8,7 +8,12 @@ export interface HttpHealthcheck {
   expected_status?: number;
 }
 
-export type ServiceHealthcheck = ProcessHealthcheck | HttpHealthcheck;
+export interface TcpHealthcheck {
+  type: "tcp";
+  address: string;
+}
+
+export type ServiceHealthcheck = ProcessHealthcheck | HttpHealthcheck | TcpHealthcheck;
 
 export interface ServiceHealthResult {
   type: ServiceHealthcheck["type"] | "unknown";

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -13,7 +13,12 @@ export interface TcpHealthcheck {
   address: string;
 }
 
-export type ServiceHealthcheck = ProcessHealthcheck | HttpHealthcheck | TcpHealthcheck;
+export interface FileHealthcheck {
+  type: "file";
+  file: string;
+}
+
+export type ServiceHealthcheck = ProcessHealthcheck | HttpHealthcheck | TcpHealthcheck | FileHealthcheck;
 
 export interface ServiceHealthResult {
   type: ServiceHealthcheck["type"] | "unknown";

--- a/src/runtime/layout.ts
+++ b/src/runtime/layout.ts
@@ -1,7 +1,6 @@
 import {
-  DEFAULT_DATA_ROOT,
   DEFAULT_SERVICES_ROOT,
-  DEFAULT_STATE_ROOT,
+  DEFAULT_WORKSPACE_ROOT,
   type RuntimeBoundarySummary,
   type ServiceRootConfig,
 } from "../contracts/service-root.js";
@@ -9,8 +8,7 @@ import {
 export function createDefaultServiceRootConfig(): ServiceRootConfig {
   return {
     servicesRoot: DEFAULT_SERVICES_ROOT,
-    dataRoot: DEFAULT_DATA_ROOT,
-    stateRoot: DEFAULT_STATE_ROOT,
+    workspaceRoot: DEFAULT_WORKSPACE_ROOT,
   };
 }
 

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,3 +1,7 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import { LifecycleStateError } from "../../server/errors.js";
+import { startManagedProcess, stopManagedProcess } from "../execution/supervisor.js";
+import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
 
@@ -23,12 +27,41 @@ function applyState(
   };
 }
 
+function updateRuntimeState(
+  serviceId: string,
+  recipe: (current: ServiceLifecycleState) => ServiceLifecycleState,
+): ServiceLifecycleState {
+  const current = getLifecycleState(serviceId);
+  return setLifecycleState(serviceId, recipe(current));
+}
+
+async function persistProcessExit(
+  service: DiscoveredService,
+  exitCode: number | null,
+): Promise<void> {
+  const state = updateRuntimeState(service.manifest.id, (current) => ({
+    ...current,
+    running: false,
+    runtime: {
+      ...current.runtime,
+      pid: null,
+      exitCode: exitCode ?? current.runtime.exitCode,
+    },
+  }));
+
+  await writeServiceState(service, state);
+}
+
 export function installService(serviceId: string): LifecycleActionResult {
   return applyState(serviceId, "install", (current) => ({
     nextState: {
       ...current,
       installed: true,
       running: false,
+      runtime: {
+        ...current.runtime,
+        pid: null,
+      },
     },
     message: "Install completed.",
   }));
@@ -37,7 +70,7 @@ export function installService(serviceId: string): LifecycleActionResult {
 export function configService(serviceId: string): LifecycleActionResult {
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new Error(`Cannot config service \"${serviceId}\" before install.`);
+    throw new LifecycleStateError(`Cannot config service "${serviceId}" before install.`);
   }
 
   return applyState(serviceId, "config", (state) => ({
@@ -49,52 +82,107 @@ export function configService(serviceId: string): LifecycleActionResult {
   }));
 }
 
-export function startService(serviceId: string): LifecycleActionResult {
+export async function startService(service: DiscoveredService): Promise<LifecycleActionResult> {
+  const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new Error(`Cannot start service \"${serviceId}\" before install.`);
+    throw new LifecycleStateError(`Cannot start service "${serviceId}" before install.`);
   }
   if (!current.configured) {
-    throw new Error(`Cannot start service \"${serviceId}\" before config.`);
+    throw new LifecycleStateError(`Cannot start service "${serviceId}" before config.`);
   }
+  if (current.running) {
+    throw new LifecycleStateError(`Cannot start service "${serviceId}" because it is already running.`);
+  }
+  if (!service.manifest.executable) {
+    throw new LifecycleStateError(`Cannot start service "${serviceId}" because no executable is configured.`);
+  }
+
+  const handle = await startManagedProcess({
+    service,
+    onExit: async ({ exitCode, wasStopping }) => {
+      if (wasStopping) {
+        return;
+      }
+      await persistProcessExit(service, exitCode);
+    },
+  });
 
   return applyState(serviceId, "start", (state) => ({
     nextState: {
       ...state,
       running: true,
+      runtime: {
+        pid: handle.pid,
+        startedAt: handle.startedAt,
+        exitCode: null,
+        command: handle.command,
+      },
     },
     message: "Start completed.",
   }));
 }
 
-export function stopService(serviceId: string): LifecycleActionResult {
+export async function stopService(service: DiscoveredService): Promise<LifecycleActionResult> {
+  const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.running) {
-    throw new Error(`Cannot stop service \"${serviceId}\" because it is not running.`);
+    throw new LifecycleStateError(`Cannot stop service "${serviceId}" because it is not running.`);
   }
+
+  const stopped = await stopManagedProcess(serviceId);
 
   return applyState(serviceId, "stop", (state) => ({
     nextState: {
       ...state,
       running: false,
+      runtime: {
+        ...state.runtime,
+        pid: null,
+        exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
+      },
     },
     message: "Stop completed.",
   }));
 }
 
-export function restartService(serviceId: string): LifecycleActionResult {
+export async function restartService(service: DiscoveredService): Promise<LifecycleActionResult> {
+  const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new Error(`Cannot restart service \"${serviceId}\" before install.`);
+    throw new LifecycleStateError(`Cannot restart service "${serviceId}" before install.`);
   }
   if (!current.configured) {
-    throw new Error(`Cannot restart service \"${serviceId}\" before config.`);
+    throw new LifecycleStateError(`Cannot restart service "${serviceId}" before config.`);
   }
+  if (!service.manifest.executable) {
+    throw new LifecycleStateError(`Cannot restart service "${serviceId}" because no executable is configured.`);
+  }
+
+  if (current.running) {
+    await stopManagedProcess(serviceId);
+  }
+
+  const handle = await startManagedProcess({
+    service,
+    onExit: async ({ exitCode, wasStopping }) => {
+      if (wasStopping) {
+        return;
+      }
+      await persistProcessExit(service, exitCode);
+    },
+  });
 
   return applyState(serviceId, "restart", (state) => ({
     nextState: {
       ...state,
       running: true,
+      runtime: {
+        pid: handle.pid,
+        startedAt: handle.startedAt,
+        exitCode: null,
+        command: handle.command,
+      },
     },
     message: "Restart completed.",
   }));

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -9,6 +9,12 @@ function createInitialState(): ServiceLifecycleState {
     running: false,
     lastAction: null,
     actionHistory: [],
+    runtime: {
+      pid: null,
+      startedAt: null,
+      exitCode: null,
+      command: null,
+    },
   };
 }
 
@@ -25,6 +31,12 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
     running: current.running,
     lastAction: current.lastAction,
     actionHistory: [...current.actionHistory],
+    runtime: {
+      pid: current.runtime.pid,
+      startedAt: current.runtime.startedAt,
+      exitCode: current.runtime.exitCode,
+      command: current.runtime.command,
+    },
   };
 }
 
@@ -35,6 +47,12 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
     running: nextState.running,
     lastAction: nextState.lastAction,
     actionHistory: [...nextState.actionHistory],
+    runtime: {
+      pid: nextState.runtime.pid,
+      startedAt: nextState.runtime.startedAt,
+      exitCode: nextState.runtime.exitCode,
+      command: nextState.runtime.command,
+    },
   };
 
   lifecycleState.set(serviceId, cloned);

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -1,11 +1,19 @@
 export type LifecycleAction = "install" | "config" | "start" | "stop" | "restart";
 
+export interface ServiceRuntimeState {
+  pid: number | null;
+  startedAt: string | null;
+  exitCode: number | null;
+  command: string | null;
+}
+
 export interface ServiceLifecycleState {
   installed: boolean;
   configured: boolean;
   running: boolean;
   lastAction: LifecycleAction | null;
   actionHistory: LifecycleAction[];
+  runtime: ServiceRuntimeState;
 }
 
 export interface LifecycleActionResult {

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -1,0 +1,77 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import { setLifecycleState } from "../lifecycle/store.js";
+import type { LifecycleAction, ServiceLifecycleState } from "../lifecycle/types.js";
+import { readStoredState } from "./readState.js";
+
+interface StoredInstallState {
+  installed?: boolean;
+}
+
+interface StoredConfigState {
+  configured?: boolean;
+}
+
+interface StoredRuntimeState {
+  running?: boolean;
+  pid?: number | null;
+  startedAt?: string | null;
+  exitCode?: number | null;
+  command?: string | null;
+  lastAction?: LifecycleAction | null;
+  actionHistory?: LifecycleAction[];
+}
+
+function isLifecycleAction(value: unknown): value is LifecycleAction {
+  return value === "install" || value === "config" || value === "start" || value === "stop" || value === "restart";
+}
+
+function parseLifecycleState(snapshot: {
+  install: unknown | null;
+  config: unknown | null;
+  runtime: unknown | null;
+}): ServiceLifecycleState | null {
+  const install = snapshot.install as StoredInstallState | null;
+  const config = snapshot.config as StoredConfigState | null;
+  const runtime = snapshot.runtime as StoredRuntimeState | null;
+
+  const installed = install?.installed === true;
+  const configured = config?.configured === true;
+  const running = false;
+  const actionHistory = Array.isArray(runtime?.actionHistory)
+    ? runtime.actionHistory.filter((action): action is LifecycleAction => isLifecycleAction(action))
+    : [];
+  const lastAction = isLifecycleAction(runtime?.lastAction) ? runtime.lastAction : null;
+
+  if (!installed && !configured && runtime?.running !== true && actionHistory.length === 0 && lastAction === null) {
+    return null;
+  }
+
+  return {
+    installed,
+    configured,
+    running,
+    lastAction,
+    actionHistory,
+    runtime: {
+      pid: null,
+      startedAt: typeof runtime?.startedAt === "string" ? runtime.startedAt : null,
+      exitCode: typeof runtime?.exitCode === "number" ? runtime.exitCode : null,
+      command: typeof runtime?.command === "string" ? runtime.command : null,
+    },
+  };
+}
+
+export async function rehydrateLifecycleState(service: DiscoveredService): Promise<ServiceLifecycleState | null> {
+  const snapshot = await readStoredState(service.serviceRoot);
+  const state = parseLifecycleState(snapshot);
+
+  if (state) {
+    setLifecycleState(service.manifest.id, state);
+  }
+
+  return state;
+}
+
+export async function rehydrateDiscoveredServices(services: DiscoveredService[]): Promise<void> {
+  await Promise.all(services.map((service) => rehydrateLifecycleState(service)));
+}

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -57,6 +57,10 @@ export async function writeServiceState(
       JSON.stringify(
         {
           running: lifecycle.running,
+          pid: lifecycle.runtime.pid,
+          startedAt: lifecycle.runtime.startedAt,
+          exitCode: lifecycle.runtime.exitCode,
+          command: lifecycle.runtime.command,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,
         },

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,0 +1,62 @@
+export interface ApiErrorBody {
+  error: string;
+  message: string;
+  statusCode: number;
+}
+
+export class ApiError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+
+  constructor(code: string, statusCode: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class LifecycleStateError extends Error {
+  readonly code = "invalid_lifecycle_state";
+  readonly statusCode = 409;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "LifecycleStateError";
+  }
+}
+
+export function toApiErrorBody(error: unknown): ApiErrorBody {
+  if (error instanceof ApiError) {
+    return {
+      error: error.code,
+      message: error.message,
+      statusCode: error.statusCode,
+    };
+  }
+
+  if (error instanceof LifecycleStateError) {
+    return {
+      error: error.code,
+      message: error.message,
+      statusCode: error.statusCode,
+    };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const maybeError = error as { code?: unknown; statusCode?: unknown; message?: unknown };
+    if (typeof maybeError.code === "string" && typeof maybeError.statusCode === "number") {
+      return {
+        error: maybeError.code,
+        message: typeof maybeError.message === "string" ? maybeError.message : "Request failed.",
+        statusCode: maybeError.statusCode,
+      };
+    }
+  }
+
+  return {
+    error: "internal_error",
+    message: error instanceof Error ? error.message : "Unknown API failure.",
+    statusCode: 500,
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,12 +25,17 @@ import { buildServiceLogs } from "../runtime/operator/logs.js";
 import { buildServiceVariables } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
+import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
+import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
+import { stopAllManagedProcesses } from "../runtime/execution/supervisor.js";
+import { ApiError, toApiErrorBody } from "./errors.js";
 import type { LifecycleActionResponse, ServiceDetailResponse, ServiceSummary } from "../contracts/api.js";
 
 export interface ApiServerOptions {
   port?: number;
   version?: string;
   servicesRoot?: string;
+  workspaceRoot?: string;
 }
 
 export interface RunningApiServer {
@@ -50,6 +55,7 @@ function notFound(response: ServerResponse): void {
   writeJson(response, 404, {
     error: "not_found",
     message: "Route not found.",
+    statusCode: 404,
   });
 }
 
@@ -114,20 +120,20 @@ async function executeLifecycleAction(
   registry: Awaited<ReturnType<typeof loadRuntimeModel>>["registry"],
 ): Promise<LifecycleActionResponse> {
   const serviceId = service.manifest.id;
-  const result = (() => {
+  const result = await (async () => {
     switch (action) {
       case "install":
         return installService(serviceId);
       case "config":
         return configService(serviceId);
       case "start":
-        return startService(serviceId);
+        return await startService(service);
       case "stop":
-        return stopService(serviceId);
+        return await stopService(service);
       case "restart":
-        return restartService(serviceId);
+        return await restartService(service);
       default:
-        throw new Error(`Unknown lifecycle action: ${action}`);
+        throw new ApiError("invalid_action", 400, `Unknown lifecycle action: ${action}`);
     }
   })();
 
@@ -150,17 +156,17 @@ async function executeLifecycleAction(
 async function routeRequest(
   request: IncomingMessage,
   response: ServerResponse,
-  options: Required<Pick<ApiServerOptions, "version" | "servicesRoot">>,
+  config: RuntimeConfig,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
   if (request.method === "GET" && url.pathname === "/api/health") {
-    writeJson(response, 200, createHealthResponse(options.version));
+    writeJson(response, 200, createHealthResponse(config.version));
     return;
   }
 
   if (request.method === "GET" && url.pathname === "/api/services") {
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const services = await Promise.all(
       runtimeModel.discovered.map((service) => createServiceSummary(service, runtimeModel.graph, runtimeModel.registry)),
     );
@@ -170,7 +176,7 @@ async function routeRequest(
 
   if (url.pathname.startsWith("/api/services/")) {
     const pathParts = url.pathname.split("/").filter(Boolean);
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = decodeURIComponent(pathParts[2] ?? "");
     const service = runtimeModel.registry.getById(serviceId);
 
@@ -218,7 +224,7 @@ async function routeRequest(
   }
 
   if (request.method === "GET" && url.pathname === "/api/runtime") {
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceSummaries = await Promise.all(
       runtimeModel.discovered.map((service) => createServiceSummary(service, runtimeModel.graph, runtimeModel.registry)),
     );
@@ -229,7 +235,8 @@ async function routeRequest(
       response,
       200,
       createRuntimeSummaryResponse({
-        servicesRoot: options.servicesRoot,
+        servicesRoot: config.servicesRoot,
+        workspaceRoot: config.workspaceRoot,
         totalServices: runtimeModel.registry.count(),
         enabledServices: runtimeModel.registry.countEnabled(),
         dependencyEdges: runtimeModel.graph.listEdges().length,
@@ -241,7 +248,7 @@ async function routeRequest(
   }
 
   if (request.method === "GET" && url.pathname === "/api/dependencies") {
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(
       response,
       200,
@@ -254,14 +261,14 @@ async function routeRequest(
   }
 
   if (request.method === "GET" && url.pathname === "/api/variables") {
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const payload = runtimeModel.discovered.map((service) => buildServiceVariables(service));
     writeJson(response, 200, { services: payload });
     return;
   }
 
   if (request.method === "GET" && url.pathname === "/api/network") {
-    const runtimeModel = await loadRuntimeModel(options.servicesRoot);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const payload = runtimeModel.discovered.map((service) => buildServiceNetwork(service));
     writeJson(response, 200, { services: payload });
     return;
@@ -271,24 +278,21 @@ async function routeRequest(
 }
 
 export function createApiServer(options: ApiServerOptions = {}): Server {
-  const resolvedOptions = {
-    version: options.version ?? "0.1.0",
-    servicesRoot: options.servicesRoot ?? "./services",
-  };
+  const resolvedConfig = resolveRuntimeConfig(options);
 
   return createServer((request, response) => {
-    void routeRequest(request, response, resolvedOptions).catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : "Unknown API failure.";
-      writeJson(response, 500, {
-        error: "internal_error",
-        message,
-      });
+    void routeRequest(request, response, resolvedConfig).catch((error: unknown) => {
+      const body = toApiErrorBody(error);
+      writeJson(response, body.statusCode, body);
     });
   });
 }
 
 export async function startApiServer(options: ApiServerOptions = {}): Promise<RunningApiServer> {
-  const server = createApiServer(options);
+  const config = await ensureRuntimeConfig(resolveRuntimeConfig(options));
+  const bootModel = await loadRuntimeModel(config.servicesRoot);
+  await rehydrateDiscoveredServices(bootModel.discovered);
+  const server = createApiServer(config);
   const port = options.port ?? 18080;
 
   server.listen(port, "127.0.0.1");
@@ -306,6 +310,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
     port: resolvedPort,
     url: `http://127.0.0.1:${resolvedPort}`,
     stop: async () => {
+      await stopAllManagedProcesses();
       server.close();
       await once(server, "close");
     },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -78,7 +78,7 @@ async function createServiceSummary(
 ): Promise<ServiceSummary> {
   const dependencySummary = graph.getServiceDependencies(service.manifest.id);
   const lifecycle = getLifecycleState(service.manifest.id);
-  const health = await evaluateServiceHealth(service.manifest, lifecycle);
+  const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot);
   const logs = buildServiceLogs(service, lifecycle);
   const variables = buildServiceVariables(service);
   const network = buildServiceNetwork(service);
@@ -138,7 +138,7 @@ async function executeLifecycleAction(
   })();
 
   const persisted = await writeServiceState(service, result.state);
-  const health = await evaluateServiceHealth(service.manifest, result.state);
+  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot);
   const provider = resolveProviderExecution(service, registry);
 
   return {
@@ -187,7 +187,7 @@ async function routeRequest(
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "health") {
       const lifecycle = getLifecycleState(serviceId);
-      const health = await evaluateServiceHealth(service.manifest, lifecycle);
+      const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot);
       writeJson(response, 200, createServiceHealthResponse(serviceId, health));
       return;
     }

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import os from "node:os";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
+import { clearPersistedFixtureState } from "./test-helpers.js";
 
 async function getJson(url) {
   const response = await fetch(url);
@@ -30,6 +33,7 @@ test("GET /api/health returns core API health", async () => {
 
 test("GET /api/services returns discovered services from the tracked services root", async () => {
   const servicesRoot = path.resolve("services");
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -37,14 +41,60 @@ test("GET /api/services returns discovered services from the tracked services ro
 
     assert.equal(result.status, 200);
     assert.ok(Array.isArray(result.body.services));
-    assert.equal(result.body.services.length, 3);
+    assert.equal(result.body.services.length, 4);
     assert.deepEqual(
       result.body.services.map((service) => service.id),
-      ["@node", "@python", "echo-service"],
+      ["@node", "@python", "echo-service", "node-sample-service"],
     );
     assert.equal(result.body.services[0].status, "discovered");
     assert.equal(result.body.services[0].source, "manifest");
   } finally {
     await apiServer.stop();
+    await clearPersistedFixtureState(servicesRoot);
   }
+});
+
+test("runtime boots from explicit servicesRoot and workspaceRoot config", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-config-"));
+  const workspaceRoot = path.join(tempRoot, "workspace");
+
+  try {
+    const apiServer = await startApiServer({
+      port: 0,
+      servicesRoot: path.resolve("services"),
+      workspaceRoot,
+      version: "config-test",
+    });
+
+    try {
+      const result = await getJson(`${apiServer.url}/api/runtime`);
+
+      assert.equal(result.status, 200);
+      assert.equal(result.body.runtime.servicesRoot, path.resolve("services"));
+      assert.equal(result.body.runtime.workspaceRoot, path.resolve(workspaceRoot));
+    } finally {
+      await apiServer.stop();
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("runtime rejects a missing servicesRoot during startup validation", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-config-"));
+  const missingServicesRoot = path.join(tempRoot, "missing-services");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  await mkdir(workspaceRoot, { recursive: true });
+
+  await assert.rejects(
+    () =>
+      startApiServer({
+        port: 0,
+        servicesRoot: missingServicesRoot,
+        workspaceRoot,
+      }),
+    /servicesRoot does not exist/i,
+  );
+
+  await rm(tempRoot, { recursive: true, force: true });
 });

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -200,6 +200,70 @@ test("TCP healthcheck lifecycle actions stay 200 when the probe is unavailable",
   }
 });
 
+test("GET /api/services/:id/health supports bounded file healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const serviceRoot = await writeManifest(servicesRoot, "file-service", {
+    id: "file-service",
+    name: "File Service",
+    description: "Temporary service for file health proof.",
+    healthcheck: {
+      type: "file",
+      file: "./runtime/ready.txt",
+    },
+  });
+  await mkdir(path.join(serviceRoot, "runtime"), { recursive: true });
+  await writeFile(path.join(serviceRoot, "runtime", "ready.txt"), "ok");
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/file-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "file-service");
+    assert.equal(body.health.type, "file");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /found expected file/i);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("file healthcheck lifecycle actions stay 200 when the file is unavailable", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  await writeExecutableFixtureService(servicesRoot, "file-health-fixture", {
+    healthcheck: {
+      type: "file",
+      file: "./runtime/ready.txt",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/file-health-fixture/install`);
+    const config = await postJson(`${apiServer.url}/api/services/file-health-fixture/config`);
+    const start = await postJson(`${apiServer.url}/api/services/file-health-fixture/start`);
+    const stop = await postJson(`${apiServer.url}/api/services/file-health-fixture/stop`);
+
+    for (const response of [install, config, start, stop]) {
+      assert.equal(response.status, 200);
+      assert.equal(response.body.health.type, "file");
+      assert.equal(response.body.health.healthy, false);
+      assert.match(response.body.health.detail, /did not find expected file/i);
+    }
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("runtime summary reports healthy services", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -1,28 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import net from "node:net";
 import path from "node:path";
-import os from "node:os";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { once } from "node:events";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { getServiceStatePaths } from "../dist/runtime/state/paths.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
-
-async function makeTempServicesRoot() {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-state-"));
-  const servicesRoot = path.join(tempRoot, "services");
-  await mkdir(servicesRoot, { recursive: true });
-  return { tempRoot, servicesRoot };
-}
-
-async function writeManifest(servicesRoot, serviceId, body) {
-  const serviceRoot = path.join(servicesRoot, serviceId);
-  await mkdir(serviceRoot, { recursive: true });
-  await writeFile(path.join(serviceRoot, "service.json"), JSON.stringify(body, null, 2));
-  return serviceRoot;
-}
+import { makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 async function postJson(url) {
   const response = await fetch(url, { method: "POST" });
@@ -35,12 +22,7 @@ async function postJson(url) {
 test("lifecycle actions write structured .state records to disk", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();
-  const serviceRoot = await writeManifest(servicesRoot, "echo-service", {
-    id: "echo-service",
-    name: "Echo Service",
-    description: "Temporary service for state persistence proof.",
-    healthcheck: { type: "process" },
-  });
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "echo-service");
 
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
@@ -111,15 +93,117 @@ test("GET /api/services/:id/health supports bounded HTTP healthchecks", async ()
   }
 });
 
+test("GET /api/services/:id/health supports bounded TCP healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  const tcpServer = net.createServer((socket) => {
+    socket.end("OK");
+  });
+  tcpServer.listen(0, "127.0.0.1");
+  await once(tcpServer, "listening");
+  const tcpAddress = tcpServer.address();
+  if (!tcpAddress || typeof tcpAddress === "string") {
+    throw new Error("TCP probe server failed to bind.");
+  }
+
+  await writeManifest(servicesRoot, "tcp-service", {
+    id: "tcp-service",
+    name: "TCP Service",
+    description: "Temporary service for TCP health proof.",
+    healthcheck: {
+      type: "tcp",
+      address: `127.0.0.1:${tcpAddress.port}`,
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/tcp-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "tcp-service");
+    assert.equal(body.health.type, "tcp");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /connected successfully/i);
+  } finally {
+    await apiServer.stop();
+    tcpServer.close();
+    await once(tcpServer, "close");
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("HTTP healthcheck lifecycle actions stay 200 when the probe is unavailable", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  await writeExecutableFixtureService(servicesRoot, "http-health-fixture", {
+    healthcheck: {
+      type: "http",
+      url: "http://127.0.0.1:65534/health",
+      expected_status: 200,
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/http-health-fixture/install`);
+    const config = await postJson(`${apiServer.url}/api/services/http-health-fixture/config`);
+    const start = await postJson(`${apiServer.url}/api/services/http-health-fixture/start`);
+    const stop = await postJson(`${apiServer.url}/api/services/http-health-fixture/stop`);
+
+    for (const response of [install, config, start, stop]) {
+      assert.equal(response.status, 200);
+      assert.equal(response.body.health.type, "http");
+      assert.equal(response.body.health.healthy, false);
+      assert.match(response.body.health.detail, /HTTP healthcheck failed:/i);
+    }
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("TCP healthcheck lifecycle actions stay 200 when the probe is unavailable", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  await writeExecutableFixtureService(servicesRoot, "tcp-health-fixture", {
+    healthcheck: {
+      type: "tcp",
+      address: "127.0.0.1:65533",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/tcp-health-fixture/install`);
+    const config = await postJson(`${apiServer.url}/api/services/tcp-health-fixture/config`);
+    const start = await postJson(`${apiServer.url}/api/services/tcp-health-fixture/start`);
+    const stop = await postJson(`${apiServer.url}/api/services/tcp-health-fixture/stop`);
+
+    for (const response of [install, config, start, stop]) {
+      assert.equal(response.status, 200);
+      assert.equal(response.body.health.type, "tcp");
+      assert.equal(response.body.health.healthy, false);
+      assert.match(response.body.health.detail, /TCP healthcheck failed:/i);
+    }
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("runtime summary reports healthy services", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();
-  await writeManifest(servicesRoot, "echo-service", {
-    id: "echo-service",
-    name: "Echo Service",
-    description: "Temporary service for runtime health proof.",
-    healthcheck: { type: "process" },
-  });
+  await writeExecutableFixtureService(servicesRoot, "echo-service");
 
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
@@ -133,6 +217,99 @@ test("runtime summary reports healthy services", async () => {
 
     assert.equal(response.status, 200);
     assert.equal(body.runtime.healthyServices, 1);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("startup rehydrates persisted lifecycle state from service .state files", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const serviceRoot = await writeManifest(servicesRoot, "echo-service", {
+    id: "echo-service",
+    name: "Echo Service",
+    description: "Temporary service for rehydration proof.",
+    healthcheck: { type: "process" },
+  });
+
+  const statePaths = getServiceStatePaths(serviceRoot);
+  await mkdir(statePaths.stateRoot, { recursive: true });
+  await writeFile(path.join(statePaths.stateRoot, "install.json"), JSON.stringify({ installed: true, lastAction: "install" }, null, 2));
+  await writeFile(path.join(statePaths.stateRoot, "config.json"), JSON.stringify({ configured: true, lastAction: "config" }, null, 2));
+  await writeFile(
+    path.join(statePaths.stateRoot, "runtime.json"),
+    JSON.stringify(
+      {
+        running: true,
+        pid: 12345,
+        startedAt: "2026-04-20T00:00:00.000Z",
+        exitCode: null,
+        command: "node runtime/fixture-service.mjs",
+        lastAction: "start",
+        actionHistory: ["install", "config", "start"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const detailResponse = await fetch(`${apiServer.url}/api/services/echo-service`);
+    const detailBody = await detailResponse.json();
+    const runtimeResponse = await fetch(`${apiServer.url}/api/runtime`);
+    const runtimeBody = await runtimeResponse.json();
+
+    assert.equal(detailResponse.status, 200);
+    assert.equal(detailBody.service.lifecycle.installed, true);
+    assert.equal(detailBody.service.lifecycle.configured, true);
+    assert.equal(detailBody.service.lifecycle.running, false);
+    assert.deepEqual(detailBody.service.lifecycle.actionHistory, ["install", "config", "start"]);
+    assert.equal(detailBody.service.lifecycle.runtime.pid, null);
+    assert.equal(detailBody.service.lifecycle.runtime.command, "node runtime/fixture-service.mjs");
+    assert.equal(runtimeResponse.status, 200);
+    assert.equal(runtimeBody.runtime.runningServices, 0);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("managed process exits update lifecycle and persisted runtime state", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "short-lived-service", {
+    autoExitMs: 150,
+    exitCode: 7,
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/short-lived-service/install`);
+    await postJson(`${apiServer.url}/api/services/short-lived-service/config`);
+    const start = await postJson(`${apiServer.url}/api/services/short-lived-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.state.running, true);
+    assert.equal(start.body.state.runtime.pid > 0, true);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const detailResponse = await fetch(`${apiServer.url}/api/services/short-lived-service`);
+    const detailBody = await detailResponse.json();
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(detailResponse.status, 200);
+    assert.equal(detailBody.service.lifecycle.running, false);
+    assert.equal(detailBody.service.lifecycle.runtime.pid, null);
+    assert.equal(detailBody.service.lifecycle.runtime.exitCode, 7);
+    assert.equal(stored.runtime.running, false);
+    assert.equal(stored.runtime.exitCode, 7);
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -1,10 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import path from "node:path";
+import { rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
-
-const servicesRoot = path.resolve("services");
+import { readStoredState } from "../dist/runtime/state/readState.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
 
 async function postJson(url) {
   const response = await fetch(url, { method: "POST" });
@@ -14,8 +14,21 @@ async function postJson(url) {
   };
 }
 
+async function waitFor(predicate, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
 test("lifecycle actions execute in the expected bounded order", async () => {
   resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -35,29 +48,72 @@ test("lifecycle actions execute in the expected bounded order", async () => {
     assert.equal(start.status, 200);
     assert.equal(start.body.action, "start");
     assert.equal(start.body.state.running, true);
+    assert.equal(start.body.state.runtime.pid > 0, true);
+    assert.equal(typeof start.body.state.runtime.command, "string");
 
     const restart = await postJson(`${apiServer.url}/api/services/echo-service/restart`);
     assert.equal(restart.status, 200);
     assert.equal(restart.body.action, "restart");
     assert.equal(restart.body.state.running, true);
+    assert.equal(restart.body.state.runtime.pid > 0, true);
 
     const stop = await postJson(`${apiServer.url}/api/services/echo-service/stop`);
     assert.equal(stop.status, 200);
     assert.equal(stop.body.action, "stop");
     assert.equal(stop.body.state.running, false);
+    assert.equal(stop.body.state.runtime.pid, null);
 
-    const detailResponse = await fetch(`${apiServer.url}/api/services/echo-service`);
-    const detailBody = await detailResponse.json();
+    let detailBody;
+    await waitFor(async () => {
+      const detailResponse = await fetch(`${apiServer.url}/api/services/echo-service`);
+      detailBody = await detailResponse.json();
+      return detailBody.service.lifecycle.runtime.exitCode === 0;
+    });
+
     assert.deepEqual(detailBody.service.lifecycle.actionHistory, ["install", "config", "start", "restart", "stop"]);
     assert.equal(detailBody.service.lifecycle.lastAction, "stop");
+    assert.equal(detailBody.service.lifecycle.runtime.exitCode, 0);
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("intentional stop keeps persisted lifecycle metadata on stop", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "echo-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/echo-service/install`);
+    await postJson(`${apiServer.url}/api/services/echo-service/config`);
+    await postJson(`${apiServer.url}/api/services/echo-service/start`);
+
+    const stop = await postJson(`${apiServer.url}/api/services/echo-service/stop`);
+    assert.equal(stop.status, 200);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime.lastAction === "stop" && stored.runtime.running === false;
+    });
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.lastAction, "stop");
+    assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "start", "stop"]);
+    assert.equal(stored.runtime.running, false);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 
 test("start fails before config and keeps the error explicit", async () => {
   resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -65,17 +121,41 @@ test("start fails before config and keeps the error explicit", async () => {
     assert.equal(install.status, 200);
 
     const start = await postJson(`${apiServer.url}/api/services/echo-service/start`);
-    assert.equal(start.status, 500);
-    assert.equal(start.body.error, "internal_error");
+    assert.equal(start.status, 409);
+    assert.equal(start.body.error, "invalid_lifecycle_state");
+    assert.equal(start.body.statusCode, 409);
     assert.match(start.body.message, /before config/i);
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("unknown lifecycle actions return a deterministic client error", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  await writeExecutableFixtureService(servicesRoot, "echo-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await postJson(`${apiServer.url}/api/services/echo-service/ship-it`);
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, "invalid_action");
+    assert.equal(response.body.statusCode, 400);
+    assert.match(response.body.message, /unknown lifecycle action/i);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 
 test("runtime summary reflects running services after lifecycle actions", async () => {
   resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -91,5 +171,6 @@ test("runtime summary reflects running services after lifecycle actions", async 
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -98,6 +98,36 @@ test("loadServiceManifest accepts bounded tcp healthchecks", async () => {
   }
 });
 
+test("loadServiceManifest accepts bounded file healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "file-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "file-service",
+        name: "File Service",
+        description: "Service with bounded file health.",
+        healthcheck: {
+          type: "file",
+          file: "./runtime/ready.txt",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "file",
+      file: "./runtime/ready.txt",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -68,6 +68,36 @@ test("loadServiceManifest fails explicitly for malformed manifests", async () =>
   }
 });
 
+test("loadServiceManifest accepts bounded tcp healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "tcp-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "tcp-service",
+        name: "TCP Service",
+        description: "Service with bounded tcp health.",
+        healthcheck: {
+          type: "tcp",
+          address: "127.0.0.1:4012",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "tcp",
+      address: "127.0.0.1:4012",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {
@@ -103,24 +133,13 @@ test("GET /api/services returns manifest-backed data from the configured service
   }
 });
 
-test("GET /api/services returns explicit error when a manifest is malformed", async () => {
+test("runtime startup fails explicitly when a manifest is malformed", async () => {
   const servicesRoot = await makeTempServicesRoot();
   await writeManifest(servicesRoot, "broken-service", {
     id: "broken-service",
     description: "Missing name should fail",
   });
 
-  const apiServer = await startApiServer({ port: 0, servicesRoot });
-
-  try {
-    const response = await fetch(`${apiServer.url}/api/services`);
-    const body = await response.json();
-
-    assert.equal(response.status, 500);
-    assert.equal(body.error, "internal_error");
-    assert.match(body.message, /expected non-empty string for "name"/i);
-  } finally {
-    await apiServer.stop();
-    await rm(servicesRoot, { recursive: true, force: true });
-  }
+  await assert.rejects(() => startApiServer({ port: 0, servicesRoot }), /expected non-empty string for "name"/i);
+  await rm(servicesRoot, { recursive: true, force: true });
 });

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { clearPersistedFixtureState } from "./test-helpers.js";
 
 const servicesRoot = path.resolve("services");
 
@@ -16,6 +17,7 @@ async function postJson(url) {
 
 test("service detail includes richer operator metadata", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -25,15 +27,17 @@ test("service detail includes richer operator metadata", async () => {
     assert.equal(response.status, 200);
     assert.equal(body.service.operator.logPath.endsWith(path.join("services", "echo-service", "logs", "service.log")), true);
     assert.equal(body.service.operator.variableCount >= 3, true);
-    assert.equal(body.service.operator.endpointCount >= 1, true);
+    assert.equal(body.service.operator.endpointCount >= 2, true);
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/services/:id/logs returns operator log payload", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -50,11 +54,13 @@ test("GET /api/services/:id/logs returns operator log payload", async () => {
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/services/:id/variables returns manifest and derived variables", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -68,11 +74,13 @@ test("GET /api/services/:id/variables returns manifest and derived variables", a
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/services/:id/network returns operator network endpoints", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -82,14 +90,17 @@ test("GET /api/services/:id/network returns operator network endpoints", async (
     assert.equal(response.status, 200);
     assert.equal(body.network.serviceId, "echo-service");
     assert.ok(body.network.endpoints.some((entry) => entry.label === "service"));
+    assert.ok(body.network.endpoints.some((entry) => entry.label === "ui"));
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/variables and /api/network aggregate operator surfaces across services", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -104,8 +115,10 @@ test("GET /api/variables and /api/network aggregate operator surfaces across ser
     assert.equal(Array.isArray(networkBody.services), true);
     assert.ok(variablesBody.services.some((service) => service.serviceId === "echo-service"));
     assert.ok(networkBody.services.some((service) => service.serviceId === "@node"));
+    assert.ok(networkBody.services.some((service) => service.serviceId === "node-sample-service"));
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });

--- a/tests/provider-execution.test.js
+++ b/tests/provider-execution.test.js
@@ -8,6 +8,7 @@ import { discoverServices } from "../dist/runtime/discovery/discoverServices.js"
 import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { resolveProviderExecution } from "../dist/runtime/providers/resolveProvider.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { clearPersistedFixtureState } from "./test-helpers.js";
 
 const servicesRoot = path.resolve("services");
 
@@ -45,13 +46,26 @@ test("provider resolution returns direct execution for standalone services", asy
   assert.deepEqual(plan.args, ["--version"]);
 });
 
-test("provider resolution returns node execution for provider-backed services", async () => {
+test("provider resolution returns direct execution for the local echo fixture service", async () => {
   const discovered = await discoverServices(servicesRoot);
   const registry = createServiceRegistry(discovered);
   const echoService = registry.getById("echo-service");
 
   assert.ok(echoService);
   const plan = resolveProviderExecution(echoService, registry);
+
+  assert.equal(plan.provider, "direct");
+  assert.equal(plan.executable, "node");
+  assert.deepEqual(plan.args, ["runtime/fixture-harness.mjs"]);
+});
+
+test("provider resolution returns node execution for provider-backed services", async () => {
+  const discovered = await discoverServices(servicesRoot);
+  const registry = createServiceRegistry(discovered);
+  const nodeSampleService = registry.getById("node-sample-service");
+
+  assert.ok(nodeSampleService);
+  const plan = resolveProviderExecution(nodeSampleService, registry);
 
   assert.equal(plan.provider, "node");
   assert.equal(plan.providerServiceId, "@node");
@@ -94,23 +108,25 @@ test("provider resolution returns python execution for python-backed services", 
 
 test("provider-backed lifecycle action includes provider details in API responses", async () => {
   resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    await postJson(`${apiServer.url}/api/services/echo-service/install`);
-    await postJson(`${apiServer.url}/api/services/echo-service/config`);
-    const start = await postJson(`${apiServer.url}/api/services/echo-service/start`);
+    await postJson(`${apiServer.url}/api/services/node-sample-service/install`);
+    await postJson(`${apiServer.url}/api/services/node-sample-service/config`);
+    const start = await postJson(`${apiServer.url}/api/services/node-sample-service/start`);
 
     assert.equal(start.status, 200);
     assert.equal(start.body.provider.provider, "node");
     assert.equal(start.body.provider.commandPreview, "node runtime/server.js");
 
-    const detail = await fetch(`${apiServer.url}/api/services/echo-service`);
+    const detail = await fetch(`${apiServer.url}/api/services/node-sample-service`);
     const detailBody = await detail.json();
     assert.equal(detailBody.service.provider.provider, "node");
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
@@ -136,6 +152,7 @@ test("unknown provider ids fail explicitly", async () => {
 
       assert.equal(response.status, 500);
       assert.equal(body.error, "internal_error");
+      assert.equal(body.statusCode, 500);
       assert.match(body.message, /Unknown provider service id/i);
     } finally {
       await apiServer.stop();

--- a/tests/registry-runtime-state.test.js
+++ b/tests/registry-runtime-state.test.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 import { DependencyGraph, createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { startApiServer } from "../dist/server/index.js";
+import { clearPersistedFixtureState } from "./test-helpers.js";
 
 const servicesRoot = path.resolve("services");
 
@@ -12,20 +13,26 @@ test("ServiceRegistry and DependencyGraph model dependencies and dependents", as
   const registry = createServiceRegistry(discovered);
   const graph = new DependencyGraph(registry);
 
-  assert.equal(registry.count(), 3);
-  assert.equal(registry.countEnabled(), 3);
+  assert.equal(registry.count(), 4);
+  assert.equal(registry.countEnabled(), 4);
   assert.ok(registry.getById("echo-service"));
+  assert.ok(registry.getById("node-sample-service"));
 
   const echoSummary = graph.getServiceDependencies("echo-service");
-  assert.deepEqual(echoSummary.dependencies, ["@node"]);
+  assert.deepEqual(echoSummary.dependencies, []);
   assert.deepEqual(echoSummary.dependents, []);
 
   const nodeSummary = graph.getServiceDependencies("@node");
   assert.deepEqual(nodeSummary.dependencies, []);
-  assert.deepEqual(nodeSummary.dependents, ["echo-service"]);
+  assert.deepEqual(nodeSummary.dependents, ["node-sample-service"]);
+
+  const nodeSampleSummary = graph.getServiceDependencies("node-sample-service");
+  assert.deepEqual(nodeSampleSummary.dependencies, ["@node"]);
+  assert.deepEqual(nodeSampleSummary.dependents, []);
 });
 
 test("GET /api/services/:id returns discovered service detail with dependency context", async () => {
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -34,15 +41,17 @@ test("GET /api/services/:id returns discovered service detail with dependency co
 
     assert.equal(response.status, 200);
     assert.equal(body.service.id, "echo-service");
-    assert.deepEqual(body.service.dependencies, ["@node"]);
+    assert.deepEqual(body.service.dependencies, []);
     assert.deepEqual(body.service.dependents, []);
     assert.equal(body.service.source, "manifest");
   } finally {
     await apiServer.stop();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/runtime returns runtime summary state", async () => {
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -50,16 +59,18 @@ test("GET /api/runtime returns runtime summary state", async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.runtime.totalServices, 3);
-    assert.equal(body.runtime.enabledServices, 3);
+    assert.equal(body.runtime.totalServices, 4);
+    assert.equal(body.runtime.enabledServices, 4);
     assert.equal(body.runtime.dependencyEdges, 1);
     assert.equal(body.runtime.servicesRoot, servicesRoot);
   } finally {
     await apiServer.stop();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });
 
 test("GET /api/dependencies returns graph nodes and edges", async () => {
+  await clearPersistedFixtureState(servicesRoot);
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -67,9 +78,10 @@ test("GET /api/dependencies returns graph nodes and edges", async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.dependencies.nodes.length, 3);
-    assert.deepEqual(body.dependencies.edges, [{ from: "@node", to: "echo-service" }]);
+    assert.equal(body.dependencies.nodes.length, 4);
+    assert.deepEqual(body.dependencies.edges, [{ from: "@node", to: "node-sample-service" }]);
   } finally {
     await apiServer.stop();
+    await clearPersistedFixtureState(servicesRoot);
   }
 });

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,0 +1,81 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+
+export async function clearPersistedFixtureState(servicesRoot) {
+  const entries = await readdir(servicesRoot, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => rm(path.join(servicesRoot, entry.name, ".state"), { recursive: true, force: true })),
+  );
+}
+
+export async function makeTempServicesRoot(prefix = "service-lasso-fixture-") {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const servicesRoot = path.join(tempRoot, "services");
+  await mkdir(servicesRoot, { recursive: true });
+  return { tempRoot, servicesRoot };
+}
+
+export async function writeManifest(servicesRoot, serviceId, body) {
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  await mkdir(serviceRoot, { recursive: true });
+  await writeFile(path.join(serviceRoot, "service.json"), JSON.stringify(body, null, 2));
+  return serviceRoot;
+}
+
+export async function writeExecutableFixtureService(
+  servicesRoot,
+  serviceId,
+  options = {},
+) {
+  const {
+    autoExitMs = null,
+    exitCode = 0,
+    healthcheck = { type: "process" },
+  } = options;
+
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  const runtimeRoot = path.join(serviceRoot, "runtime");
+  await mkdir(runtimeRoot, { recursive: true });
+
+  const scriptPath = path.join(runtimeRoot, "fixture-service.mjs");
+  const scriptSource = `
+const heartbeat = setInterval(() => {}, 1000);
+const exitCode = Number(process.env.FIXTURE_EXIT_CODE ?? "${exitCode}");
+const autoExitMs = Number(process.env.FIXTURE_AUTO_EXIT_MS ?? "${autoExitMs ?? ""}");
+
+function shutdown() {
+  clearInterval(heartbeat);
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
+  setTimeout(() => {
+    clearInterval(heartbeat);
+    process.exit(exitCode);
+  }, autoExitMs);
+}
+`.trim();
+
+  await writeFile(scriptPath, scriptSource);
+  await writeManifest(servicesRoot, serviceId, {
+    id: serviceId,
+    name: serviceId,
+    description: `Executable fixture for ${serviceId}.`,
+    executable: process.execPath,
+    args: [path.relative(serviceRoot, scriptPath)],
+    env: {
+      FIXTURE_EXIT_CODE: String(exitCode),
+      ...(autoExitMs !== null ? { FIXTURE_AUTO_EXIT_MS: String(autoExitMs) } : {}),
+    },
+    healthcheck,
+  });
+
+  return { serviceRoot, scriptPath };
+}


### PR DESCRIPTION
## Summary
- land the first bounded execution-backed runtime/supervision slice
- add bounded tcp and file manifest-health support with direct tests
- refresh backlog/spec/docs and add the autonomous execution task list

## Verification
- npm test
- result: 40 passed, 0 failed
- released Echo Service artifact smoke through Service Lasso for:
  - execution-backed start/stop
  - tcp health
  - file health
