### PR TITLE
ISS-032: add runtime log archival and retention

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -39,7 +39,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-029` | `done` | Add manager-level orchestration actions | `SPEC-002`, `AC-4I` | Landed bounded `startAll` / `stopAll` orchestration with deterministic startup/shutdown order, explicit skip reasons, and direct API proof. |
 | `ISS-030` | `done` | Capture managed stdout/stderr and make runtime logs first-class | `SPEC-002`, `AC-4J` | Landed bounded managed stdout/stderr capture into runtime-owned per-service log files with API exposure of recent output and persisted runtime log-path state. |
 | `ISS-031` | `done` | Add bounded `reload` and `autostart` orchestration follow-up | `SPEC-002`, `AC-4K` | Landed bounded `reload` and `autostart` orchestration with manifest opt-in, boot-time autostart, and deterministic reload stop/restart behavior. |
-| `ISS-032` | `todo` | Add bounded archival and retention for runtime logs | `SPEC-002` | Extend runtime-owned logs with bounded retention and archival rules so log evidence does not remain unbounded or ad hoc. |
+| `ISS-032` | `done` | Add bounded archival and retention for runtime logs | `SPEC-002`, `AC-4L` | Landed bounded per-service runtime-log archival on next start with deterministic retention pruning and logs API archive metadata. |
+| `ISS-033` | `todo` | Add bounded process/runtime metrics surfaces | `SPEC-002` | Extend runtime evidence beyond pid/running state with bounded process/termination/log metrics that remain stable across restart and API reads. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -75,7 +76,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-029` | `done` | `ISS-029` | Implement bounded manager-level orchestration actions with direct tests | `SPEC-002`, `AC-4I` | Runtime exposes deterministic `startAll` / `stopAll` orchestration aligned with dependency-aware startup sequencing and explicit skip reasons |
 | `TASK-030` | `done` | `ISS-030` | Capture managed stdout/stderr into runtime-owned log surfaces | `SPEC-002`, `AC-4J` | Managed processes write stdout/stderr into stable runtime log outputs that the API and persisted state can report consistently |
 | `TASK-031` | `done` | `ISS-031` | Add bounded `reload` and `autostart` orchestration semantics | `SPEC-002`, `AC-4K` | Runtime exposes explicit, deterministic `reload` and `autostart` behavior on top of the current bounded orchestration model |
-| `TASK-032` | `todo` | `ISS-032` | Add bounded archival and retention rules for runtime-owned logs | `SPEC-002` | Runtime-owned logs roll forward under explicit bounded retention and archival behavior instead of remaining unbounded per-service files |
+| `TASK-032` | `done` | `ISS-032` | Add bounded archival and retention rules for runtime-owned logs | `SPEC-002`, `AC-4L` | Runtime-owned per-service logs archive prior runs on the next managed start, prune older archives deterministically, and expose retained archive metadata through the logs API |
+| `TASK-033` | `todo` | `ISS-033` | Add bounded process/runtime metrics surfaces | `SPEC-002` | Runtime exposes bounded process/termination/log metrics beyond pid/running state without overclaiming donor-depth process-tree parity |
 
 ## Next Recommended Item
-The next best item is `TASK-032`: add bounded archival and retention rules for runtime-owned logs so the new managed log surfaces stay durable and reviewable without growing unbounded.
+The next best item is `TASK-033`: add bounded process/runtime metrics surfaces so the runtime can report richer execution evidence beyond pid/running state while staying within the current bounded supervision slice.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -38,6 +38,7 @@ Explicitly out of scope for this spec:
 - `AC-4I`: The runtime supports a bounded manager-level orchestration slice so `startAll` and `stopAll` can operate across enabled services in deterministic order with explicit skip reasons and direct API proof.
 - `AC-4J`: The runtime owns a bounded managed-log slice so supervised processes write stdout/stderr into stable runtime-owned log files, the API exposes real recent log output, and persisted runtime state records the runtime log locations.
 - `AC-4K`: The runtime extends bounded orchestration with explicit `reload` and `autostart` semantics so services can opt into startup orchestration, startup can trigger autostart deterministically, and runtime `reload` can rediscover manifests while stopping and restarting previously running eligible services with direct API proof.
+- `AC-4L`: The runtime extends bounded observability with explicit per-service runtime-log archival and retention so new managed runs roll forward without unbounded log growth and the logs API can surface retained recent archives deterministically.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -56,6 +57,7 @@ Required evidence for this spec:
 - direct proof that runtime-level `startAll` / `stopAll` orchestration can start and stop eligible services in deterministic order while reporting explicit skip reasons for ineligible services
 - direct proof that supervised processes write real stdout/stderr output into runtime-owned log files, that the logs API exposes recent captured output, and that persisted runtime state records the runtime log paths
 - direct proof that `autostart`-eligible services can start automatically on runtime boot and through a runtime action, and that `reload` can rediscover manifests while stopping and restarting previously running eligible services deterministically
+- direct proof that prior per-service runtime log files are archived on the next managed start, that retention prunes older archives deterministically, and that the logs API surfaces retained archive metadata
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -231,6 +231,7 @@ The first bounded core slices added so far include:
 - first `.state` persistence helpers
 - operator data surfaces
 - bounded provider planning
+- bounded per-service runtime log archival and retention
 - first API server layer
 
 This is meaningful progress, but it is **not full donor runtime parity yet**.
@@ -242,7 +243,7 @@ Major donor runtime behavior still remains to be migrated more fully, including:
 - full setup/install mechanics such as archive extraction and setup commands
 - fuller shared env/globalenv handling beyond the current bounded slice
 - broader health/readiness flow beyond the current bounded slice
-- fuller runtime logging archival/retention implementation
+- fuller run-level `workspaceRoot` logging archival/retention implementation
 - process/runtime metrics and broader manager/runtime parity
 
 Important current boundary:

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -135,7 +135,7 @@ Current honest label:
     - runtime log locations are stable and documented
 
 13. archival and retention model
-    status: queued
+    status: done
     proof:
     - run/log retention rules exist and are enforced
 
@@ -201,6 +201,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**archival and retention model**
+**process/runtime metrics**
 
-That is the next clean donor-parity step because the runtime now has bounded manager-level orchestration plus runtime-owned managed-process logs, and the next observability gap is to make retention and archival explicit instead of leaving log lifetime unmanaged.
+That is the next clean donor-parity step because the runtime now has bounded runtime-owned log archival/retention, and the next observability gap is to expose richer execution evidence than pid/running state without jumping prematurely to full donor-depth process-tree metrics.

--- a/docs/development/core-runtime-comprehensive-review.md
+++ b/docs/development/core-runtime-comprehensive-review.md
@@ -32,7 +32,7 @@ These assumptions were used consistently throughout the review:
 Automated verification was run during the review:
 
 - command: `npm test`
-- result: `43 passed, 0 failed`
+- result: `66 passed, 0 failed`
 
 What that test run directly proves:
 - API startup
@@ -42,15 +42,19 @@ What that test run directly proves:
 - lifecycle ordering and guardrails
 - state writes
 - bounded `process`, `http`, `tcp`, `file`, and `variable` health behavior
+- bounded readiness wait-loop behavior
 - runtime summary behavior
 - operator logs/variables/network surfaces
 - provider resolution and provider-backed response payloads
+- bounded install/config materialization
+- bounded `globalenv` propagation
+- bounded port negotiation
+- bounded orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
+- bounded per-service runtime-log archival and retention
 
 What that test run does **not** prove:
 - full donor-depth process supervision parity
 - archive/setup mechanics
-- runtime-owned port negotiation
-- shared `globalenv` propagation
 - broader donor parity
 
 ## Executive summary
@@ -73,11 +77,10 @@ But the project is **not** at donor runtime parity.
 The largest remaining gaps are:
 - real process spawning and supervision
 - setup/install execution mechanics
-- broader health/readiness behavior
-- shared `globalenv`
-- runtime-owned port negotiation
+- broader health/provider/runtime parity beyond the current bounded slice
 - broader manager/runtime parity beyond the current bounded orchestration slice
-- fuller runtime logging/archival implementation
+- fuller run-level `workspaceRoot` logging/archival implementation
+- process/runtime metrics
 
 Separately, the documentation set has important drift issues:
 - canonical manifest docs are broader than the runtime really supports
@@ -314,7 +317,12 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - in-memory service registry and dependency graph basics
 - bounded lifecycle actions for `install`, `config`, `start`, `stop`, and `restart`
 - one bounded real execution/supervision path for directly executable services
+- bounded provider-backed execution through `@node`
 - bounded health handling for `process`, `http`, `tcp`, `file`, and `variable`
+- bounded readiness wait loops
+- bounded manifest-driven `globalenv`
+- bounded runtime-owned port negotiation
+- bounded install/config materialization
 - structured per-service `.state` writes
 - bounded manager-level orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
 - operator data surfaces for logs, variables, and network
@@ -326,12 +334,12 @@ These donor/runtime concerns are meaningfully represented in the current code an
 These donor/runtime concerns are represented directionally, but not at donor depth:
 
 - dependency behavior
-  - current code models dependencies and exposes them via API
-  - donor code also performs dependency startup and wait orchestration
+  - current code models dependencies, exposes them via API, and performs bounded dependency-aware startup ordering with readiness waits
+  - donor code still goes broader with deeper recursive orchestration and manager parity
 
 - lifecycle behavior
-  - current code proves lifecycle state transitions
-  - donor code performs execution-backed lifecycle work
+  - current code now proves bounded execution-backed lifecycle work for direct and one provider-backed path
+  - donor code still goes broader with deeper supervision and action breadth
 
 - health model
   - current code supports `process`, `http`, bounded `tcp`, bounded `file`, and bounded `variable`
@@ -339,11 +347,11 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - the sibling `lasso-echoservice` harness provides direct integration proof for the bounded `tcp`, `file`, and `variable` slices
 
 - provider/runtime behavior
-  - current code resolves provider relationships and command previews
-  - donor code actually executes through provider/runtime services
+  - current code resolves provider relationships and executes through one bounded provider-managed path
+  - donor code still goes broader with fuller provider/runtime parity
 
 - logging
-  - current code now captures bounded managed stdout/stderr into runtime-owned per-service log files and exposes recent output through the API
+  - current code now captures bounded managed stdout/stderr into runtime-owned per-service log files, archives prior per-service runs on the next managed start, retains a bounded recent archive set, and exposes recent output plus archive metadata through the API
   - donor code still goes broader with run-level logging, archival, and retention behavior
 
 - state model
@@ -360,13 +368,11 @@ These major donor/runtime behaviors are not implemented in the current code:
 - process-tree tracking and runtime metrics
 - archive extraction via `setuparchive`
 - command-driven setup/install pipeline
-- runtime-owned port reservation
-- port collision handling
-- dynamic port reassignment
-- shared `globalenv` propagation
+- donor-depth runtime-owned port reservation/reassignment beyond the bounded negotiated slice
+- broader shared `globalenv` export/import parity beyond the bounded merged-env slice
 - broader health behavior beyond bounded `process`, `http`, `tcp`, `file`, and `variable`
 - dependency readiness loops and start-chain orchestration
-- fuller runtime logging, archival, and retention implementation
+- fuller run-level `workspaceRoot` logging, archival, and retention implementation
 
 ## Major donor behavior areas
 
@@ -394,11 +400,11 @@ Current status:
 Current implementation covers:
 - standalone runtime entrypoint
 - bounded API server startup
+- bounded `startAll`, `stopAll`, `reload`, and `autostart`
 
 Current implementation does not yet cover:
 - donor manager orchestration depth
 - donor admin/UI surface
-- autostart behavior
 
 ## 3. Registry and dependency graph
 
@@ -422,9 +428,10 @@ Current status:
 Current implementation covers:
 - bounded lifecycle state transitions
 - sequencing guardrails
+- bounded execution-backed lifecycle behavior for direct and one provider-backed path
+- bounded install/config materialization
 
 Current implementation does not yet cover:
-- execution-backed lifecycle behavior
 - broader actions such as uninstall/update/rollback/reset
 
 ## 5. Health behavior
@@ -445,6 +452,7 @@ Current implementation covers:
 - bounded `tcp`
 - bounded `file`
 - bounded `variable`
+- bounded readiness wait loops
 
 Related current harness capability:
 - the released `lasso-echoservice` binary already exposes TCP health simulation endpoints and controls
@@ -462,7 +470,16 @@ Donor behavior:
 - provider-aware setup behavior
 
 Current status:
-- not covered beyond bounded state semantics
+- partially covered
+
+Current implementation covers:
+- bounded install/config file materialization on disk
+- persisted install/config artifact metadata for rerunnable config generation
+
+Current implementation does not yet cover:
+- archive extraction
+- command-driven setup/install execution depth
+- provider-aware setup parity beyond the bounded file-materialization slice
 
 ## 7. Process supervision
 
@@ -474,7 +491,16 @@ Donor behavior:
 - process-tree stats
 
 Current status:
-- not covered
+- partially covered
+
+Current implementation covers:
+- one bounded child-process supervision path
+- bounded provider-backed execution through one provider path
+- deterministic termination evidence and runtime-owned log capture
+
+Current implementation does not yet cover:
+- process-tree statistics
+- fuller donor runtime supervision depth
 
 ## 8. Port negotiation
 
@@ -484,7 +510,15 @@ Donor behavior:
 - replacement ports can be assigned
 
 Current status:
-- not covered
+- partially covered
+
+Current implementation covers:
+- bounded manifest-driven port declarations
+- deterministic runtime-owned port negotiation during config/start
+- bounded collision handling and resolved network/operator surfaces
+
+Current implementation does not yet cover:
+- donor-depth replacement/reassignment semantics beyond the bounded negotiated slice
 
 ## 9. Shared environment model
 
@@ -494,7 +528,15 @@ Donor behavior:
 - merged env is pushed back into services
 
 Current status:
-- not covered
+- partially covered
+
+Current implementation covers:
+- bounded manifest-driven `globalenv` emission
+- deterministic merged shared env exposure through the API
+- shared env injection into managed service execution and variable-health resolution
+
+Current implementation does not yet cover:
+- broader cross-service export/import behavior beyond the current bounded merged-env slice
 
 ## 10. Logging and archival
 
@@ -505,15 +547,17 @@ Donor behavior:
 - old-log cleanup
 
 Current status:
-- partially covered in docs only, not implementation
+- partially covered
 
 Current implementation covers:
-- bounded operator log surfaces
+- bounded managed stdout/stderr capture into runtime-owned per-service log files
+- bounded per-service runtime-log archival on the next managed start
+- bounded per-service archive retention pruning with API-visible archive metadata
 
 Current docs define a preferred future model:
 - `docs/development/core-runtime-logging-model.md`
 
-Current implementation does not yet realize that model.
+Current implementation does not yet realize the broader run-level `workspaceRoot` model described there.
 
 ## SPEC-002 coverage judgment
 
@@ -588,10 +632,10 @@ That label is supported by:
 
 1. Choose the next bounded major migration unit explicitly.
 2. Prefer one of these as the next execution item:
-   - execution-backed demo path
-   - setup/install mechanics
-   - process supervision
-   - runtime-owned port negotiation
+   - process/runtime metrics
+   - deeper supervision parity
+   - demo-instance hardening
+   - `lasso-@serviceadmin` integration validation
 
 ## Final judgment
 

--- a/docs/development/core-runtime-donor-coverage-audit.md
+++ b/docs/development/core-runtime-donor-coverage-audit.md
@@ -25,7 +25,7 @@ Primary current-repo inputs reviewed:
 
 Verification run used for this audit:
 - `npm test`
-- result: `43 passed, 0 failed`
+- result: `66 passed, 0 failed`
 
 ## Bottom line
 
@@ -82,7 +82,7 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - current code resolves provider relationships and command previews
   - donor code actually executes through provider/runtime services
 - logging
-  - current code captures bounded managed stdout/stderr into runtime-owned per-service log files and exposes recent output through the API
+  - current code captures bounded managed stdout/stderr into runtime-owned per-service log files, archives prior per-service runs on the next managed start, retains a bounded recent archive set, and exposes recent output plus archive metadata through the API
   - donor code still goes broader with run-level logging, archival, and retention behavior
 - state model
   - current code writes the first structured `.state/` slice
@@ -102,7 +102,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - `globalenv` export/import propagation across services
 - broader health behavior beyond bounded `process`, `http`, `tcp`, `file`, and `variable`
 - dependency readiness loops and start-chain orchestration
-- fuller runtime logging, archival, and retention implementation
+- fuller run-level `workspaceRoot` logging, archival, and retention implementation
 
 ## Donor-to-current mapping
 
@@ -135,6 +135,7 @@ Current implementation covers:
 Current implementation covers:
 - standalone runtime entrypoint
 - bounded API server startup
+- bounded `startAll`, `stopAll`, `reload`, and `autostart` orchestration
 
 Current implementation does not yet cover:
 - donor-style standalone manager orchestration
@@ -155,10 +156,10 @@ Current implementation covers:
 - service registry
 - dependency graph modeling
 - API exposure of dependencies/dependents
+- dependency-aware startup ordering
+- bounded readiness-aware dependency startup
 
 Current implementation does not yet cover:
-- dependency wait loops
-- dependency-driven service startup orchestration
 - recursive start-chain handling
 
 ## 4. Lifecycle actions
@@ -175,9 +176,10 @@ Current implementation covers:
 - explicit action ordering
 - action error handling for invalid sequencing
 - one bounded real execution/supervision path for directly executable services
+- bounded provider-backed execution through `@node`
+- bounded install/config materialization with persisted artifact metadata
 
 Current implementation does not yet cover:
-- execution-backed lifecycle behavior
 - uninstall/update/rollback/reset semantics
 - donor-style setup/install completion semantics
 
@@ -196,9 +198,7 @@ Current implementation covers:
 - bounded `tcp` health checks
 - bounded `file` health checks
 - bounded `variable` health checks
-
-Current implementation does not yet cover:
-- readiness wait loops tied to actual startup
+- bounded readiness wait loops tied to actual startup
 
 Related current test-harness note:
 - the sibling `lasso-echoservice` repo already exposes TCP health simulation endpoints and controls for integration testing
@@ -216,11 +216,17 @@ Related current test-harness note:
 - provider/runtime-aware setup behavior
 
 ### Current status
-- not covered beyond bounded state semantics
+- partially covered
 
-Current implementation only proves:
+Current implementation covers:
 - the conceptual split between `install` and `config`
-- bounded action-state recording
+- bounded install/config file materialization on disk
+- persisted install/config artifact metadata for rerunnable config generation
+
+Current implementation does not yet cover:
+- archive extraction
+- command-driven setup/install execution depth
+- provider-aware setup parity beyond the bounded file-materialization slice
 
 ## 7. Process supervision
 
@@ -238,9 +244,10 @@ Current implementation covers:
 - one bounded child-process supervision path
 - PID/runtime metadata persistence
 - stop handling and exit observation for directly executable services
+- bounded provider-backed execution through one provider path
+- deterministic lifecycle termination evidence and runtime-owned log capture
 
 Current implementation does not yet cover:
-- broader provider-backed supervision parity
 - process-tree statistics
 - fuller donor runtime supervision depth
 
@@ -252,9 +259,15 @@ Current implementation does not yet cover:
 - replacement ports can be assigned
 
 ### Current status
-- not covered
+- partially covered
 
-Current code surfaces network/operator data from manifests but does not own port negotiation.
+Current implementation covers:
+- bounded manifest-driven port declarations
+- deterministic runtime-owned port negotiation during config/start
+- bounded collision handling and resolved network/operator surfaces
+
+Current implementation does not yet cover:
+- donor-depth replacement/reassignment semantics beyond the bounded negotiated slice
 
 ## 9. Shared environment model
 
@@ -264,9 +277,15 @@ Current code surfaces network/operator data from manifests but does not own port
 - merged env is pushed back into services
 
 ### Current status
-- not covered
+- partially covered
 
-Current code only exposes bounded manifest env plus a few derived variables.
+Current implementation covers:
+- bounded manifest-driven `globalenv` emission
+- deterministic merged shared env exposure through the API
+- shared env injection into managed service execution and variable-health resolution
+
+Current implementation does not yet cover:
+- broader cross-service export/import behavior beyond the current bounded merged-env slice
 
 ## 10. Logging and archival
 
@@ -283,11 +302,13 @@ Current code covers:
 - bounded managed stdout/stderr capture for supervised processes
 - bounded API log surfaces backed by captured process output
 - persisted runtime log-path state for managed services
+- bounded per-service runtime-log archival on the next managed start
+- bounded per-service archive retention pruning with API-visible archive metadata
 
 Current docs define a preferred future model:
 - `docs/development/core-runtime-logging-model.md`
 
-Current implementation does not yet realize the broader run-level archival model described there.
+Current implementation does not yet realize the broader run-level `workspaceRoot` archival model described there.
 
 ## SPEC-002 coverage judgment
 
@@ -313,7 +334,7 @@ So the implementation is ahead of the spec wording.
 Current automated verification status for the bounded core slice:
 
 - command run: `npm test`
-- result: `43 passed, 0 failed`
+- result: `66 passed, 0 failed`
 
 The passing suite directly verifies:
 - API startup
@@ -322,10 +343,16 @@ The passing suite directly verifies:
 - registry/dependency graph basics
 - lifecycle ordering and guardrails
 - state writes
-- `process` and `http` health behavior
+- `process`, `http`, `tcp`, `file`, and `variable` health behavior
+- readiness wait-loop behavior
 - runtime summary behavior
 - operator logs/variables/network surfaces
 - provider resolution and provider-backed response payloads
+- bounded install/config materialization
+- bounded `globalenv` propagation
+- bounded port negotiation
+- bounded orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
+- bounded per-service runtime-log archival and retention
 
 This is strong evidence for the currently implemented slice.
 
@@ -335,7 +362,7 @@ It is **not** evidence for the unmigrated donor behaviors listed above.
 
 1. The current codebase is no longer bootstrap-only and does satisfy the main bounded intent of the first standalone runtime slice.
 2. The donor runtime remains substantially broader than the current implementation.
-3. The largest missing donor areas are setup depth, supervision depth, run-level archival/retention, and broader manager/runtime parity.
+3. The largest missing donor areas are setup depth, supervision depth, process/runtime metrics, and broader manager/runtime parity.
 4. The migration docs are directionally correct about those missing areas.
 5. `SPEC-002` should be refreshed so its wording reflects the implemented slice rather than the pre-implementation state.
 6. The passing test suite gives strong direct proof for the bounded slice, but should not be used to imply donor parity.
@@ -346,10 +373,10 @@ It is **not** evidence for the unmigrated donor behaviors listed above.
 2. Keep using `docs/development/core-runtime-migration-plan.md` as the main donor-gap tracker.
 3. Choose the next major migration unit explicitly rather than mixing several donor gaps at once.
 4. Prefer one of these as the next bounded execution item:
-   - execution-backed demo path
-   - setup/install mechanics
-   - process supervision
-   - runtime-owned port negotiation
+   - process/runtime metrics
+   - deeper supervision parity
+   - demo-instance hardening
+   - `lasso-@serviceadmin` integration validation
 
 ## Final judgment
 

--- a/docs/development/core-runtime-logging-model.md
+++ b/docs/development/core-runtime-logging-model.md
@@ -2,6 +2,11 @@
 
 This document defines the recommended logging and archival model for the `service-lasso` core runtime.
 
+Current implementation note:
+- the runtime currently ships a bounded per-service log model under `servicesRoot/<service>/logs/`
+- prior per-service runtime logs are archived on the next managed start with bounded retention
+- the broader `workspaceRoot/logs/runs/<runId>/` model described below remains the target architecture, not the current full implementation
+
 It intentionally uses:
 - `servicesRoot` for the managed services tree
 - `workspaceRoot` for Service Lasso runtime-managed working data

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -4,7 +4,7 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { buildServiceVariables } from "../operator/variables.js";
-import { getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
+import { archiveRuntimeLogs, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
 
 export interface ManagedProcessHandle {
@@ -31,6 +31,7 @@ interface ManagedProcessRecord {
   stdoutBuffer: string;
   stderrBuffer: string;
   exitPromise: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
+  finalizePromise: Promise<void>;
 }
 
 interface StartProcessOptions {
@@ -47,11 +48,13 @@ interface StartProcessOptions {
 }
 
 const managedProcesses = new Map<string, ManagedProcessRecord>();
+const managedProcessFinalizers = new Map<string, Promise<void>>();
 
 async function prepareRuntimeLogStreams(serviceRoot: string): Promise<{
   paths: ServiceRuntimeLogPaths;
   streams: ManagedProcessRecord["logStreams"];
 }> {
+  await archiveRuntimeLogs(serviceRoot);
   const paths = getServiceRuntimeLogPaths(serviceRoot);
   await mkdir(path.dirname(paths.logPath), { recursive: true });
 
@@ -112,7 +115,7 @@ function attachRuntimeLogCapture(record: ManagedProcessRecord): void {
     flushBufferedLines("stderr");
   });
 
-  record.exitPromise.finally(async () => {
+  record.finalizePromise = record.exitPromise.then(async () => {
     flushBufferedLines("stdout", true);
     flushBufferedLines("stderr", true);
     await closeRuntimeLogStreams(record.logStreams);
@@ -160,6 +163,11 @@ export function hasManagedProcess(serviceId: string): boolean {
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
   const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
   const serviceId = service.manifest.id;
+
+  const priorFinalizer = managedProcessFinalizers.get(serviceId);
+  if (priorFinalizer) {
+    await priorFinalizer;
+  }
 
   if (managedProcesses.has(serviceId)) {
     throw new Error(`Service "${serviceId}" already has a managed process.`);
@@ -212,10 +220,12 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
     stdoutBuffer: "",
     stderrBuffer: "",
     exitPromise,
+    finalizePromise: Promise.resolve(),
   };
 
   managedProcesses.set(serviceId, record);
   attachRuntimeLogCapture(record);
+  managedProcessFinalizers.set(serviceId, record.finalizePromise);
 
   void exitPromise.then(async ({ exitCode, signal }) => {
     const current = managedProcesses.get(serviceId);
@@ -233,6 +243,12 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
         signal,
         wasStopping: record.stopping,
       });
+    }
+  });
+
+  void record.finalizePromise.finally(() => {
+    if (managedProcessFinalizers.get(serviceId) === record.finalizePromise) {
+      managedProcessFinalizers.delete(serviceId);
     }
   });
 
@@ -268,7 +284,13 @@ export async function stopManagedProcess(
     }, timeoutMs).unref?.();
   });
 
-  return Promise.race([record.exitPromise, timeoutPromise]);
+  const result = await Promise.race([record.exitPromise, timeoutPromise]);
+  const finalizer = managedProcessFinalizers.get(serviceId);
+  if (finalizer) {
+    await finalizer;
+  }
+
+  return result;
 }
 
 export async function stopAllManagedProcesses(): Promise<void> {

--- a/src/runtime/operator/logs.ts
+++ b/src/runtime/operator/logs.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { readFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rename, rm, stat } from "node:fs/promises";
 import type { DiscoveredService } from "../../contracts/service.js";
 import type { ServiceLifecycleState } from "../lifecycle/types.js";
 
@@ -14,9 +14,22 @@ export interface ServiceRuntimeLogPaths {
   stderrPath: string;
 }
 
+export interface ServiceRuntimeLogArchive {
+  archiveId: string;
+  archivedAt: string;
+  directoryPath: string;
+  logPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+}
+
 export interface ServiceLogsPayload extends ServiceRuntimeLogPaths {
   serviceId: string;
   entries: ServiceLogEntry[];
+  archives: ServiceRuntimeLogArchive[];
+  retention: {
+    maxArchives: number;
+  };
 }
 
 interface PersistedRuntimeLogEntry {
@@ -24,14 +37,131 @@ interface PersistedRuntimeLogEntry {
   message?: string;
 }
 
+export const SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION = 3;
+
+export function getServiceRuntimeLogsRoot(serviceRoot: string): string {
+  return path.join(serviceRoot, "logs");
+}
+
 export function getServiceRuntimeLogPaths(serviceRoot: string): ServiceRuntimeLogPaths {
-  const runtimeLogsRoot = path.join(serviceRoot, "logs", "runtime");
+  const runtimeLogsRoot = path.join(getServiceRuntimeLogsRoot(serviceRoot), "runtime");
 
   return {
     logPath: path.join(runtimeLogsRoot, "service.log"),
     stdoutPath: path.join(runtimeLogsRoot, "stdout.log"),
     stderrPath: path.join(runtimeLogsRoot, "stderr.log"),
   };
+}
+
+export function getServiceRuntimeArchiveRoot(serviceRoot: string): string {
+  return path.join(getServiceRuntimeLogsRoot(serviceRoot), "archive");
+}
+
+function getArchiveLogPaths(archiveRoot: string): ServiceRuntimeLogPaths {
+  return {
+    logPath: path.join(archiveRoot, "service.log"),
+    stdoutPath: path.join(archiveRoot, "stdout.log"),
+    stderrPath: path.join(archiveRoot, "stderr.log"),
+  };
+}
+
+function buildArchiveId(timestamp: Date): string {
+  return timestamp.toISOString().replace(/[:.]/g, "-");
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listRuntimeLogFiles(serviceRoot: string): Promise<Array<{ source: string; target: string }>> {
+  const currentPaths = getServiceRuntimeLogPaths(serviceRoot);
+  const files = Object.values(currentPaths);
+  const existing = await Promise.all(files.map(async (source) => ({ source, exists: await pathExists(source) })));
+
+  return existing
+    .filter((entry) => entry.exists)
+    .map((entry) => ({
+      source: entry.source,
+      target: path.basename(entry.source),
+    }));
+}
+
+async function buildArchiveRecord(archiveRoot: string, archiveId: string): Promise<ServiceRuntimeLogArchive> {
+  const archivePaths = getArchiveLogPaths(archiveRoot);
+  const stats = await stat(archiveRoot);
+
+  return {
+    archiveId,
+    archivedAt: stats.mtime.toISOString(),
+    directoryPath: archiveRoot,
+    ...archivePaths,
+  };
+}
+
+async function pruneRuntimeLogArchives(
+  serviceRoot: string,
+  maxArchives = SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION,
+): Promise<ServiceRuntimeLogArchive[]> {
+  const archiveRoot = getServiceRuntimeArchiveRoot(serviceRoot);
+  let archiveDirectories: string[] = [];
+
+  try {
+    const entries = await readdir(archiveRoot, { withFileTypes: true });
+    archiveDirectories = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort().reverse();
+  } catch {
+    return [];
+  }
+
+  const staleArchiveIds = archiveDirectories.slice(maxArchives);
+
+  await Promise.all(staleArchiveIds.map((archiveId) => rm(path.join(archiveRoot, archiveId), { recursive: true, force: true })));
+
+  return Promise.all(
+    archiveDirectories
+      .slice(0, maxArchives)
+      .map((archiveId) => buildArchiveRecord(path.join(archiveRoot, archiveId), archiveId)),
+  );
+}
+
+export async function archiveRuntimeLogs(
+  serviceRoot: string,
+  maxArchives = SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION,
+): Promise<ServiceRuntimeLogArchive[]> {
+  const files = await listRuntimeLogFiles(serviceRoot);
+  if (files.length === 0) {
+    return pruneRuntimeLogArchives(serviceRoot, maxArchives);
+  }
+
+  const archiveRoot = getServiceRuntimeArchiveRoot(serviceRoot);
+  await mkdir(archiveRoot, { recursive: true });
+
+  const baseArchiveId = buildArchiveId(new Date());
+  let archiveId = baseArchiveId;
+  let archiveDirectory = path.join(archiveRoot, archiveId);
+  let suffix = 1;
+
+  while (await pathExists(archiveDirectory)) {
+    archiveId = `${baseArchiveId}-${suffix}`;
+    archiveDirectory = path.join(archiveRoot, archiveId);
+    suffix += 1;
+  }
+
+  await mkdir(archiveDirectory, { recursive: true });
+
+  await Promise.all(
+    files.map(({ source, target }) => rename(source, path.join(archiveDirectory, target))),
+  );
+
+  return pruneRuntimeLogArchives(serviceRoot, maxArchives);
+}
+
+export async function listRuntimeLogArchives(serviceRoot: string): Promise<ServiceRuntimeLogArchive[]> {
+  return pruneRuntimeLogArchives(serviceRoot, SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION);
 }
 
 function buildSyntheticEntries(serviceId: string, lifecycle: ServiceLifecycleState): ServiceLogEntry[] {
@@ -75,10 +205,15 @@ export async function buildServiceLogs(
 ): Promise<ServiceLogsPayload> {
   const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
   const capturedEntries = await readRuntimeLogEntries(runtimeLogPaths.logPath);
+  const archives = await listRuntimeLogArchives(service.serviceRoot);
 
   return {
     serviceId: service.manifest.id,
     ...runtimeLogPaths,
     entries: capturedEntries.length > 0 ? capturedEntries : buildSyntheticEntries(service.manifest.id, lifecycle),
+    archives,
+    retention: {
+      maxArchives: SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION,
+    },
   };
 }

--- a/src/server/routes/logs.ts
+++ b/src/server/routes/logs.ts
@@ -7,6 +7,17 @@ export interface ServiceLogsResponse {
     stdoutPath: string;
     stderrPath: string;
     entries: ServiceLogEntryResponse[];
+    archives: {
+      archiveId: string;
+      archivedAt: string;
+      directoryPath: string;
+      logPath: string;
+      stdoutPath: string;
+      stderrPath: string;
+    }[];
+    retention: {
+      maxArchives: number;
+    };
   };
 }
 

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, readdir, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { clearPersistedFixtureState, makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
@@ -66,6 +66,8 @@ test("GET /api/services/:id/logs returns operator log payload", async () => {
     assert.equal(body.logs.logPath.endsWith(path.join("services", "echo-service", "logs", "runtime", "service.log")), true);
     assert.equal(body.logs.stdoutPath.endsWith(path.join("services", "echo-service", "logs", "runtime", "stdout.log")), true);
     assert.equal(body.logs.stderrPath.endsWith(path.join("services", "echo-service", "logs", "runtime", "stderr.log")), true);
+    assert.equal(body.logs.retention.maxArchives, 3);
+    assert.deepEqual(body.logs.archives, []);
     assert.deepEqual(body.logs.entries.map((entry) => entry.message), ["echo-service:install", "echo-service:config"]);
   } finally {
     await apiServer.stop();
@@ -103,6 +105,8 @@ test("managed stdout/stderr are captured into runtime-owned log files and surfac
     });
 
     assert.equal(logsResponse.response.status, 200);
+    assert.equal(logsResponse.body.logs.retention.maxArchives, 3);
+    assert.deepEqual(logsResponse.body.logs.archives, []);
     assert.deepEqual(
       logsResponse.body.logs.entries.map((entry) => `${entry.level}:${entry.message}`).sort(),
       ["stderr:hello stderr", "stdout:hello stdout", "stdout:second stdout"].sort(),
@@ -132,6 +136,70 @@ test("managed stdout/stderr are captured into runtime-owned log files and surfac
     );
 
     await postJson(`${apiServer.url}/api/services/loggy-service/stop`);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("runtime logs archive previous runs and enforce bounded retention", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-log-archive-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "archive-loggy-service", {
+    stdoutLines: ["archive stdout"],
+    stderrLines: ["archive stderr"],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/archive-loggy-service/install`);
+    await postJson(`${apiServer.url}/api/services/archive-loggy-service/config`);
+
+    for (let run = 0; run < 5; run += 1) {
+      const start = await postJson(`${apiServer.url}/api/services/archive-loggy-service/start`);
+      assert.equal(start.status, 200);
+
+      await waitFor(async () => {
+        const response = await fetch(`${apiServer.url}/api/services/archive-loggy-service/logs`);
+        const body = await response.json();
+        if (body.logs.entries.some((entry) => entry.message === "archive stdout")) {
+          return body;
+        }
+        return null;
+      });
+
+      const stop = await postJson(`${apiServer.url}/api/services/archive-loggy-service/stop`);
+      assert.equal(stop.status, 200);
+    }
+
+    const logsResponse = await fetch(`${apiServer.url}/api/services/archive-loggy-service/logs`);
+    const logsBody = await logsResponse.json();
+
+    assert.equal(logsResponse.status, 200);
+    assert.equal(logsBody.logs.retention.maxArchives, 3);
+    assert.equal(logsBody.logs.archives.length, 3);
+    assert.deepEqual(
+      logsBody.logs.entries
+        .filter((entry) => entry.message.length > 0)
+        .map((entry) => `${entry.level}:${entry.message}`)
+        .sort(),
+      ["stderr:archive stderr", "stdout:archive stdout"].sort(),
+    );
+
+    for (const archive of logsBody.logs.archives) {
+      const archivedCombined = await readFile(archive.logPath, "utf8");
+      const archivedStdout = await readFile(archive.stdoutPath, "utf8");
+      const archivedStderr = await readFile(archive.stderrPath, "utf8");
+
+      assert.match(archivedCombined, /archive stdout/);
+      assert.match(archivedCombined, /archive stderr/);
+      assert.match(archivedStdout, /archive stdout/);
+      assert.match(archivedStderr, /archive stderr/);
+    }
+
+    const archiveDirectories = await readdir(path.join(serviceRoot, "logs", "archive"), { withFileTypes: true });
+    assert.equal(archiveDirectories.filter((entry) => entry.isDirectory()).length, 3);
   } finally {
     await apiServer.stop();
     resetLifecycleState();

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -27,7 +27,10 @@ export async function clearPersistedFixtureState(servicesRoot) {
   await Promise.all(
     entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => removeDirectoryWithRetry(path.join(servicesRoot, entry.name, ".state"))),
+      .flatMap((entry) => [
+        removeDirectoryWithRetry(path.join(servicesRoot, entry.name, ".state")),
+        removeDirectoryWithRetry(path.join(servicesRoot, entry.name, "logs")),
+      ]),
   );
 }
 


### PR DESCRIPTION
## Summary
- add bounded per-service runtime log archival and retention to the managed log surface
- wait for prior log finalization before restarting a service so archival is deterministic
- update governance and review docs to mark ISS-032 done and queue process/runtime metrics next

## Testing
- npm test