### PR TITLE
ISS-024: add bounded runtime port negotiation

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -30,7 +30,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-020` | `done` | Add bounded `file` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded file-based readiness checks with automated tests and released Echo Service file proof. |
 | `ISS-021` | `done` | Add bounded `variable` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded variable-presence checks with automated tests and released Echo Service variable proof. |
 | `ISS-022` | `done` | Add bounded readiness wait-loop behavior for startup health | `SPEC-002`, `AC-4D` | Landed bounded readiness waiting with donor-aligned retry fields, deterministic ready/not-ready outcomes, and automated start/restart verification. |
-| `ISS-023` | `in_progress` | Add bounded manifest-driven globalenv propagation | `SPEC-002`, `AC-4E` | In progress: merge manifest `globalenv` deterministically, expose it through the API, and inject it into managed service execution. |
+| `ISS-023` | `done` | Add bounded manifest-driven globalenv propagation | `SPEC-002`, `AC-4E` | Landed bounded manifest-driven shared env merging, API exposure, and managed-process env injection. |
+| `ISS-024` | `in_progress` | Add bounded runtime-owned port negotiation | `SPEC-002`, `AC-4F` | In progress: negotiate declared ports during config/start, resolve collisions deterministically, and expose assigned ports through network/operator surfaces. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -57,7 +58,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-020` | `done` | `ISS-020` | Implement bounded `file` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = file`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service file proof |
 | `TASK-021` | `done` | `ISS-021` | Implement bounded `variable` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = variable`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service variable proof |
 | `TASK-022` | `done` | `ISS-022` | Implement bounded readiness wait loops for start/restart flows | `SPEC-002`, `AC-4D` | Start/restart can wait on donor-aligned health retries, succeed when readiness becomes healthy, and fail deterministically when the readiness window expires |
-| `TASK-023` | `in_progress` | `ISS-023` | Implement bounded manifest-driven globalenv merging and API/runtime propagation | `SPEC-002`, `AC-4E` | Runtime accepts manifest `globalenv`, merges it deterministically, exposes the merged map through the API, and injects shared env into managed service execution |
+| `TASK-023` | `done` | `ISS-023` | Implement bounded manifest-driven globalenv merging and API/runtime propagation | `SPEC-002`, `AC-4E` | Runtime accepts manifest `globalenv`, merges it deterministically, exposes the merged map through the API, and injects shared env into managed service execution |
+| `TASK-024` | `in_progress` | `ISS-024` | Implement bounded runtime-owned port negotiation and network resolution | `SPEC-002`, `AC-4F` | Runtime accepts manifest port declarations, assigns ports during config/start with deterministic collision handling, and exposes assigned ports plus resolved URLs through the API |
 
 ## Next Recommended Item
-The next best item is `TASK-023`: add bounded manifest-driven `globalenv` propagation so the runtime can move from isolated env handling toward donor-style shared runtime env behavior.
+The next best item is `TASK-024`: add bounded runtime-owned port negotiation so Service Lasso can move from manifest-only URL surfaces toward managed assigned-port behavior.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -32,6 +32,7 @@ Explicitly out of scope for this spec:
 - `AC-4C`: The runtime broadens bounded health support beyond `process` and `http` by directly accepting and evaluating at least one additional donor-aligned manifest health type with runnable verification evidence.
 - `AC-4D`: The runtime can optionally wait for bounded startup readiness using donor-aligned health retry fields so start/restart flows can distinguish "process launched" from "service became ready".
 - `AC-4E`: The runtime supports a bounded manifest-driven `globalenv` propagation model so services can emit shared env values, the runtime can merge them deterministically, and operator/API surfaces can expose the merged shared env.
+- `AC-4F`: The runtime owns a bounded port-negotiation slice so manifests can declare desired ports, runtime config/start can resolve collisions deterministically, and operator/API surfaces can expose the assigned ports and resolved URLs.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -44,6 +45,7 @@ Required evidence for this spec:
 - direct proof that at least one additional donor-aligned manifest health type can be parsed and evaluated successfully by the runtime
 - direct proof that configured readiness wait loops can succeed and time out deterministically during bounded start behavior
 - direct proof that bounded manifest-driven `globalenv` values can be merged and injected into dependent service execution/runtime API output
+- direct proof that bounded runtime port negotiation can assign ports, resolve collisions deterministically, and surface resolved network data through the API
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -73,14 +73,14 @@ Current honest label:
 ### Wave 2: Shared environment and runtime negotiation
 
 4. `globalenv` propagation model
-   status: in progress
+   status: done
    proof:
    - runtime can read emitted shared env data
    - runtime can surface merged shared env to dependent services or operator API
    - Echo Service and at least one dependent fixture prove the flow
 
 5. runtime-owned port negotiation
-   status: queued
+   status: in progress
    proof:
    - runtime can reserve or resolve service ports
    - collisions are detected deterministically
@@ -199,6 +199,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**`globalenv` propagation model**
+**runtime-owned port negotiation**
 
-That is the next clean donor-parity step after readiness, and it starts moving Service Lasso from isolated service env handling toward bounded shared runtime env propagation.
+That is the next clean donor-parity step after bounded shared env, and it starts moving Service Lasso from manifest-only endpoint descriptions toward runtime-assigned network behavior.

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -8,20 +8,23 @@
   "args": ["runtime/fixture-harness.mjs"],
   "env": {
     "ECHO_MESSAGE": "hello from echo-service harness",
-    "ECHO_PORT": "4010",
+    "ECHO_PORT": "${SERVICE_PORT}",
     "ECHO_LOG_PATH": "./runtime/echo.log",
     "ECHO_STATE_PATH": "./runtime/state.json",
     "ECHO_DB_PATH": "./runtime/echo.sqlite"
   },
+  "ports": {
+    "service": 4010
+  },
   "urls": [
     {
       "label": "ui",
-      "url": "http://127.0.0.1:4010/",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/",
       "kind": "local"
     },
     {
       "label": "service",
-      "url": "http://127.0.0.1:4010/health",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/health",
       "kind": "local"
     }
   ],

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -8,10 +8,13 @@
   "execservice": "@node",
   "executable": "node",
   "args": ["runtime/server.js"],
+  "ports": {
+    "service": 4020
+  },
   "urls": [
     {
       "label": "service",
-      "url": "http://127.0.0.1:4020",
+      "url": "http://127.0.0.1:${SERVICE_PORT}",
       "kind": "local"
     }
   ],

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -6,6 +6,10 @@ export interface ServiceEndpoint {
   kind?: string;
 }
 
+export interface ServicePortDeclaration {
+  [name: string]: number;
+}
+
 export interface ServiceManifest {
   id: string;
   name: string;
@@ -16,6 +20,7 @@ export interface ServiceManifest {
   healthcheck?: ServiceHealthcheck;
   env?: Record<string, string>;
   globalenv?: Record<string, string>;
+  ports?: ServicePortDeclaration;
   urls?: ServiceEndpoint[];
   execservice?: string;
   executable?: string;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -125,6 +125,19 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"globalenv\" to be a string map.`);
   }
 
+  const rawPorts = record.ports;
+  if (
+    rawPorts !== undefined &&
+    (!rawPorts ||
+      typeof rawPorts !== "object" ||
+      Array.isArray(rawPorts) ||
+      Object.values(rawPorts).some(
+        (value) => typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 65535,
+      ))
+  ) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected \"ports\" to be a map of integer port values between 0 and 65535.`);
+  }
+
   const rawExecservice = record.execservice;
   if (rawExecservice !== undefined && (typeof rawExecservice !== "string" || rawExecservice.trim().length === 0)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"execservice\" to be a non-empty string.`);
@@ -170,6 +183,9 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     env: rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined,
     globalenv: rawGlobalEnv
       ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
+      : undefined,
+    ports: rawPorts
+      ? Object.fromEntries(Object.entries(rawPorts as Record<string, number>).map(([key, value]) => [key.trim(), value]))
       : undefined,
     urls: rawUrls?.map((entry) => ({
       label: (entry as Record<string, string>).label.trim(),

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -23,6 +23,7 @@ interface ManagedProcessRecord {
 interface StartProcessOptions {
   service: DiscoveredService;
   sharedGlobalEnv?: Record<string, string>;
+  resolvedPorts?: Record<string, number>;
   onExit?: (payload: {
     service: DiscoveredService;
     exitCode: number | null;
@@ -53,9 +54,10 @@ function buildCommandString(executable: string, args: string[]): string {
 function buildProcessEnvironment(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = {},
 ): NodeJS.ProcessEnv {
   const serviceVariables = Object.fromEntries(
-    buildServiceVariables(service, sharedGlobalEnv).variables.map((entry) => [entry.key, entry.value]),
+    buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
   );
 
   return {
@@ -69,7 +71,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, sharedGlobalEnv, onExit } = options;
+  const { service, sharedGlobalEnv, resolvedPorts, onExit } = options;
   const serviceId = service.manifest.id;
 
   if (managedProcesses.has(serviceId)) {
@@ -83,7 +85,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const child = spawn(executable, args, {
     cwd: service.serviceRoot,
-    env: buildProcessEnvironment(service, sharedGlobalEnv),
+    env: buildProcessEnvironment(service, sharedGlobalEnv, resolvedPorts),
     stdio: "ignore",
     windowsHide: true,
   });

--- a/src/runtime/health/checkVariable.ts
+++ b/src/runtime/health/checkVariable.ts
@@ -6,6 +6,7 @@ export async function checkVariableHealth(
   healthcheck: VariableHealthcheck,
   service?: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = service?.manifest.ports ?? {},
 ): Promise<ServiceHealthResult> {
   if (!service) {
     return {
@@ -15,7 +16,7 @@ export async function checkVariableHealth(
     };
   }
 
-  const entry = resolveServiceVariable(service, healthcheck.variable, sharedGlobalEnv);
+  const entry = resolveServiceVariable(service, healthcheck.variable, sharedGlobalEnv, resolvedPorts);
   if (!entry || entry.value.trim().length === 0) {
     return {
       type: "variable",

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -34,7 +34,12 @@ export async function evaluateServiceHealth(
   }
 
   if (healthcheck.type === "variable") {
-    return checkVariableHealth(healthcheck, service, sharedGlobalEnv);
+    return checkVariableHealth(
+      healthcheck,
+      service,
+      sharedGlobalEnv,
+      Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : manifest.ports ?? {},
+    );
   }
 
   return {

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -4,6 +4,7 @@ import { startManagedProcess, stopManagedProcess } from "../execution/supervisor
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
 import { collectRuntimeGlobalEnv } from "../operator/variables.js";
+import { negotiateServicePorts } from "../ports/negotiate.js";
 import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
@@ -71,16 +72,26 @@ export function installService(serviceId: string): LifecycleActionResult {
   }));
 }
 
-export function configService(serviceId: string): LifecycleActionResult {
+export async function configService(
+  service: DiscoveredService,
+  registry?: ServiceRegistry,
+): Promise<LifecycleActionResult> {
+  const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
     throw new LifecycleStateError(`Cannot config service "${serviceId}" before install.`);
   }
 
+  const resolvedPorts = registry ? await negotiateServicePorts(service, registry.list()) : current.runtime.ports;
+
   return applyState(serviceId, "config", (state) => ({
     nextState: {
       ...state,
       configured: true,
+      runtime: {
+        ...state.runtime,
+        ports: resolvedPorts,
+      },
     },
     message: "Config completed.",
   }));
@@ -106,9 +117,15 @@ export async function startService(
   }
 
   const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const resolvedPorts = Object.keys(current.runtime.ports).length > 0
+    ? current.runtime.ports
+    : registry
+      ? await negotiateServicePorts(service, registry.list())
+      : {};
   const handle = await startManagedProcess({
     service,
     sharedGlobalEnv,
+    resolvedPorts,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -125,6 +142,7 @@ export async function startService(
       startedAt: handle.startedAt,
       exitCode: null,
       command: handle.command,
+      ports: resolvedPorts,
     },
   }));
 
@@ -210,9 +228,15 @@ export async function restartService(
   }
 
   const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const resolvedPorts = Object.keys(current.runtime.ports).length > 0
+    ? current.runtime.ports
+    : registry
+      ? await negotiateServicePorts(service, registry.list())
+      : {};
   const handle = await startManagedProcess({
     service,
     sharedGlobalEnv,
+    resolvedPorts,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -229,6 +253,7 @@ export async function restartService(
       startedAt: handle.startedAt,
       exitCode: null,
       command: handle.command,
+      ports: resolvedPorts,
     },
   }));
 

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -14,6 +14,7 @@ function createInitialState(): ServiceLifecycleState {
       startedAt: null,
       exitCode: null,
       command: null,
+      ports: {},
     },
   };
 }
@@ -36,6 +37,7 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
       startedAt: current.runtime.startedAt,
       exitCode: current.runtime.exitCode,
       command: current.runtime.command,
+      ports: { ...current.runtime.ports },
     },
   };
 }
@@ -52,6 +54,7 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
       startedAt: nextState.runtime.startedAt,
       exitCode: nextState.runtime.exitCode,
       command: nextState.runtime.command,
+      ports: { ...nextState.runtime.ports },
     },
   };
 

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -5,6 +5,7 @@ export interface ServiceRuntimeState {
   startedAt: string | null;
   exitCode: number | null;
   command: string | null;
+  ports: Record<string, number>;
 }
 
 export interface ServiceLifecycleState {

--- a/src/runtime/operator/network.ts
+++ b/src/runtime/operator/network.ts
@@ -1,4 +1,5 @@
 import type { DiscoveredService, ServiceEndpoint } from "../../contracts/service.js";
+import { buildServiceVariables } from "./variables.js";
 
 export interface ServiceNetworkEntry {
   label: string;
@@ -8,25 +9,48 @@ export interface ServiceNetworkEntry {
 
 export interface ServiceNetworkPayload {
   serviceId: string;
+  ports: Record<string, number>;
   endpoints: ServiceNetworkEntry[];
 }
 
-function normalizeEndpoint(entry: ServiceEndpoint): ServiceNetworkEntry {
+function renderEndpointUrl(
+  entry: ServiceEndpoint,
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string>,
+  resolvedPorts: Record<string, number>,
+): ServiceNetworkEntry {
+  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables;
+  const url = entry.url.replace(/\$\{([^}]+)\}/g, (match, key) => {
+    const resolved = variables.find((candidate) => candidate.key === key.trim());
+    return resolved ? resolved.value : match;
+  });
+
   return {
     label: entry.label,
-    url: entry.url,
+    url,
     kind: entry.kind ?? "service",
   };
 }
 
-export function buildServiceNetwork(service: DiscoveredService): ServiceNetworkPayload {
-  const manifestEndpoints = (service.manifest.urls ?? []).map(normalizeEndpoint);
+export function buildServiceNetwork(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
+): ServiceNetworkPayload {
+  const manifestEndpoints = (service.manifest.urls ?? []).map((entry) =>
+    renderEndpointUrl(entry, service, sharedGlobalEnv, resolvedPorts),
+  );
   const healthEndpoint =
     service.manifest.healthcheck?.type === "http"
       ? [
           {
             label: "health",
-            url: service.manifest.healthcheck.url,
+            url: renderEndpointUrl(
+              { label: "health", url: service.manifest.healthcheck.url, kind: "health" },
+              service,
+              sharedGlobalEnv,
+              resolvedPorts,
+            ).url,
             kind: "health",
           },
         ]
@@ -34,6 +58,7 @@ export function buildServiceNetwork(service: DiscoveredService): ServiceNetworkP
 
   return {
     serviceId: service.manifest.id,
+    ports: { ...resolvedPorts },
     endpoints: [...manifestEndpoints, ...healthEndpoint],
   };
 }

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -1,5 +1,6 @@
 import { getServiceStatePaths } from "../state/paths.js";
 import type { DiscoveredService } from "../../contracts/service.js";
+import { getLifecycleState } from "../lifecycle/store.js";
 
 export interface ServiceVariableEntry {
   key: string;
@@ -10,6 +11,29 @@ export interface ServiceVariableEntry {
 export interface ServiceVariablesPayload {
   serviceId: string;
   variables: ServiceVariableEntry[];
+}
+
+function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVariableEntry[] {
+  const entries: ServiceVariableEntry[] = [];
+
+  for (const [name, value] of Object.entries(resolvedPorts)) {
+    const normalizedName = name.trim().replace(/[^A-Za-z0-9]+/g, "_").toUpperCase();
+    entries.push({
+      key: `${normalizedName}_PORT`,
+      value: String(value),
+      scope: "derived",
+    });
+
+    if (normalizedName === "SERVICE") {
+      entries.push({
+        key: "SERVICE_PORT",
+        value: String(value),
+        scope: "derived",
+      });
+    }
+  }
+
+  return entries;
 }
 
 function replaceVariableSelectors(value: string, variables: ServiceVariableEntry[]): string {
@@ -23,9 +47,10 @@ function replaceVariableSelectors(value: string, variables: ServiceVariableEntry
 export function buildServiceVariables(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): ServiceVariablesPayload {
   const statePaths = getServiceStatePaths(service.serviceRoot);
-  const manifestVariables = Object.entries(service.manifest.env ?? {}).map(([key, value]) => ({
+  const rawManifestVariables = Object.entries(service.manifest.env ?? {}).map(([key, value]) => ({
     key,
     value,
     scope: "manifest" as const,
@@ -53,7 +78,13 @@ export function buildServiceVariables(
       value: statePaths.stateRoot,
       scope: "derived",
     },
+    ...buildPortVariables(resolvedPorts),
   ];
+
+  const manifestVariables = rawManifestVariables.map((entry) => ({
+    ...entry,
+    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables]),
+  }));
 
   return {
     serviceId: service.manifest.id,
@@ -70,8 +101,9 @@ function normalizeVariableSelector(selector: string): string {
 export function collectServiceGlobalEnv(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): Record<string, string> {
-  const variables = buildServiceVariables(service, sharedGlobalEnv).variables;
+  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables;
   const configuredGlobalEnv = service.manifest.globalenv ?? {};
 
   return Object.fromEntries(
@@ -83,7 +115,9 @@ export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<s
   const sharedGlobalEnv: Record<string, string> = {};
 
   for (const service of services) {
-    Object.assign(sharedGlobalEnv, collectServiceGlobalEnv(service, sharedGlobalEnv));
+    const state = getLifecycleState(service.manifest.id);
+    const resolvedPorts = Object.keys(state.runtime.ports).length > 0 ? state.runtime.ports : service.manifest.ports ?? {};
+    Object.assign(sharedGlobalEnv, collectServiceGlobalEnv(service, sharedGlobalEnv, resolvedPorts));
   }
 
   return sharedGlobalEnv;
@@ -93,7 +127,8 @@ export function resolveServiceVariable(
   service: DiscoveredService,
   selector: string,
   sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): ServiceVariableEntry | undefined {
   const key = normalizeVariableSelector(selector);
-  return buildServiceVariables(service, sharedGlobalEnv).variables.find((entry) => entry.key === key);
+  return buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.find((entry) => entry.key === key);
 }

--- a/src/runtime/ports/negotiate.ts
+++ b/src/runtime/ports/negotiate.ts
@@ -1,0 +1,81 @@
+import net from "node:net";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+
+const DEFAULT_DYNAMIC_PORT_START = 4000;
+const DEFAULT_PORT_HOST = "127.0.0.1";
+
+function isUsablePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+function nextCandidatePort(preferredPort: number): number {
+  return preferredPort === 0 ? DEFAULT_DYNAMIC_PORT_START : preferredPort;
+}
+
+async function isPortFree(port: number, host = DEFAULT_PORT_HOST): Promise<boolean> {
+  const server = net.createServer();
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, host, () => resolve());
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }).catch(() => undefined);
+    }
+  }
+}
+
+function collectReservedPorts(services: DiscoveredService[], currentServiceId: string): Set<number> {
+  const reservedPorts = new Set<number>();
+
+  for (const service of services) {
+    const state = getLifecycleState(service.manifest.id);
+    for (const port of Object.values(state.runtime.ports)) {
+      if (service.manifest.id !== currentServiceId && isUsablePort(port)) {
+        reservedPorts.add(port);
+      }
+    }
+  }
+
+  return reservedPorts;
+}
+
+export async function negotiateServicePorts(
+  service: DiscoveredService,
+  services: DiscoveredService[],
+): Promise<Record<string, number>> {
+  const desiredPorts = service.manifest.ports ?? {};
+  const currentPorts = getLifecycleState(service.manifest.id).runtime.ports;
+  const negotiatedPorts: Record<string, number> = {};
+  const reservedPorts = collectReservedPorts(services, service.manifest.id);
+
+  for (const [name, desiredPort] of Object.entries(desiredPorts)) {
+    const existingPort = currentPorts[name];
+    if (isUsablePort(existingPort)) {
+      negotiatedPorts[name] = existingPort;
+      reservedPorts.add(existingPort);
+      continue;
+    }
+
+    let candidatePort = nextCandidatePort(desiredPort);
+    while (reservedPorts.has(candidatePort) || !(await isPortFree(candidatePort))) {
+      candidatePort += 1;
+      if (candidatePort > 65535) {
+        throw new Error(`Unable to negotiate a free port for service "${service.manifest.id}" port "${name}".`);
+      }
+    }
+
+    negotiatedPorts[name] = candidatePort;
+    reservedPorts.add(candidatePort);
+  }
+
+  return negotiatedPorts;
+}

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -17,6 +17,7 @@ interface StoredRuntimeState {
   startedAt?: string | null;
   exitCode?: number | null;
   command?: string | null;
+  ports?: Record<string, number>;
   lastAction?: LifecycleAction | null;
   actionHistory?: LifecycleAction[];
 }
@@ -57,6 +58,14 @@ function parseLifecycleState(snapshot: {
       startedAt: typeof runtime?.startedAt === "string" ? runtime.startedAt : null,
       exitCode: typeof runtime?.exitCode === "number" ? runtime.exitCode : null,
       command: typeof runtime?.command === "string" ? runtime.command : null,
+      ports:
+        runtime?.ports && typeof runtime.ports === "object" && !Array.isArray(runtime.ports)
+          ? Object.fromEntries(
+              Object.entries(runtime.ports).filter(
+                ([, value]) => typeof value === "number" && Number.isInteger(value) && value > 0,
+              ),
+            )
+          : {},
     },
   };
 }

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -61,6 +61,7 @@ export async function writeServiceState(
           startedAt: lifecycle.runtime.startedAt,
           exitCode: lifecycle.runtime.exitCode,
           command: lifecycle.runtime.command,
+          ports: lifecycle.runtime.ports,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,
         },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -80,10 +80,11 @@ async function createServiceSummary(
 ): Promise<ServiceSummary> {
   const dependencySummary = graph.getServiceDependencies(service.manifest.id);
   const lifecycle = getLifecycleState(service.manifest.id);
+  const resolvedPorts = Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
   const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service, sharedGlobalEnv);
   const logs = buildServiceLogs(service, lifecycle);
-  const variables = buildServiceVariables(service, sharedGlobalEnv);
-  const network = buildServiceNetwork(service);
+  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts);
+  const network = buildServiceNetwork(service, sharedGlobalEnv, resolvedPorts);
   const provider = resolveProviderExecution(service, registry);
 
   return {
@@ -128,7 +129,7 @@ async function executeLifecycleAction(
       case "install":
         return installService(serviceId);
       case "config":
-        return configService(serviceId);
+        return await configService(service, registry);
       case "start":
         return await startService(service, registry);
       case "stop":
@@ -205,12 +206,24 @@ async function routeRequest(
     }
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "variables") {
-      writeJson(response, 200, createServiceVariablesResponse(buildServiceVariables(service, sharedGlobalEnv)));
+      const lifecycle = getLifecycleState(serviceId);
+      const resolvedPorts = Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
+      writeJson(
+        response,
+        200,
+        createServiceVariablesResponse(buildServiceVariables(service, sharedGlobalEnv, resolvedPorts)),
+      );
       return;
     }
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "network") {
-      writeJson(response, 200, createServiceNetworkResponse(buildServiceNetwork(service)));
+      const lifecycle = getLifecycleState(serviceId);
+      const resolvedPorts = Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
+      writeJson(
+        response,
+        200,
+        createServiceNetworkResponse(buildServiceNetwork(service, sharedGlobalEnv, resolvedPorts)),
+      );
       return;
     }
 
@@ -275,7 +288,15 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/variables") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
-    const payload = runtimeModel.discovered.map((service) => buildServiceVariables(service, sharedGlobalEnv));
+    const payload = runtimeModel.discovered.map((service) =>
+      buildServiceVariables(
+        service,
+        sharedGlobalEnv,
+        Object.keys(getLifecycleState(service.manifest.id).runtime.ports).length > 0
+          ? getLifecycleState(service.manifest.id).runtime.ports
+          : service.manifest.ports ?? {},
+      ),
+    );
     writeJson(response, 200, { services: payload });
     return;
   }
@@ -288,7 +309,16 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/network") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    const payload = runtimeModel.discovered.map((service) => buildServiceNetwork(service));
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
+    const payload = runtimeModel.discovered.map((service) =>
+      buildServiceNetwork(
+        service,
+        sharedGlobalEnv,
+        Object.keys(getLifecycleState(service.manifest.id).runtime.ports).length > 0
+          ? getLifecycleState(service.manifest.id).runtime.ports
+          : service.manifest.ports ?? {},
+      ),
+    );
     writeJson(response, 200, { services: payload });
     return;
   }

--- a/src/server/routes/network.ts
+++ b/src/server/routes/network.ts
@@ -1,6 +1,7 @@
 export interface ServiceNetworkResponse {
   network: {
     serviceId: string;
+    ports: Record<string, number>;
     endpoints: { label: string; url: string; kind: string }[];
   };
 }

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -184,7 +184,7 @@ test("start waits for configured readiness and returns healthy once ready", asyn
     healthcheck: {
       type: "file",
       file: "./runtime/ready.txt",
-      retries: 6,
+      retries: 8,
       interval: 50,
       start_period: 25,
     },

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -222,6 +222,36 @@ test("loadServiceManifest accepts bounded globalenv emission maps", async () => 
   }
 });
 
+test("loadServiceManifest accepts bounded ports declarations", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "port-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "port-service",
+        name: "Port Service",
+        description: "Service with bounded port declarations.",
+        ports: {
+          service: 43100,
+          ui: 0,
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.ports, {
+      service: 43100,
+      ui: 0,
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -195,12 +195,150 @@ test("GET /api/services/:id/network returns operator network endpoints", async (
 
     assert.equal(response.status, 200);
     assert.equal(body.network.serviceId, "echo-service");
+    assert.equal(body.network.ports.service, 4010);
     assert.ok(body.network.endpoints.some((entry) => entry.label === "service"));
     assert.ok(body.network.endpoints.some((entry) => entry.label === "ui"));
+    assert.ok(body.network.endpoints.some((entry) => entry.url === "http://127.0.0.1:4010/health"));
   } finally {
     await apiServer.stop();
     resetLifecycleState();
     await clearPersistedFixtureState(servicesRoot);
+  }
+});
+
+test("config negotiates colliding ports deterministically and surfaces resolved network endpoints", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-ports-");
+
+  await writeExecutableFixtureService(servicesRoot, "alpha-service", {
+    ports: { service: 43100 },
+    env: { ECHO_PORT: "${SERVICE_PORT}" },
+    urls: undefined,
+  });
+
+  await writeManifest(servicesRoot, "alpha-service", {
+    id: "alpha-service",
+    name: "Alpha Service",
+    description: "First service claiming a port.",
+    executable: process.execPath,
+    args: ["runtime/fixture-service.mjs"],
+    env: {
+      FIXTURE_EXIT_CODE: "0",
+      ECHO_PORT: "${SERVICE_PORT}",
+    },
+    ports: {
+      service: 43100,
+    },
+    urls: [
+      {
+        label: "service",
+        url: "http://127.0.0.1:${SERVICE_PORT}/health",
+      },
+    ],
+    healthcheck: { type: "process" },
+  });
+
+  await writeExecutableFixtureService(servicesRoot, "beta-service", {
+    ports: { service: 43100 },
+    env: { ECHO_PORT: "${SERVICE_PORT}" },
+  });
+  await writeManifest(servicesRoot, "beta-service", {
+    id: "beta-service",
+    name: "Beta Service",
+    description: "Second service colliding on the same preferred port.",
+    executable: process.execPath,
+    args: ["runtime/fixture-service.mjs"],
+    env: {
+      FIXTURE_EXIT_CODE: "0",
+      ECHO_PORT: "${SERVICE_PORT}",
+    },
+    ports: {
+      service: 43100,
+    },
+    urls: [
+      {
+        label: "service",
+        url: "http://127.0.0.1:${SERVICE_PORT}/health",
+      },
+    ],
+    healthcheck: { type: "process" },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/alpha-service/install`);
+    await postJson(`${apiServer.url}/api/services/beta-service/install`);
+
+    const alphaConfig = await postJson(`${apiServer.url}/api/services/alpha-service/config`);
+    const betaConfig = await postJson(`${apiServer.url}/api/services/beta-service/config`);
+
+    assert.equal(alphaConfig.status, 200);
+    assert.equal(betaConfig.status, 200);
+    assert.equal(alphaConfig.body.state.runtime.ports.service, 43100);
+    assert.equal(betaConfig.body.state.runtime.ports.service > 43100, true);
+
+    const alphaNetwork = await fetch(`${apiServer.url}/api/services/alpha-service/network`);
+    const alphaBody = await alphaNetwork.json();
+    const betaNetwork = await fetch(`${apiServer.url}/api/services/beta-service/network`);
+    const betaBody = await betaNetwork.json();
+
+    assert.equal(alphaBody.network.ports.service, 43100);
+    assert.equal(betaBody.network.ports.service > 43100, true);
+    assert.ok(alphaBody.network.endpoints.some((entry) => entry.url === "http://127.0.0.1:43100/health"));
+    assert.ok(
+      betaBody.network.endpoints.some(
+        (entry) => entry.url === `http://127.0.0.1:${betaBody.network.ports.service}/health`,
+      ),
+    );
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("managed processes receive negotiated port env values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-ports-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "port-env-service", {
+    captureEnvKeys: ["SERVICE_PORT", "ECHO_PORT"],
+    env: {
+      ECHO_PORT: "${SERVICE_PORT}",
+    },
+    ports: {
+      service: 43120,
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/port-env-service/install`);
+    const config = await postJson(`${apiServer.url}/api/services/port-env-service/config`);
+    await postJson(`${apiServer.url}/api/services/port-env-service/start`);
+
+    const envSnapshot = JSON.parse(
+      await waitFor(async () => {
+        try {
+          return await readFile(path.join(serviceRoot, "runtime", "env.json"), "utf8");
+        } catch (error) {
+          if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+            return null;
+          }
+          throw error;
+        }
+      }),
+    );
+
+    assert.equal(envSnapshot.SERVICE_PORT, String(config.body.state.runtime.ports.service));
+    assert.equal(envSnapshot.ECHO_PORT, String(config.body.state.runtime.ports.service));
+
+    await postJson(`${apiServer.url}/api/services/port-env-service/stop`);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -41,6 +41,7 @@ export async function writeExecutableFixtureService(
     captureEnvFileRelativePath = "./runtime/env.json",
     env = {},
     globalenv = {},
+    ports = undefined,
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -126,6 +127,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
         : {}),
     },
     globalenv,
+    ports,
     healthcheck,
   });
 


### PR DESCRIPTION
## Summary
- add bounded manifest port declarations and runtime port negotiation during config/start
- expose assigned ports and resolved URLs through network/operator surfaces
- inject negotiated port values into managed process env

## Verification
- npm test