### PR TITLE
ISS-057: Record core release readiness evidence

### DIFF
--- a/docs/development/release-readiness-validation.md
+++ b/docs/development/release-readiness-validation.md
@@ -26,16 +26,17 @@ Do not treat green repo tests as release readiness by themselves.
 
 | Scenario | Required proof | Status | Evidence |
 | --- | --- | --- | --- |
-| Fresh clone of `service-lasso` installs dependencies | `npm install` from clean checkout succeeds | Pending | |
-| Core regression suite passes | `npm test` passes | Pending | |
-| Release artifact stages cleanly | release staging/verification command succeeds | Pending | |
-| Version follows project pattern | produced version is `yyyy.m.d-<shortsha>` | Pending | |
-| GitHub release artifact has expected shape | artifact includes built runtime, package payload, docs, metadata | Pending | |
+| Fresh clone of `service-lasso` installs dependencies | `npm install` from clean checkout succeeds | Verified | 2026-04-24: fresh clone at `a4674fb`; `npm ci` passed in `C:\projects\service-lasso\.tmp\iss-057-core-validation-20260424`. |
+| Core regression suite passes | `npm test` passes | Verified | 2026-04-24: fresh clone `npm test` passed with 84 tests. |
+| Release artifact stages cleanly | release staging/verification command succeeds | Verified | 2026-04-24: fresh clone `npm run release:verify` passed for `service-lasso-0.1.0`; versioned override also passed for `service-lasso-2026.4.24-a4674fb`. |
+| Version follows project pattern | produced version is `yyyy.m.d-<shortsha>` | Verified | 2026-04-24: `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-a4674fb` produced `service-lasso-2026.4.24-a4674fb.tar.gz` and `service-lasso-package-2026.4.24-a4674fb`. |
+| GitHub release artifact has expected shape | artifact includes built runtime, package payload, docs, metadata | Pending | Requires validation against a GitHub release created from a protected-branch push, not only local staged artifacts. |
 | GitHub Packages install works | clean consumer installs `@service-lasso/service-lasso` from `npm.pkg.github.com` | Pending | |
-| Installed CLI starts | consumer can run `service-lasso --help` and start runtime | Pending | |
+| Installed CLI starts | consumer can run `service-lasso --help` and start runtime | Verified | 2026-04-24: clean consumer installed staged `.tgz`; `npx service-lasso help` worked; package API boot worked through `startApiServer`. |
+| Packaged CLI reports release version | consumer can run `service-lasso --version` and see the installed package version | Invalidated | 2026-04-24: staged package version was `2026.4.24-a4674fb`, but `npx service-lasso --version` returned `0.1.0`; follow-up issue `#60`. |
 | CLI install works without start | consumer can run `service-lasso install <serviceId>` | Pending | |
-| Runtime lists services | consumer runtime reports configured services through API | Pending | |
-| Runtime starts and stops Echo Service | start/stop works from installed package context | Pending | |
+| Runtime lists services | consumer runtime reports configured services through API | Verified | 2026-04-24: installed package API probe returned 4 services, including `echo-service`. |
+| Runtime starts and stops Echo Service | start/stop works from installed package context | Verified | 2026-04-24: installed package API probe ran `install`, `config`, `start`, and `stop` for `echo-service`; final detail showed `echoRunning: false`. |
 
 ## Service Acquisition
 
@@ -93,6 +94,7 @@ Validate each repo:
 | Offline preloaded startup | preloaded artifact starts without network access | Pending | |
 | Repeated install/start/stop | repeated lifecycle stays stable | Pending | |
 | Service crash/error/abort | runtime exposes failure state and logs | Pending | |
+| Packaged CLI version mismatch | installed CLI reports the staged package version | Invalidated | Follow-up issue `#60`: staged `2026.4.24-a4674fb` package reports `0.1.0` from `npx service-lasso --version`. |
 
 ## Execution Order
 
@@ -107,3 +109,9 @@ Validate each repo:
 ## Evidence Log
 
 Record exact commands, dates, commit SHAs, release versions, artifact names, and outcomes here or in linked issue comments during execution.
+
+- 2026-04-24: fresh clone validation at `a4674fb` in `C:\projects\service-lasso\.tmp\iss-057-core-validation-20260424`.
+- 2026-04-24: `npm ci`, `npm test`, `npm run release:verify`, and `npm run package:verify` passed in the fresh clone.
+- 2026-04-24: versioned artifact validation with `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-a4674fb` produced and verified `service-lasso-2026.4.24-a4674fb.tar.gz` plus `service-lasso-package-2026.4.24-a4674fb`.
+- 2026-04-24: clean CLI consumer installed `service-lasso-service-lasso-2026.4.24-a4674fb.tgz`; `npx service-lasso help` worked, but `npx service-lasso --version` returned `0.1.0`, tracked as issue `#60`.
+- 2026-04-24: clean API consumer installed the staged package, booted the runtime at `http://127.0.0.1:18192`, listed 4 services, and ran `echo-service` through `install`, `config`, `start`, and `stop`.


### PR DESCRIPTION
## Summary
- record the first `ISS-057` core release-readiness execution evidence
- mark fresh clone install/test/release/package validation rows as verified
- record clean staged-package CLI/API consumer proof
- track the packaged CLI version mismatch as invalidated with follow-up issue #60

## Verification
- fresh clone at `a4674fb`: `npm ci`, `npm test`, `npm run release:verify`, `npm run package:verify`
- versioned override: `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-a4674fb npm run release:verify` and `npm run package:verify`
- clean CLI consumer: staged package install plus `npx service-lasso help` and `npx service-lasso --version`
- clean API consumer: staged package install, runtime boot, `/api/services`, and `echo-service` install/config/start/stop
- local working tree: `npm test` passed with 84 tests

Issue #58 remains open for remaining reference-app, GitHub Packages, GitHub release, Service Admin, service acquisition, and failure-scenario validation.