### PR TITLE
ISS-023: add bounded globalenv propagation

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -29,7 +29,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
 | `ISS-020` | `done` | Add bounded `file` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded file-based readiness checks with automated tests and released Echo Service file proof. |
 | `ISS-021` | `done` | Add bounded `variable` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded variable-presence checks with automated tests and released Echo Service variable proof. |
-| `ISS-022` | `in_progress` | Add bounded readiness wait-loop behavior for startup health | `SPEC-002`, `AC-4D` | In progress: make startup optionally wait for donor-aligned health retries so services are only reported ready when the configured health signal succeeds within bounds. |
+| `ISS-022` | `done` | Add bounded readiness wait-loop behavior for startup health | `SPEC-002`, `AC-4D` | Landed bounded readiness waiting with donor-aligned retry fields, deterministic ready/not-ready outcomes, and automated start/restart verification. |
+| `ISS-023` | `in_progress` | Add bounded manifest-driven globalenv propagation | `SPEC-002`, `AC-4E` | In progress: merge manifest `globalenv` deterministically, expose it through the API, and inject it into managed service execution. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -55,7 +56,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
 | `TASK-020` | `done` | `ISS-020` | Implement bounded `file` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = file`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service file proof |
 | `TASK-021` | `done` | `ISS-021` | Implement bounded `variable` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = variable`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service variable proof |
-| `TASK-022` | `in_progress` | `ISS-022` | Implement bounded readiness wait loops for start/restart flows | `SPEC-002`, `AC-4D` | Start/restart can wait on donor-aligned health retries, succeed when readiness becomes healthy, and fail deterministically when the readiness window expires |
+| `TASK-022` | `done` | `ISS-022` | Implement bounded readiness wait loops for start/restart flows | `SPEC-002`, `AC-4D` | Start/restart can wait on donor-aligned health retries, succeed when readiness becomes healthy, and fail deterministically when the readiness window expires |
+| `TASK-023` | `in_progress` | `ISS-023` | Implement bounded manifest-driven globalenv merging and API/runtime propagation | `SPEC-002`, `AC-4E` | Runtime accepts manifest `globalenv`, merges it deterministically, exposes the merged map through the API, and injects shared env into managed service execution |
 
 ## Next Recommended Item
-The next best item is `TASK-022`: finish bounded readiness and wait-loop behavior so the runtime can turn bounded health checks into bounded startup readiness proof.
+The next best item is `TASK-023`: add bounded manifest-driven `globalenv` propagation so the runtime can move from isolated env handling toward donor-style shared runtime env behavior.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -31,6 +31,7 @@ Explicitly out of scope for this spec:
 - `AC-4B`: The runtime includes one bounded real execution/supervision path that can start, observe, stop, and persist runtime state for a directly executable service definition.
 - `AC-4C`: The runtime broadens bounded health support beyond `process` and `http` by directly accepting and evaluating at least one additional donor-aligned manifest health type with runnable verification evidence.
 - `AC-4D`: The runtime can optionally wait for bounded startup readiness using donor-aligned health retry fields so start/restart flows can distinguish "process launched" from "service became ready".
+- `AC-4E`: The runtime supports a bounded manifest-driven `globalenv` propagation model so services can emit shared env values, the runtime can merge them deterministically, and operator/API surfaces can expose the merged shared env.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -42,6 +43,7 @@ Required evidence for this spec:
 - direct proof that the bounded execution supervisor can start and stop a real process while persisting runtime state updates
 - direct proof that at least one additional donor-aligned manifest health type can be parsed and evaluated successfully by the runtime
 - direct proof that configured readiness wait loops can succeed and time out deterministically during bounded start behavior
+- direct proof that bounded manifest-driven `globalenv` values can be merged and injected into dependent service execution/runtime API output
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -65,7 +65,7 @@ Current honest label:
    - tests prove healthy and unhealthy cases
 
 3. readiness and wait-loop behavior
-   status: in progress
+   status: done
    proof:
    - start flow can wait for configured health readiness within bounded timeout/retry rules
    - tests prove success, timeout, and failure behavior
@@ -73,7 +73,7 @@ Current honest label:
 ### Wave 2: Shared environment and runtime negotiation
 
 4. `globalenv` propagation model
-   status: queued
+   status: in progress
    proof:
    - runtime can read emitted shared env data
    - runtime can surface merged shared env to dependent services or operator API
@@ -199,6 +199,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**readiness and wait-loop behavior**
+**`globalenv` propagation model**
 
-That is the next smallest clean donor-parity step after bounded `variable`, and it turns the bounded health model into bounded startup-readiness proof.
+That is the next clean donor-parity step after readiness, and it starts moving Service Lasso from isolated service env handling toward bounded shared runtime env propagation.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -42,6 +42,10 @@ export interface ServiceSummary {
   };
 }
 
+export interface GlobalEnvResponse {
+  globalenv: Record<string, string>;
+}
+
 export interface ServicesResponse {
   services: ServiceSummary[];
 }

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -15,6 +15,7 @@ export interface ServiceManifest {
   depend_on?: string[];
   healthcheck?: ServiceHealthcheck;
   env?: Record<string, string>;
+  globalenv?: Record<string, string>;
   urls?: ServiceEndpoint[];
   execservice?: string;
   executable?: string;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -114,6 +114,17 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"env\" to be a string map.`);
   }
 
+  const rawGlobalEnv = record.globalenv;
+  if (
+    rawGlobalEnv !== undefined &&
+    (!rawGlobalEnv ||
+      typeof rawGlobalEnv !== "object" ||
+      Array.isArray(rawGlobalEnv) ||
+      Object.values(rawGlobalEnv).some((value) => typeof value !== "string"))
+  ) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected \"globalenv\" to be a string map.`);
+  }
+
   const rawExecservice = record.execservice;
   if (rawExecservice !== undefined && (typeof rawExecservice !== "string" || rawExecservice.trim().length === 0)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"execservice\" to be a non-empty string.`);
@@ -157,6 +168,9 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     depend_on: dependOn?.map((dependency) => dependency.trim()),
     healthcheck,
     env: rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined,
+    globalenv: rawGlobalEnv
+      ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
+      : undefined,
     urls: rawUrls?.map((entry) => ({
       label: (entry as Record<string, string>).label.trim(),
       url: (entry as Record<string, string>).url.trim(),

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
+import { buildServiceVariables } from "../operator/variables.js";
 
 export interface ManagedProcessHandle {
   pid: number;
@@ -21,6 +22,7 @@ interface ManagedProcessRecord {
 
 interface StartProcessOptions {
   service: DiscoveredService;
+  sharedGlobalEnv?: Record<string, string>;
   onExit?: (payload: {
     service: DiscoveredService;
     exitCode: number | null;
@@ -48,13 +50,17 @@ function buildCommandString(executable: string, args: string[]): string {
   return [executable, ...args].join(" ");
 }
 
-function buildProcessEnvironment(service: DiscoveredService): NodeJS.ProcessEnv {
+function buildProcessEnvironment(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+  const serviceVariables = Object.fromEntries(
+    buildServiceVariables(service, sharedGlobalEnv).variables.map((entry) => [entry.key, entry.value]),
+  );
+
   return {
     ...process.env,
-    ...service.manifest.env,
-    SERVICE_ID: service.manifest.id,
-    SERVICE_ROOT: service.serviceRoot,
-    SERVICE_STATE_ROOT: path.join(service.serviceRoot, ".state"),
+    ...serviceVariables,
   };
 }
 
@@ -63,7 +69,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, onExit } = options;
+  const { service, sharedGlobalEnv, onExit } = options;
   const serviceId = service.manifest.id;
 
   if (managedProcesses.has(serviceId)) {
@@ -77,7 +83,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const child = spawn(executable, args, {
     cwd: service.serviceRoot,
-    env: buildProcessEnvironment(service),
+    env: buildProcessEnvironment(service, sharedGlobalEnv),
     stdio: "ignore",
     windowsHide: true,
   });

--- a/src/runtime/health/checkVariable.ts
+++ b/src/runtime/health/checkVariable.ts
@@ -5,6 +5,7 @@ import type { ServiceHealthResult, VariableHealthcheck } from "./types.js";
 export async function checkVariableHealth(
   healthcheck: VariableHealthcheck,
   service?: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
 ): Promise<ServiceHealthResult> {
   if (!service) {
     return {
@@ -14,7 +15,7 @@ export async function checkVariableHealth(
     };
   }
 
-  const entry = resolveServiceVariable(service, healthcheck.variable);
+  const entry = resolveServiceVariable(service, healthcheck.variable, sharedGlobalEnv);
   if (!entry || entry.value.trim().length === 0) {
     return {
       type: "variable",

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -13,6 +13,7 @@ export async function evaluateServiceHealth(
   lifecycle: ServiceLifecycleState,
   serviceRoot?: string,
   service?: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
 ): Promise<ServiceHealthResult> {
   const healthcheck = manifest.healthcheck;
 
@@ -33,7 +34,7 @@ export async function evaluateServiceHealth(
   }
 
   if (healthcheck.type === "variable") {
-    return checkVariableHealth(healthcheck, service);
+    return checkVariableHealth(healthcheck, service, sharedGlobalEnv);
   }
 
   return {

--- a/src/runtime/health/waitForReadiness.ts
+++ b/src/runtime/health/waitForReadiness.ts
@@ -42,13 +42,17 @@ function resolveReadinessOptions(healthcheck?: ServiceHealthcheck): {
   };
 }
 
-export async function waitForServiceReadiness(service: DiscoveredService): Promise<ReadinessWaitResult> {
+export async function waitForServiceReadiness(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): Promise<ReadinessWaitResult> {
   const { enabled, attempts, intervalMs, startPeriodMs } = resolveReadinessOptions(service.manifest.healthcheck);
   let lastHealth = await evaluateServiceHealth(
     service.manifest,
     getLifecycleState(service.manifest.id),
     service.serviceRoot,
     service,
+    sharedGlobalEnv,
   );
 
   if (!enabled) {
@@ -71,6 +75,7 @@ export async function waitForServiceReadiness(service: DiscoveredService): Promi
       getLifecycleState(service.manifest.id),
       service.serviceRoot,
       service,
+      sharedGlobalEnv,
     );
 
     if (lastHealth.healthy) {

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -2,6 +2,8 @@ import type { DiscoveredService } from "../../contracts/service.js";
 import { LifecycleStateError } from "../../server/errors.js";
 import { startManagedProcess, stopManagedProcess } from "../execution/supervisor.js";
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { collectRuntimeGlobalEnv } from "../operator/variables.js";
 import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
@@ -84,7 +86,10 @@ export function configService(serviceId: string): LifecycleActionResult {
   }));
 }
 
-export async function startService(service: DiscoveredService): Promise<LifecycleActionResult> {
+export async function startService(
+  service: DiscoveredService,
+  registry?: ServiceRegistry,
+): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
@@ -100,8 +105,10 @@ export async function startService(service: DiscoveredService): Promise<Lifecycl
     throw new LifecycleStateError(`Cannot start service "${serviceId}" because no executable is configured.`);
   }
 
+  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
   const handle = await startManagedProcess({
     service,
+    sharedGlobalEnv,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -121,7 +128,7 @@ export async function startService(service: DiscoveredService): Promise<Lifecycl
     },
   }));
 
-  const readiness = await waitForServiceReadiness(service);
+  const readiness = await waitForServiceReadiness(service, sharedGlobalEnv);
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
     return applyState(
@@ -182,7 +189,10 @@ export async function stopService(service: DiscoveredService): Promise<Lifecycle
   }));
 }
 
-export async function restartService(service: DiscoveredService): Promise<LifecycleActionResult> {
+export async function restartService(
+  service: DiscoveredService,
+  registry?: ServiceRegistry,
+): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
@@ -199,8 +209,10 @@ export async function restartService(service: DiscoveredService): Promise<Lifecy
     await stopManagedProcess(serviceId);
   }
 
+  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
   const handle = await startManagedProcess({
     service,
+    sharedGlobalEnv,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -220,7 +232,7 @@ export async function restartService(service: DiscoveredService): Promise<Lifecy
     },
   }));
 
-  const readiness = await waitForServiceReadiness(service);
+  const readiness = await waitForServiceReadiness(service, sharedGlobalEnv);
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
     return applyState(

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -4,7 +4,7 @@ import type { DiscoveredService } from "../../contracts/service.js";
 export interface ServiceVariableEntry {
   key: string;
   value: string;
-  scope: "manifest" | "derived";
+  scope: "manifest" | "derived" | "global";
 }
 
 export interface ServiceVariablesPayload {
@@ -12,12 +12,29 @@ export interface ServiceVariablesPayload {
   variables: ServiceVariableEntry[];
 }
 
-export function buildServiceVariables(service: DiscoveredService): ServiceVariablesPayload {
+function replaceVariableSelectors(value: string, variables: ServiceVariableEntry[]): string {
+  return value.replace(/\$\{([^}]+)\}/g, (match, key) => {
+    const normalizedKey = normalizeVariableSelector(key);
+    const entry = variables.find((candidate) => candidate.key === normalizedKey);
+    return entry ? entry.value : match;
+  });
+}
+
+export function buildServiceVariables(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): ServiceVariablesPayload {
   const statePaths = getServiceStatePaths(service.serviceRoot);
   const manifestVariables = Object.entries(service.manifest.env ?? {}).map(([key, value]) => ({
     key,
     value,
     scope: "manifest" as const,
+  }));
+
+  const globalVariables = Object.entries(sharedGlobalEnv).map(([key, value]) => ({
+    key,
+    value,
+    scope: "global" as const,
   }));
 
   const derivedVariables: ServiceVariableEntry[] = [
@@ -40,7 +57,7 @@ export function buildServiceVariables(service: DiscoveredService): ServiceVariab
 
   return {
     serviceId: service.manifest.id,
-    variables: [...manifestVariables, ...derivedVariables],
+    variables: [...manifestVariables, ...globalVariables, ...derivedVariables],
   };
 }
 
@@ -50,7 +67,33 @@ function normalizeVariableSelector(selector: string): string {
   return (match?.[1] ?? trimmed).trim();
 }
 
-export function resolveServiceVariable(service: DiscoveredService, selector: string): ServiceVariableEntry | undefined {
+export function collectServiceGlobalEnv(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): Record<string, string> {
+  const variables = buildServiceVariables(service, sharedGlobalEnv).variables;
+  const configuredGlobalEnv = service.manifest.globalenv ?? {};
+
+  return Object.fromEntries(
+    Object.entries(configuredGlobalEnv).map(([key, value]) => [key, replaceVariableSelectors(value, variables)]),
+  );
+}
+
+export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<string, string> {
+  const sharedGlobalEnv: Record<string, string> = {};
+
+  for (const service of services) {
+    Object.assign(sharedGlobalEnv, collectServiceGlobalEnv(service, sharedGlobalEnv));
+  }
+
+  return sharedGlobalEnv;
+}
+
+export function resolveServiceVariable(
+  service: DiscoveredService,
+  selector: string,
+  sharedGlobalEnv: Record<string, string> = {},
+): ServiceVariableEntry | undefined {
   const key = normalizeVariableSelector(selector);
-  return buildServiceVariables(service).variables.find((entry) => entry.key === key);
+  return buildServiceVariables(service, sharedGlobalEnv).variables.find((entry) => entry.key === key);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
 import { createServiceVariablesResponse } from "./routes/variables.js";
 import { createServiceNetworkResponse } from "./routes/network.js";
+import { createGlobalEnvResponse } from "./routes/globalenv.js";
 import { discoverServices } from "../runtime/discovery/discoverServices.js";
 import { DependencyGraph, createServiceRegistry } from "../runtime/manager/DependencyGraph.js";
 import {
@@ -22,7 +23,7 @@ import { evaluateServiceHealth } from "../runtime/health/evaluateHealth.js";
 import { getServiceStatePaths } from "../runtime/state/paths.js";
 import { writeServiceState } from "../runtime/state/writeState.js";
 import { buildServiceLogs } from "../runtime/operator/logs.js";
-import { buildServiceVariables } from "../runtime/operator/variables.js";
+import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
@@ -75,12 +76,13 @@ async function createServiceSummary(
   service: Awaited<ReturnType<typeof loadRuntimeModel>>["discovered"][number],
   graph: DependencyGraph,
   registry: Awaited<ReturnType<typeof loadRuntimeModel>>["registry"],
+  sharedGlobalEnv: Record<string, string>,
 ): Promise<ServiceSummary> {
   const dependencySummary = graph.getServiceDependencies(service.manifest.id);
   const lifecycle = getLifecycleState(service.manifest.id);
-  const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service);
+  const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service, sharedGlobalEnv);
   const logs = buildServiceLogs(service, lifecycle);
-  const variables = buildServiceVariables(service);
+  const variables = buildServiceVariables(service, sharedGlobalEnv);
   const network = buildServiceNetwork(service);
   const provider = resolveProviderExecution(service, registry);
 
@@ -120,6 +122,7 @@ async function executeLifecycleAction(
   registry: Awaited<ReturnType<typeof loadRuntimeModel>>["registry"],
 ): Promise<LifecycleActionResponse> {
   const serviceId = service.manifest.id;
+  const sharedGlobalEnv = collectRuntimeGlobalEnv(registry.list());
   const result = await (async () => {
     switch (action) {
       case "install":
@@ -127,18 +130,18 @@ async function executeLifecycleAction(
       case "config":
         return configService(serviceId);
       case "start":
-        return await startService(service);
+        return await startService(service, registry);
       case "stop":
         return await stopService(service);
       case "restart":
-        return await restartService(service);
+        return await restartService(service, registry);
       default:
         throw new ApiError("invalid_action", 400, `Unknown lifecycle action: ${action}`);
     }
   })();
 
   const persisted = await writeServiceState(service, result.state);
-  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot, service);
+  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot, service, sharedGlobalEnv);
   const provider = resolveProviderExecution(service, registry);
 
   return {
@@ -167,8 +170,11 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/services") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
     const services = await Promise.all(
-      runtimeModel.discovered.map((service) => createServiceSummary(service, runtimeModel.graph, runtimeModel.registry)),
+      runtimeModel.discovered.map((service) =>
+        createServiceSummary(service, runtimeModel.graph, runtimeModel.registry, sharedGlobalEnv),
+      ),
     );
     writeJson(response, 200, createServicesResponse(services));
     return;
@@ -177,6 +183,7 @@ async function routeRequest(
   if (url.pathname.startsWith("/api/services/")) {
     const pathParts = url.pathname.split("/").filter(Boolean);
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
     const serviceId = decodeURIComponent(pathParts[2] ?? "");
     const service = runtimeModel.registry.getById(serviceId);
 
@@ -187,7 +194,7 @@ async function routeRequest(
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "health") {
       const lifecycle = getLifecycleState(serviceId);
-      const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service);
+      const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service, sharedGlobalEnv);
       writeJson(response, 200, createServiceHealthResponse(serviceId, health));
       return;
     }
@@ -198,7 +205,7 @@ async function routeRequest(
     }
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "variables") {
-      writeJson(response, 200, createServiceVariablesResponse(buildServiceVariables(service)));
+      writeJson(response, 200, createServiceVariablesResponse(buildServiceVariables(service, sharedGlobalEnv)));
       return;
     }
 
@@ -211,7 +218,9 @@ async function routeRequest(
       writeJson(
         response,
         200,
-        createServiceDetailResponse(await createServiceSummary(service, runtimeModel.graph, runtimeModel.registry)),
+        createServiceDetailResponse(
+          await createServiceSummary(service, runtimeModel.graph, runtimeModel.registry, sharedGlobalEnv),
+        ),
       );
       return;
     }
@@ -225,8 +234,11 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/runtime") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
     const serviceSummaries = await Promise.all(
-      runtimeModel.discovered.map((service) => createServiceSummary(service, runtimeModel.graph, runtimeModel.registry)),
+      runtimeModel.discovered.map((service) =>
+        createServiceSummary(service, runtimeModel.graph, runtimeModel.registry, sharedGlobalEnv),
+      ),
     );
     const runningServices = serviceSummaries.filter((service) => service.lifecycle?.running).length;
     const healthyServices = serviceSummaries.filter((service) => service.health?.healthy).length;
@@ -262,8 +274,15 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/variables") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    const payload = runtimeModel.discovered.map((service) => buildServiceVariables(service));
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
+    const payload = runtimeModel.discovered.map((service) => buildServiceVariables(service, sharedGlobalEnv));
     writeJson(response, 200, { services: payload });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/globalenv") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, createGlobalEnvResponse(collectRuntimeGlobalEnv(runtimeModel.registry.list())));
     return;
   }
 

--- a/src/server/routes/globalenv.ts
+++ b/src/server/routes/globalenv.ts
@@ -1,0 +1,5 @@
+import type { GlobalEnvResponse } from "../../contracts/api.js";
+
+export function createGlobalEnvResponse(globalenv: Record<string, string>): GlobalEnvResponse {
+  return { globalenv };
+}

--- a/src/server/routes/variables.ts
+++ b/src/server/routes/variables.ts
@@ -1,7 +1,7 @@
 export interface ServiceVariablesResponse {
   variables: {
     serviceId: string;
-    variables: { key: string; value: string; scope: "manifest" | "derived" }[];
+    variables: { key: string; value: string; scope: "manifest" | "derived" | "global" }[];
   };
 }
 

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -191,6 +191,37 @@ test("loadServiceManifest accepts donor-aligned readiness retry fields", async (
   }
 });
 
+test("loadServiceManifest accepts bounded globalenv emission maps", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "emitter-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "emitter-service",
+        name: "Emitter Service",
+        description: "Service with bounded globalenv emission.",
+        env: {
+          ECHO_MESSAGE: "hello shared env",
+        },
+        globalenv: {
+          SHARED_MESSAGE: "${ECHO_MESSAGE}",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.globalenv, {
+      SHARED_MESSAGE: "${ECHO_MESSAGE}",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -1,9 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
-import { clearPersistedFixtureState } from "./test-helpers.js";
+import { clearPersistedFixtureState, makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 const servicesRoot = path.resolve("services");
 
@@ -13,6 +14,19 @@ async function postJson(url) {
     status: response.status,
     body: await response.json(),
   };
+}
+
+async function waitFor(readinessCheck, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await readinessCheck();
+    if (result) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
 }
 
 test("service detail includes richer operator metadata", async () => {
@@ -75,6 +89,98 @@ test("GET /api/services/:id/variables returns manifest and derived variables", a
     await apiServer.stop();
     resetLifecycleState();
     await clearPersistedFixtureState(servicesRoot);
+  }
+});
+
+test("GET /api/globalenv returns the merged bounded shared env map", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-globalenv-");
+  const apiServer = await (async () => {
+    await writeManifest(servicesRoot, "emitter-service", {
+      id: "emitter-service",
+      name: "Emitter Service",
+      description: "Emits shared env.",
+      env: {
+        ECHO_MESSAGE: "hello shared env",
+      },
+      globalenv: {
+        SHARED_MESSAGE: "${ECHO_MESSAGE}",
+      },
+    });
+
+    return startApiServer({ port: 0, servicesRoot });
+  })();
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/globalenv`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.globalenv, {
+      SHARED_MESSAGE: "hello shared env",
+    });
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service variables include merged globalenv entries and managed processes receive them", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-globalenv-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "consumer-service", {
+    captureEnvKeys: ["SHARED_MESSAGE"],
+  });
+
+  await writeManifest(servicesRoot, "emitter-service", {
+    id: "emitter-service",
+    name: "Emitter Service",
+    description: "Emits shared env.",
+    env: {
+      ECHO_MESSAGE: "hello shared env",
+    },
+    globalenv: {
+      SHARED_MESSAGE: "${ECHO_MESSAGE}",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const variablesResponse = await fetch(`${apiServer.url}/api/services/consumer-service/variables`);
+    const variablesBody = await variablesResponse.json();
+
+    assert.equal(variablesResponse.status, 200);
+    assert.ok(
+      variablesBody.variables.variables.some(
+        (entry) => entry.key === "SHARED_MESSAGE" && entry.value === "hello shared env" && entry.scope === "global",
+      ),
+    );
+
+    await postJson(`${apiServer.url}/api/services/consumer-service/install`);
+    await postJson(`${apiServer.url}/api/services/consumer-service/config`);
+    await postJson(`${apiServer.url}/api/services/consumer-service/start`);
+
+    const envSnapshot = JSON.parse(
+      await waitFor(async () => {
+        try {
+          return await readFile(path.join(serviceRoot, "runtime", "env.json"), "utf8");
+        } catch (error) {
+          if ((error && typeof error === "object" && "code" in error && error.code === "ENOENT")) {
+            return null;
+          }
+          throw error;
+        }
+      }),
+    );
+    assert.equal(envSnapshot.SHARED_MESSAGE, "hello shared env");
+
+    await postJson(`${apiServer.url}/api/services/consumer-service/stop`);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -37,6 +37,10 @@ export async function writeExecutableFixtureService(
     healthcheck = { type: "process" },
     readyFileAfterMs = null,
     readyFileRelativePath = "./runtime/ready.txt",
+    captureEnvKeys = [],
+    captureEnvFileRelativePath = "./runtime/env.json",
+    env = {},
+    globalenv = {},
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -53,6 +57,10 @@ const exitCode = Number(process.env.FIXTURE_EXIT_CODE ?? "${exitCode}");
 const autoExitMs = Number(process.env.FIXTURE_AUTO_EXIT_MS ?? "${autoExitMs ?? ""}");
 const readyFileRelativePath = process.env.FIXTURE_READY_FILE ?? "";
 const readyFileDelayMs = Number(process.env.FIXTURE_READY_FILE_DELAY_MS ?? "");
+const captureEnvPath = process.env.FIXTURE_CAPTURE_ENV_FILE ?? "";
+const captureEnvKeys = process.env.FIXTURE_CAPTURE_ENV_KEYS
+  ? JSON.parse(process.env.FIXTURE_CAPTURE_ENV_KEYS)
+  : [];
 
 function shutdown() {
   clearInterval(heartbeat);
@@ -65,8 +73,19 @@ async function writeReadyFile() {
   await writeFile(targetPath, "ready");
 }
 
+async function writeEnvSnapshot() {
+  const targetPath = path.resolve(process.cwd(), captureEnvPath);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  const payload = Object.fromEntries(captureEnvKeys.map((key) => [key, process.env[key] ?? null]));
+  await writeFile(targetPath, JSON.stringify(payload, null, 2));
+}
+
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
+
+if (captureEnvPath && Array.isArray(captureEnvKeys) && captureEnvKeys.length > 0) {
+  void writeEnvSnapshot();
+}
 
 if (readyFileRelativePath && Number.isFinite(readyFileDelayMs) && readyFileDelayMs >= 0) {
   setTimeout(() => {
@@ -91,6 +110,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     args: [path.relative(serviceRoot, scriptPath)],
     env: {
       FIXTURE_EXIT_CODE: String(exitCode),
+      ...env,
       ...(autoExitMs !== null ? { FIXTURE_AUTO_EXIT_MS: String(autoExitMs) } : {}),
       ...(readyFileAfterMs !== null
         ? {
@@ -98,7 +118,14 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
             FIXTURE_READY_FILE_DELAY_MS: String(readyFileAfterMs),
           }
         : {}),
+      ...(captureEnvKeys.length > 0
+        ? {
+            FIXTURE_CAPTURE_ENV_FILE: captureEnvFileRelativePath,
+            FIXTURE_CAPTURE_ENV_KEYS: JSON.stringify(captureEnvKeys),
+          }
+        : {}),
     },
+    globalenv,
     healthcheck,
   });
 


### PR DESCRIPTION
## Summary
- add bounded manifest-driven globalenv parsing and merged runtime collection
- expose merged globalenv through the API and service variable surfaces
- inject shared globalenv into managed process execution

## Verification
- npm test