### PR TITLE
ISS-021: add bounded variable health support

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -28,6 +28,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-018` | `done` | Turn `echo-service` into a runnable Go harness fixture | `SPEC-002`, `AC-4A` | Landed with a Go-based sample service exposing UI and API actions plus log/state/SQLite persistence surfaces. |
 | `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
 | `ISS-020` | `done` | Add bounded `file` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded file-based readiness checks with automated tests and released Echo Service file proof. |
+| `ISS-021` | `done` | Add bounded `variable` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded variable-presence checks with automated tests and released Echo Service variable proof. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -52,6 +53,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-018` | `done` | `ISS-018` | Implement the `echo-service` Go harness fixture with UI, API, and persistence behaviors | `SPEC-002`, `AC-4A` | `echo-service` now builds and runs as a Go harness with action endpoints, browser UI, logs, state snapshots, and SQLite writes |
 | `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
 | `TASK-020` | `done` | `ISS-020` | Implement bounded `file` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = file`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service file proof |
+| `TASK-021` | `done` | `ISS-021` | Implement bounded `variable` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = variable`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service variable proof |
 
 ## Next Recommended Item
-The next best item is the next bounded donor-health slice after `TASK-020`: add `variable` manifest-health support with deterministic evaluation and direct Echo Service-backed verification.
+The next best item is the next donor-health slice after `TASK-021`: add readiness and wait-loop behavior so the runtime can turn bounded health checks into bounded startup readiness proof.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This slice now establishes the first real API spine, the first canonical manifes
 Note on repo split:
 - the canonical Echo Service implementation now lives in the sibling repo `C:\projects\service-lasso\lasso-echoservice`
 - `service-lasso/services/echo-service/` remains a thin local fixture manifest so the core repo stays self-contained for discovery/runtime tests
-- the sibling Echo Service repo now includes harness-only HTTP and TCP health simulation endpoints for runtime testing, and `service-lasso` itself now evaluates bounded manifest health types `process`, `http`, `tcp`, and `file`
+- the sibling Echo Service repo now includes harness-only HTTP and TCP health simulation endpoints for runtime testing, and `service-lasso` itself now evaluates bounded manifest health types `process`, `http`, `tcp`, `file`, and `variable`
 
 For the detailed layout note, see:
 

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -248,8 +248,8 @@ Major donor runtime behavior still remains to be migrated more fully, including:
 
 Important current boundary:
 - the sibling `lasso-echoservice` harness can already simulate HTTP and TCP health targets for testing and demo hardening
-- `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, `tcp`, and `file`
-- broader donor-health migration work still remains for types such as `variable` plus readiness-loop behavior
+- `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, `tcp`, `file`, and `variable`
+- broader donor-health migration work still remains for readiness-loop behavior on top of those bounded checks
 
 Again, that is why the repo should be read as:
 

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -28,6 +28,7 @@ Already done:
   - `http`
   - `tcp`
   - `file`
+  - `variable`
 - Echo Service harness repo and released-artifact proof through the runtime
 
 Current honest label:
@@ -57,14 +58,14 @@ Current honest label:
    - released Echo Service artifact can be checked against a real file target
 
 2. bounded `variable` health support
-   status: next
+   status: done
    proof:
    - manifest parsing accepts `healthcheck.type = variable`
    - runtime can evaluate a bounded variable source deterministically
    - tests prove healthy and unhealthy cases
 
 3. readiness and wait-loop behavior
-   status: queued
+   status: next
    proof:
    - start flow can wait for configured health readiness within bounded timeout/retry rules
    - tests prove success, timeout, and failure behavior
@@ -198,6 +199,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**bounded `variable` health support**
+**readiness and wait-loop behavior**
 
-That is the next smallest clean donor-parity step after bounded `file`, and it keeps the health migration moving with strong Echo Service-backed verification.
+That is the next smallest clean donor-parity step after bounded `variable`, and it turns the bounded health model into bounded startup-readiness proof.

--- a/docs/development/core-runtime-comprehensive-review.md
+++ b/docs/development/core-runtime-comprehensive-review.md
@@ -32,7 +32,7 @@ These assumptions were used consistently throughout the review:
 Automated verification was run during the review:
 
 - command: `npm test`
-- result: `40 passed, 0 failed`
+- result: `43 passed, 0 failed`
 
 What that test run directly proves:
 - API startup
@@ -41,7 +41,7 @@ What that test run directly proves:
 - registry/dependency graph basics
 - lifecycle ordering and guardrails
 - state writes
-- bounded `process`, `http`, `tcp`, and `file` health behavior
+- bounded `process`, `http`, `tcp`, `file`, and `variable` health behavior
 - runtime summary behavior
 - operator logs/variables/network surfaces
 - provider resolution and provider-backed response payloads
@@ -314,7 +314,7 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - in-memory service registry and dependency graph basics
 - bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
 - one bounded real execution/supervision path for directly executable services
-- bounded health handling for `process`, `http`, `tcp`, and `file`
+- bounded health handling for `process`, `http`, `tcp`, `file`, and `variable`
 - structured per-service `.state` writes
 - operator data surfaces for logs, variables, and network
 - provider relationship resolution/planning for direct, `@node`, and `@python`
@@ -333,9 +333,9 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - donor code performs execution-backed lifecycle work
 
 - health model
-  - current code supports `process`, `http`, bounded `tcp`, and bounded `file`
-  - donor code also supports `variable` and readiness waiting loops
-  - the sibling `lasso-echoservice` harness provides direct integration proof for the bounded `tcp` and `file` slices
+  - current code supports `process`, `http`, bounded `tcp`, bounded `file`, and bounded `variable`
+  - donor code still extends that into readiness waiting loops
+  - the sibling `lasso-echoservice` harness provides direct integration proof for the bounded `tcp`, `file`, and `variable` slices
 
 - provider/runtime behavior
   - current code resolves provider relationships and command previews
@@ -363,7 +363,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - port collision handling
 - dynamic port reassignment
 - shared `globalenv` propagation
-- broader health types beyond `process`, `http`, `tcp`, and `file`
+- broader health behavior beyond bounded `process`, `http`, `tcp`, `file`, and `variable`
 - dependency readiness loops and start-chain orchestration
 - manager-level `reload`
 - manager-level `startAll`
@@ -447,11 +447,13 @@ Current implementation covers:
 - `http`
 - bounded `tcp`
 - bounded `file`
+- bounded `variable`
 
 Related current harness capability:
 - the released `lasso-echoservice` binary already exposes TCP health simulation endpoints and controls
 - released Echo Service artifacts also provide a real file target through the harness state file
-- `service-lasso` can use that harness today as an integration target and now evaluates bounded manifest `healthcheck.type = tcp` and `healthcheck.type = file`
+- released Echo Service artifacts also provide a manifest-backed variable source through harness env
+- `service-lasso` can use that harness today as an integration target and now evaluates bounded manifest `healthcheck.type = tcp`, `healthcheck.type = file`, and `healthcheck.type = variable`
 - broader donor health parity still remains open beyond that bounded slice
 
 ## 6. Setup and install mechanics

--- a/docs/development/core-runtime-donor-coverage-audit.md
+++ b/docs/development/core-runtime-donor-coverage-audit.md
@@ -25,7 +25,7 @@ Primary current-repo inputs reviewed:
 
 Verification run used for this audit:
 - `npm test`
-- result: `40 passed, 0 failed`
+- result: `43 passed, 0 failed`
 
 ## Bottom line
 
@@ -58,7 +58,7 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - in-memory service registry and dependency graph basics
 - bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
 - one bounded real execution/supervision path for directly executable services
-- bounded health handling for `process`, `http`, `tcp`, and `file`
+- bounded health handling for `process`, `http`, `tcp`, `file`, and `variable`
 - structured per-service `.state/` writes
 - operator data surfaces for logs, variables, and network
 - provider relationship resolution/planning for direct, `@node`, and `@python`
@@ -75,8 +75,8 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - current code proves lifecycle state transitions
   - donor code performs execution-backed lifecycle work
 - health model
-  - current code supports `process`, `http`, bounded `tcp`, and bounded `file`
-  - donor code also supports `variable` and readiness waiting loops
+  - current code supports `process`, `http`, bounded `tcp`, bounded `file`, and bounded `variable`
+  - donor code also supports readiness waiting loops
 - provider/runtime behavior
   - current code resolves provider relationships and command previews
   - donor code actually executes through provider/runtime services
@@ -99,7 +99,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - command-driven setup/install pipeline
 - runtime-owned port reservation, collision handling, and reassignment
 - `globalenv` export/import propagation across services
-- broader health types beyond `process`, `http`, `tcp`, and `file`
+- broader health behavior beyond bounded `process`, `http`, `tcp`, `file`, and `variable`
 - dependency readiness loops and start-chain orchestration
 - manager-level `reload`
 - manager-level `startAll`
@@ -198,15 +198,16 @@ Current implementation covers:
 - bounded `http` health checks
 - bounded `tcp` health checks
 - bounded `file` health checks
+- bounded `variable` health checks
 
 Current implementation does not yet cover:
-- `variable`
 - readiness wait loops tied to actual startup
 
 Related current test-harness note:
 - the sibling `lasso-echoservice` repo already exposes TCP health simulation endpoints and controls for integration testing
 - that harness capability is now paired with bounded `service-lasso` runtime support for manifest `healthcheck.type = tcp`
 - released Echo Service artifacts now also provide direct proof for bounded `service-lasso` runtime support for manifest `healthcheck.type = file`
+- released Echo Service artifacts now also provide direct proof for bounded `service-lasso` runtime support for manifest `healthcheck.type = variable`
 - broader donor health parity still remains open beyond that bounded slice
 
 ## 6. Setup and install mechanics
@@ -313,7 +314,7 @@ So the implementation is ahead of the spec wording.
 Current automated verification status for the bounded core slice:
 
 - command run: `npm test`
-- result: `40 passed, 0 failed`
+- result: `43 passed, 0 failed`
 
 The passing suite directly verifies:
 - API startup

--- a/docs/development/core-runtime-working-application-plan.md
+++ b/docs/development/core-runtime-working-application-plan.md
@@ -169,8 +169,8 @@ Why this order:
 
 Current harness note:
 - the sibling `lasso-echoservice` repo already provides HTTP and TCP health simulation targets for testing
-- that gives us a strong migration harness, and Service Lasso runtime now has bounded `tcp` and `file` manifest-health support proven against that harness
-- broader donor health parity still requires additional types such as `variable` plus readiness-loop behavior
+- that gives us a strong migration harness, and Service Lasso runtime now has bounded `tcp`, `file`, and `variable` manifest-health support proven against that harness
+- broader donor health parity still requires readiness-loop behavior on top of those bounded checks
 
 ## Phase 5A: Validate the first real consumer repo
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -52,6 +52,11 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
         type: "file",
         file: expectNonEmptyString(healthRecord.file, "healthcheck.file", manifestPath),
       };
+    } else if (healthRecord.type === "variable") {
+      healthcheck = {
+        type: "variable",
+        variable: expectNonEmptyString(healthRecord.variable, "healthcheck.variable", manifestPath),
+      };
     } else {
       throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);
     }

--- a/src/runtime/health/checkVariable.ts
+++ b/src/runtime/health/checkVariable.ts
@@ -1,0 +1,31 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import { resolveServiceVariable } from "../operator/variables.js";
+import type { ServiceHealthResult, VariableHealthcheck } from "./types.js";
+
+export async function checkVariableHealth(
+  healthcheck: VariableHealthcheck,
+  service?: DiscoveredService,
+): Promise<ServiceHealthResult> {
+  if (!service) {
+    return {
+      type: "variable",
+      healthy: false,
+      detail: "Variable healthcheck requires service context.",
+    };
+  }
+
+  const entry = resolveServiceVariable(service, healthcheck.variable);
+  if (!entry || entry.value.trim().length === 0) {
+    return {
+      type: "variable",
+      healthy: false,
+      detail: `Variable healthcheck did not resolve expected variable: ${healthcheck.variable}`,
+    };
+  }
+
+  return {
+    type: "variable",
+    healthy: true,
+    detail: `Variable healthcheck resolved ${entry.key} from ${entry.scope} scope.`,
+  };
+}

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -1,15 +1,18 @@
 import type { ServiceManifest } from "../../contracts/service.js";
+import type { DiscoveredService } from "../../contracts/service.js";
 import type { ServiceLifecycleState } from "../lifecycle/types.js";
 import { checkFileHealth } from "./checkFile.js";
 import { checkHttpHealth } from "./checkHttp.js";
 import { checkProcessHealth } from "./checkProcess.js";
 import { checkTcpHealth } from "./checkTcp.js";
+import { checkVariableHealth } from "./checkVariable.js";
 import type { ServiceHealthResult } from "./types.js";
 
 export async function evaluateServiceHealth(
   manifest: ServiceManifest,
   lifecycle: ServiceLifecycleState,
   serviceRoot?: string,
+  service?: DiscoveredService,
 ): Promise<ServiceHealthResult> {
   const healthcheck = manifest.healthcheck;
 
@@ -27,6 +30,10 @@ export async function evaluateServiceHealth(
 
   if (healthcheck.type === "file") {
     return checkFileHealth(healthcheck, serviceRoot);
+  }
+
+  if (healthcheck.type === "variable") {
+    return checkVariableHealth(healthcheck, service);
   }
 
   return {

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -18,7 +18,17 @@ export interface FileHealthcheck {
   file: string;
 }
 
-export type ServiceHealthcheck = ProcessHealthcheck | HttpHealthcheck | TcpHealthcheck | FileHealthcheck;
+export interface VariableHealthcheck {
+  type: "variable";
+  variable: string;
+}
+
+export type ServiceHealthcheck =
+  | ProcessHealthcheck
+  | HttpHealthcheck
+  | TcpHealthcheck
+  | FileHealthcheck
+  | VariableHealthcheck;
 
 export interface ServiceHealthResult {
   type: ServiceHealthcheck["type"] | "unknown";

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -43,3 +43,14 @@ export function buildServiceVariables(service: DiscoveredService): ServiceVariab
     variables: [...manifestVariables, ...derivedVariables],
   };
 }
+
+function normalizeVariableSelector(selector: string): string {
+  const trimmed = selector.trim();
+  const match = trimmed.match(/^\$\{(.+)\}$/);
+  return (match?.[1] ?? trimmed).trim();
+}
+
+export function resolveServiceVariable(service: DiscoveredService, selector: string): ServiceVariableEntry | undefined {
+  const key = normalizeVariableSelector(selector);
+  return buildServiceVariables(service).variables.find((entry) => entry.key === key);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -78,7 +78,7 @@ async function createServiceSummary(
 ): Promise<ServiceSummary> {
   const dependencySummary = graph.getServiceDependencies(service.manifest.id);
   const lifecycle = getLifecycleState(service.manifest.id);
-  const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot);
+  const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service);
   const logs = buildServiceLogs(service, lifecycle);
   const variables = buildServiceVariables(service);
   const network = buildServiceNetwork(service);
@@ -138,7 +138,7 @@ async function executeLifecycleAction(
   })();
 
   const persisted = await writeServiceState(service, result.state);
-  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot);
+  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot, service);
   const provider = resolveProviderExecution(service, registry);
 
   return {
@@ -187,7 +187,7 @@ async function routeRequest(
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "health") {
       const lifecycle = getLifecycleState(serviceId);
-      const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot);
+      const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service);
       writeJson(response, 200, createServiceHealthResponse(serviceId, health));
       return;
     }

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -264,6 +264,71 @@ test("file healthcheck lifecycle actions stay 200 when the file is unavailable",
   }
 });
 
+test("GET /api/services/:id/health supports bounded variable healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  await writeManifest(servicesRoot, "variable-service", {
+    id: "variable-service",
+    name: "Variable Service",
+    description: "Temporary service for variable health proof.",
+    env: {
+      ECHO_MESSAGE: "hello from variable health",
+    },
+    healthcheck: {
+      type: "variable",
+      variable: "${ECHO_MESSAGE}",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/variable-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "variable-service");
+    assert.equal(body.health.type, "variable");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /resolved ECHO_MESSAGE/i);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("variable healthcheck lifecycle actions stay 200 when the variable is unavailable", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  await writeExecutableFixtureService(servicesRoot, "variable-health-fixture", {
+    healthcheck: {
+      type: "variable",
+      variable: "${MISSING_VALUE}",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/variable-health-fixture/install`);
+    const config = await postJson(`${apiServer.url}/api/services/variable-health-fixture/config`);
+    const start = await postJson(`${apiServer.url}/api/services/variable-health-fixture/start`);
+    const stop = await postJson(`${apiServer.url}/api/services/variable-health-fixture/stop`);
+
+    for (const response of [install, config, start, stop]) {
+      assert.equal(response.status, 200);
+      assert.equal(response.body.health.type, "variable");
+      assert.equal(response.body.health.healthy, false);
+      assert.match(response.body.health.detail, /did not resolve expected variable/i);
+    }
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("runtime summary reports healthy services", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -128,6 +128,36 @@ test("loadServiceManifest accepts bounded file healthchecks", async () => {
   }
 });
 
+test("loadServiceManifest accepts bounded variable healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "variable-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "variable-service",
+        name: "Variable Service",
+        description: "Service with bounded variable health.",
+        healthcheck: {
+          type: "variable",
+          variable: "${ECHO_MESSAGE}",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "variable",
+      variable: "${ECHO_MESSAGE}",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {


### PR DESCRIPTION
## Summary
- add bounded variable manifest-health support
- share variable resolution between operator surfaces and health evaluation
- update backlog/docs/task list for the next readiness slice

## Verification
- npm test
- result: 43 passed, 0 failed
- released Echo Service artifact smoke through Service Lasso for variable health
