### PR TITLE
ISS-025: bounded setup/install mechanics

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -31,7 +31,9 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-021` | `done` | Add bounded `variable` manifest-health support | `SPEC-002`, `AC-4C` | Landed bounded variable-presence checks with automated tests and released Echo Service variable proof. |
 | `ISS-022` | `done` | Add bounded readiness wait-loop behavior for startup health | `SPEC-002`, `AC-4D` | Landed bounded readiness waiting with donor-aligned retry fields, deterministic ready/not-ready outcomes, and automated start/restart verification. |
 | `ISS-023` | `done` | Add bounded manifest-driven globalenv propagation | `SPEC-002`, `AC-4E` | Landed bounded manifest-driven shared env merging, API exposure, and managed-process env injection. |
-| `ISS-024` | `in_progress` | Add bounded runtime-owned port negotiation | `SPEC-002`, `AC-4F` | In progress: negotiate declared ports during config/start, resolve collisions deterministically, and expose assigned ports through network/operator surfaces. |
+| `ISS-024` | `done` | Add bounded runtime-owned port negotiation | `SPEC-002`, `AC-4F` | Landed bounded manifest port declarations, deterministic collision-aware negotiation, and resolved network/variable/runtime surfaces. |
+| `ISS-025` | `done` | Add bounded setup/install mechanics with materialized artifacts | `SPEC-002`, `AC-4G` | Landed bounded manifest-driven install/config file materialization with persisted lifecycle artifact metadata and rerunnable effective config output. |
+| `ISS-026` | `todo` | Extend provider-backed execution parity beyond direct executables | `SPEC-002`, `AC-4H` | Run at least one service through its provider execution path and surface provider-backed runtime evidence through the API. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -59,7 +61,9 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-021` | `done` | `ISS-021` | Implement bounded `variable` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = variable`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service variable proof |
 | `TASK-022` | `done` | `ISS-022` | Implement bounded readiness wait loops for start/restart flows | `SPEC-002`, `AC-4D` | Start/restart can wait on donor-aligned health retries, succeed when readiness becomes healthy, and fail deterministically when the readiness window expires |
 | `TASK-023` | `done` | `ISS-023` | Implement bounded manifest-driven globalenv merging and API/runtime propagation | `SPEC-002`, `AC-4E` | Runtime accepts manifest `globalenv`, merges it deterministically, exposes the merged map through the API, and injects shared env into managed service execution |
-| `TASK-024` | `in_progress` | `ISS-024` | Implement bounded runtime-owned port negotiation and network resolution | `SPEC-002`, `AC-4F` | Runtime accepts manifest port declarations, assigns ports during config/start with deterministic collision handling, and exposes assigned ports plus resolved URLs through the API |
+| `TASK-024` | `done` | `ISS-024` | Implement bounded runtime-owned port negotiation and network resolution | `SPEC-002`, `AC-4F` | Runtime accepts manifest port declarations, assigns ports during config/start with deterministic collision handling, and exposes assigned ports plus resolved URLs through the API |
+| `TASK-025` | `done` | `ISS-025` | Implement bounded install/config artifact materialization with direct tests | `SPEC-002`, `AC-4G` | Install/config materialize service-scoped files on disk, persist artifact metadata in lifecycle state, and support rerunnable effective config generation without reinstall |
+| `TASK-026` | `todo` | `ISS-026` | Implement one bounded provider-backed execution path with direct tests | `SPEC-002`, `AC-4H` | At least one provider-backed service executes through its provider path and exposes provider/runtime evidence through the API and persisted state |
 
 ## Next Recommended Item
-The next best item is `TASK-024`: add bounded runtime-owned port negotiation so Service Lasso can move from manifest-only URL surfaces toward managed assigned-port behavior.
+The next best item is `TASK-026`: extend provider-backed execution parity so Service Lasso can run at least one service through its provider path rather than only direct executable definitions.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -33,6 +33,8 @@ Explicitly out of scope for this spec:
 - `AC-4D`: The runtime can optionally wait for bounded startup readiness using donor-aligned health retry fields so start/restart flows can distinguish "process launched" from "service became ready".
 - `AC-4E`: The runtime supports a bounded manifest-driven `globalenv` propagation model so services can emit shared env values, the runtime can merge them deterministically, and operator/API surfaces can expose the merged shared env.
 - `AC-4F`: The runtime owns a bounded port-negotiation slice so manifests can declare desired ports, runtime config/start can resolve collisions deterministically, and operator/API surfaces can expose the assigned ports and resolved URLs.
+- `AC-4G`: The runtime supports a bounded install/config materialization slice so manifests can declare service-scoped files to generate, `install` can perform a real preparation step on disk, `config` can render effective runtime config with resolved variables, and lifecycle/state output records what was materialized.
+- `AC-4H`: The runtime extends bounded provider-backed execution so at least one provider-managed service can run through its provider path and surface provider/runtime evidence through the API and persisted state.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -46,6 +48,8 @@ Required evidence for this spec:
 - direct proof that configured readiness wait loops can succeed and time out deterministically during bounded start behavior
 - direct proof that bounded manifest-driven `globalenv` values can be merged and injected into dependent service execution/runtime API output
 - direct proof that bounded runtime port negotiation can assign ports, resolve collisions deterministically, and surface resolved network data through the API
+- direct proof that bounded install/config actions can materialize service-scoped files on disk and persist artifact metadata for rerunnable effective config generation
+- direct proof that at least one provider-backed service can execute through its provider path and report provider/runtime evidence through the API
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -80,7 +80,7 @@ Current honest label:
    - Echo Service and at least one dependent fixture prove the flow
 
 5. runtime-owned port negotiation
-   status: in progress
+   status: done
    proof:
    - runtime can reserve or resolve service ports
    - collisions are detected deterministically
@@ -89,7 +89,7 @@ Current honest label:
 ### Wave 3: Setup and lifecycle depth
 
 6. bounded setup/install mechanics
-   status: queued
+   status: done
    proof:
    - setup/install is more than state recording
    - at least one real setup path executes and records outcome
@@ -199,6 +199,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**runtime-owned port negotiation**
+**provider-backed execution parity**
 
-That is the next clean donor-parity step after bounded shared env, and it starts moving Service Lasso from manifest-only endpoint descriptions toward runtime-assigned network behavior.
+That is the next clean donor-parity step after bounded setup/install mechanics, and it moves Service Lasso beyond direct executables by proving one real provider-managed execution path end to end.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build && node --test tests/**/*.test.js",
+    "test": "npm run build && node --test --test-concurrency=1 tests/**/*.test.js",
     "dev": "npm run build && node --enable-source-maps dist/index.js",
     "start": "node --enable-source-maps dist/index.js"
   },

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -13,6 +13,22 @@
     "ECHO_STATE_PATH": "./runtime/state.json",
     "ECHO_DB_PATH": "./runtime/echo.sqlite"
   },
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/install.txt",
+        "content": "installed ${SERVICE_ID}\n"
+      }
+    ]
+  },
+  "config": {
+    "files": [
+      {
+        "path": "./runtime/config.json",
+        "content": "{\n  \"serviceId\": \"${SERVICE_ID}\",\n  \"port\": \"${SERVICE_PORT}\",\n  \"logPath\": \"${ECHO_LOG_PATH}\",\n  \"statePath\": \"${ECHO_STATE_PATH}\",\n  \"dbPath\": \"${ECHO_DB_PATH}\"\n}\n"
+      }
+    ]
+  },
   "ports": {
     "service": 4010
   },

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -10,6 +10,15 @@ export interface ServicePortDeclaration {
   [name: string]: number;
 }
 
+export interface ServiceMaterializedFile {
+  path: string;
+  content: string;
+}
+
+export interface ServiceActionMaterialization {
+  files?: ServiceMaterializedFile[];
+}
+
 export interface ServiceManifest {
   id: string;
   name: string;
@@ -22,6 +31,8 @@ export interface ServiceManifest {
   globalenv?: Record<string, string>;
   ports?: ServicePortDeclaration;
   urls?: ServiceEndpoint[];
+  install?: ServiceActionMaterialization;
+  config?: ServiceActionMaterialization;
   execservice?: string;
   executable?: string;
   args?: string[];

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -48,6 +48,49 @@ function readHealthcheckReadinessOptions(
   };
 }
 
+function readActionMaterialization(
+  value: unknown,
+  field: "install" | "config",
+  manifestPath: string,
+): ServiceManifest["install"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    record.files !== undefined &&
+    (!Array.isArray(record.files) ||
+      record.files.some(
+        (entry) =>
+          !entry ||
+          typeof entry !== "object" ||
+          Array.isArray(entry) ||
+          typeof (entry as Record<string, unknown>).path !== "string" ||
+          typeof (entry as Record<string, unknown>).content !== "string",
+      ))
+  ) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "${field}.files" to be an array of { path, content } objects.`,
+    );
+  }
+
+  if (!record.files) {
+    return {};
+  }
+
+  return {
+    files: record.files.map((entry) => ({
+      path: expectNonEmptyString((entry as Record<string, string>).path, `${field}.files.path`, manifestPath),
+      content: (entry as Record<string, string>).content,
+    })),
+  };
+}
+
 export function validateServiceManifest(input: unknown, manifestPath: string): ServiceManifest {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected a JSON object.`);
@@ -172,6 +215,9 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"urls\" to be an array of { label, url } objects.`);
   }
 
+  const install = readActionMaterialization(record.install, "install", manifestPath);
+  const config = readActionMaterialization(record.config, "config", manifestPath);
+
   return {
     id: expectNonEmptyString(record.id, "id", manifestPath),
     name: expectNonEmptyString(record.name, "name", manifestPath),
@@ -192,6 +238,8 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
       url: (entry as Record<string, string>).url.trim(),
       kind: typeof (entry as Record<string, unknown>).kind === "string" ? ((entry as Record<string, string>).kind).trim() : undefined,
     })),
+    install,
+    config,
     execservice: typeof rawExecservice === "string" ? rawExecservice.trim() : undefined,
     executable: typeof rawExecutable === "string" ? rawExecutable.trim() : undefined,
     args: rawArgs?.map((entry) => entry.trim()),

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -5,6 +5,7 @@ import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
 import { collectRuntimeGlobalEnv } from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
+import { materializeConfigArtifacts, materializeInstallArtifacts } from "../setup/materialize.js";
 import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
@@ -57,12 +58,20 @@ async function persistProcessExit(
   await writeServiceState(service, state);
 }
 
-export function installService(serviceId: string): LifecycleActionResult {
+export async function installService(
+  service: DiscoveredService,
+  registry?: ServiceRegistry,
+): Promise<LifecycleActionResult> {
+  const serviceId = service.manifest.id;
+  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const artifacts = await materializeInstallArtifacts(service, sharedGlobalEnv);
+
   return applyState(serviceId, "install", (current) => ({
     nextState: {
       ...current,
       installed: true,
       running: false,
+      installArtifacts: artifacts,
       runtime: {
         ...current.runtime,
         pid: null,
@@ -83,11 +92,14 @@ export async function configService(
   }
 
   const resolvedPorts = registry ? await negotiateServicePorts(service, registry.list()) : current.runtime.ports;
+  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const artifacts = await materializeConfigArtifacts(service, sharedGlobalEnv, resolvedPorts);
 
   return applyState(serviceId, "config", (state) => ({
     nextState: {
       ...state,
       configured: true,
+      configArtifacts: artifacts,
       runtime: {
         ...state.runtime,
         ports: resolvedPorts,

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -9,6 +9,14 @@ function createInitialState(): ServiceLifecycleState {
     running: false,
     lastAction: null,
     actionHistory: [],
+    installArtifacts: {
+      files: [],
+      updatedAt: null,
+    },
+    configArtifacts: {
+      files: [],
+      updatedAt: null,
+    },
     runtime: {
       pid: null,
       startedAt: null,
@@ -32,6 +40,14 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
     running: current.running,
     lastAction: current.lastAction,
     actionHistory: [...current.actionHistory],
+    installArtifacts: {
+      files: [...current.installArtifacts.files],
+      updatedAt: current.installArtifacts.updatedAt,
+    },
+    configArtifacts: {
+      files: [...current.configArtifacts.files],
+      updatedAt: current.configArtifacts.updatedAt,
+    },
     runtime: {
       pid: current.runtime.pid,
       startedAt: current.runtime.startedAt,
@@ -49,6 +65,14 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
     running: nextState.running,
     lastAction: nextState.lastAction,
     actionHistory: [...nextState.actionHistory],
+    installArtifacts: {
+      files: [...nextState.installArtifacts.files],
+      updatedAt: nextState.installArtifacts.updatedAt,
+    },
+    configArtifacts: {
+      files: [...nextState.configArtifacts.files],
+      updatedAt: nextState.configArtifacts.updatedAt,
+    },
     runtime: {
       pid: nextState.runtime.pid,
       startedAt: nextState.runtime.startedAt,

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -1,5 +1,10 @@
 export type LifecycleAction = "install" | "config" | "start" | "stop" | "restart";
 
+export interface ServiceMaterializedArtifactsState {
+  files: string[];
+  updatedAt: string | null;
+}
+
 export interface ServiceRuntimeState {
   pid: number | null;
   startedAt: string | null;
@@ -14,6 +19,8 @@ export interface ServiceLifecycleState {
   running: boolean;
   lastAction: LifecycleAction | null;
   actionHistory: LifecycleAction[];
+  installArtifacts: ServiceMaterializedArtifactsState;
+  configArtifacts: ServiceMaterializedArtifactsState;
   runtime: ServiceRuntimeState;
 }
 

--- a/src/runtime/setup/materialize.ts
+++ b/src/runtime/setup/materialize.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import type { DiscoveredService, ServiceActionMaterialization } from "../../contracts/service.js";
+import { buildServiceVariables } from "../operator/variables.js";
+
+export interface MaterializedArtifactResult {
+  files: string[];
+  updatedAt: string;
+}
+
+function renderTemplate(source: string, variables: ReturnType<typeof buildServiceVariables>["variables"]): string {
+  return source.replace(/\$\{([^}]+)\}/g, (match, selector) => {
+    const key = selector.trim();
+    const resolved = variables.find((entry) => entry.key === key);
+    return resolved ? resolved.value : match;
+  });
+}
+
+function resolveArtifactPath(serviceRoot: string, relativePath: string): { absolutePath: string; relativePath: string } {
+  if (relativePath.trim().length === 0) {
+    throw new Error("Materialized file path must be a non-empty relative path.");
+  }
+
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Materialized file path must stay relative to the service root: ${relativePath}`);
+  }
+
+  const absolutePath = path.resolve(serviceRoot, relativePath);
+  const normalizedRelative = path.relative(serviceRoot, absolutePath);
+  if (
+    normalizedRelative.length === 0 ||
+    normalizedRelative === "." ||
+    normalizedRelative.startsWith("..") ||
+    path.isAbsolute(normalizedRelative)
+  ) {
+    throw new Error(`Materialized file path escapes the service root: ${relativePath}`);
+  }
+
+  return {
+    absolutePath,
+    relativePath: normalizedRelative.replaceAll("\\", "/"),
+  };
+}
+
+async function materializeFiles(
+  service: DiscoveredService,
+  definition: ServiceActionMaterialization | undefined,
+  sharedGlobalEnv: Record<string, string>,
+  resolvedPorts: Record<string, number>,
+): Promise<MaterializedArtifactResult> {
+  const files = definition?.files ?? [];
+  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables;
+  const materializedPaths: string[] = [];
+
+  for (const file of files) {
+    const renderedRelativePath = renderTemplate(file.path, variables);
+    const renderedContent = renderTemplate(file.content, variables);
+    const { absolutePath, relativePath } = resolveArtifactPath(service.serviceRoot, renderedRelativePath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, renderedContent, "utf8");
+    materializedPaths.push(relativePath);
+  }
+
+  return {
+    files: materializedPaths,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export async function materializeInstallArtifacts(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = {},
+): Promise<MaterializedArtifactResult> {
+  return materializeFiles(service, service.manifest.install, sharedGlobalEnv, resolvedPorts);
+}
+
+export async function materializeConfigArtifacts(
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = {},
+): Promise<MaterializedArtifactResult> {
+  return materializeFiles(service, service.manifest.config, sharedGlobalEnv, resolvedPorts);
+}

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -5,10 +5,14 @@ import { readStoredState } from "./readState.js";
 
 interface StoredInstallState {
   installed?: boolean;
+  files?: string[];
+  updatedAt?: string | null;
 }
 
 interface StoredConfigState {
   configured?: boolean;
+  files?: string[];
+  updatedAt?: string | null;
 }
 
 interface StoredRuntimeState {
@@ -53,6 +57,14 @@ function parseLifecycleState(snapshot: {
     running,
     lastAction,
     actionHistory,
+    installArtifacts: {
+      files: Array.isArray(install?.files) ? install.files.filter((file): file is string => typeof file === "string") : [],
+      updatedAt: typeof install?.updatedAt === "string" ? install.updatedAt : null,
+    },
+    configArtifacts: {
+      files: Array.isArray(config?.files) ? config.files.filter((file): file is string => typeof file === "string") : [],
+      updatedAt: typeof config?.updatedAt === "string" ? config.updatedAt : null,
+    },
     runtime: {
       pid: null,
       startedAt: typeof runtime?.startedAt === "string" ? runtime.startedAt : null,

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -36,6 +36,8 @@ export async function writeServiceState(
         {
           installed: lifecycle.installed,
           lastAction: lifecycle.lastAction,
+          files: lifecycle.installArtifacts.files,
+          updatedAt: lifecycle.installArtifacts.updatedAt,
         },
         null,
         2,
@@ -47,6 +49,8 @@ export async function writeServiceState(
         {
           configured: lifecycle.configured,
           lastAction: lifecycle.lastAction,
+          files: lifecycle.configArtifacts.files,
+          updatedAt: lifecycle.configArtifacts.updatedAt,
         },
         null,
         2,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -127,7 +127,7 @@ async function executeLifecycleAction(
   const result = await (async () => {
     switch (action) {
       case "install":
-        return installService(serviceId);
+        return await installService(service, registry);
       case "config":
         return await configService(service, registry);
       case "start":

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -365,8 +365,14 @@ test("startup rehydrates persisted lifecycle state from service .state files", a
 
   const statePaths = getServiceStatePaths(serviceRoot);
   await mkdir(statePaths.stateRoot, { recursive: true });
-  await writeFile(path.join(statePaths.stateRoot, "install.json"), JSON.stringify({ installed: true, lastAction: "install" }, null, 2));
-  await writeFile(path.join(statePaths.stateRoot, "config.json"), JSON.stringify({ configured: true, lastAction: "config" }, null, 2));
+  await writeFile(
+    path.join(statePaths.stateRoot, "install.json"),
+    JSON.stringify({ installed: true, lastAction: "install", files: ["runtime/install.txt"], updatedAt: "2026-04-20T00:00:00.000Z" }, null, 2),
+  );
+  await writeFile(
+    path.join(statePaths.stateRoot, "config.json"),
+    JSON.stringify({ configured: true, lastAction: "config", files: ["runtime/config.json"], updatedAt: "2026-04-20T00:01:00.000Z" }, null, 2),
+  );
   await writeFile(
     path.join(statePaths.stateRoot, "runtime.json"),
     JSON.stringify(
@@ -397,6 +403,8 @@ test("startup rehydrates persisted lifecycle state from service .state files", a
     assert.equal(detailBody.service.lifecycle.configured, true);
     assert.equal(detailBody.service.lifecycle.running, false);
     assert.deepEqual(detailBody.service.lifecycle.actionHistory, ["install", "config", "start"]);
+    assert.deepEqual(detailBody.service.lifecycle.installArtifacts.files, ["runtime/install.txt"]);
+    assert.deepEqual(detailBody.service.lifecycle.configArtifacts.files, ["runtime/config.json"]);
     assert.equal(detailBody.service.lifecycle.runtime.pid, null);
     assert.equal(detailBody.service.lifecycle.runtime.command, "node runtime/fixture-service.mjs");
     assert.equal(runtimeResponse.status, 200);

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { rm } from "node:fs/promises";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
@@ -73,6 +74,102 @@ test("lifecycle actions execute in the expected bounded order", async () => {
     assert.deepEqual(detailBody.service.lifecycle.actionHistory, ["install", "config", "start", "restart", "stop"]);
     assert.equal(detailBody.service.lifecycle.lastAction, "stop");
     assert.equal(detailBody.service.lifecycle.runtime.exitCode, 0);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("install and config materialize bounded on-disk artifacts and persist them in lifecycle state", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "materialized-service", {
+    ports: {
+      service: 41234,
+    },
+    install: {
+      files: [
+        {
+          path: "./runtime/install.txt",
+          content: "installed ${SERVICE_ID}",
+        },
+      ],
+    },
+    config: {
+      files: [
+        {
+          path: "./runtime/config.env",
+          content: "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ROOT=${SERVICE_ROOT}\n",
+        },
+      ],
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/materialized-service/install`);
+    const config = await postJson(`${apiServer.url}/api/services/materialized-service/config`);
+
+    const installPath = path.join(serviceRoot, "runtime", "install.txt");
+    const configPath = path.join(serviceRoot, "runtime", "config.env");
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 200);
+    assert.deepEqual(install.body.state.installArtifacts.files, ["runtime/install.txt"]);
+    assert.equal(typeof install.body.state.installArtifacts.updatedAt, "string");
+    assert.equal(await readFile(installPath, "utf8"), "installed materialized-service");
+
+    assert.equal(config.status, 200);
+    assert.deepEqual(config.body.state.configArtifacts.files, ["runtime/config.env"]);
+    assert.equal(typeof config.body.state.configArtifacts.updatedAt, "string");
+    assert.equal(await readFile(configPath, "utf8"), `SERVICE_PORT=41234\nSERVICE_ROOT=${serviceRoot}\n`);
+    assert.deepEqual(stored.install.files, ["runtime/install.txt"]);
+    assert.deepEqual(stored.config.files, ["runtime/config.env"]);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config can rerun without reinstall and rewrites effective config artifacts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "rerunnable-config-service", {
+    ports: {
+      service: 41235,
+    },
+    config: {
+      files: [
+        {
+          path: "./runtime/config.env",
+          content: "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ID=${SERVICE_ID}\n",
+        },
+      ],
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/rerunnable-config-service/install`);
+
+    const firstConfig = await postJson(`${apiServer.url}/api/services/rerunnable-config-service/config`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const secondConfig = await postJson(`${apiServer.url}/api/services/rerunnable-config-service/config`);
+
+    const configPath = path.join(serviceRoot, "runtime", "config.env");
+    const detailResponse = await fetch(`${apiServer.url}/api/services/rerunnable-config-service`);
+    const detailBody = await detailResponse.json();
+
+    assert.equal(firstConfig.status, 200);
+    assert.equal(secondConfig.status, 200);
+    assert.equal(secondConfig.body.state.configured, true);
+    assert.deepEqual(secondConfig.body.state.actionHistory, ["install", "config", "config"]);
+    assert.equal(await readFile(configPath, "utf8"), "SERVICE_PORT=41235\nSERVICE_ID=rerunnable-config-service\n");
+    assert.equal(detailResponse.status, 200);
+    assert.deepEqual(detailBody.service.lifecycle.configArtifacts.files, ["runtime/config.env"]);
+    assert.equal(typeof detailBody.service.lifecycle.configArtifacts.updatedAt, "string");
   } finally {
     await apiServer.stop();
     resetLifecycleState();

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -252,6 +252,60 @@ test("loadServiceManifest accepts bounded ports declarations", async () => {
   }
 });
 
+test("loadServiceManifest accepts bounded install/config file materialization", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "materialized-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "materialized-service",
+        name: "Materialized Service",
+        description: "Service with bounded install/config file outputs.",
+        install: {
+          files: [
+            {
+              path: "./runtime/install.txt",
+              content: "installed ${SERVICE_ID}",
+            },
+          ],
+        },
+        config: {
+          files: [
+            {
+              path: "./runtime/config.json",
+              content: "{\"port\":\"${SERVICE_PORT}\"}",
+            },
+          ],
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.install, {
+      files: [
+        {
+          path: "./runtime/install.txt",
+          content: "installed ${SERVICE_ID}",
+        },
+      ],
+    });
+    assert.deepEqual(manifest.config, {
+      files: [
+        {
+          path: "./runtime/config.json",
+          content: "{\"port\":\"${SERVICE_PORT}\"}",
+        },
+      ],
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services returns manifest-backed data from the configured services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const apiServer = await (async () => {

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -2,13 +2,32 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 
+async function removeDirectoryWithRetry(targetPath, attempts = 5) {
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      await rm(targetPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!error || typeof error !== "object" || !("code" in error)) {
+        throw error;
+      }
+
+      if ((error.code !== "EPERM" && error.code !== "EBUSY") || index === attempts - 1) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50 * (index + 1)));
+    }
+  }
+}
+
 export async function clearPersistedFixtureState(servicesRoot) {
   const entries = await readdir(servicesRoot, { withFileTypes: true });
 
   await Promise.all(
     entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => rm(path.join(servicesRoot, entry.name, ".state"), { recursive: true, force: true })),
+      .map((entry) => removeDirectoryWithRetry(path.join(servicesRoot, entry.name, ".state"))),
   );
 }
 
@@ -42,6 +61,8 @@ export async function writeExecutableFixtureService(
     env = {},
     globalenv = {},
     ports = undefined,
+    install = undefined,
+    config = undefined,
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -128,6 +149,8 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     },
     globalenv,
     ports,
+    install,
+    config,
     healthcheck,
   });
 


### PR DESCRIPTION
## Summary
- add bounded manifest-driven install/config file materialization
- persist materialized artifact metadata in lifecycle state and .state snapshots
- add direct tests for install/config artifacts and rerunnable config generation

## Verification
- npm test