### PR TITLE
ISS-022: add bounded readiness wait-loop behavior

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -29,6 +29,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
 | `ISS-020` | `done` | Add bounded `file` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded file-based readiness checks with automated tests and released Echo Service file proof. |
 | `ISS-021` | `done` | Add bounded `variable` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded variable-presence checks with automated tests and released Echo Service variable proof. |
+| `ISS-022` | `in_progress` | Add bounded readiness wait-loop behavior for startup health | `SPEC-002`, `AC-4D` | In progress: make startup optionally wait for donor-aligned health retries so services are only reported ready when the configured health signal succeeds within bounds. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -54,6 +55,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
 | `TASK-020` | `done` | `ISS-020` | Implement bounded `file` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = file`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service file proof |
 | `TASK-021` | `done` | `ISS-021` | Implement bounded `variable` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = variable`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service variable proof |
+| `TASK-022` | `in_progress` | `ISS-022` | Implement bounded readiness wait loops for start/restart flows | `SPEC-002`, `AC-4D` | Start/restart can wait on donor-aligned health retries, succeed when readiness becomes healthy, and fail deterministically when the readiness window expires |
 
 ## Next Recommended Item
-The next best item is the next donor-health slice after `TASK-021`: add readiness and wait-loop behavior so the runtime can turn bounded health checks into bounded startup readiness proof.
+The next best item is `TASK-022`: finish bounded readiness and wait-loop behavior so the runtime can turn bounded health checks into bounded startup readiness proof.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -30,6 +30,7 @@ Explicitly out of scope for this spec:
 - `AC-4A`: The tracked fixture set includes a runnable harness-style sample service that can be started independently and used to exercise API/UI, persistence, and behavior-simulation flows for later runtime supervision work.
 - `AC-4B`: The runtime includes one bounded real execution/supervision path that can start, observe, stop, and persist runtime state for a directly executable service definition.
 - `AC-4C`: The runtime broadens bounded health support beyond `process` and `http` by directly accepting and evaluating at least one additional donor-aligned manifest health type with runnable verification evidence.
+- `AC-4D`: The runtime can optionally wait for bounded startup readiness using donor-aligned health retry fields so start/restart flows can distinguish "process launched" from "service became ready".
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -40,6 +41,7 @@ Required evidence for this spec:
 - direct proof that the tracked harness fixture can start locally and expose its documented API/UI surface
 - direct proof that the bounded execution supervisor can start and stop a real process while persisting runtime state updates
 - direct proof that at least one additional donor-aligned manifest health type can be parsed and evaluated successfully by the runtime
+- direct proof that configured readiness wait loops can succeed and time out deterministically during bounded start behavior
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -65,7 +65,7 @@ Current honest label:
    - tests prove healthy and unhealthy cases
 
 3. readiness and wait-loop behavior
-   status: next
+   status: in progress
    proof:
    - start flow can wait for configured health readiness within bounded timeout/retry rules
    - tests prove success, timeout, and failure behavior

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -9,6 +9,45 @@ function expectNonEmptyString(value: unknown, field: string, manifestPath: strin
   return value.trim();
 }
 
+function expectOptionalWholeNumber(
+  value: unknown,
+  field: string,
+  manifestPath: string,
+  minimum = 0,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < minimum) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "${field}" to be an integer greater than or equal to ${minimum}.`,
+    );
+  }
+
+  return value;
+}
+
+function readHealthcheckReadinessOptions(
+  healthRecord: Record<string, unknown>,
+  manifestPath: string,
+): Record<string, number> {
+  const interval = expectOptionalWholeNumber(healthRecord.interval, "healthcheck.interval", manifestPath, 1);
+  const retries = expectOptionalWholeNumber(healthRecord.retries, "healthcheck.retries", manifestPath, 1);
+  const startPeriod = expectOptionalWholeNumber(
+    healthRecord.start_period,
+    "healthcheck.start_period",
+    manifestPath,
+    0,
+  );
+
+  return {
+    ...(interval !== undefined ? { interval } : {}),
+    ...(retries !== undefined ? { retries } : {}),
+    ...(startPeriod !== undefined ? { start_period: startPeriod } : {}),
+  };
+}
+
 export function validateServiceManifest(input: unknown, manifestPath: string): ServiceManifest {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected a JSON object.`);
@@ -33,29 +72,34 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     }
 
     const healthRecord = rawHealthcheck as Record<string, unknown>;
+    const readinessOptions = readHealthcheckReadinessOptions(healthRecord, manifestPath);
     if (healthRecord.type === "process") {
-      healthcheck = { type: "process" };
+      healthcheck = { type: "process", ...readinessOptions };
     } else if (healthRecord.type === "http") {
       healthcheck = {
         type: "http",
         url: expectNonEmptyString(healthRecord.url, "healthcheck.url", manifestPath),
         expected_status:
           typeof healthRecord.expected_status === "number" ? healthRecord.expected_status : undefined,
+        ...readinessOptions,
       };
     } else if (healthRecord.type === "tcp") {
       healthcheck = {
         type: "tcp",
         address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath),
+        ...readinessOptions,
       };
     } else if (healthRecord.type === "file") {
       healthcheck = {
         type: "file",
         file: expectNonEmptyString(healthRecord.file, "healthcheck.file", manifestPath),
+        ...readinessOptions,
       };
     } else if (healthRecord.type === "variable") {
       healthcheck = {
         type: "variable",
         variable: expectNonEmptyString(healthRecord.variable, "healthcheck.variable", manifestPath),
+        ...readinessOptions,
       };
     } else {
       throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -1,24 +1,30 @@
-export interface ProcessHealthcheck {
+export interface HealthcheckReadinessOptions {
+  interval?: number;
+  retries?: number;
+  start_period?: number;
+}
+
+export interface ProcessHealthcheck extends HealthcheckReadinessOptions {
   type: "process";
 }
 
-export interface HttpHealthcheck {
+export interface HttpHealthcheck extends HealthcheckReadinessOptions {
   type: "http";
   url: string;
   expected_status?: number;
 }
 
-export interface TcpHealthcheck {
+export interface TcpHealthcheck extends HealthcheckReadinessOptions {
   type: "tcp";
   address: string;
 }
 
-export interface FileHealthcheck {
+export interface FileHealthcheck extends HealthcheckReadinessOptions {
   type: "file";
   file: string;
 }
 
-export interface VariableHealthcheck {
+export interface VariableHealthcheck extends HealthcheckReadinessOptions {
   type: "variable";
   variable: string;
 }

--- a/src/runtime/health/waitForReadiness.ts
+++ b/src/runtime/health/waitForReadiness.ts
@@ -1,0 +1,100 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import { evaluateServiceHealth } from "./evaluateHealth.js";
+import type { ServiceHealthcheck, ServiceHealthResult } from "./types.js";
+
+const DEFAULT_READINESS_INTERVAL_MS = 1_000;
+
+export interface ReadinessWaitResult {
+  enabled: boolean;
+  ready: boolean;
+  health: ServiceHealthResult;
+  attempts: number;
+  message: string;
+}
+
+function resolveReadinessOptions(healthcheck?: ServiceHealthcheck): {
+  enabled: boolean;
+  attempts: number;
+  intervalMs: number;
+  startPeriodMs: number;
+} {
+  if (!healthcheck) {
+    return {
+      enabled: false,
+      attempts: 1,
+      intervalMs: DEFAULT_READINESS_INTERVAL_MS,
+      startPeriodMs: 0,
+    };
+  }
+
+  const enabled =
+    healthcheck.retries !== undefined ||
+    healthcheck.interval !== undefined ||
+    healthcheck.start_period !== undefined;
+
+  return {
+    enabled,
+    attempts: Math.max(healthcheck.retries ?? 1, 1),
+    intervalMs: healthcheck.interval ?? DEFAULT_READINESS_INTERVAL_MS,
+    startPeriodMs: healthcheck.start_period ?? 0,
+  };
+}
+
+export async function waitForServiceReadiness(service: DiscoveredService): Promise<ReadinessWaitResult> {
+  const { enabled, attempts, intervalMs, startPeriodMs } = resolveReadinessOptions(service.manifest.healthcheck);
+  let lastHealth = await evaluateServiceHealth(
+    service.manifest,
+    getLifecycleState(service.manifest.id),
+    service.serviceRoot,
+    service,
+  );
+
+  if (!enabled) {
+    return {
+      enabled: false,
+      ready: true,
+      health: lastHealth,
+      attempts: 1,
+      message: "Start completed.",
+    };
+  }
+
+  if (startPeriodMs > 0) {
+    await delay(startPeriodMs);
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lastHealth = await evaluateServiceHealth(
+      service.manifest,
+      getLifecycleState(service.manifest.id),
+      service.serviceRoot,
+      service,
+    );
+
+    if (lastHealth.healthy) {
+      return {
+        enabled: true,
+        ready: true,
+        health: lastHealth,
+        attempts: attempt,
+        message: `Start completed after readiness succeeded on attempt ${attempt} of ${attempts}.`,
+      };
+    }
+
+    if (attempt < attempts) {
+      await delay(intervalMs);
+    }
+  }
+
+  return {
+    enabled: true,
+    ready: false,
+    health: lastHealth,
+    attempts,
+    message:
+      `Service did not become ready after ${attempts} readiness attempt(s)` +
+      ` with interval ${intervalMs}ms and start period ${startPeriodMs}ms.`,
+  };
+}

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,6 +1,7 @@
 import type { DiscoveredService } from "../../contracts/service.js";
 import { LifecycleStateError } from "../../server/errors.js";
 import { startManagedProcess, stopManagedProcess } from "../execution/supervisor.js";
+import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
@@ -9,6 +10,7 @@ function applyState(
   serviceId: string,
   action: LifecycleAction,
   recipe: (current: ServiceLifecycleState) => { nextState: ServiceLifecycleState; message: string },
+  ok = true,
 ): LifecycleActionResult {
   const current = getLifecycleState(serviceId);
   const { nextState, message } = recipe(current);
@@ -19,7 +21,7 @@ function applyState(
   });
 
   return {
-    ok: true,
+    ok,
     action,
     serviceId,
     state,
@@ -108,18 +110,52 @@ export async function startService(service: DiscoveredService): Promise<Lifecycl
     },
   });
 
+  updateRuntimeState(serviceId, (state) => ({
+    ...state,
+    running: true,
+    runtime: {
+      pid: handle.pid,
+      startedAt: handle.startedAt,
+      exitCode: null,
+      command: handle.command,
+    },
+  }));
+
+  const readiness = await waitForServiceReadiness(service);
+  if (!readiness.ready) {
+    const stopped = await stopManagedProcess(serviceId);
+    return applyState(
+      serviceId,
+      "start",
+      (state) => ({
+        nextState: {
+          ...state,
+          running: false,
+          runtime: {
+            ...state.runtime,
+            pid: null,
+            exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
+          },
+        },
+        message: readiness.message,
+      }),
+      false,
+    );
+  }
+
   return applyState(serviceId, "start", (state) => ({
     nextState: {
       ...state,
       running: true,
       runtime: {
+        ...state.runtime,
         pid: handle.pid,
         startedAt: handle.startedAt,
         exitCode: null,
         command: handle.command,
       },
     },
-    message: "Start completed.",
+    message: readiness.message,
   }));
 }
 
@@ -173,17 +209,51 @@ export async function restartService(service: DiscoveredService): Promise<Lifecy
     },
   });
 
+  updateRuntimeState(serviceId, (state) => ({
+    ...state,
+    running: true,
+    runtime: {
+      pid: handle.pid,
+      startedAt: handle.startedAt,
+      exitCode: null,
+      command: handle.command,
+    },
+  }));
+
+  const readiness = await waitForServiceReadiness(service);
+  if (!readiness.ready) {
+    const stopped = await stopManagedProcess(serviceId);
+    return applyState(
+      serviceId,
+      "restart",
+      (state) => ({
+        nextState: {
+          ...state,
+          running: false,
+          runtime: {
+            ...state.runtime,
+            pid: null,
+            exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
+          },
+        },
+        message: readiness.message,
+      }),
+      false,
+    );
+  }
+
   return applyState(serviceId, "restart", (state) => ({
     nextState: {
       ...state,
       running: true,
       runtime: {
+        ...state.runtime,
         pid: handle.pid,
         startedAt: handle.startedAt,
         exitCode: null,
         command: handle.command,
       },
     },
-    message: "Restart completed.",
+    message: readiness.message.replace(/^Start/, "Restart"),
   }));
 }

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -174,3 +174,81 @@ test("runtime summary reflects running services after lifecycle actions", async 
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("start waits for configured readiness and returns healthy once ready", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  await writeExecutableFixtureService(servicesRoot, "ready-file-service", {
+    readyFileAfterMs: 120,
+    readyFileRelativePath: "./runtime/ready.txt",
+    healthcheck: {
+      type: "file",
+      file: "./runtime/ready.txt",
+      retries: 6,
+      interval: 50,
+      start_period: 25,
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/ready-file-service/install`);
+    await postJson(`${apiServer.url}/api/services/ready-file-service/config`);
+
+    const startedAt = Date.now();
+    const start = await postJson(`${apiServer.url}/api/services/ready-file-service/start`);
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.state.running, true);
+    assert.equal(start.body.health.type, "file");
+    assert.equal(start.body.health.healthy, true);
+    assert.match(start.body.message, /readiness succeeded/i);
+    assert.ok(elapsedMs >= 75);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("start returns a deterministic non-ready result when readiness times out", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "not-ready-service", {
+    healthcheck: {
+      type: "file",
+      file: "./runtime/ready.txt",
+      retries: 3,
+      interval: 25,
+      start_period: 10,
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/not-ready-service/install`);
+    await postJson(`${apiServer.url}/api/services/not-ready-service/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/not-ready-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, false);
+    assert.equal(start.body.action, "start");
+    assert.equal(start.body.state.running, false);
+    assert.equal(start.body.state.runtime.pid, null);
+    assert.equal(start.body.health.type, "file");
+    assert.equal(start.body.health.healthy, false);
+    assert.match(start.body.message, /did not become ready/i);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.lastAction, "start");
+    assert.equal(stored.runtime.running, false);
+    assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "start"]);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -158,6 +158,39 @@ test("loadServiceManifest accepts bounded variable healthchecks", async () => {
   }
 });
 
+test("loadServiceManifest accepts donor-aligned readiness retry fields", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "http-ready-service", {
+      id: "http-ready-service",
+      name: "HTTP Ready Service",
+      description: "Manifest proving readiness retry parsing.",
+      healthcheck: {
+        type: "http",
+        url: "http://127.0.0.1:18080/health",
+        expected_status: 200,
+        retries: 5,
+        interval: 250,
+        start_period: 100,
+      },
+    });
+
+    const manifest = await loadServiceManifest(path.join(servicesRoot, "http-ready-service", "service.json"));
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "http",
+      url: "http://127.0.0.1:18080/health",
+      expected_status: 200,
+      retries: 5,
+      interval: 250,
+      start_period: 100,
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -35,6 +35,8 @@ export async function writeExecutableFixtureService(
     autoExitMs = null,
     exitCode = 0,
     healthcheck = { type: "process" },
+    readyFileAfterMs = null,
+    readyFileRelativePath = "./runtime/ready.txt",
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -43,17 +45,34 @@ export async function writeExecutableFixtureService(
 
   const scriptPath = path.join(runtimeRoot, "fixture-service.mjs");
   const scriptSource = `
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+
 const heartbeat = setInterval(() => {}, 1000);
 const exitCode = Number(process.env.FIXTURE_EXIT_CODE ?? "${exitCode}");
 const autoExitMs = Number(process.env.FIXTURE_AUTO_EXIT_MS ?? "${autoExitMs ?? ""}");
+const readyFileRelativePath = process.env.FIXTURE_READY_FILE ?? "";
+const readyFileDelayMs = Number(process.env.FIXTURE_READY_FILE_DELAY_MS ?? "");
 
 function shutdown() {
   clearInterval(heartbeat);
   process.exit(0);
 }
 
+async function writeReadyFile() {
+  const targetPath = path.resolve(process.cwd(), readyFileRelativePath);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, "ready");
+}
+
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
+
+if (readyFileRelativePath && Number.isFinite(readyFileDelayMs) && readyFileDelayMs >= 0) {
+  setTimeout(() => {
+    void writeReadyFile();
+  }, readyFileDelayMs);
+}
 
 if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
   setTimeout(() => {
@@ -73,6 +92,12 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     env: {
       FIXTURE_EXIT_CODE: String(exitCode),
       ...(autoExitMs !== null ? { FIXTURE_AUTO_EXIT_MS: String(autoExitMs) } : {}),
+      ...(readyFileAfterMs !== null
+        ? {
+            FIXTURE_READY_FILE: readyFileRelativePath,
+            FIXTURE_READY_FILE_DELAY_MS: String(readyFileAfterMs),
+          }
+        : {}),
     },
     healthcheck,
   });


### PR DESCRIPTION
## Summary
- add donor-aligned readiness retry parsing for healthchecks
- wait on configured readiness during start/restart flows
- add readiness success and timeout tests

## Verification
- npm test