### PR TITLE
ISS-016: harden demo instance flow and regression proof

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -23,7 +23,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-013` | `done` | Add runtime startup config loading for `servicesRoot` and `workspaceRoot` | `SPEC-002` | Landed with validated startup config resolution, explicit `workspaceRoot`, and invalid-root rejection. |
 | `ISS-014` | `done` | Rehydrate runtime and lifecycle state on startup | `SPEC-002` | Landed with startup rehydration from persisted `.state` records into runtime/detail summaries. |
 | `ISS-015` | `done` | Add real process execution and supervision slice | `SPEC-002`, `AC-4B` | Landed with the first bounded execution supervisor, persisted runtime metadata, and released Echo Service artifact proof through the core runtime. |
-| `ISS-016` | `todo` | Demo-instance hardening and regression verification | `SPEC-002` | Validate demo-readiness loop from startup through multi-service runtime operations. |
+| `ISS-016` | `done` | Demo-instance hardening and regression verification | `SPEC-002`, `AC-4N` | Landed explicit demo start/reset/smoke commands plus regression proof that exercises direct and provider-backed demo services end to end against explicit runtime roots. |
 | `ISS-017` | `todo` | Establish package boundaries for core + reference apps | `SPEC-002` | Define and scaffold `packages/core`, `packages/app-electron`, and `packages/app-node` with explicit core/no-UI-framework boundary. |
 | `ISS-018` | `done` | Turn `echo-service` into a runnable Go harness fixture | `SPEC-002`, `AC-4A` | Landed with a Go-based sample service exposing UI and API actions plus log/state/SQLite persistence surfaces. |
 | `ISS-019` | `done` | Broaden bounded runtime health support with donor-aligned manifest types | `SPEC-002`, `AC-4C` | Landed the first broader health slice with bounded `tcp` manifest-health support plus automated and released-harness verification. |
@@ -41,6 +41,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-031` | `done` | Add bounded `reload` and `autostart` orchestration follow-up | `SPEC-002`, `AC-4K` | Landed bounded `reload` and `autostart` orchestration with manifest opt-in, boot-time autostart, and deterministic reload stop/restart behavior. |
 | `ISS-032` | `done` | Add bounded archival and retention for runtime logs | `SPEC-002`, `AC-4L` | Landed bounded per-service runtime-log archival on next start with deterministic retention pruning and logs API archive metadata. |
 | `ISS-033` | `done` | Add bounded process/runtime metrics surfaces | `SPEC-002`, `AC-4M` | Landed bounded persisted launch/termination/duration metrics plus live log-count metrics through service detail, dedicated metrics routes, and restart-stable runtime state. |
+| `ISS-034` | `todo` | Validate `lasso-@serviceadmin` against the current runtime/API | `SPEC-002` | Use the current bounded runtime plus released Echo Service artifacts as the first real consumer integration proof before package/template rollout. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -60,7 +61,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-013` | `done` | `ISS-013` | Implement runtime config loading + validation (`servicesRoot`, `workspaceRoot`) | `SPEC-002` | Runtime boots from explicit validated roots, surfaces `workspaceRoot`, and rejects missing `servicesRoot` |
 | `TASK-014` | `done` | `ISS-014` | Implement startup rehydration from persisted runtime/lifecycle state | `SPEC-002` | Startup restores persisted lifecycle state and runtime summaries/detail endpoints reflect the rehydrated state |
 | `TASK-015` | `done` | `ISS-015` | Add first bounded execution supervisor for one provider path | `SPEC-002`, `AC-4B` | Real process launch/stop supervision works with persisted runtime state updates and released Echo Service artifacts can be run through the core runtime |
-| `TASK-016` | `todo` | `ISS-016` | Run demo-instance hardening checklist and regression suite | `SPEC-002` | Demo-instance plan checkpoints are met with repeatable validation evidence |
+| `TASK-016` | `done` | `ISS-016` | Run demo-instance hardening checklist and regression suite | `SPEC-002`, `AC-4N` | The repo exposes explicit demo start/reset/smoke commands, the smoke flow validates direct and provider-backed demo services end to end, and the demo can be rerun from a clean reset without manual cleanup |
 | `TASK-017` | `todo` | `ISS-017` | Scaffold package split (`core`, `app-electron`, `app-node`) and baseline build wiring | `SPEC-002` | Monorepo package map exists with core exports/CLI target and reference app placeholders consuming core |
 | `TASK-018` | `done` | `ISS-018` | Implement the `echo-service` Go harness fixture with UI, API, and persistence behaviors | `SPEC-002`, `AC-4A` | `echo-service` now builds and runs as a Go harness with action endpoints, browser UI, logs, state snapshots, and SQLite writes |
 | `TASK-019` | `done` | `ISS-019` | Implement bounded `tcp` manifest-health support with direct tests | `SPEC-002`, `AC-4C` | Runtime accepts `healthcheck.type = tcp`, reports healthy/unhealthy results deterministically, and has direct verification coverage including released Echo Service TCP-port proof |
@@ -78,6 +79,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-031` | `done` | `ISS-031` | Add bounded `reload` and `autostart` orchestration semantics | `SPEC-002`, `AC-4K` | Runtime exposes explicit, deterministic `reload` and `autostart` behavior on top of the current bounded orchestration model |
 | `TASK-032` | `done` | `ISS-032` | Add bounded archival and retention rules for runtime-owned logs | `SPEC-002`, `AC-4L` | Runtime-owned per-service logs archive prior runs on the next managed start, prune older archives deterministically, and expose retained archive metadata through the logs API |
 | `TASK-033` | `done` | `ISS-033` | Add bounded process/runtime metrics surfaces | `SPEC-002`, `AC-4M` | Runtime exposes bounded launch/termination/duration/log metrics beyond pid/running state, persists the owned metrics across restart, and surfaces them through dedicated metrics routes without overclaiming donor-depth process-tree parity |
+| `TASK-034` | `todo` | `ISS-034` | Run `lasso-@serviceadmin` integration validation against the current runtime/API | `SPEC-002` | The admin UI can consume the current runtime/API against the bounded demo/runtime shape without special-case hacks, and any discovered contract gaps are recorded as governed follow-up work |
 
 ## Next Recommended Item
-The next best item is `TASK-016`: run demo-instance hardening and regression verification so the current bounded execution-backed runtime can be proven end to end with the stronger observability now in place.
+The next best item is `TASK-034`: validate `lasso-@serviceadmin` against the current runtime/API now that the bounded demo and regression proof are in place.

--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -40,6 +40,7 @@ Explicitly out of scope for this spec:
 - `AC-4K`: The runtime extends bounded orchestration with explicit `reload` and `autostart` semantics so services can opt into startup orchestration, startup can trigger autostart deterministically, and runtime `reload` can rediscover manifests while stopping and restarting previously running eligible services with direct API proof.
 - `AC-4L`: The runtime extends bounded observability with explicit per-service runtime-log archival and retention so new managed runs roll forward without unbounded log growth and the logs API can surface retained recent archives deterministically.
 - `AC-4M`: The runtime extends bounded observability with explicit process/runtime metrics so persisted runtime state and API/operator surfaces can report launch, termination, duration, and log-count evidence beyond pid/running state without claiming full donor-depth process-tree metrics.
+- `AC-4N`: The runtime provides one explicit demo-instance quickstart, reset path, and scripted smoke validation flow so a reviewer can exercise the bounded runtime end to end against explicit `servicesRoot` and `workspaceRoot` without manual repo cleanup.
 - `AC-5`: Core repo build/validation/release plumbing exists at a minimum viable level so the repo behaves like an actual product repository.
 - `AC-6`: Project docs/backlog/spec traceability clearly identify which runtime behavior is now implemented here versus which behavior still lives only in donor/reference material.
 
@@ -60,6 +61,7 @@ Required evidence for this spec:
 - direct proof that `autostart`-eligible services can start automatically on runtime boot and through a runtime action, and that `reload` can rediscover manifests while stopping and restarting previously running eligible services deterministically
 - direct proof that prior per-service runtime log files are archived on the next managed start, that retention prunes older archives deterministically, and that the logs API surfaces retained archive metadata
 - direct proof that persisted runtime state and API/operator surfaces expose bounded launch, termination, duration, and log-count metrics that survive runtime restart and remain consistent with current managed log files
+- direct proof that the documented demo-instance smoke flow can start the runtime against explicit roots, exercise one direct service plus one provider-backed service, inspect runtime/operator surfaces, stop the services cleanly, and rerun from a reset state
 - build/validation proof for the new core source tree
 - documentation updates that map the new runtime slice to the canonical contract/docs
 - explicit residual-gap notes for lifecycle/provider behaviors not yet implemented

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ npm run test
 npm run dev
 ```
 
+## Demo instance commands
+
+The repo now includes an explicit bounded demo flow that uses the tracked `services/` tree as `servicesRoot` and `workspace/demo-instance/` as the default `workspaceRoot`.
+
+```bash
+npm run demo:start
+npm run demo:smoke
+npm run demo:reset
+```
+
+What these do:
+
+- `npm run demo:start` builds and starts the runtime against the demo roots so a reviewer can inspect `/api/health`, `/api/services`, `/api/runtime`, and `/api/dependencies`
+- `npm run demo:smoke` runs the end-to-end scripted demo proof for the direct `echo-service` path plus the provider-backed `node-sample-service` path
+- `npm run demo:reset` removes demo workspace/state/artifact output so the demo can be rerun cleanly without manual cleanup
+
+The scripted smoke flow is also covered by `tests/demo-instance.test.js`.
+
 ## Donor Reference Snapshot
 
 ## Donor Reference Snapshot

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -233,6 +233,7 @@ The first bounded core slices added so far include:
 - bounded provider planning
 - bounded per-service runtime log archival and retention
 - bounded process/runtime metrics
+- explicit demo start/reset/smoke commands for a reviewable bounded runtime instance
 - first API server layer
 
 This is meaningful progress, but it is **not full donor runtime parity yet**.
@@ -251,6 +252,10 @@ Important current boundary:
 - the sibling `lasso-echoservice` harness can already simulate HTTP and TCP health targets for testing and demo hardening
 - `service-lasso` runtime itself now implements bounded manifest health evaluation for `process`, `http`, `tcp`, `file`, and `variable`
 - broader donor-health migration work still remains for readiness-loop behavior on top of those bounded checks
+
+Current demo note:
+- the repo now provides `npm run demo:start`, `npm run demo:smoke`, and `npm run demo:reset`
+- those commands exercise the bounded direct-service and provider-backed demo flow against explicit `servicesRoot` and `workspaceRoot`
 
 Again, that is why the repo should be read as:
 

--- a/docs/development/core-runtime-autonomous-task-list.md
+++ b/docs/development/core-runtime-autonomous-task-list.md
@@ -147,7 +147,7 @@ Current honest label:
 ### Wave 6: Demo and consumer validation
 
 15. demo-instance hardening
-    status: queued
+    status: done
     proof:
     - demo path proves real execution-backed behavior
     - demo cannot be satisfied by state flips alone
@@ -201,6 +201,6 @@ Current honest label:
 
 The next implementation slice from this list is:
 
-**demo-instance hardening**
+**`lasso-@serviceadmin` integration validation**
 
-That is the next clean delivery step because the runtime now has bounded execution, orchestration, runtime-owned logs, archival/retention, and bounded process/runtime metrics, so the highest-value next proof is an honest end-to-end demo flow that uses those capabilities together.
+That is the next clean delivery step because the runtime now has a bounded end-to-end demo flow with direct regression proof, so the highest-value next check is validating that the first real consumer repo can use the current API/runtime without special-case hacks.

--- a/docs/development/core-runtime-demo-instance-plan.md
+++ b/docs/development/core-runtime-demo-instance-plan.md
@@ -1,12 +1,16 @@
 # Core runtime demo-instance plan
 
-This document defines the practical plan for turning the current bounded `service-lasso` core runtime into a reviewable demo instance.
+This document now doubles as the current demo-instance quickstart and the residual-hardening note for the bounded `service-lasso` demo flow.
 
-It is intentionally narrower than the full product/runtime roadmap. The goal is not "finish Service Lasso" in one jump. The goal is to produce a demoable, testable instance that proves the core runtime shape end to end.
+The original goal was to turn the core runtime into a reviewable demo instance. That bounded goal is now implemented. The current purpose of this document is to show:
+- what the demo proves today
+- which commands are the canonical demo commands
+- what evidence the scripted demo smoke actually checks
+- what still remains outside the bounded demo slice
 
 ## Purpose
 
-The demo instance should let us prove, in one local runnable slice, that `service-lasso` can:
+The demo instance proves, in one local runnable slice, that `service-lasso` can:
 - start a real core API process
 - load a real managed service tree from `services/`
 - expose service/runtime/operator endpoints from that tree
@@ -15,24 +19,45 @@ The demo instance should let us prove, in one local runnable slice, that `servic
 - show provider execution behavior for the demo services
 - give the UI/harness a stable target to exercise
 
-## Current starting point
+## Current demo commands
 
-The repo already has the first bounded core slices in place:
-- API server entrypoint
-- manifest discovery and validation
-- registry and dependency graph
-- bounded lifecycle actions
-- bounded process/http health evaluation
-- `.state` file writing/reading helpers
-- operator data surfaces (logs, variables, network)
-- provider execution planning (direct, node, python)
-- direct tests covering those slices
+Use these commands from the repo root:
 
-What it does **not** yet provide is a full reviewable demo instance with a clear startup model, stable validation flow, and real end-to-end demo semantics.
+```bash
+npm run demo:start
+npm run demo:smoke
+npm run demo:reset
+```
 
-## Demo-instance success bar
+Default demo roots:
+- `servicesRoot = <repo>/services`
+- `workspaceRoot = <repo>/workspace/demo-instance`
 
-The demo instance is good enough when all of the following are true:
+Override flags when needed:
+- `--services-root=<path>`
+- `--workspace-root=<path>`
+- `--port=<number>`
+- `--preserve` for `demo:smoke` if you want to keep demo output after the smoke run
+
+`demo:start`:
+- builds the repo
+- starts the runtime against the demo roots
+- prints the API URL, `servicesRoot`, and `workspaceRoot`
+
+`demo:smoke`:
+- resets the demo roots first
+- starts the runtime against explicit roots
+- exercises the bounded end-to-end flow
+- stops the runtime and resets the demo again unless `--preserve` is set
+
+`demo:reset`:
+- removes the demo workspace
+- removes tracked demo `.state` and `logs` output
+- removes manifest-declared install/config artifact files for the demo service set
+
+## Implemented success bar
+
+The bounded demo instance is considered implemented because all of the following are now true:
 
 1. A reviewer can start the core runtime with one documented command.
 2. The runtime comes up against a known demo `services/` root.
@@ -41,6 +66,25 @@ The demo instance is good enough when all of the following are true:
 5. Structured `.state` files can be inspected before and after lifecycle actions.
 6. The demo can be re-run cleanly without hand-editing the repo.
 7. There is one documented smoke test flow for humans and one scripted validation flow for automation.
+
+Important honesty rule:
+- this demo is execution-backed, not state-flip-only
+- the smoke flow proves one direct managed service path and one provider-backed path
+- passing docs or state-file inspection alone is not enough
+
+## Current demo service set
+
+The bounded demo currently uses:
+- `echo-service` as the direct managed service path
+- `@node` as the runtime provider dependency
+- `node-sample-service` as the provider-backed managed service path
+
+This keeps the demo small while still proving:
+- direct execution
+- provider-backed execution
+- dependency-aware startup
+- runtime/operator surfaces
+- persisted runtime/state/log/metrics evidence
 
 ## Scope boundary for the demo
 
@@ -62,197 +106,71 @@ The demo instance is good enough when all of the following are true:
 - full UI/operator product completion
 - all future runtime hardening work
 
-## Recommended demo-instance shape
+## Current scripted smoke flow
 
-### Runtime mode
-Use the current Node/TypeScript runtime in development mode as the first demo target.
+`npm run demo:smoke` currently verifies all of the following:
 
-### Runtime roots
-The demo path should use both:
-- `servicesRoot`
-- `workspaceRoot`
-
-Preferred first step:
-- keep the current tracked `services/` tree as the default demo `servicesRoot` for now
-- add an explicit demo `workspaceRoot` so runtime-managed logs/work data do not float implicitly
-- tighten the current demo services so they behave like an intentional fixture set rather than just test input
-
-### Demo services
-The first demo set should stay small and explicit:
-- `@node`
-- `@python`
-- one runnable harness service such as `echo-service`, with API + UI surfaces that can simulate lifecycle-adjacent behavior for demo and supervision hardening
-- optionally one HTTP-health demo service if it materially improves the review flow
-
-The demo services should be designed for clarity, not realism overload.
-
-## Phased plan
-
-## Phase 1, stabilize the current demo entry
-
-Goal:
-make the current runtime easy to start and inspect as a demo target.
-
-Required outcomes:
-- document the exact startup command
-- document the default demo URL/port
-- document the main review endpoints
-- confirm the runtime loads the intended `servicesRoot`
-- confirm the runtime writes its working data to the intended `workspaceRoot`
-- add a short reviewer smoke-test checklist
-
-Suggested deliverables:
-- README/demo section or dedicated quickstart section
-- one demo smoke-test doc
-- one tiny helper script if startup is still awkward
-
-Exit evidence:
-- a fresh reviewer can start the runtime and hit `/api/health`, `/api/services`, `/api/runtime`, and `/api/dependencies`
-
-## Phase 2, harden the demo service set
-
-Goal:
-make the demo services feel intentional and reviewable.
-
-Required outcomes:
-- each demo service has a clearly valid `service.json`
-- provider relationships are explicit and understandable
-- operator surfaces return useful demo data
-- health behavior is predictable
-
-Suggested deliverables:
-- tidy current manifests for demo clarity
-- add missing metadata that helps runtime/operator inspection
-- ensure one service clearly demonstrates provider-backed execution
-
-Exit evidence:
-- service detail, variables, network, logs, and provider fields are all meaningful in the demo API output
-
-## Phase 3, add a real demo lifecycle flow
-
-Goal:
-make the demo prove actual state transitions, not just static discovery.
-
-Required outcomes:
-- one demo service has a documented lifecycle walkthrough
-- lifecycle actions update both API-visible state and `.state` files
-- health output reflects the lifecycle state in a reviewable way
-
-Suggested deliverables:
-- one demo walkthrough covering install/config/start/health/stop
-- one script or command block that runs the flow end to end
-- one doc section showing where state files are written
-
-Exit evidence:
-- the lifecycle walkthrough works from a clean starting state and produces the expected files/responses
-
-## Phase 4, add demo reset and rerun support
-
-Goal:
-make the demo repeatable without manual cleanup pain.
-
-Required outcomes:
-- documented reset/cleanup path
-- no mystery leftover state between runs
-- reviewers can rerun the demo cleanly
-
-Suggested deliverables:
-- reset script or documented cleanup command
-- demo-state location docs
-- scripted smoke flow that can be rerun repeatedly
-
-Exit evidence:
-- demo can be run, reset, and run again with the same expected outputs
-
-## Phase 5, add automation-grade demo validation
-
-Goal:
-turn the demo into a reliable proof target for CI/harness/UI work.
-
-Required outcomes:
-- one scripted validation flow exercises the demo instance
-- the scripted flow checks key API responses and lifecycle outcomes
-- the flow is suitable for future CI integration
-
-Suggested deliverables:
-- script under `scripts/`
-- integration test or smoke-test wrapper
-- clear pass/fail output
-
-Exit evidence:
-- one command validates the demo instance behavior without manual inspection
-
-## Highest-priority gaps to close first
-
-These are the most valuable next moves if the goal is a credible demo instance:
-
-1. **Documented startup path**
-   - the runtime already starts, but the demo path should be explicit and reviewer-friendly
-
-2. **Intentional demo service set**
-   - the current `services/` tree should read like a demo fixture set, not just test scaffolding
-
-3. **Lifecycle walkthrough**
-   - reviewers should be able to see a single clean service go through a bounded action sequence
-
-4. **Demo reset path**
-   - reruns should not depend on manual state cleanup guesswork
-
-5. **Scripted smoke validation**
-   - the demo should become a reliable proof target for future UI/harness integration
-
-## Recommended implementation order
-
-1. Document startup + review endpoints
-2. Tighten the demo service manifests
-3. Write the lifecycle walkthrough
-4. Add demo reset/cleanup support
-5. Add scripted smoke validation
-6. Only then expand toward more realistic execution behavior
-
-## Concrete reviewer flow we should target
-
-The first good demo review should look like this:
-
-1. Run one command to start `service-lasso` with both `servicesRoot` and `workspaceRoot`
-2. Open or fetch:
+1. reset the demo roots to a known clean state
+2. start the runtime against explicit `servicesRoot` and `workspaceRoot`
+3. confirm:
    - `/api/health`
    - `/api/services`
    - `/api/runtime`
    - `/api/dependencies`
-3. Inspect one service detail endpoint
-4. Trigger:
+4. run `echo-service` through:
    - `install`
    - `config`
    - `start`
-5. Recheck:
-   - service detail
-   - service health
-   - runtime summary
-   - `.state` files
-6. Trigger `stop`
-7. Recheck runtime + state
-8. Reset the demo cleanly
+5. confirm `echo-service`:
+   - reports healthy
+   - writes runtime logs
+   - exposes runtime metrics
+   - persists `.state/runtime.json`
+6. run `@node` and `node-sample-service` through `install` and `config`
+7. start `node-sample-service`
+8. confirm provider-backed evidence and bounded `@node` dependency launch evidence
+9. confirm aggregate runtime metrics include the exercised services
+10. run runtime `stopAll`
+11. confirm the direct and provider-backed services are stopped cleanly
+12. stop the runtime and reset demo output again by default
 
-If that flow is smooth, the demo instance is already useful.
+The regression wrapper for this flow is:
+- `tests/demo-instance.test.js`
+
+## Quick reviewer flow
+
+For a manual review:
+
+1. Run `npm run demo:start`
+2. Fetch or open:
+   - `/api/health`
+   - `/api/services`
+   - `/api/runtime`
+   - `/api/dependencies`
+3. Run lifecycle actions against `echo-service`:
+   - `install`
+   - `config`
+   - `start`
+   - `stop`
+4. Inspect:
+   - `/api/services/echo-service`
+   - `/api/services/echo-service/health`
+   - `/api/services/echo-service/logs`
+   - `/api/services/echo-service/metrics`
+   - `services/echo-service/.state/`
+5. Run `npm run demo:reset` when done
+
+## Evidence expectations
+
+The minimum honest evidence for this demo slice is:
+- `npm run demo:smoke`
+- `npm test`
+
+Anything weaker should be treated as partial proof only.
 
 ## Relationship to later runtime hardening
 
 This demo plan does **not** replace the broader runtime roadmap.
 
-After the demo instance is working, the next likely hardening tracks are still:
-- better API error/status semantics
-- runtime model loading/validation strategy
-- state rehydration on startup
-- stronger dependency/provider validation
-- broader real execution behavior
-
-Those are important, but they should not block the first good demo instance unless they are directly needed to make the demo credible.
-
-## Recommended next execution item
-
-The next best step is:
-
-**Create the first explicit demo quickstart + smoke-test path for the current runtime.**
-
-That gives the project an immediately reviewable target and makes later hardening easier to validate.
+The bounded demo slice does not replace later hardening work. The main follow-on consumer proof should now be:
+- `lasso-@serviceadmin` integration validation against the current runtime API using the same bounded demo/runtime shape

--- a/docs/development/core-runtime-working-application-plan.md
+++ b/docs/development/core-runtime-working-application-plan.md
@@ -12,16 +12,16 @@ It is based on:
 What is already true:
 - the repo has a real bounded runtime slice
 - `npm test` passes for that bounded slice
-- discovery, validation, registry, lifecycle state, bounded health, operator surfaces, and API startup all exist
+- discovery, validation, registry, execution-backed lifecycle behavior, bounded health, operator surfaces, and API startup all exist
+- the repo now exposes explicit `demo:start`, `demo:smoke`, and `demo:reset` commands for the bounded review/demo flow
 
 What is not true yet:
-- the runtime does not yet launch and supervise real managed processes
 - the docs still blur current behavior and future direction in several places
-- the current demo plan can overstate readiness without proving real execution
+- the first real consumer repo still needs to be validated against the current runtime/API
 
 The honest current label remains:
 
-**bounded core runtime slice implemented; working application not complete yet**
+**bounded working core runtime implemented with explicit demo proof; broader consumer/runtime parity still not complete**
 
 ## Goal
 
@@ -221,12 +221,9 @@ They should remain outside core and never redefine the core runtime contract.
 
 If we are choosing the next best steps right now, the recommended order is:
 
-1. `TASK-012` - normalize API error semantics
-2. `TASK-013` - add explicit runtime config loading for `servicesRoot` and `workspaceRoot`
-3. `TASK-014` - add startup rehydration
-4. `TASK-015` - land the first real execution/supervision slice
-5. tighten the demo-instance plan and run `TASK-016`
-6. refresh the highest-drift docs alongside that work
+1. validate `lasso-@serviceadmin` against the current bounded runtime/API
+2. refresh the highest-drift docs alongside that consumer validation work
+3. establish package boundaries for core + reference apps
 
 ## What "working application" means in this repo
 
@@ -238,6 +235,7 @@ For this repo, "working application" should mean all of the following are true:
 - runtime persists and rehydrates enough state to survive restart meaningfully
 - runtime exposes stable API responses and error contracts
 - runtime can support a credible demo flow with execution evidence
+- repo provides an explicit resettable demo quickstart and scripted smoke proof
 
 It does **not** need to mean full donor parity yet.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test --test-concurrency=1 tests/**/*.test.js",
     "dev": "npm run build && node --enable-source-maps dist/index.js",
-    "start": "node --enable-source-maps dist/index.js"
+    "start": "node --enable-source-maps dist/index.js",
+    "demo:start": "npm run build && node scripts/demo-start.mjs",
+    "demo:reset": "npm run build && node scripts/demo-reset.mjs",
+    "demo:smoke": "npm run build && node scripts/demo-smoke.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -1,0 +1,237 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { access, readFile, rm } from "node:fs/promises";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+export const repoRoot = path.resolve(scriptDir, "..");
+export const defaultDemoServicesRoot = path.join(repoRoot, "services");
+export const defaultDemoWorkspaceRoot = path.join(repoRoot, "workspace", "demo-instance");
+export const demoServiceIds = ["echo-service", "@node", "node-sample-service"];
+
+function parseFlag(args, name) {
+  const prefix = `--${name}=`;
+  const match = args.find((value) => value.startsWith(prefix));
+  return match ? match.slice(prefix.length) : undefined;
+}
+
+export function resolveDemoOptions(args = process.argv.slice(2)) {
+  return {
+    servicesRoot: path.resolve(parseFlag(args, "services-root") ?? defaultDemoServicesRoot),
+    workspaceRoot: path.resolve(parseFlag(args, "workspace-root") ?? defaultDemoWorkspaceRoot),
+    port: Number(parseFlag(args, "port") ?? process.env.SERVICE_LASSO_PORT ?? 18080),
+    preserve: args.includes("--preserve"),
+  };
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeManifestDeclaredFiles(serviceRoot) {
+  const manifestPath = path.join(serviceRoot, "service.json");
+  if (!(await pathExists(manifestPath))) {
+    return;
+  }
+
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const declaredFiles = [
+    ...(manifest.install?.files ?? []),
+    ...(manifest.config?.files ?? []),
+  ]
+    .map((entry) => (typeof entry?.path === "string" ? entry.path : null))
+    .filter((entry) => entry);
+
+  await Promise.all(
+    declaredFiles.map((relativePath) =>
+      rm(path.resolve(serviceRoot, relativePath), { force: true, recursive: true }),
+    ),
+  );
+}
+
+export async function resetDemoInstance(options = {}) {
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+
+  await rm(workspaceRoot, { recursive: true, force: true });
+
+  await Promise.all(
+    demoServiceIds.map(async (serviceId) => {
+      const serviceRoot = path.join(servicesRoot, serviceId);
+      await Promise.all([
+        rm(path.join(serviceRoot, ".state"), { recursive: true, force: true }),
+        rm(path.join(serviceRoot, "logs"), { recursive: true, force: true }),
+      ]);
+      await removeManifestDeclaredFiles(serviceRoot);
+    }),
+  );
+}
+
+async function importDistModule(relativePath) {
+  return import(pathToFileURL(path.join(repoRoot, "dist", relativePath)).href);
+}
+
+export async function startDemoRuntime(options = {}) {
+  const { startRuntimeApp } = await importDistModule(path.join("runtime", "app.js"));
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+  const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
+
+  return startRuntimeApp({
+    servicesRoot,
+    workspaceRoot,
+    port,
+    version: process.env.npm_package_version ?? "0.1.0",
+  });
+}
+
+async function getJson(url, method = "GET") {
+  const response = await fetch(url, { method });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function assertCondition(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function waitFor(check, timeoutMs = 2_000, intervalMs = 50) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await check();
+    if (value) {
+      return value;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`Condition not met within ${timeoutMs}ms.`);
+}
+
+export async function runDemoSmoke(options = {}) {
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+  const port = options.port ?? 0;
+  const preserve = options.preserve === true;
+
+  await resetDemoInstance({ servicesRoot, workspaceRoot });
+
+  const runtime = await startDemoRuntime({ servicesRoot, workspaceRoot, port });
+
+  try {
+    const health = await getJson(`${runtime.apiServer.url}/api/health`);
+    const services = await getJson(`${runtime.apiServer.url}/api/services`);
+    const runtimeSummary = await getJson(`${runtime.apiServer.url}/api/runtime`);
+    const dependencies = await getJson(`${runtime.apiServer.url}/api/dependencies`);
+
+    assertCondition(health.status === 200, "Expected /api/health to return 200.");
+    assertCondition(services.status === 200, "Expected /api/services to return 200.");
+    assertCondition(runtimeSummary.status === 200, "Expected /api/runtime to return 200.");
+    assertCondition(dependencies.status === 200, "Expected /api/dependencies to return 200.");
+    assertCondition(
+      services.body.services.some((service) => service.id === "echo-service"),
+      "Expected echo-service in demo services list.",
+    );
+    assertCondition(
+      services.body.services.some((service) => service.id === "node-sample-service"),
+      "Expected node-sample-service in demo services list.",
+    );
+
+    for (const action of ["install", "config", "start"]) {
+      const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/${action}`, "POST");
+      assertCondition(result.status === 200, `Expected echo-service ${action} to return 200.`);
+    }
+
+    const echoHealth = await getJson(`${runtime.apiServer.url}/api/services/echo-service/health`);
+    const echoLogs = await waitFor(async () => {
+      const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/logs`);
+      if (result.body.logs.entries.length > 0) {
+        return result;
+      }
+      return null;
+    });
+    const echoMetrics = await getJson(`${runtime.apiServer.url}/api/services/echo-service/metrics`);
+    const echoState = JSON.parse(await readFile(path.join(servicesRoot, "echo-service", ".state", "runtime.json"), "utf8"));
+
+    assertCondition(echoHealth.body.health.healthy === true, "Expected echo-service health to be healthy after start.");
+    assertCondition(echoLogs.body.logs.logPath.endsWith(path.join("echo-service", "logs", "runtime", "service.log")), "Expected echo-service runtime log path.");
+    assertCondition(echoMetrics.body.metrics.process.launchCount === 1, "Expected echo-service launch count to be 1.");
+    assertCondition(echoMetrics.body.metrics.process.running === true, "Expected echo-service metrics to report running.");
+    assertCondition(echoState.running === true, "Expected echo-service persisted runtime state to report running.");
+
+    for (const serviceId of ["@node", "node-sample-service"]) {
+      for (const action of ["install", "config"]) {
+        const result = await getJson(`${runtime.apiServer.url}/api/services/${encodeURIComponent(serviceId)}/${action}`, "POST");
+        assertCondition(result.status === 200, `Expected ${serviceId} ${action} to return 200.`);
+      }
+    }
+
+    const providerStart = await getJson(`${runtime.apiServer.url}/api/services/node-sample-service/start`, "POST");
+    assertCondition(providerStart.status === 200, "Expected node-sample-service start to return 200.");
+    assertCondition(providerStart.body.provider.provider === "node", "Expected node-sample-service provider to resolve to node.");
+
+    const providerDetail = await getJson(`${runtime.apiServer.url}/api/services/node-sample-service`);
+    const providerMetrics = await getJson(`${runtime.apiServer.url}/api/services/node-sample-service/metrics`);
+    const nodeProviderDetail = await getJson(`${runtime.apiServer.url}/api/services/%40node`);
+    const nodeProviderMetrics = await getJson(`${runtime.apiServer.url}/api/services/%40node/metrics`);
+    const aggregateMetrics = await getJson(`${runtime.apiServer.url}/api/metrics`);
+
+    assertCondition(providerDetail.body.service.lifecycle.running === true, "Expected node-sample-service to be running.");
+    assertCondition(providerMetrics.body.metrics.process.provider === "node", "Expected node-sample-service metrics provider.");
+    assertCondition(providerMetrics.body.metrics.process.launchCount === 1, "Expected node-sample-service launch count to be 1.");
+    assertCondition(nodeProviderDetail.body.service.id === "@node", "Expected @node provider detail to be available.");
+    assertCondition(nodeProviderMetrics.body.metrics.process.launchCount >= 1, "Expected @node dependency to have launch evidence.");
+    assertCondition(
+      nodeProviderMetrics.body.metrics.process.lastTermination === "exited"
+        || nodeProviderMetrics.body.metrics.process.running === true,
+      "Expected @node dependency to show bounded launch or running evidence.",
+    );
+    assertCondition(
+      aggregateMetrics.body.services.some((service) => service.serviceId === "echo-service"),
+      "Expected aggregate metrics to include echo-service.",
+    );
+
+    const stopAll = await getJson(`${runtime.apiServer.url}/api/runtime/actions/stopAll`, "POST");
+    assertCondition(stopAll.status === 200, "Expected stopAll to return 200.");
+    assertCondition(
+      stopAll.body.results.some((result) => result.serviceId === "echo-service"),
+      "Expected stopAll to include echo-service.",
+    );
+    assertCondition(
+      stopAll.body.results.some((result) => result.serviceId === "node-sample-service"),
+      "Expected stopAll to include node-sample-service.",
+    );
+
+    const stoppedEchoMetrics = await getJson(`${runtime.apiServer.url}/api/services/echo-service/metrics`);
+    const stoppedProviderMetrics = await getJson(`${runtime.apiServer.url}/api/services/node-sample-service/metrics`);
+
+    assertCondition(stoppedEchoMetrics.body.metrics.process.running === false, "Expected echo-service to be stopped.");
+    assertCondition(stoppedEchoMetrics.body.metrics.process.stopCount >= 1, "Expected echo-service stop count.");
+    assertCondition(stoppedProviderMetrics.body.metrics.process.running === false, "Expected node-sample-service to be stopped.");
+
+    return {
+      url: runtime.apiServer.url,
+      servicesRoot,
+      workspaceRoot,
+      summary: {
+        health: health.body.status,
+        runtimeServices: runtimeSummary.body.runtime.totalServices,
+        demoServicesExercised: ["echo-service", "@node", "node-sample-service"],
+      },
+    };
+  } finally {
+    await runtime.apiServer.stop();
+
+    if (!preserve) {
+      await resetDemoInstance({ servicesRoot, workspaceRoot });
+    }
+  }
+}

--- a/scripts/demo-reset.mjs
+++ b/scripts/demo-reset.mjs
@@ -1,0 +1,8 @@
+import { resolveDemoOptions, resetDemoInstance } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+await resetDemoInstance(options);
+
+console.log("[service-lasso demo] reset complete");
+console.log(`- servicesRoot: ${options.servicesRoot}`);
+console.log(`- workspaceRoot: ${options.workspaceRoot}`);

--- a/scripts/demo-smoke.mjs
+++ b/scripts/demo-smoke.mjs
@@ -1,0 +1,10 @@
+import { resolveDemoOptions, runDemoSmoke } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const result = await runDemoSmoke(options);
+
+console.log("[service-lasso demo] smoke passed");
+console.log(`- api: ${result.url}`);
+console.log(`- servicesRoot: ${result.servicesRoot}`);
+console.log(`- workspaceRoot: ${result.workspaceRoot}`);
+console.log(`- exercised: ${result.summary.demoServicesExercised.join(", ")}`);

--- a/scripts/demo-start.mjs
+++ b/scripts/demo-start.mjs
@@ -1,0 +1,18 @@
+import { resolveDemoOptions, startDemoRuntime } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const runtime = await startDemoRuntime(options);
+
+console.log("[service-lasso demo] runtime started");
+console.log(`- api: ${runtime.apiServer.url}`);
+console.log(`- servicesRoot: ${runtime.serviceRoot.servicesRoot}`);
+console.log(`- workspaceRoot: ${runtime.serviceRoot.workspaceRoot}`);
+console.log("- stop: Ctrl+C");
+
+const shutdown = async () => {
+  await runtime.apiServer.stop();
+  process.exit(0);
+};
+
+process.on("SIGINT", () => void shutdown());
+process.on("SIGTERM", () => void shutdown());

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+test("demo smoke script validates the bounded demo instance end to end", async () => {
+  const demoScript = path.resolve("scripts", "demo-smoke.mjs");
+
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [demoScript], {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        SERVICE_LASSO_PORT: "0",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+
+  assert.equal(result.code, 0, `Expected demo smoke to pass.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  assert.match(result.stdout, /\[service-lasso demo] smoke passed/);
+  assert.match(result.stdout, /echo-service, @node, node-sample-service/);
+});


### PR DESCRIPTION
## Summary\n- add explicit demo start, reset, and smoke scripts for the bounded runtime instance\n- add a regression test that runs the scripted demo smoke flow end to end\n- update spec, backlog, README, and demo planning docs to reflect the implemented demo proof\n\n## Verification\n- npm run demo:smoke\n- npm test