### PR TITLE
ISS-026: provider-backed execution parity

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -33,7 +33,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-023` | `done` | Add bounded manifest-driven globalenv propagation | `SPEC-002`, `AC-4E` | Landed bounded manifest-driven shared env merging, API exposure, and managed-process env injection. |
 | `ISS-024` | `done` | Add bounded runtime-owned port negotiation | `SPEC-002`, `AC-4F` | Landed bounded manifest port declarations, deterministic collision-aware negotiation, and resolved network/variable/runtime surfaces. |
 | `ISS-025` | `done` | Add bounded setup/install mechanics with materialized artifacts | `SPEC-002`, `AC-4G` | Landed bounded manifest-driven install/config file materialization with persisted lifecycle artifact metadata and rerunnable effective config output. |
-| `ISS-026` | `todo` | Extend provider-backed execution parity beyond direct executables | `SPEC-002`, `AC-4H` | Run at least one service through its provider execution path and surface provider-backed runtime evidence through the API. |
+| `ISS-026` | `done` | Extend provider-backed execution parity beyond direct executables | `SPEC-002`, `AC-4H` | Landed real `@node` provider-backed execution for the tracked sample service with provider env injection and persisted provider/runtime evidence through the API/state model. |
+| `ISS-027` | `todo` | Harden lifecycle depth evidence for restart, crash, and intentional stop paths | `SPEC-002` | Keep persisted runtime evidence deterministic across restart, crash exit, and intentional stop flows before broader orchestration work. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -63,7 +64,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-023` | `done` | `ISS-023` | Implement bounded manifest-driven globalenv merging and API/runtime propagation | `SPEC-002`, `AC-4E` | Runtime accepts manifest `globalenv`, merges it deterministically, exposes the merged map through the API, and injects shared env into managed service execution |
 | `TASK-024` | `done` | `ISS-024` | Implement bounded runtime-owned port negotiation and network resolution | `SPEC-002`, `AC-4F` | Runtime accepts manifest port declarations, assigns ports during config/start with deterministic collision handling, and exposes assigned ports plus resolved URLs through the API |
 | `TASK-025` | `done` | `ISS-025` | Implement bounded install/config artifact materialization with direct tests | `SPEC-002`, `AC-4G` | Install/config materialize service-scoped files on disk, persist artifact metadata in lifecycle state, and support rerunnable effective config generation without reinstall |
-| `TASK-026` | `todo` | `ISS-026` | Implement one bounded provider-backed execution path with direct tests | `SPEC-002`, `AC-4H` | At least one provider-backed service executes through its provider path and exposes provider/runtime evidence through the API and persisted state |
+| `TASK-026` | `done` | `ISS-026` | Implement one bounded provider-backed execution path with direct tests | `SPEC-002`, `AC-4H` | The tracked `@node` sample executes through its provider path, provider env reaches the managed process, and provider/runtime evidence is exposed through the API and persisted state |
+| `TASK-027` | `todo` | `ISS-027` | Harden lifecycle depth evidence across restart/crash/intentional stop flows | `SPEC-002` | Persisted runtime evidence stays deterministic across restart, crash exits, and intentional stops |
 
 ## Next Recommended Item
-The next best item is `TASK-026`: extend provider-backed execution parity so Service Lasso can run at least one service through its provider path rather than only direct executable definitions.
+The next best item is `TASK-027`: harden lifecycle depth evidence so restart, crash, and intentional stop flows keep deterministic persisted runtime state before orchestration work widens.

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -95,7 +95,7 @@ Current honest label:
    - at least one real setup path executes and records outcome
 
 7. provider-backed execution parity
-   status: queued
+   status: done
    proof:
    - at least one provider-backed service is actually executed through its provider path
    - provider-backed state and health are visible through the API
@@ -199,6 +199,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**provider-backed execution parity**
+**lifecycle depth hardening**
 
-That is the next clean donor-parity step after bounded setup/install mechanics, and it moves Service Lasso beyond direct executables by proving one real provider-managed execution path end to end.
+That is the next clean donor-parity step after provider-backed execution, and it keeps persisted runtime evidence honest across restart, crash, and intentional stop paths before orchestration gets broader.

--- a/services/node-sample-service/runtime/server.mjs
+++ b/services/node-sample-service/runtime/server.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const heartbeat = setInterval(() => {}, 1000);
+
+async function writeProviderEnvSnapshot() {
+  const targetPath = path.resolve(process.cwd(), process.env.NODE_SAMPLE_ENV_PATH ?? "./.state/provider-env.json");
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(
+    targetPath,
+    JSON.stringify(
+      {
+        NODE_ENV: process.env.NODE_ENV ?? null,
+        SERVICE_PORT: process.env.SERVICE_PORT ?? null,
+        NODE_SAMPLE_PORT: process.env.NODE_SAMPLE_PORT ?? null,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function shutdown() {
+  clearInterval(heartbeat);
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+void writeProviderEnvSnapshot();

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -1,13 +1,16 @@
 {
   "id": "node-sample-service",
   "name": "Node Sample Service",
-  "description": "Tracked provider-backed sample service used to preserve @node execution-plan coverage.",
+  "description": "Tracked provider-backed sample service used to prove real @node execution through the core runtime.",
   "version": "0.1.0",
   "enabled": true,
   "depend_on": ["@node"],
   "execservice": "@node",
-  "executable": "node",
-  "args": ["runtime/server.js"],
+  "args": ["runtime/server.mjs"],
+  "env": {
+    "NODE_SAMPLE_ENV_PATH": "./.state/provider-env.json",
+    "NODE_SAMPLE_PORT": "${SERVICE_PORT}"
+  },
   "ports": {
     "service": 4020
   },

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { buildServiceVariables } from "../operator/variables.js";
+import type { ProviderExecutionPlan } from "../providers/types.js";
 
 export interface ManagedProcessHandle {
   pid: number;
@@ -22,6 +23,7 @@ interface ManagedProcessRecord {
 
 interface StartProcessOptions {
   service: DiscoveredService;
+  executionPlan: ProviderExecutionPlan;
   sharedGlobalEnv?: Record<string, string>;
   resolvedPorts?: Record<string, number>;
   onExit?: (payload: {
@@ -34,13 +36,13 @@ interface StartProcessOptions {
 
 const managedProcesses = new Map<string, ManagedProcessRecord>();
 
-function resolveExecutable(service: DiscoveredService): string {
-  const executable = service.manifest.executable;
-  if (!executable) {
-    throw new Error(`Service "${service.manifest.id}" has no executable configured.`);
-  }
+function resolveExecutable(service: DiscoveredService, executionPlan: ProviderExecutionPlan): string {
+  const executable = executionPlan.executable;
 
-  if (path.isAbsolute(executable) || executable.startsWith(".") || executable.includes("/") || executable.includes("\\")) {
+  if (
+    executionPlan.provider === "direct" &&
+    (path.isAbsolute(executable) || executable.startsWith(".") || executable.includes("/") || executable.includes("\\"))
+  ) {
     return path.resolve(service.serviceRoot, executable);
   }
 
@@ -53,6 +55,7 @@ function buildCommandString(executable: string, args: string[]): string {
 
 function buildProcessEnvironment(
   service: DiscoveredService,
+  executionPlan: ProviderExecutionPlan,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
 ): NodeJS.ProcessEnv {
@@ -62,6 +65,7 @@ function buildProcessEnvironment(
 
   return {
     ...process.env,
+    ...executionPlan.providerEnv,
     ...serviceVariables,
   };
 }
@@ -71,21 +75,21 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, sharedGlobalEnv, resolvedPorts, onExit } = options;
+  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
   const serviceId = service.manifest.id;
 
   if (managedProcesses.has(serviceId)) {
     throw new Error(`Service "${serviceId}" already has a managed process.`);
   }
 
-  const executable = resolveExecutable(service);
-  const args = service.manifest.args ?? [];
+  const executable = resolveExecutable(service, executionPlan);
+  const args = executionPlan.args;
   const command = buildCommandString(executable, args);
   const startedAt = new Date().toISOString();
 
   const child = spawn(executable, args, {
     cwd: service.serviceRoot,
-    env: buildProcessEnvironment(service, sharedGlobalEnv, resolvedPorts),
+    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts),
     stdio: "ignore",
     windowsHide: true,
   });

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -5,6 +5,8 @@ import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
 import { collectRuntimeGlobalEnv } from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
+import { createDirectExecutionPlan } from "../providers/direct.js";
+import { resolveProviderExecution } from "../providers/resolveProvider.js";
 import { materializeConfigArtifacts, materializeInstallArtifacts } from "../setup/materialize.js";
 import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
@@ -56,6 +58,23 @@ async function persistProcessExit(
   }));
 
   await writeServiceState(service, state);
+}
+
+function resolveExecutionPlanForLifecycle(
+  service: DiscoveredService,
+  registry?: ServiceRegistry,
+) {
+  if (service.manifest.execservice) {
+    if (!registry) {
+      throw new LifecycleStateError(
+        `Cannot start service "${service.manifest.id}" because provider resolution requires a registry context.`,
+      );
+    }
+
+    return resolveProviderExecution(service, registry);
+  }
+
+  return createDirectExecutionPlan(service.manifest);
 }
 
 export async function installService(
@@ -124,7 +143,8 @@ export async function startService(
   if (current.running) {
     throw new LifecycleStateError(`Cannot start service "${serviceId}" because it is already running.`);
   }
-  if (!service.manifest.executable) {
+  const executionPlan = resolveExecutionPlanForLifecycle(service, registry);
+  if (executionPlan.provider === "direct" && !service.manifest.executable) {
     throw new LifecycleStateError(`Cannot start service "${serviceId}" because no executable is configured.`);
   }
 
@@ -136,6 +156,7 @@ export async function startService(
       : {};
   const handle = await startManagedProcess({
     service,
+    executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
     onExit: async ({ exitCode, wasStopping }) => {
@@ -154,6 +175,8 @@ export async function startService(
       startedAt: handle.startedAt,
       exitCode: null,
       command: handle.command,
+      provider: executionPlan.provider,
+      providerServiceId: executionPlan.providerServiceId,
       ports: resolvedPorts,
     },
   }));
@@ -190,6 +213,8 @@ export async function startService(
         startedAt: handle.startedAt,
         exitCode: null,
         command: handle.command,
+        provider: executionPlan.provider,
+        providerServiceId: executionPlan.providerServiceId,
       },
     },
     message: readiness.message,
@@ -231,7 +256,8 @@ export async function restartService(
   if (!current.configured) {
     throw new LifecycleStateError(`Cannot restart service "${serviceId}" before config.`);
   }
-  if (!service.manifest.executable) {
+  const executionPlan = resolveExecutionPlanForLifecycle(service, registry);
+  if (executionPlan.provider === "direct" && !service.manifest.executable) {
     throw new LifecycleStateError(`Cannot restart service "${serviceId}" because no executable is configured.`);
   }
 
@@ -247,6 +273,7 @@ export async function restartService(
       : {};
   const handle = await startManagedProcess({
     service,
+    executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
     onExit: async ({ exitCode, wasStopping }) => {
@@ -265,6 +292,8 @@ export async function restartService(
       startedAt: handle.startedAt,
       exitCode: null,
       command: handle.command,
+      provider: executionPlan.provider,
+      providerServiceId: executionPlan.providerServiceId,
       ports: resolvedPorts,
     },
   }));
@@ -301,6 +330,8 @@ export async function restartService(
         startedAt: handle.startedAt,
         exitCode: null,
         command: handle.command,
+        provider: executionPlan.provider,
+        providerServiceId: executionPlan.providerServiceId,
       },
     },
     message: readiness.message.replace(/^Start/, "Restart"),

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -22,6 +22,8 @@ function createInitialState(): ServiceLifecycleState {
       startedAt: null,
       exitCode: null,
       command: null,
+      provider: null,
+      providerServiceId: null,
       ports: {},
     },
   };
@@ -53,6 +55,8 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
       startedAt: current.runtime.startedAt,
       exitCode: current.runtime.exitCode,
       command: current.runtime.command,
+      provider: current.runtime.provider,
+      providerServiceId: current.runtime.providerServiceId,
       ports: { ...current.runtime.ports },
     },
   };
@@ -78,6 +82,8 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
       startedAt: nextState.runtime.startedAt,
       exitCode: nextState.runtime.exitCode,
       command: nextState.runtime.command,
+      provider: nextState.runtime.provider,
+      providerServiceId: nextState.runtime.providerServiceId,
       ports: { ...nextState.runtime.ports },
     },
   };

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -10,6 +10,8 @@ export interface ServiceRuntimeState {
   startedAt: string | null;
   exitCode: number | null;
   command: string | null;
+  provider: "direct" | "node" | "python" | null;
+  providerServiceId: string | null;
   ports: Record<string, number>;
 }
 

--- a/src/runtime/providers/direct.ts
+++ b/src/runtime/providers/direct.ts
@@ -11,5 +11,6 @@ export function createDirectExecutionPlan(manifest: ServiceManifest): ProviderEx
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
+    providerEnv: {},
   };
 }

--- a/src/runtime/providers/node.ts
+++ b/src/runtime/providers/node.ts
@@ -1,9 +1,12 @@
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "./types.js";
 
-export function createNodeExecutionPlan(manifest: ServiceManifest): ProviderExecutionPlan {
-  const executable = manifest.executable ?? "node";
-  const args = manifest.args ?? [];
+export function createNodeExecutionPlan(
+  serviceManifest: ServiceManifest,
+  providerManifest: ServiceManifest,
+): ProviderExecutionPlan {
+  const executable = providerManifest.executable ?? "node";
+  const args = serviceManifest.args ?? [];
 
   return {
     provider: "node",
@@ -11,5 +14,6 @@ export function createNodeExecutionPlan(manifest: ServiceManifest): ProviderExec
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
+    providerEnv: providerManifest.env ?? {},
   };
 }

--- a/src/runtime/providers/python.ts
+++ b/src/runtime/providers/python.ts
@@ -1,9 +1,12 @@
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "./types.js";
 
-export function createPythonExecutionPlan(manifest: ServiceManifest): ProviderExecutionPlan {
-  const executable = manifest.executable ?? "python";
-  const args = manifest.args ?? [];
+export function createPythonExecutionPlan(
+  serviceManifest: ServiceManifest,
+  providerManifest: ServiceManifest,
+): ProviderExecutionPlan {
+  const executable = providerManifest.executable ?? "python";
+  const args = serviceManifest.args ?? [];
 
   return {
     provider: "python",
@@ -11,5 +14,6 @@ export function createPythonExecutionPlan(manifest: ServiceManifest): ProviderEx
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
+    providerEnv: providerManifest.env ?? {},
   };
 }

--- a/src/runtime/providers/resolveProvider.ts
+++ b/src/runtime/providers/resolveProvider.ts
@@ -15,15 +15,16 @@ export function resolveProviderExecution(
     return createDirectExecutionPlan(service.manifest);
   }
 
-  if (!registry.getById(providerServiceId)) {
+  const providerService = registry.getById(providerServiceId);
+  if (!providerService) {
     throw new Error(`Unknown provider service id: ${providerServiceId}`);
   }
 
   switch (providerServiceId) {
     case "@node":
-      return createNodeExecutionPlan(service.manifest);
+      return createNodeExecutionPlan(service.manifest, providerService.manifest);
     case "@python":
-      return createPythonExecutionPlan(service.manifest);
+      return createPythonExecutionPlan(service.manifest, providerService.manifest);
     default:
       throw new Error(`Unsupported provider service id: ${providerServiceId}`);
   }

--- a/src/runtime/providers/types.ts
+++ b/src/runtime/providers/types.ts
@@ -6,4 +6,5 @@ export interface ProviderExecutionPlan {
   executable: string;
   args: string[];
   commandPreview: string;
+  providerEnv: Record<string, string>;
 }

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -21,6 +21,8 @@ interface StoredRuntimeState {
   startedAt?: string | null;
   exitCode?: number | null;
   command?: string | null;
+  provider?: "direct" | "node" | "python" | null;
+  providerServiceId?: string | null;
   ports?: Record<string, number>;
   lastAction?: LifecycleAction | null;
   actionHistory?: LifecycleAction[];
@@ -70,6 +72,10 @@ function parseLifecycleState(snapshot: {
       startedAt: typeof runtime?.startedAt === "string" ? runtime.startedAt : null,
       exitCode: typeof runtime?.exitCode === "number" ? runtime.exitCode : null,
       command: typeof runtime?.command === "string" ? runtime.command : null,
+      provider: runtime?.provider === "direct" || runtime?.provider === "node" || runtime?.provider === "python"
+        ? runtime.provider
+        : null,
+      providerServiceId: typeof runtime?.providerServiceId === "string" ? runtime.providerServiceId : null,
       ports:
         runtime?.ports && typeof runtime.ports === "object" && !Array.isArray(runtime.ports)
           ? Object.fromEntries(

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -65,6 +65,8 @@ export async function writeServiceState(
           startedAt: lifecycle.runtime.startedAt,
           exitCode: lifecycle.runtime.exitCode,
           command: lifecycle.runtime.command,
+          provider: lifecycle.runtime.provider,
+          providerServiceId: lifecycle.runtime.providerServiceId,
           ports: lifecycle.runtime.ports,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,

--- a/tests/provider-execution.test.js
+++ b/tests/provider-execution.test.js
@@ -2,13 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { resolveProviderExecution } from "../dist/runtime/providers/resolveProvider.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { clearPersistedFixtureState } from "./test-helpers.js";
+import { readStoredState } from "../dist/runtime/state/readState.js";
 
 const servicesRoot = path.resolve("services");
 
@@ -18,6 +19,19 @@ async function postJson(url) {
     status: response.status,
     body: await response.json(),
   };
+}
+
+async function waitFor(readinessCheck, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await readinessCheck();
+    if (result) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
 }
 
 async function makeTempServicesRoot() {
@@ -69,7 +83,8 @@ test("provider resolution returns node execution for provider-backed services", 
 
   assert.equal(plan.provider, "node");
   assert.equal(plan.providerServiceId, "@node");
-  assert.equal(plan.commandPreview, "node runtime/server.js");
+  assert.equal(plan.commandPreview, "node runtime/server.mjs");
+  assert.equal(plan.providerEnv.NODE_ENV, "development");
 });
 
 test("provider resolution returns python execution for python-backed services", async () => {
@@ -101,6 +116,7 @@ test("provider resolution returns python execution for python-backed services", 
     assert.equal(plan.provider, "python");
     assert.equal(plan.providerServiceId, "@python");
     assert.equal(plan.commandPreview, "python app.py");
+    assert.equal(plan.providerEnv.NODE_ENV, undefined);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
@@ -118,11 +134,39 @@ test("provider-backed lifecycle action includes provider details in API response
 
     assert.equal(start.status, 200);
     assert.equal(start.body.provider.provider, "node");
-    assert.equal(start.body.provider.commandPreview, "node runtime/server.js");
+    assert.equal(start.body.provider.commandPreview, "node runtime/server.mjs");
+    assert.equal(start.body.state.runtime.provider, "node");
+    assert.equal(start.body.state.runtime.providerServiceId, "@node");
+    assert.equal(start.body.state.runtime.command, "node runtime/server.mjs");
 
     const detail = await fetch(`${apiServer.url}/api/services/node-sample-service`);
     const detailBody = await detail.json();
     assert.equal(detailBody.service.provider.provider, "node");
+    assert.equal(detailBody.service.lifecycle.runtime.provider, "node");
+    assert.equal(detailBody.service.lifecycle.runtime.providerServiceId, "@node");
+
+    const providerEnvSnapshot = JSON.parse(
+      await waitFor(async () => {
+        try {
+          return await readFile(path.join(servicesRoot, "node-sample-service", ".state", "provider-env.json"), "utf8");
+        } catch (error) {
+          if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+            return null;
+          }
+          throw error;
+        }
+      }),
+    );
+    assert.equal(providerEnvSnapshot.NODE_ENV, "development");
+    assert.equal(providerEnvSnapshot.SERVICE_PORT, "4020");
+    assert.equal(providerEnvSnapshot.NODE_SAMPLE_PORT, "4020");
+
+    const stored = await readStoredState(path.join(servicesRoot, "node-sample-service"));
+    assert.equal(stored.runtime.provider, "node");
+    assert.equal(stored.runtime.providerServiceId, "@node");
+
+    const stop = await postJson(`${apiServer.url}/api/services/node-sample-service/stop`);
+    assert.equal(stop.status, 200);
   } finally {
     await apiServer.stop();
     resetLifecycleState();


### PR DESCRIPTION
## Summary
- make the real process supervisor execute the resolved provider plan rather than only direct service executables
- turn the tracked node sample into a runnable provider-backed fixture
- persist provider/runtime evidence and verify provider env injection through direct tests

## Verification
- npm test