### PR TITLE
ISS-029: add bounded manager-level orchestration actions

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -36,7 +36,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-026` | `done` | Extend provider-backed execution parity beyond direct executables | `SPEC-002`, `AC-4H` | Landed real `@node` provider-backed execution for the tracked sample service with provider env injection and persisted provider/runtime evidence through the API/state model. |
 | `ISS-027` | `done` | Harden lifecycle depth evidence for restart, crash, and intentional stop paths | `SPEC-002` | Landed bounded termination evidence with deterministic restart/crash/stop runtime state across API and persisted `.state` output. |
 | `ISS-028` | `done` | Add dependency-aware startup ordering | `SPEC-002` | Landed bounded dependency-aware startup sequencing with deterministic order, readiness-aware startup, and no duplicate restarts for running dependencies. |
-| `ISS-029` | `todo` | Add manager-level orchestration actions | `SPEC-002` | Introduce bounded `startAll` / `stopAll` orchestration on top of the dependency-aware startup model before widening further runtime orchestration. |
+| `ISS-029` | `done` | Add manager-level orchestration actions | `SPEC-002`, `AC-4I` | Landed bounded `startAll` / `stopAll` orchestration with deterministic startup/shutdown order, explicit skip reasons, and direct API proof. |
+| `ISS-030` | `todo` | Capture managed stdout/stderr and make runtime logs first-class | `SPEC-002` | Extend the execution supervisor so managed process output becomes stable runtime-owned evidence instead of remaining external-only process output. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -69,7 +70,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-026` | `done` | `ISS-026` | Implement one bounded provider-backed execution path with direct tests | `SPEC-002`, `AC-4H` | The tracked `@node` sample executes through its provider path, provider env reaches the managed process, and provider/runtime evidence is exposed through the API and persisted state |
 | `TASK-027` | `done` | `ISS-027` | Harden lifecycle depth evidence across restart/crash/intentional stop flows | `SPEC-002` | Persisted runtime evidence stays deterministic across restart, crash exits, and intentional stops |
 | `TASK-028` | `done` | `ISS-028` | Implement dependency-aware startup ordering with direct tests | `SPEC-002` | Runtime starts services in dependency order and respects bounded readiness-aware sequencing for dependent services |
-| `TASK-029` | `todo` | `ISS-029` | Implement bounded manager-level orchestration actions with direct tests | `SPEC-002` | Runtime exposes deterministic `startAll` / `stopAll` orchestration aligned with dependency-aware startup sequencing |
+| `TASK-029` | `done` | `ISS-029` | Implement bounded manager-level orchestration actions with direct tests | `SPEC-002`, `AC-4I` | Runtime exposes deterministic `startAll` / `stopAll` orchestration aligned with dependency-aware startup sequencing and explicit skip reasons |
+| `TASK-030` | `todo` | `ISS-030` | Capture managed stdout/stderr into runtime-owned log surfaces | `SPEC-002` | Managed processes write stdout/stderr into stable runtime log outputs that the API and persisted state can report consistently |
 
 ## Next Recommended Item
-The next best item is `TASK-029`: add bounded manager-level orchestration actions so the runtime can build on dependency-aware startup with deterministic `startAll` / `stopAll` behavior.
+The next best item is `TASK-030`: capture managed stdout/stderr into runtime-owned log surfaces so the runtime can prove real process output instead of relying on synthetic/operator-only log views.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -35,6 +35,7 @@ Explicitly out of scope for this spec:
 - `AC-4F`: The runtime owns a bounded port-negotiation slice so manifests can declare desired ports, runtime config/start can resolve collisions deterministically, and operator/API surfaces can expose the assigned ports and resolved URLs.
 - `AC-4G`: The runtime supports a bounded install/config materialization slice so manifests can declare service-scoped files to generate, `install` can perform a real preparation step on disk, `config` can render effective runtime config with resolved variables, and lifecycle/state output records what was materialized.
 - `AC-4H`: The runtime extends bounded provider-backed execution so at least one provider-managed service can run through its provider path and surface provider/runtime evidence through the API and persisted state.
+- `AC-4I`: The runtime supports a bounded manager-level orchestration slice so `startAll` and `stopAll` can operate across enabled services in deterministic order with explicit skip reasons and direct API proof.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -50,6 +51,7 @@ Required evidence for this spec:
 - direct proof that bounded runtime port negotiation can assign ports, resolve collisions deterministically, and surface resolved network data through the API
 - direct proof that bounded install/config actions can materialize service-scoped files on disk and persist artifact metadata for rerunnable effective config generation
 - direct proof that at least one provider-backed service can execute through its provider path and report provider/runtime evidence through the API
+- direct proof that runtime-level `startAll` / `stopAll` orchestration can start and stop eligible services in deterministic order while reporting explicit skip reasons for ineligible services
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -114,43 +114,45 @@ Current honest label:
    - runtime can start services in dependency order
    - readiness-aware dependency startup is covered by tests
 
-10. manager-level orchestration
-    status: queued
-    scope:
-    - `startAll`
-    - `stopAll`
-    - `reload`
-    - `autostart`
+10. manager-level orchestration (`startAll` / `stopAll`)
+    status: done
     proof:
-    - orchestration behavior is deterministic and test-covered
+    - runtime-level orchestration starts eligible services in deterministic dependency-aware order
+    - runtime-level orchestration stops running services in deterministic shutdown order
+    - API responses include explicit skip reasons for ineligible services
+
+11. reload/autostart orchestration follow-up
+    status: queued
+    proof:
+    - `reload` and `autostart` semantics are explicit, deterministic, and test-covered
 
 ### Wave 5: Runtime observability parity
 
-11. stdout/stderr capture and runtime log ownership
+12. stdout/stderr capture and runtime log ownership
     status: queued
     proof:
     - managed process output is captured
     - runtime log locations are stable and documented
 
-12. archival and retention model
+13. archival and retention model
     status: queued
     proof:
     - run/log retention rules exist and are enforced
 
-13. process/runtime metrics
+14. process/runtime metrics
     status: queued
     proof:
     - runtime exposes bounded process evidence beyond pid/running state
 
 ### Wave 6: Demo and consumer validation
 
-14. demo-instance hardening
+15. demo-instance hardening
     status: queued
     proof:
     - demo path proves real execution-backed behavior
     - demo cannot be satisfied by state flips alone
 
-15. `lasso-@serviceadmin` integration validation
+16. `lasso-@serviceadmin` integration validation
     status: queued
     proof:
     - admin UI consumes the current runtime/API without special-case hacks
@@ -158,12 +160,12 @@ Current honest label:
 
 ### Wave 7: Package and template rollout
 
-16. core package boundary scaffolding
+17. core package boundary scaffolding
     status: queued
     proof:
     - package split exists and remains aligned with the runtime-root model
 
-17. reference app/template rollout
+18. reference app/template rollout
     status: queued
     scope:
     - `@service-lasso/service-lasso-app-web`
@@ -176,17 +178,17 @@ Current honest label:
 
 ### Wave 8: Documentation truth pass
 
-18. canonical manifest/reference cleanup
+19. canonical manifest/reference cleanup
     status: queued
     proof:
     - canonical docs no longer overstate unsupported contract fields
 
-19. stale planning/spec cleanup
+20. stale planning/spec cleanup
     status: queued
     proof:
     - README, spec, plan, and migration docs agree with current implementation
 
-20. final donor parity review
+21. final donor parity review
     status: queued
     proof:
     - every donor capability is marked:
@@ -199,6 +201,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**manager-level orchestration**
+**stdout/stderr capture and runtime log ownership**
 
-That is the next clean donor-parity step after dependency-aware startup ordering, and it builds the first bounded orchestration surface on top of deterministic dependency-aware startup.
+That is the next clean donor-parity step after bounded manager-level orchestration, because the runtime now needs first-class ownership of real managed-process output before deeper orchestration, retention, and operator parity can be claimed.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -88,3 +88,15 @@ export interface ServiceHealthResponse {
   serviceId: string;
   health: ServiceHealthResult;
 }
+
+export interface RuntimeOrchestrationSkippedService {
+  serviceId: string;
+  reason: string;
+}
+
+export interface RuntimeOrchestrationResponse {
+  action: "startAll" | "stopAll";
+  ok: boolean;
+  results: LifecycleActionResponse[];
+  skipped: RuntimeOrchestrationSkippedService[];
+}

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -177,7 +177,8 @@ export async function startService(
       }
 
       if (!dependencyState.running) {
-        await startService(dependency, registry);
+        const dependencyResult = await startService(dependency, registry);
+        await writeServiceState(dependency, dependencyResult.state);
       }
     }
   }

--- a/src/runtime/manager/DependencyGraph.ts
+++ b/src/runtime/manager/DependencyGraph.ts
@@ -93,6 +93,27 @@ export class DependencyGraph {
     visit(serviceId);
     return ordered;
   }
+
+  getGlobalStartupOrder(): string[] {
+    const ordered = new Set<string>();
+    const serviceIds = this.#registry
+      .list()
+      .map((service) => service.manifest.id)
+      .sort((left, right) => left.localeCompare(right));
+
+    for (const serviceId of serviceIds) {
+      for (const dependencyId of this.getStartupOrder(serviceId)) {
+        ordered.add(dependencyId);
+      }
+      ordered.add(serviceId);
+    }
+
+    return [...ordered];
+  }
+
+  getGlobalShutdownOrder(): string[] {
+    return [...this.getGlobalStartupOrder()].reverse();
+  }
 }
 
 export function createServiceRegistry(services: DiscoveredService[]): ServiceRegistry {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,7 +30,12 @@ import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from ".
 import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
 import { stopAllManagedProcesses } from "../runtime/execution/supervisor.js";
 import { ApiError, toApiErrorBody } from "./errors.js";
-import type { LifecycleActionResponse, ServiceDetailResponse, ServiceSummary } from "../contracts/api.js";
+import type {
+  LifecycleActionResponse,
+  RuntimeOrchestrationResponse,
+  ServiceDetailResponse,
+  ServiceSummary,
+} from "../contracts/api.js";
 
 export interface ApiServerOptions {
   port?: number;
@@ -71,6 +76,8 @@ async function loadRuntimeModel(servicesRoot: string) {
     graph,
   };
 }
+
+type RuntimeModel = Awaited<ReturnType<typeof loadRuntimeModel>>;
 
 async function createServiceSummary(
   service: Awaited<ReturnType<typeof loadRuntimeModel>>["discovered"][number],
@@ -119,11 +126,9 @@ function createServiceDetailResponse(service: ServiceSummary): ServiceDetailResp
 
 async function executeLifecycleAction(
   action: string,
-  service: Awaited<ReturnType<typeof loadRuntimeModel>>["discovered"][number],
-  registry: Awaited<ReturnType<typeof loadRuntimeModel>>["registry"],
+  service: RuntimeModel["discovered"][number],
+  registry: RuntimeModel["registry"],
 ): Promise<LifecycleActionResponse> {
-  const serviceId = service.manifest.id;
-  const sharedGlobalEnv = collectRuntimeGlobalEnv(registry.list());
   const result = await (async () => {
     switch (action) {
       case "install":
@@ -141,8 +146,23 @@ async function executeLifecycleAction(
     }
   })();
 
+  return await buildLifecycleActionResponse(service, registry, result);
+}
+
+async function buildLifecycleActionResponse(
+  service: RuntimeModel["discovered"][number],
+  registry: RuntimeModel["registry"],
+  result: Awaited<ReturnType<typeof installService>>,
+): Promise<LifecycleActionResponse> {
   const persisted = await writeServiceState(service, result.state);
-  const health = await evaluateServiceHealth(service.manifest, result.state, service.serviceRoot, service, sharedGlobalEnv);
+  const sharedGlobalEnv = collectRuntimeGlobalEnv(registry.list());
+  const health = await evaluateServiceHealth(
+    service.manifest,
+    result.state,
+    service.serviceRoot,
+    service,
+    sharedGlobalEnv,
+  );
   const provider = resolveProviderExecution(service, registry);
 
   return {
@@ -154,6 +174,64 @@ async function executeLifecycleAction(
     health,
     statePaths: persisted.paths,
     provider,
+  };
+}
+
+async function executeRuntimeOrchestrationAction(
+  action: "startAll" | "stopAll",
+  runtimeModel: RuntimeModel,
+): Promise<RuntimeOrchestrationResponse> {
+  const orderedServiceIds =
+    action === "startAll"
+      ? runtimeModel.graph.getGlobalStartupOrder()
+      : runtimeModel.graph.getGlobalShutdownOrder();
+  const results: LifecycleActionResponse[] = [];
+  const skipped: RuntimeOrchestrationResponse["skipped"] = [];
+
+  for (const serviceId of orderedServiceIds) {
+    const service = runtimeModel.registry.getById(serviceId);
+
+    if (!service || service.manifest.enabled === false) {
+      continue;
+    }
+
+    const lifecycle = getLifecycleState(serviceId);
+
+    if (action === "startAll") {
+      if (lifecycle.running) {
+        skipped.push({ serviceId, reason: "already_running" });
+        continue;
+      }
+
+      if (!lifecycle.installed) {
+        skipped.push({ serviceId, reason: "not_installed" });
+        continue;
+      }
+
+      if (!lifecycle.configured) {
+        skipped.push({ serviceId, reason: "not_configured" });
+        continue;
+      }
+
+      const result = await startService(service, runtimeModel.registry);
+      results.push(await buildLifecycleActionResponse(service, runtimeModel.registry, result));
+      continue;
+    }
+
+    if (!lifecycle.running) {
+      skipped.push({ serviceId, reason: "not_running" });
+      continue;
+    }
+
+    const result = await stopService(service);
+    results.push(await buildLifecycleActionResponse(service, runtimeModel.registry, result));
+  }
+
+  return {
+    action,
+    ok: true,
+    results,
+    skipped,
   };
 }
 
@@ -269,6 +347,18 @@ async function routeRequest(
         healthyServices,
       }),
     );
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname.startsWith("/api/runtime/actions/")) {
+    const action = url.pathname.split("/").filter(Boolean)[3];
+
+    if (action !== "startAll" && action !== "stopAll") {
+      throw new ApiError("invalid_action", 400, `Unknown runtime action: ${action}`);
+    }
+
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, await executeRuntimeOrchestrationAction(action, runtimeModel));
     return;
   }
 

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -4,10 +4,23 @@ import path from "node:path";
 import os from "node:os";
 import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
-import { clearPersistedFixtureState } from "./test-helpers.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import {
+  clearPersistedFixtureState,
+  makeTempServicesRoot,
+  writeExecutableFixtureService,
+} from "./test-helpers.js";
 
 async function getJson(url) {
   const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function postJson(url) {
+  const response = await fetch(url, { method: "POST" });
   return {
     status: response.status,
     body: await response.json(),
@@ -97,4 +110,85 @@ test("runtime rejects a missing servicesRoot during startup validation", async (
   );
 
   await rm(tempRoot, { recursive: true, force: true });
+});
+
+test("POST /api/runtime/actions/startAll and stopAll orchestrate eligible services in deterministic order", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-actions-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  await writeExecutableFixtureService(servicesRoot, "bravo-service", {
+    depend_on: ["alpha-service"],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    for (const serviceId of ["alpha-service", "bravo-service"]) {
+      let result = await postJson(`${apiServer.url}/api/services/${serviceId}/install`);
+      assert.equal(result.status, 200);
+      result = await postJson(`${apiServer.url}/api/services/${serviceId}/config`);
+      assert.equal(result.status, 200);
+    }
+
+    const startAll = await postJson(`${apiServer.url}/api/runtime/actions/startAll`);
+    assert.equal(startAll.status, 200);
+    assert.equal(startAll.body.action, "startAll");
+    assert.equal(startAll.body.ok, true);
+    assert.deepEqual(
+      startAll.body.results.map((result) => result.serviceId),
+      ["alpha-service", "bravo-service"],
+    );
+    assert.deepEqual(startAll.body.skipped, []);
+    assert.equal(startAll.body.results[0].state.running, true);
+    assert.equal(startAll.body.results[1].state.running, true);
+
+    const stopAll = await postJson(`${apiServer.url}/api/runtime/actions/stopAll`);
+    assert.equal(stopAll.status, 200);
+    assert.equal(stopAll.body.action, "stopAll");
+    assert.equal(stopAll.body.ok, true);
+    assert.deepEqual(
+      stopAll.body.results.map((result) => result.serviceId),
+      ["bravo-service", "alpha-service"],
+    );
+    assert.deepEqual(stopAll.body.skipped, []);
+    assert.equal(stopAll.body.results[0].state.running, false);
+    assert.equal(stopAll.body.results[1].state.running, false);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/runtime/actions/startAll skips ineligible services deterministically", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-skips-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-installed-only");
+  await writeExecutableFixtureService(servicesRoot, "bravo-missing-install");
+  await writeExecutableFixtureService(servicesRoot, "charlie-running");
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    let result = await postJson(`${apiServer.url}/api/services/alpha-installed-only/install`);
+    assert.equal(result.status, 200);
+
+    for (const action of ["install", "config", "start"]) {
+      result = await postJson(`${apiServer.url}/api/services/charlie-running/${action}`);
+      assert.equal(result.status, 200);
+    }
+
+    const startAll = await postJson(`${apiServer.url}/api/runtime/actions/startAll`);
+    assert.equal(startAll.status, 200);
+    assert.equal(startAll.body.action, "startAll");
+    assert.equal(startAll.body.ok, true);
+    assert.deepEqual(startAll.body.results, []);
+    assert.deepEqual(startAll.body.skipped, [
+      { serviceId: "alpha-installed-only", reason: "not_configured" },
+      { serviceId: "bravo-missing-install", reason: "not_installed" },
+      { serviceId: "charlie-running", reason: "already_running" },
+    ]);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Summary:
- add bounded runtime-level startAll / stopAll orchestration actions
- expose deterministic skip reasons and global startup/shutdown ordering through the API
- update SPEC-002, backlog, and the autonomous task list for AC-4I and the next queued slice

Spec / issue binding:
- Issue: ISS-029
- Task: TASK-029
- Spec: SPEC-002
- Acceptance criteria: AC-4I

Verification:
- npm test