### PR TITLE
Document app service inventory requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ Current package-boundary note:
 - the publishable package is staged separately as a self-contained payload for `@service-lasso/service-lasso`
 - the starter/template apps live outside this repo as sibling repos under `C:\projects\service-lasso`
 
+Reference app inventory rule:
+
+- every repo that uses Service Lasso should own its own tracked `services/` folder
+- that folder should contain the service manifests for the exact services that repo intends to manage
+- if a repo includes `services/service-admin/service.json`, it should also include the manifests needed to satisfy Service Admin's service dependencies
+- the current baseline stack for the reference repos is:
+  - `services/echo-service/service.json`
+  - `services/service-admin/service.json`
+  - `services/@node/service.json`
+  - `services/@traefik/service.json`
+- runtime env such as `VITE_SERVICE_LASSO_API_BASE_URL` still belongs in app/runtime config, not as separate service manifests
+
 Note on repo split:
 - the canonical Echo Service implementation now lives in the sibling repo `C:\projects\service-lasso\lasso-echoservice`
 - `service-lasso/services/echo-service/` remains a thin local fixture manifest so the core repo stays self-contained for discovery/runtime tests

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -89,6 +89,17 @@ These should all consume the same canonical runtime model based on:
 - `servicesRoot`
 - `workspaceRoot`
 
+Reference app inventory rule:
+- each reference app repo should own a tracked `services/` folder for the services that app intends to manage
+- `services/` is part of the app repo contract, not something inferred from sibling repos at runtime
+- if a reference app includes `service-admin`, it should also carry the service manifests needed to satisfy Service Admin's declared service dependencies
+- the current baseline inventory for the starter repos is:
+  - `services/echo-service/service.json`
+  - `services/service-admin/service.json`
+  - `services/@node/service.json`
+  - `services/@traefik/service.json`
+- environment settings like `VITE_SERVICE_LASSO_API_BASE_URL` remain app/runtime configuration, not extra service manifests
+
 The next concrete delivery step for those starter repos is:
 - consume published `@service-lasso/service-lasso`
 - remain clonable and executable

--- a/docs/development/core-runtime-package-architecture.md
+++ b/docs/development/core-runtime-package-architecture.md
@@ -96,6 +96,16 @@ They consume the canonical runtime package and should use the same runtime-root 
 - `servicesRoot`
 - `workspaceRoot`
 
+They should also own the exact tracked service inventory they intend to manage under repo-local `services/`.
+
+Current baseline inventory rule for the starter repos:
+- `services/echo-service/service.json`
+- `services/service-admin/service.json`
+- `services/@node/service.json`
+- `services/@traefik/service.json`
+
+If a starter repo includes `service-admin`, it should also include the manifests needed to satisfy Service Admin's declared service dependencies rather than relying on hidden sibling-repo state.
+
 They should never redefine the core contract or replace the core runtime boundary.
 
 Before broad reference-template rollout, the existing sibling consumer repo `lasso-@serviceadmin` should be used as the first post-core integration check against the real runtime/API, ideally backed by released `lasso-echoservice` artifacts.


### PR DESCRIPTION
## Summary
- document that every Service Lasso app/reference repo owns its own tracked services inventory
- record that service-admin requires its declared dependency manifests in that inventory
- lock the baseline starter stack to echo-service, service-admin, @node, and @traefik

## Verification
- git diff --check