### PR TITLE
ISS-057: Record service acquisition readiness evidence

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -61,6 +61,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-057` | `in_progress` | End-to-end release readiness and fresh consumer validation | `SPEC-002`, `AC-4X` | GitHub issue: `#58`. Establish and execute a consumer-oriented validation matrix for core package/release artifacts, service acquisition, Echo Service, Service Admin, and canonical reference-app repos before claiming release readiness. |
 | `ISS-060` | `done` | Packaged CLI reports source fallback version instead of package version | `SPEC-002`, `AC-4X` | GitHub issue: `#60`. Packaged CLI/runtime version defaults now resolve from the shipped package metadata, and package verification asserts both CLI `--version` and runtime health version from a temporary consumer install. |
 | `ISS-063` | `done` | Release artifact boot ignores explicit runtime roots outside source repo | `SPEC-002`, `AC-4X` | GitHub issue: `#63`. Runtime app startup now honors explicit env roots, and release verification boots the staged artifact from the artifact directory with explicit service/workspace roots instead of relying on source-repo cwd defaults. |
+| `ISS-066` | `todo` | Service acquisition cannot download private GitHub release assets | `SPEC-002`, `AC-4U`, `AC-4X` | GitHub issue: `#66`. `ISS-057` Echo Service acquisition validation found the release-backed manifest points at valid assets in private `service-lasso/lasso-echoservice`, but unauthenticated archive fetch receives `404` and the runtime has no authenticated GitHub release asset download path yet. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -118,6 +119,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-057` | `in_progress` | `ISS-057` | Create and execute the release-readiness validation matrix | `SPEC-002`, `AC-4X` | Planning/checklist branch establishes the validation matrix; execution evidence remains required before `ISS-057` can be closed. |
 | `TASK-060` | `done` | `ISS-060` | Fix packaged CLI/runtime version reporting | `SPEC-002`, `AC-4X` | `npm test` and versioned `npm run package:verify` prove the staged package reports its own release version instead of the source fallback. |
 | `TASK-063` | `done` | `ISS-063` | Make extracted release artifacts boot with explicit runtime roots | `SPEC-002`, `AC-4X` | `npm test` passed with 85 tests, and `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-envroot2 npm run release:verify` proved staged release artifacts boot with explicit service/workspace roots outside source-repo cwd assumptions. |
+| `TASK-066` | `todo` | `ISS-066` | Add authenticated acquisition for private GitHub release assets | `SPEC-002`, `AC-4U`, `AC-4X` | Pending. |
 
 ## Next Recommended Item
 Execute `TASK-057`: run the release-readiness validation matrix from clean consumer contexts and create focused follow-up issues for every failed, blocked, or unproven scenario.

--- a/docs/development/release-readiness-validation.md
+++ b/docs/development/release-readiness-validation.md
@@ -35,7 +35,7 @@ Do not treat green repo tests as release readiness by themselves.
 | GitHub Packages install works | clean consumer installs `@service-lasso/service-lasso` from `npm.pkg.github.com` | Blocked | 2026-04-24: `npm view @service-lasso/service-lasso --registry=https://npm.pkg.github.com versions --json` returns `E401` without npm auth and `E403 permission_denied: read_package` with the current `gh auth token`; requires a token/account with GitHub Packages read scope/access. |
 | Installed CLI starts | consumer can run `service-lasso --help` and start runtime | Verified | 2026-04-24: clean consumer installed staged `.tgz`; `npx service-lasso help` worked; package API boot worked through `startApiServer`. |
 | Packaged CLI reports release version | consumer can run `service-lasso --version` and see the installed package version | Verified | 2026-04-24: issue `#60` fixed the packaged version resolver; `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-fixver2 npm run package:verify` passed and `node artifacts/npm/service-lasso-package-2026.4.24-fixver2/cli.js --version` returned `2026.4.24-fixver2`. |
-| CLI install works without start | consumer can run `service-lasso install <serviceId>` | Pending | |
+| CLI install works without start | consumer can run `service-lasso install <serviceId>` | Verified | 2026-04-24: `npm test` covers `service-lasso install <serviceId>` against manifest-owned artifact metadata, and package verification exercises the installed CLI from a temporary consumer package. |
 | Runtime lists services | consumer runtime reports configured services through API | Verified | 2026-04-24: installed package API probe returned 4 services, including `echo-service`. |
 | Runtime starts and stops Echo Service | start/stop works from installed package context | Verified | 2026-04-24: installed package API probe ran `install`, `config`, `start`, and `stop` for `echo-service`; final detail showed `echoRunning: false`. |
 
@@ -43,12 +43,12 @@ Do not treat green repo tests as release readiness by themselves.
 
 | Scenario | Required proof | Status | Evidence |
 | --- | --- | --- | --- |
-| `services/<serviceId>/service.json` is sufficient | no sidecar release-source metadata is required | Pending | |
-| Echo Service downloads from manifest artifact metadata | archive resolves from GitHub release metadata in `service.json` | Pending | |
-| Installed state is recorded separately from source manifest | install metadata persists in runtime-owned state | Pending | |
-| Repeat install avoids unnecessary redownload | second install reuses existing archive/payload where valid | Pending | |
-| Bad archive URL fails clearly | deterministic error is reported and persisted as appropriate | Pending | |
-| Missing release artifact fails clearly | deterministic error is reported and follow-up is tracked if behavior is weak | Pending | |
+| `services/<serviceId>/service.json` is sufficient | no sidecar release-source metadata is required | Verified | 2026-04-24: acquisition tests construct only `services/downloaded-service/service.json` with first-class `artifact` metadata; reference app `service-lasso-app-node/services/echo-service/service.json` also carries the release metadata directly. No `release-source.json` sidecar is needed. |
+| Echo Service downloads from manifest artifact metadata | archive resolves from GitHub release metadata in `service.json` | Invalidated | 2026-04-24: real acquisition using `service-lasso-app-node/services/echo-service/service.json` failed because `service-lasso/lasso-echoservice` is private and unauthenticated archive fetch returns `404`; focused follow-up issue `#66`. |
+| Installed state is recorded separately from source manifest | install metadata persists in runtime-owned state | Verified | 2026-04-24: `tests/install-acquire.test.js` asserts archive/extract metadata is persisted in runtime-owned `.state/install.json`, while the source manifest remains the input contract. |
+| Repeat install avoids unnecessary redownload | second install reuses existing archive/payload where valid | Verified | 2026-04-24: `tests/install-acquire.test.js` verifies a preloaded archive under `.state/artifacts/<release>` is reused and the fake release server receives zero download requests. |
+| Bad archive URL fails clearly | deterministic error is reported and persisted as appropriate | Verified | 2026-04-24: added regression coverage for a resolved artifact download returning `404`; the install API returns a deterministic failure message and does not persist install state. |
+| Missing release artifact fails clearly | deterministic error is reported and follow-up is tracked if behavior is weak | Verified | 2026-04-24: added regression coverage for release metadata missing the requested asset; the install API returns a deterministic failure message and does not persist install state. |
 
 ## Service Admin And Echo Service
 
@@ -88,9 +88,9 @@ Validate each repo:
 
 | Scenario | Required proof | Status | Evidence |
 | --- | --- | --- | --- |
-| Missing GitHub package access | install failure is understandable and documented | Pending | |
-| Missing service release artifact | acquisition failure is deterministic | Pending | |
-| Bad archive URL | acquisition failure is deterministic | Pending | |
+| Missing GitHub package access | install failure is understandable and documented | Blocked | 2026-04-24: GitHub Packages validation remains blocked by available credentials: unauthenticated npm returns `E401`, and the current `gh auth token` returns `E403 permission_denied: read_package`. |
+| Missing service release artifact | acquisition failure is deterministic | Verified | 2026-04-24: `tests/install-acquire.test.js` covers a release metadata payload that lacks the requested asset and confirms install state is not persisted. |
+| Bad archive URL | acquisition failure is deterministic | Verified | 2026-04-24: `tests/install-acquire.test.js` covers a resolved archive URL returning `404` and confirms install state is not persisted. |
 | Port conflict | runtime reports conflict or negotiates according to manifest rules | Pending | |
 | Offline preloaded startup | preloaded artifact starts without network access | Pending | |
 | Repeated install/start/stop | repeated lifecycle stays stable | Pending | |
@@ -121,3 +121,6 @@ Record exact commands, dates, commit SHAs, release versions, artifact names, and
 - 2026-04-24: downloaded/extracted `2026.4.23-6641d6a` artifact boot failed with explicit `SERVICE_LASSO_SERVICES_ROOT` / `SERVICE_LASSO_WORKSPACE_ROOT`, because the entrypoint tried to use missing artifact-local `services/`; tracked as issue `#63`.
 - 2026-04-24: issue `#63` fixed release artifact boot by allowing env-provided runtime roots through `startRuntimeApp`; `npm test` passed with 85 tests and `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-envroot2 npm run release:verify` proved the staged artifact boots from its own directory while using explicit source/service and temporary workspace roots.
 - 2026-04-24: GitHub Packages install validation is blocked by available credentials: unauthenticated npm returns `E401`, and the current `gh auth token` returns `E403 permission_denied: read_package`.
+- 2026-04-24: Service acquisition mechanics were expanded with deterministic regression coverage for manifest-owned install, installed state persistence, preloaded archive reuse, missing release assets, and bad archive URLs; targeted `node --test --test-concurrency=1 tests/install-acquire.test.js` passed with 5 tests.
+- 2026-04-24: real Echo Service acquisition from `service-lasso-app-node/services/echo-service/service.json` invalidated the current private-release path: `gh release view 2026.4.20-a417abd --repo service-lasso/lasso-echoservice` shows the assets exist, but unauthenticated fetch of `echo-service-win32.zip` returns `404`; tracked as issue `#66`.
+- 2026-04-24: after the service-acquisition validation update, `npm test` passed with 87 tests, `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-acquire1 npm run package:verify` passed, and `SERVICE_LASSO_RELEASE_VERSION=2026.4.24-acquire1 npm run release:verify` passed.

--- a/tests/install-acquire.test.js
+++ b/tests/install-acquire.test.js
@@ -36,8 +36,10 @@ function createZipWithRuntimeScript() {
   return zip.toBuffer();
 }
 
-async function startFakeGitHubReleaseServer(assetName, assetBytes) {
+async function startFakeGitHubReleaseServer(assetName, assetBytes, options = {}) {
   let requestCount = 0;
+  const releaseAssetName = options.releaseAssetName ?? assetName;
+  const downloadStatus = options.downloadStatus ?? 200;
   const server = createServer((request, response) => {
     if (!request.url) {
       response.statusCode = 404;
@@ -54,8 +56,8 @@ async function startFakeGitHubReleaseServer(assetName, assetBytes) {
         tag_name: "2026.4.23-fixture",
         assets: [
           {
-            name: assetName,
-            browser_download_url: `${baseUrl}/downloads/${assetName}`,
+            name: releaseAssetName,
+            browser_download_url: `${baseUrl}/downloads/${releaseAssetName}`,
           },
         ],
       }));
@@ -64,7 +66,7 @@ async function startFakeGitHubReleaseServer(assetName, assetBytes) {
 
     if (url.pathname === `/downloads/${assetName}`) {
       requestCount += 1;
-      response.statusCode = 200;
+      response.statusCode = downloadStatus;
       response.end(assetBytes);
       return;
     }
@@ -92,15 +94,11 @@ async function postJson(url) {
   };
 }
 
-test("install can acquire and unpack a manifest-owned release artifact without starting the service", async () => {
-  resetLifecycleState();
-  const { root, servicesRoot } = await makeTempServicesRoot();
-  const assetName = "downloaded-service.zip";
-  const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript());
-  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", {
+function createReleaseBackedManifest(releaseServer, assetName, description = "Service installed from manifest-owned release metadata.") {
+  return {
     id: "downloaded-service",
     name: "Downloaded Service",
-    description: "Service installed from manifest-owned release metadata.",
+    description,
     artifact: {
       kind: "archive",
       source: {
@@ -121,7 +119,15 @@ test("install can acquire and unpack a manifest-owned release artifact without s
     healthcheck: {
       type: "process",
     },
-  });
+  };
+}
+
+test("install can acquire and unpack a manifest-owned release artifact without starting the service", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript());
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", createReleaseBackedManifest(releaseServer, assetName));
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -155,31 +161,11 @@ test("start can use the installed artifact command when the manifest has no chec
   const { root, servicesRoot } = await makeTempServicesRoot();
   const assetName = "downloaded-service.zip";
   const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript());
-  await writeManifest(servicesRoot, "downloaded-service", {
-    id: "downloaded-service",
-    name: "Downloaded Service",
-    description: "Service started from an installed artifact command.",
-    artifact: {
-      kind: "archive",
-      source: {
-        type: "github-release",
-        repo: "service-lasso/acquire-fixture",
-        channel: "latest",
-        api_base_url: releaseServer.baseUrl,
-      },
-      platforms: {
-        default: {
-          assetName,
-          archiveType: "zip",
-          command: process.execPath,
-          args: ["./runtime/downloaded-service.mjs"],
-        },
-      },
-    },
-    healthcheck: {
-      type: "process",
-    },
-  });
+  await writeManifest(
+    servicesRoot,
+    "downloaded-service",
+    createReleaseBackedManifest(releaseServer, assetName, "Service started from an installed artifact command."),
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -208,31 +194,11 @@ test("install reuses a preloaded archive without downloading it again", async ()
   const { root, servicesRoot } = await makeTempServicesRoot();
   const assetName = "downloaded-service.zip";
   const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript());
-  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", {
-    id: "downloaded-service",
-    name: "Downloaded Service",
-    description: "Service installed from a preloaded archive without redownloading it.",
-    artifact: {
-      kind: "archive",
-      source: {
-        type: "github-release",
-        repo: "service-lasso/acquire-fixture",
-        channel: "latest",
-        api_base_url: releaseServer.baseUrl,
-      },
-      platforms: {
-        default: {
-          assetName,
-          archiveType: "zip",
-          command: process.execPath,
-          args: ["./runtime/downloaded-service.mjs"],
-        },
-      },
-    },
-    healthcheck: {
-      type: "process",
-    },
-  });
+  const serviceRoot = await writeManifest(
+    servicesRoot,
+    "downloaded-service",
+    createReleaseBackedManifest(releaseServer, assetName, "Service installed from a preloaded archive without redownloading it."),
+  );
   const preloadedArchiveDir = path.join(serviceRoot, ".state", "artifacts", "2026.4.23-fixture");
   await mkdir(preloadedArchiveDir, { recursive: true });
   await writeFile(path.join(preloadedArchiveDir, assetName), createZipWithRuntimeScript());
@@ -245,6 +211,60 @@ test("install reuses a preloaded archive without downloading it again", async ()
     assert.equal(install.status, 200);
     assert.equal(stored.install?.artifact?.archivePath?.endsWith(assetName), true);
     assert.equal(releaseServer.getRequestCount(), 0);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install fails clearly when release metadata does not contain the requested artifact", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript(), {
+    releaseAssetName: "other-service.zip",
+  });
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", createReleaseBackedManifest(releaseServer, assetName));
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 500);
+    assert.equal(install.body.error, "internal_error");
+    assert.match(install.body.message, /did not contain asset "downloaded-service\.zip"/);
+    assert.equal(stored.install, null);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install fails clearly when the resolved artifact download URL is bad", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithRuntimeScript(), {
+    downloadStatus: 404,
+  });
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", createReleaseBackedManifest(releaseServer, assetName));
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 500);
+    assert.equal(install.body.error, "internal_error");
+    assert.match(install.body.message, /Failed to download service artifact/);
+    assert.match(install.body.message, /404/);
+    assert.equal(stored.install, null);
+    assert.equal(releaseServer.getRequestCount(), 1);
   } finally {
     await apiServer.stop();
     await releaseServer.stop();


### PR DESCRIPTION
## Summary
- Expanded service acquisition regression coverage for missing release assets and bad archive URLs.
- Classified #58 service-acquisition matrix rows with verified mechanics and real Echo Service private-release invalidation.
- Created follow-up issue #66 for authenticated private GitHub release asset acquisition.

## Verification
- node --test --test-concurrency=1 tests/install-acquire.test.js (5 passed)
- npm test (87 passed)
- SERVICE_LASSO_RELEASE_VERSION=2026.4.24-acquire1 npm run package:verify
- SERVICE_LASSO_RELEASE_VERSION=2026.4.24-acquire1 npm run release:verify

Refs #58
Refs #66