### PR TITLE
ISS-033: add bounded process/runtime metrics

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -40,7 +40,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-030` | `done` | Capture managed stdout/stderr and make runtime logs first-class | `SPEC-002`, `AC-4J` | Landed bounded managed stdout/stderr capture into runtime-owned per-service log files with API exposure of recent output and persisted runtime log-path state. |
 | `ISS-031` | `done` | Add bounded `reload` and `autostart` orchestration follow-up | `SPEC-002`, `AC-4K` | Landed bounded `reload` and `autostart` orchestration with manifest opt-in, boot-time autostart, and deterministic reload stop/restart behavior. |
 | `ISS-032` | `done` | Add bounded archival and retention for runtime logs | `SPEC-002`, `AC-4L` | Landed bounded per-service runtime-log archival on next start with deterministic retention pruning and logs API archive metadata. |
-| `ISS-033` | `todo` | Add bounded process/runtime metrics surfaces | `SPEC-002` | Extend runtime evidence beyond pid/running state with bounded process/termination/log metrics that remain stable across restart and API reads. |
+| `ISS-033` | `done` | Add bounded process/runtime metrics surfaces | `SPEC-002`, `AC-4M` | Landed bounded persisted launch/termination/duration metrics plus live log-count metrics through service detail, dedicated metrics routes, and restart-stable runtime state. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -77,7 +77,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-030` | `done` | `ISS-030` | Capture managed stdout/stderr into runtime-owned log surfaces | `SPEC-002`, `AC-4J` | Managed processes write stdout/stderr into stable runtime log outputs that the API and persisted state can report consistently |
 | `TASK-031` | `done` | `ISS-031` | Add bounded `reload` and `autostart` orchestration semantics | `SPEC-002`, `AC-4K` | Runtime exposes explicit, deterministic `reload` and `autostart` behavior on top of the current bounded orchestration model |
 | `TASK-032` | `done` | `ISS-032` | Add bounded archival and retention rules for runtime-owned logs | `SPEC-002`, `AC-4L` | Runtime-owned per-service logs archive prior runs on the next managed start, prune older archives deterministically, and expose retained archive metadata through the logs API |
-| `TASK-033` | `todo` | `ISS-033` | Add bounded process/runtime metrics surfaces | `SPEC-002` | Runtime exposes bounded process/termination/log metrics beyond pid/running state without overclaiming donor-depth process-tree parity |
+| `TASK-033` | `done` | `ISS-033` | Add bounded process/runtime metrics surfaces | `SPEC-002`, `AC-4M` | Runtime exposes bounded launch/termination/duration/log metrics beyond pid/running state, persists the owned metrics across restart, and surfaces them through dedicated metrics routes without overclaiming donor-depth process-tree parity |
 
 ## Next Recommended Item
-The next best item is `TASK-033`: add bounded process/runtime metrics surfaces so the runtime can report richer execution evidence beyond pid/running state while staying within the current bounded supervision slice.
+The next best item is `TASK-016`: run demo-instance hardening and regression verification so the current bounded execution-backed runtime can be proven end to end with the stronger observability now in place.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -39,6 +39,7 @@ Explicitly out of scope for this spec:
 - `AC-4J`: The runtime owns a bounded managed-log slice so supervised processes write stdout/stderr into stable runtime-owned log files, the API exposes real recent log output, and persisted runtime state records the runtime log locations.
 - `AC-4K`: The runtime extends bounded orchestration with explicit `reload` and `autostart` semantics so services can opt into startup orchestration, startup can trigger autostart deterministically, and runtime `reload` can rediscover manifests while stopping and restarting previously running eligible services with direct API proof.
 - `AC-4L`: The runtime extends bounded observability with explicit per-service runtime-log archival and retention so new managed runs roll forward without unbounded log growth and the logs API can surface retained recent archives deterministically.
+- `AC-4M`: The runtime extends bounded observability with explicit process/runtime metrics so persisted runtime state and API/operator surfaces can report launch, termination, duration, and log-count evidence beyond pid/running state without claiming full donor-depth process-tree metrics.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -58,6 +59,7 @@ Required evidence for this spec:
 - direct proof that supervised processes write real stdout/stderr output into runtime-owned log files, that the logs API exposes recent captured output, and that persisted runtime state records the runtime log paths
 - direct proof that `autostart`-eligible services can start automatically on runtime boot and through a runtime action, and that `reload` can rediscover manifests while stopping and restarting previously running eligible services deterministically
 - direct proof that prior per-service runtime log files are archived on the next managed start, that retention prunes older archives deterministically, and that the logs API surfaces retained archive metadata
+- direct proof that persisted runtime state and API/operator surfaces expose bounded launch, termination, duration, and log-count metrics that survive runtime restart and remain consistent with current managed log files
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -232,6 +232,7 @@ The first bounded core slices added so far include:
 - operator data surfaces
 - bounded provider planning
 - bounded per-service runtime log archival and retention
+- bounded process/runtime metrics
 - first API server layer
 
 This is meaningful progress, but it is **not full donor runtime parity yet**.
@@ -244,7 +245,7 @@ Major donor runtime behavior still remains to be migrated more fully, including:
 - fuller shared env/globalenv handling beyond the current bounded slice
 - broader health/readiness flow beyond the current bounded slice
 - fuller run-level `workspaceRoot` logging archival/retention implementation
-- process/runtime metrics and broader manager/runtime parity
+- donor-depth process/runtime metrics and broader manager/runtime parity
 
 Important current boundary:
 - the sibling `lasso-echoservice` harness can already simulate HTTP and TCP health targets for testing and demo hardening

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -140,7 +140,7 @@ Current honest label:
     - run/log retention rules exist and are enforced
 
 14. process/runtime metrics
-    status: queued
+    status: done
     proof:
     - runtime exposes bounded process evidence beyond pid/running state
 
@@ -201,6 +201,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**process/runtime metrics**
+**demo-instance hardening**
 
-That is the next clean donor-parity step because the runtime now has bounded runtime-owned log archival/retention, and the next observability gap is to expose richer execution evidence than pid/running state without jumping prematurely to full donor-depth process-tree metrics.
+That is the next clean delivery step because the runtime now has bounded execution, orchestration, runtime-owned logs, archival/retention, and bounded process/runtime metrics, so the highest-value next proof is an honest end-to-end demo flow that uses those capabilities together.

--- a/docs/development/core-runtime-comprehensive-review.md
+++ b/docs/development/core-runtime-comprehensive-review.md
@@ -32,7 +32,7 @@ These assumptions were used consistently throughout the review:
 Automated verification was run during the review:
 
 - command: `npm test`
-- result: `66 passed, 0 failed`
+- result: `67 passed, 0 failed`
 
 What that test run directly proves:
 - API startup
@@ -51,6 +51,7 @@ What that test run directly proves:
 - bounded port negotiation
 - bounded orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
 - bounded per-service runtime-log archival and retention
+- bounded process/runtime metrics
 
 What that test run does **not** prove:
 - full donor-depth process supervision parity
@@ -80,7 +81,7 @@ The largest remaining gaps are:
 - broader health/provider/runtime parity beyond the current bounded slice
 - broader manager/runtime parity beyond the current bounded orchestration slice
 - fuller run-level `workspaceRoot` logging/archival implementation
-- process/runtime metrics
+- donor-depth process-tree/runtime telemetry
 
 Separately, the documentation set has important drift issues:
 - canonical manifest docs are broader than the runtime really supports
@@ -326,6 +327,7 @@ These donor/runtime concerns are meaningfully represented in the current code an
 - structured per-service `.state` writes
 - bounded manager-level orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
 - operator data surfaces for logs, variables, and network
+- bounded process/runtime metrics
 - provider relationship resolution/planning for direct, `@node`, and `@python`
 - direct automated verification for the implemented slice
 
@@ -358,6 +360,10 @@ These donor/runtime concerns are represented directionally, but not at donor dep
   - current code writes the first structured `.state/` slice
   - donor code includes PID/runtime/process evidence and startup recovery concerns not yet implemented here
 
+- process/runtime telemetry
+  - current code exposes bounded launch, termination, duration, and log-count metrics
+  - donor code still goes broader with process-tree stats, memory telemetry, and richer runtime evidence
+
 ## What is not covered yet
 
 These major donor/runtime behaviors are not implemented in the current code:
@@ -365,7 +371,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - full donor-depth stop/kill/restart control over managed processes
 - exit handling and `ignoreexiterror`
 - PID file management as a real runtime concern
-- process-tree tracking and runtime metrics
+- donor-depth process-tree tracking and runtime telemetry
 - archive extraction via `setuparchive`
 - command-driven setup/install pipeline
 - donor-depth runtime-owned port reservation/reassignment beyond the bounded negotiated slice
@@ -632,10 +638,10 @@ That label is supported by:
 
 1. Choose the next bounded major migration unit explicitly.
 2. Prefer one of these as the next execution item:
-   - process/runtime metrics
-   - deeper supervision parity
    - demo-instance hardening
+   - deeper supervision parity
    - `lasso-@serviceadmin` integration validation
+   - package-boundary/reference-app follow-through
 
 ## Final judgment
 

--- a/docs/development/core-runtime-donor-coverage-audit.md
+++ b/docs/development/core-runtime-donor-coverage-audit.md
@@ -25,7 +25,7 @@ Primary current-repo inputs reviewed:
 
 Verification run used for this audit:
 - `npm test`
-- result: `66 passed, 0 failed`
+- result: `67 passed, 0 failed`
 
 ## Bottom line
 
@@ -84,6 +84,9 @@ These donor/runtime concerns are represented directionally, but not at donor dep
 - logging
   - current code captures bounded managed stdout/stderr into runtime-owned per-service log files, archives prior per-service runs on the next managed start, retains a bounded recent archive set, and exposes recent output plus archive metadata through the API
   - donor code still goes broader with run-level logging, archival, and retention behavior
+- process/runtime metrics
+  - current code now persists bounded launch, termination, and duration counters and exposes those plus live log-count metrics through API/operator surfaces
+  - donor code still goes broader with process-tree stats, memory metrics, and fuller runtime telemetry
 - state model
   - current code writes the first structured `.state/` slice
   - donor code includes PID/runtime/process evidence and startup recovery concerns not yet implemented here
@@ -95,7 +98,7 @@ These major donor/runtime behaviors are not implemented in the current code:
 - full donor-depth stop/kill/restart control over managed processes
 - exit handling and `ignoreexiterror` behavior
 - PID file management as a real runtime contract
-- process-tree tracking and memory/process metrics
+- donor-depth process-tree tracking and memory/process metrics
 - archive extraction via `setuparchive`
 - command-driven setup/install pipeline
 - runtime-owned port reservation, collision handling, and reassignment
@@ -304,6 +307,7 @@ Current code covers:
 - persisted runtime log-path state for managed services
 - bounded per-service runtime-log archival on the next managed start
 - bounded per-service archive retention pruning with API-visible archive metadata
+- bounded persisted launch/termination/duration metrics plus live log-count metrics through dedicated metrics routes and service detail output
 
 Current docs define a preferred future model:
 - `docs/development/core-runtime-logging-model.md`
@@ -334,7 +338,7 @@ So the implementation is ahead of the spec wording.
 Current automated verification status for the bounded core slice:
 
 - command run: `npm test`
-- result: `66 passed, 0 failed`
+- result: `67 passed, 0 failed`
 
 The passing suite directly verifies:
 - API startup
@@ -353,6 +357,7 @@ The passing suite directly verifies:
 - bounded port negotiation
 - bounded orchestration for `startAll`, `stopAll`, `reload`, and `autostart`
 - bounded per-service runtime-log archival and retention
+- bounded process/runtime metrics
 
 This is strong evidence for the currently implemented slice.
 
@@ -362,7 +367,7 @@ It is **not** evidence for the unmigrated donor behaviors listed above.
 
 1. The current codebase is no longer bootstrap-only and does satisfy the main bounded intent of the first standalone runtime slice.
 2. The donor runtime remains substantially broader than the current implementation.
-3. The largest missing donor areas are setup depth, supervision depth, process/runtime metrics, and broader manager/runtime parity.
+3. The largest missing donor areas are setup depth, supervision depth, donor-depth process-tree/runtime telemetry, and broader manager/runtime parity.
 4. The migration docs are directionally correct about those missing areas.
 5. `SPEC-002` should be refreshed so its wording reflects the implemented slice rather than the pre-implementation state.
 6. The passing test suite gives strong direct proof for the bounded slice, but should not be used to imply donor parity.
@@ -373,10 +378,10 @@ It is **not** evidence for the unmigrated donor behaviors listed above.
 2. Keep using `docs/development/core-runtime-migration-plan.md` as the main donor-gap tracker.
 3. Choose the next major migration unit explicitly rather than mixing several donor gaps at once.
 4. Prefer one of these as the next bounded execution item:
-   - process/runtime metrics
-   - deeper supervision parity
    - demo-instance hardening
+   - deeper supervision parity
    - `lasso-@serviceadmin` integration validation
+   - package-boundary/reference-app follow-through
 
 ## Final judgment
 

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -106,3 +106,41 @@ export interface ServiceLogEntryResponse {
   level: "info" | "stdout" | "stderr";
   message: string;
 }
+
+export interface ServiceMetricsResponse {
+  metrics: {
+    serviceId: string;
+    process: {
+      running: boolean;
+      pid: number | null;
+      command: string | null;
+      provider: "direct" | "node" | "python" | null;
+      providerServiceId: string | null;
+      startedAt: string | null;
+      finishedAt: string | null;
+      currentRunDurationMs: number | null;
+      lastRunDurationMs: number | null;
+      totalRunDurationMs: number;
+      launchCount: number;
+      stopCount: number;
+      exitCount: number;
+      crashCount: number;
+      restartCount: number;
+      lastTermination: "stopped" | "exited" | "crashed" | null;
+    };
+    logs: {
+      current: {
+        logPath: string;
+        stdoutPath: string;
+        stderrPath: string;
+        combinedEntries: number;
+        stdoutLines: number;
+        stderrLines: number;
+      };
+      archives: {
+        count: number;
+        maxArchives: number;
+      };
+    };
+  };
+}

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -13,6 +13,61 @@ import { writeServiceState } from "../state/writeState.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
 
+function calculateRunDurationMs(startedAt: string | null, finishedAt: string): number | null {
+  if (!startedAt) {
+    return null;
+  }
+
+  const startedMs = Date.parse(startedAt);
+  const finishedMs = Date.parse(finishedAt);
+
+  if (!Number.isFinite(startedMs) || !Number.isFinite(finishedMs)) {
+    return null;
+  }
+
+  return Math.max(0, finishedMs - startedMs);
+}
+
+function applyRunCompletionMetrics(
+  current: ServiceLifecycleState,
+  finishedAt: string,
+  termination: "stopped" | "exited" | "crashed",
+): ServiceLifecycleState["runtime"]["metrics"] {
+  const runDurationMs = calculateRunDurationMs(current.runtime.startedAt, finishedAt);
+
+  return {
+    ...current.runtime.metrics,
+    stopCount: current.runtime.metrics.stopCount + (termination === "stopped" ? 1 : 0),
+    exitCount: current.runtime.metrics.exitCount + (termination === "exited" ? 1 : 0),
+    crashCount: current.runtime.metrics.crashCount + (termination === "crashed" ? 1 : 0),
+    totalRunDurationMs: current.runtime.metrics.totalRunDurationMs + (runDurationMs ?? 0),
+    lastRunDurationMs: runDurationMs,
+  };
+}
+
+function applyProcessLaunchMetrics(
+  current: ServiceLifecycleState,
+  action: "start" | "restart",
+  startedAt: string,
+): ServiceLifecycleState["runtime"]["metrics"] {
+  let totalRunDurationMs = current.runtime.metrics.totalRunDurationMs;
+  let lastRunDurationMs = current.runtime.metrics.lastRunDurationMs;
+
+  if (action === "restart" && current.running) {
+    const previousRunDurationMs = calculateRunDurationMs(current.runtime.startedAt, startedAt);
+    totalRunDurationMs += previousRunDurationMs ?? 0;
+    lastRunDurationMs = previousRunDurationMs;
+  }
+
+  return {
+    ...current.runtime.metrics,
+    launchCount: current.runtime.metrics.launchCount + 1,
+    restartCount: current.runtime.metrics.restartCount + (action === "restart" ? 1 : 0),
+    totalRunDurationMs,
+    lastRunDurationMs,
+  };
+}
+
 function applyState(
   serviceId: string,
   action: LifecycleAction,
@@ -49,6 +104,7 @@ async function persistProcessExit(
   exitCode: number | null,
 ): Promise<void> {
   const finishedAt = new Date().toISOString();
+  const termination = (exitCode ?? getLifecycleState(service.manifest.id).runtime.exitCode ?? 0) === 0 ? "exited" : "crashed";
   const state = updateRuntimeState(service.manifest.id, (current) => ({
     ...current,
     running: false,
@@ -57,7 +113,8 @@ async function persistProcessExit(
       pid: null,
       finishedAt,
       exitCode: exitCode ?? current.runtime.exitCode,
-      lastTermination: (exitCode ?? current.runtime.exitCode ?? 0) === 0 ? "exited" : "crashed",
+      lastTermination: termination,
+      metrics: applyRunCompletionMetrics(current, finishedAt, termination),
     },
   }));
 
@@ -221,6 +278,7 @@ export async function startService(
         stdoutPath: handle.logs.stdoutPath,
         stderrPath: handle.logs.stderrPath,
       },
+      metrics: applyProcessLaunchMetrics(state, "start", handle.startedAt),
     },
   }));
 
@@ -240,6 +298,7 @@ export async function startService(
             finishedAt: new Date().toISOString(),
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
+            metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
           },
         },
         message: readiness.message,
@@ -288,6 +347,7 @@ export async function stopService(service: DiscoveredService): Promise<Lifecycle
         finishedAt,
         exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
         lastTermination: "stopped",
+        metrics: applyRunCompletionMetrics(state, finishedAt, "stopped"),
       },
     },
     message: "Stop completed.",
@@ -353,6 +413,7 @@ export async function restartService(
         stdoutPath: handle.logs.stdoutPath,
         stderrPath: handle.logs.stderrPath,
       },
+      metrics: applyProcessLaunchMetrics(state, "restart", handle.startedAt),
     },
   }));
 
@@ -372,6 +433,7 @@ export async function restartService(
             finishedAt: new Date().toISOString(),
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
+            metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
           },
         },
         message: readiness.message,

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -32,6 +32,15 @@ function createInitialState(): ServiceLifecycleState {
         stdoutPath: null,
         stderrPath: null,
       },
+      metrics: {
+        launchCount: 0,
+        stopCount: 0,
+        exitCount: 0,
+        crashCount: 0,
+        restartCount: 0,
+        totalRunDurationMs: 0,
+        lastRunDurationMs: null,
+      },
     },
   };
 }
@@ -72,6 +81,15 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
         stdoutPath: current.runtime.logs.stdoutPath,
         stderrPath: current.runtime.logs.stderrPath,
       },
+      metrics: {
+        launchCount: current.runtime.metrics.launchCount,
+        stopCount: current.runtime.metrics.stopCount,
+        exitCount: current.runtime.metrics.exitCount,
+        crashCount: current.runtime.metrics.crashCount,
+        restartCount: current.runtime.metrics.restartCount,
+        totalRunDurationMs: current.runtime.metrics.totalRunDurationMs,
+        lastRunDurationMs: current.runtime.metrics.lastRunDurationMs,
+      },
     },
   };
 }
@@ -105,6 +123,15 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
         logPath: nextState.runtime.logs.logPath,
         stdoutPath: nextState.runtime.logs.stdoutPath,
         stderrPath: nextState.runtime.logs.stderrPath,
+      },
+      metrics: {
+        launchCount: nextState.runtime.metrics.launchCount,
+        stopCount: nextState.runtime.metrics.stopCount,
+        exitCount: nextState.runtime.metrics.exitCount,
+        crashCount: nextState.runtime.metrics.crashCount,
+        restartCount: nextState.runtime.metrics.restartCount,
+        totalRunDurationMs: nextState.runtime.metrics.totalRunDurationMs,
+        lastRunDurationMs: nextState.runtime.metrics.lastRunDurationMs,
       },
     },
   };

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -5,6 +5,16 @@ export interface ServiceMaterializedArtifactsState {
   updatedAt: string | null;
 }
 
+export interface ServiceRuntimeMetricsState {
+  launchCount: number;
+  stopCount: number;
+  exitCount: number;
+  crashCount: number;
+  restartCount: number;
+  totalRunDurationMs: number;
+  lastRunDurationMs: number | null;
+}
+
 export interface ServiceRuntimeState {
   pid: number | null;
   startedAt: string | null;
@@ -20,6 +30,7 @@ export interface ServiceRuntimeState {
     stdoutPath: string | null;
     stderrPath: string | null;
   };
+  metrics: ServiceRuntimeMetricsState;
 }
 
 export interface ServiceLifecycleState {

--- a/src/runtime/operator/metrics.ts
+++ b/src/runtime/operator/metrics.ts
@@ -1,0 +1,124 @@
+import { readFile } from "node:fs/promises";
+import type { DiscoveredService } from "../../contracts/service.js";
+import type { ServiceLifecycleState } from "../lifecycle/types.js";
+import {
+  getServiceRuntimeLogPaths,
+  listRuntimeLogArchives,
+  SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION,
+} from "./logs.js";
+
+export interface ServiceMetricsPayload {
+  serviceId: string;
+  process: {
+    running: boolean;
+    pid: number | null;
+    command: string | null;
+    provider: "direct" | "node" | "python" | null;
+    providerServiceId: string | null;
+    startedAt: string | null;
+    finishedAt: string | null;
+    currentRunDurationMs: number | null;
+    lastRunDurationMs: number | null;
+    totalRunDurationMs: number;
+    launchCount: number;
+    stopCount: number;
+    exitCount: number;
+    crashCount: number;
+    restartCount: number;
+    lastTermination: "stopped" | "exited" | "crashed" | null;
+  };
+  logs: {
+    current: {
+      logPath: string;
+      stdoutPath: string;
+      stderrPath: string;
+      combinedEntries: number;
+      stdoutLines: number;
+      stderrLines: number;
+    };
+    archives: {
+      count: number;
+      maxArchives: number;
+    };
+  };
+}
+
+function calculateDurationMs(startedAt: string | null, finishedAt: string | null): number | null {
+  if (!startedAt || !finishedAt) {
+    return null;
+  }
+
+  const startedMs = Date.parse(startedAt);
+  const finishedMs = Date.parse(finishedAt);
+
+  if (!Number.isFinite(startedMs) || !Number.isFinite(finishedMs)) {
+    return null;
+  }
+
+  return Math.max(0, finishedMs - startedMs);
+}
+
+async function readLogLineCount(logPath: string): Promise<number> {
+  try {
+    const content = await readFile(logPath, "utf8");
+    if (content.length === 0) {
+      return 0;
+    }
+
+    return content
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0)
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+export async function buildServiceMetrics(
+  service: DiscoveredService,
+  lifecycle: ServiceLifecycleState,
+): Promise<ServiceMetricsPayload> {
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const [combinedEntries, stdoutLines, stderrLines, archives] = await Promise.all([
+    readLogLineCount(runtimeLogPaths.logPath),
+    readLogLineCount(runtimeLogPaths.stdoutPath),
+    readLogLineCount(runtimeLogPaths.stderrPath),
+    listRuntimeLogArchives(service.serviceRoot),
+  ]);
+
+  return {
+    serviceId: service.manifest.id,
+    process: {
+      running: lifecycle.running,
+      pid: lifecycle.runtime.pid,
+      command: lifecycle.runtime.command,
+      provider: lifecycle.runtime.provider,
+      providerServiceId: lifecycle.runtime.providerServiceId,
+      startedAt: lifecycle.runtime.startedAt,
+      finishedAt: lifecycle.runtime.finishedAt,
+      currentRunDurationMs: lifecycle.running
+        ? calculateDurationMs(lifecycle.runtime.startedAt, new Date().toISOString())
+        : null,
+      lastRunDurationMs: lifecycle.runtime.metrics.lastRunDurationMs,
+      totalRunDurationMs: lifecycle.runtime.metrics.totalRunDurationMs,
+      launchCount: lifecycle.runtime.metrics.launchCount,
+      stopCount: lifecycle.runtime.metrics.stopCount,
+      exitCount: lifecycle.runtime.metrics.exitCount,
+      crashCount: lifecycle.runtime.metrics.crashCount,
+      restartCount: lifecycle.runtime.metrics.restartCount,
+      lastTermination: lifecycle.runtime.lastTermination,
+    },
+    logs: {
+      current: {
+        ...runtimeLogPaths,
+        combinedEntries,
+        stdoutLines,
+        stderrLines,
+      },
+      archives: {
+        count: archives.length,
+        maxArchives: SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION,
+      },
+    },
+  };
+}

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -31,6 +31,15 @@ interface StoredRuntimeState {
     stdoutPath?: string | null;
     stderrPath?: string | null;
   };
+  metrics?: {
+    launchCount?: number;
+    stopCount?: number;
+    exitCount?: number;
+    crashCount?: number;
+    restartCount?: number;
+    totalRunDurationMs?: number;
+    lastRunDurationMs?: number | null;
+  };
   lastAction?: LifecycleAction | null;
   actionHistory?: LifecycleAction[];
 }
@@ -100,6 +109,16 @@ function parseLifecycleState(snapshot: {
         logPath: typeof runtime?.logs?.logPath === "string" ? runtime.logs.logPath : null,
         stdoutPath: typeof runtime?.logs?.stdoutPath === "string" ? runtime.logs.stdoutPath : null,
         stderrPath: typeof runtime?.logs?.stderrPath === "string" ? runtime.logs.stderrPath : null,
+      },
+      metrics: {
+        launchCount: typeof runtime?.metrics?.launchCount === "number" ? runtime.metrics.launchCount : 0,
+        stopCount: typeof runtime?.metrics?.stopCount === "number" ? runtime.metrics.stopCount : 0,
+        exitCount: typeof runtime?.metrics?.exitCount === "number" ? runtime.metrics.exitCount : 0,
+        crashCount: typeof runtime?.metrics?.crashCount === "number" ? runtime.metrics.crashCount : 0,
+        restartCount: typeof runtime?.metrics?.restartCount === "number" ? runtime.metrics.restartCount : 0,
+        totalRunDurationMs: typeof runtime?.metrics?.totalRunDurationMs === "number" ? runtime.metrics.totalRunDurationMs : 0,
+        lastRunDurationMs:
+          typeof runtime?.metrics?.lastRunDurationMs === "number" ? runtime.metrics.lastRunDurationMs : null,
       },
     },
   };

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -71,6 +71,7 @@ export async function writeServiceState(
           lastTermination: lifecycle.runtime.lastTermination,
           ports: lifecycle.runtime.ports,
           logs: lifecycle.runtime.logs,
+          metrics: lifecycle.runtime.metrics,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,
         },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import { createDependenciesResponse } from "./routes/dependencies.js";
 import { createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
+import { createServiceMetricsResponse } from "./routes/metrics.js";
 import { createServiceVariablesResponse } from "./routes/variables.js";
 import { createServiceNetworkResponse } from "./routes/network.js";
 import { createGlobalEnvResponse } from "./routes/globalenv.js";
@@ -23,6 +24,7 @@ import { evaluateServiceHealth } from "../runtime/health/evaluateHealth.js";
 import { getServiceStatePaths } from "../runtime/state/paths.js";
 import { writeServiceState } from "../runtime/state/writeState.js";
 import { buildServiceLogs, getServiceRuntimeLogPaths } from "../runtime/operator/logs.js";
+import { buildServiceMetrics } from "../runtime/operator/metrics.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
@@ -357,6 +359,11 @@ async function routeRequest(
       return;
     }
 
+    if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "metrics") {
+      writeJson(response, 200, createServiceMetricsResponse(await buildServiceMetrics(service, getLifecycleState(serviceId))));
+      return;
+    }
+
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "variables") {
       const lifecycle = getLifecycleState(serviceId);
       const resolvedPorts = Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
@@ -482,6 +489,15 @@ async function routeRequest(
           ? getLifecycleState(service.manifest.id).runtime.ports
           : service.manifest.ports ?? {},
       ),
+    );
+    writeJson(response, 200, { services: payload });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/metrics") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const payload = await Promise.all(
+      runtimeModel.discovered.map((service) => buildServiceMetrics(service, getLifecycleState(service.manifest.id))),
     );
     writeJson(response, 200, { services: payload });
     return;

--- a/src/server/routes/metrics.ts
+++ b/src/server/routes/metrics.ts
@@ -1,0 +1,9 @@
+import type { ServiceMetricsPayload } from "../../runtime/operator/metrics.js";
+
+export interface ServiceMetricsResponse {
+  metrics: ServiceMetricsPayload;
+}
+
+export function createServiceMetricsResponse(metrics: ServiceMetricsPayload): ServiceMetricsResponse {
+  return { metrics };
+}

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -207,6 +207,84 @@ test("runtime logs archive previous runs and enforce bounded retention", async (
   }
 });
 
+test("service metrics surface persisted process evidence and survive runtime restart", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-metrics-");
+  await writeExecutableFixtureService(servicesRoot, "metric-service", {
+    stdoutLines: ["metric stdout"],
+    stderrLines: ["metric stderr"],
+    autoExitMs: 75,
+    exitCode: 3,
+  });
+
+  const firstServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${firstServer.url}/api/services/metric-service/install`);
+    await postJson(`${firstServer.url}/api/services/metric-service/config`);
+    const start = await postJson(`${firstServer.url}/api/services/metric-service/start`);
+    assert.equal(start.status, 200);
+
+    const metricsResponse = await waitFor(async () => {
+      const response = await fetch(`${firstServer.url}/api/services/metric-service/metrics`);
+      const body = await response.json();
+
+      if (body.metrics.process.crashCount === 1) {
+        return { response, body };
+      }
+
+      return null;
+    }, 2_000);
+
+    assert.equal(metricsResponse.response.status, 200);
+    assert.equal(metricsResponse.body.metrics.serviceId, "metric-service");
+    assert.equal(metricsResponse.body.metrics.process.running, false);
+    assert.equal(metricsResponse.body.metrics.process.launchCount, 1);
+    assert.equal(metricsResponse.body.metrics.process.crashCount, 1);
+    assert.equal(metricsResponse.body.metrics.process.stopCount, 0);
+    assert.equal(metricsResponse.body.metrics.process.exitCount, 0);
+    assert.equal(metricsResponse.body.metrics.process.restartCount, 0);
+    assert.equal(metricsResponse.body.metrics.process.lastTermination, "crashed");
+    assert.equal(typeof metricsResponse.body.metrics.process.lastRunDurationMs, "number");
+    assert.equal(metricsResponse.body.metrics.process.currentRunDurationMs, null);
+    assert.equal(metricsResponse.body.metrics.logs.current.stdoutLines, 1);
+    assert.equal(metricsResponse.body.metrics.logs.current.stderrLines, 1);
+    assert.equal(metricsResponse.body.metrics.logs.current.combinedEntries >= 2, true);
+    assert.equal(metricsResponse.body.metrics.logs.archives.count, 0);
+  } finally {
+    await firstServer.stop();
+    resetLifecycleState();
+  }
+
+  const secondServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const detailResponse = await fetch(`${secondServer.url}/api/services/metric-service`);
+    const detailBody = await detailResponse.json();
+    const metricsResponse = await fetch(`${secondServer.url}/api/services/metric-service/metrics`);
+    const metricsBody = await metricsResponse.json();
+    const aggregateResponse = await fetch(`${secondServer.url}/api/metrics`);
+    const aggregateBody = await aggregateResponse.json();
+
+    assert.equal(detailResponse.status, 200);
+    assert.equal(detailBody.service.lifecycle.runtime.metrics.launchCount, 1);
+    assert.equal(detailBody.service.lifecycle.runtime.metrics.crashCount, 1);
+    assert.equal(detailBody.service.lifecycle.runtime.metrics.lastRunDurationMs >= 0, true);
+
+    assert.equal(metricsResponse.status, 200);
+    assert.equal(metricsBody.metrics.process.launchCount, 1);
+    assert.equal(metricsBody.metrics.process.crashCount, 1);
+    assert.equal(metricsBody.metrics.process.running, false);
+
+    assert.equal(aggregateResponse.status, 200);
+    assert.ok(aggregateBody.services.some((service) => service.serviceId === "metric-service"));
+  } finally {
+    await secondServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services/:id/variables returns manifest and derived variables", async () => {
   resetLifecycleState();
   await clearPersistedFixtureState(servicesRoot);


### PR DESCRIPTION
## Summary
- add bounded persisted process/runtime metrics to lifecycle state and rehydration
- expose per-service and aggregate metrics routes with live log-count evidence
- update governance and review docs to mark ISS-033 done and queue demo hardening next

## Testing
- npm test