### PR TITLE
ISS-057: Record reference app readiness evidence

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -64,6 +64,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-066` | `superseded` | Service acquisition cannot download private GitHub release assets | `SPEC-002`, `AC-4U`, `AC-4X` | GitHub issue: `#66`. Superseded for current release-readiness because `service-lasso/lasso-echoservice` is now public and unauthenticated Echo Service acquisition from the reference manifest succeeds; private-release auth can be reopened as a future product requirement if needed. |
 | `ISS-069` | `blocked` | GitHub Packages install remains blocked by npm auth/package access | `SPEC-002`, `AC-4S`, `AC-4X` | GitHub issue: `#69`. After repos were made public, `npm.pkg.github.com` still returns `E401` without auth and `E403 permission_denied` with the current `gh` token, so clean package install remains blocked on package access/token configuration rather than package build output. |
 | `ISS-071` | `done` | Release-backed Echo Service manifest does not prove HTTP/TCP health modes through runtime | `SPEC-002`, `AC-4C`, `AC-4X` | GitHub issue: `#71`. `npm run verify:echo-health` now proves public release-backed Echo HTTP health status transitions and TCP listener reachability transitions through runtime-observed health. |
+| `ISS-075` | `todo` | Reference app validation races on shared core package staging | `SPEC-002`, `AC-4X` | GitHub issue: `#75`. Parallel multi-repo reference-app validation can race while each repo stages the same core package output path; sequential validation passes, but the orchestration path needs isolation or explicit serialization. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -124,6 +125,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-066` | `superseded` | `ISS-066` | Add authenticated acquisition for private GitHub release assets | `SPEC-002`, `AC-4U`, `AC-4X` | Superseded for current release-readiness by making `service-lasso/lasso-echoservice` public; real Echo Service acquisition from the reference-app manifest now succeeds without auth. |
 | `TASK-069` | `blocked` | `ISS-069` | Verify GitHub Packages install from a clean consumer | `SPEC-002`, `AC-4S`, `AC-4X` | Blocked on GitHub Packages auth/package access configuration; unauthenticated npm returns `E401` and the current `gh` token returns `E403 permission_denied`. |
 | `TASK-071` | `done` | `ISS-071` | Add release-backed Echo Service HTTP/TCP health validation through runtime | `SPEC-002`, `AC-4C`, `AC-4X` | `npm run verify:echo-health` installs and starts the public Echo Service release archive, proves runtime-observed HTTP `200 -> 500 -> 200`, and proves TCP `connected -> ECONNREFUSED -> connected`. |
+| `TASK-075` | `todo` | `ISS-075` | Remove or serialize shared core package staging races in reference-app validation | `SPEC-002`, `AC-4X` | Pending. |
 
 ## Next Recommended Item
 Execute `TASK-057`: run the release-readiness validation matrix from clean consumer contexts and create focused follow-up issues for every failed, blocked, or unproven scenario.

--- a/docs/development/consumer-project-readiness-task-list.md
+++ b/docs/development/consumer-project-readiness-task-list.md
@@ -8,7 +8,9 @@ It is linked to `ISS-057` / GitHub issue `#58` and must stay aligned with `docs/
 
 Service Lasso is not fully consumer-ready until the tasks below are classified with evidence.
 
-The core runtime and public service acquisition paths are working, but external projects still need a verified package-install path, release-backed HTTP/TCP health proof, reference-app template validation, and a final promoted release.
+The core runtime, public service acquisition paths, release-backed Echo health proof, and reference-app release artifacts are working.
+
+External fresh-clone usage remains blocked until GitHub Packages auth/package access is verified, because the app templates install `@service-lasso/service-lasso` from `npm.pkg.github.com`.
 
 ## Task List
 
@@ -16,9 +18,9 @@ The core runtime and public service acquisition paths are working, but external 
 | --- | --- | --- | --- | --- |
 | `CONSUMER-001` | `blocked` | `#69` | Other projects can install `@service-lasso/service-lasso` from GitHub Packages using the documented auth path. | Clean temp consumer install from `npm.pkg.github.com`, `service-lasso --version`, and `service-lasso help`. |
 | `CONSUMER-002` | `done` | `#71` | Public release-backed Echo Service proves HTTP and TCP health mode transitions through Service Lasso runtime health. | 2026-04-24: `npm run verify:echo-health` exercised the public `2026.4.20-a417abd` Echo release archive with runtime-observed HTTP 200 -> 500 -> 200 health and TCP reachable -> unreachable -> reachable health. |
-| `CONSUMER-003` | `todo` | `#58` | Reference apps are validated as cloneable templates. | Fresh clone/install/test/release-verify for `app-node`, `app-web`, `app-electron`, `app-tauri`, and `app-packager-pkg`. |
-| `CONSUMER-004` | `todo` | `#58` | Reference app release outputs are validated as usable artifacts. | Source/bootstrap-download/preloaded artifacts exercised where each repo ships them. |
-| `CONSUMER-005` | `todo` | `#58` | Service Admin is reachable from reference app hosts, not only from its own repo. | App-host URL check for host shell plus `/admin/` route against a live runtime. |
+| `CONSUMER-003` | `blocked` | `#58`, `#69` | Reference apps are validated as cloneable templates. | 2026-04-24: prepared local repo tests passed sequentially for `app-node`, `app-web`, `app-electron`, `app-tauri`, and `app-packager-pkg`; fresh clone of `service-lasso-app-node` reached `npm ci` but failed with GitHub Packages `E401`, so true external clone/install remains blocked by `#69`. |
+| `CONSUMER-004` | `done` | `#58` | Reference app release outputs are validated as usable artifacts. | 2026-04-24: sequential `npm run release:verify` passed for all five reference repos, verifying source, runtime/bootstrap-download, and preloaded/no-download artifacts where shipped. |
+| `CONSUMER-005` | `done` | `#58` | Service Admin is reachable from reference app hosts, not only from its own repo. | 2026-04-24: reference-app host tests and release verification passed with mounted Service Admin payload checks for all five repos. |
 | `CONSUMER-006` | `todo` | `#58` | `develop` is promoted to `main` only after readiness evidence is current. | Promotion PR, green release/package workflows, timestamped GitHub release, and package publish evidence. |
 | `CONSUMER-007` | `todo` | `#58` | A fresh external project can use the released package and public service manifests. | Clean project smoke with documented package auth, `services/echo-service/service.json`, install/start/stop, and runtime API checks. |
 
@@ -35,6 +37,18 @@ Required external action:
 
 - provide a classic PAT with `read:packages`, or
 - grant the consuming GitHub Actions repository package access and use `GITHUB_TOKEN` with `packages: read`.
+
+## Reference App Validation Note
+
+Prepared local validation passed when run sequentially:
+
+- `service-lasso-app-node`: `npm test` passed 4 tests; `npm run release:verify` passed.
+- `service-lasso-app-web`: `npm test` passed 6 tests; `npm run release:verify` passed.
+- `service-lasso-app-electron`: `npm test` passed 6 tests; `npm run release:verify` passed.
+- `service-lasso-app-tauri`: `npm test` passed 6 tests; `npm run release:verify` passed.
+- `service-lasso-app-packager-pkg`: `npm test` passed 4 tests; `npm run release:verify` passed.
+
+Parallel multi-repo validation currently races on the shared core package staging directory and is tracked as `#75`. Until that is fixed, run reference-app release validation sequentially.
 
 ## Stop Rule
 

--- a/docs/development/release-readiness-validation.md
+++ b/docs/development/release-readiness-validation.md
@@ -73,15 +73,15 @@ Validate each repo:
 
 | Scenario | Required proof | Status | Evidence |
 | --- | --- | --- | --- |
-| Fresh clone works | clean checkout can install dependencies | Pending | |
-| Repo tests pass | repo-local test command succeeds | Pending | |
-| Release verification passes | repo-local release verification command succeeds | Pending | |
-| Source/template mode works | user can run from source/template checkout | Pending | |
-| Bootstrap-download artifact works | app can acquire service payloads from manifest release metadata | Pending | |
-| Preloaded/no-download artifact works offline | app starts with included service payloads and performs no first-run download | Pending | |
-| Host-owned output is visible | app shows its own UI/output, not only Service Admin | Pending | |
-| Service listing widget works | app lists services through Service Lasso API | Pending | |
-| Service Admin is reachable | app can access Service Admin UI | Pending | |
+| Fresh clone works | clean checkout can install dependencies | Blocked | 2026-04-24: fresh clone of `service-lasso-app-node` succeeded, but `npm ci` failed with GitHub Packages `E401`; this remains blocked by `#69` and applies to templates that install `@service-lasso/service-lasso` from `npm.pkg.github.com`. |
+| Repo tests pass | repo-local test command succeeds | Verified | 2026-04-24: sequential `npm test` passed for all five reference repos: `app-node` 4 tests, `app-web` 6, `app-electron` 6, `app-tauri` 6, and `app-packager-pkg` 4. Parallel multi-repo validation exposed shared staging contention tracked as `#75`. |
+| Release verification passes | repo-local release verification command succeeds | Verified | 2026-04-24: sequential `npm run release:verify` passed for all five reference repos. |
+| Source/template mode works | user can run from source/template checkout | Blocked | Prepared local source checks pass, but true fresh source checkout install remains blocked by GitHub Packages auth/package access in `#69`. |
+| Bootstrap-download artifact works | app can acquire service payloads from manifest release metadata | Verified | 2026-04-24: each reference repo `npm run release:verify` exercised runtime/bootstrap-download artifacts and verified Echo Service archive acquisition from manifest-owned metadata. |
+| Preloaded/no-download artifact works offline | app starts with included service payloads and performs no first-run download | Verified | 2026-04-24: each reference repo `npm run release:verify` exercised preloaded artifacts and verified zero first-run service archive downloads. |
+| Host-owned output is visible | app shows its own UI/output, not only Service Admin | Verified | 2026-04-24: reference-app host tests passed for shell/status routes across all five repos. |
+| Service listing widget works | app lists services through Service Lasso API | Verified | 2026-04-24: `app-web`, `app-electron`, and `app-tauri` tests passed their host-owned `/api/runtime-services` proxy/widget coverage; `app-node` and `app-packager-pkg` host-status coverage passed for their bounded host shape. |
+| Service Admin is reachable | app can access Service Admin UI | Verified | 2026-04-24: host tests and release verification passed mounted Service Admin payload checks for all five reference repos. |
 | Echo Service can be installed/started/stopped | app exercises Service Lasso lifecycle against Echo Service | Pending | |
 
 ## Failure Scenarios
@@ -96,6 +96,7 @@ Validate each repo:
 | Repeated install/start/stop | repeated lifecycle stays stable | Pending | |
 | Service crash/error/abort | runtime exposes failure state and logs | Pending | |
 | Packaged CLI version mismatch | installed CLI reports the staged package version | Verified | Issue `#60` fixed the mismatch; package verification now asserts the temporary installed CLI reports the staged package version and the runtime health version matches the package version. |
+| Parallel reference-app validation | multi-repo validation can run without shared staging races | Invalidated | 2026-04-24: parallel `npm test` across the five reference repos produced Windows `EBUSY` / `ENOTEMPTY` / missing `.tgz` failures because multiple repos stage the same core package path at once; sequential validation passed; tracked as issue `#75`. |
 
 ## Execution Order
 
@@ -133,3 +134,7 @@ Record exact commands, dates, commit SHAs, release versions, artifact names, and
 - 2026-04-24: `service-lasso/lasso-serviceadmin` validation passed with `npm test` (27 tests) and `npm run build`; runtime dashboard adapter coverage is present in the admin repo tests.
 - 2026-04-24: Echo Service HTTP/TCP health-mode validation through runtime is invalidated for the current release-backed reference manifest because it uses `process` health; tracked as issue `#71`.
 - 2026-04-24: issue `#71` is resolved by `npm run verify:echo-health`, which installs and starts the public Echo Service release archive from `service.json` artifact metadata, validates runtime-observed HTTP health `200 -> 500 -> 200`, and validates TCP health `connected -> ECONNREFUSED -> connected`. TCP proof is listener reachability/unreachability because the current runtime TCP health contract checks connection success rather than response payload.
+- 2026-04-24: prepared local reference-app validation passed sequentially: `npm test` passed in `service-lasso-app-node` (4 tests), `service-lasso-app-web` (6), `service-lasso-app-electron` (6), `service-lasso-app-tauri` (6), and `service-lasso-app-packager-pkg` (4).
+- 2026-04-24: sequential `npm run release:verify` passed in all five reference repos, verifying source, runtime/bootstrap-download, and preloaded/no-download artifacts plus mounted Service Admin payloads. `service-lasso-app-packager-pkg` verified Windows runtime/preloaded wrapper artifacts.
+- 2026-04-24: fresh clone of `service-lasso-app-node` succeeded, but `npm ci` failed with GitHub Packages `E401`; true external fresh-clone use remains blocked by package auth/access issue `#69`.
+- 2026-04-24: parallel `npm test` across all five reference repos invalidated the current multi-repo validation harness because shared core package staging produced `EBUSY` / `ENOTEMPTY` / missing `.tgz` failures on Windows; tracked as issue `#75`. Sequential validation remains the current reliable path.


### PR DESCRIPTION
## Summary

- Records reference-app readiness evidence for the consumer-readiness checklist.
- Marks prepared local repo tests and source/runtime/preloaded release artifacts verified for all five canonical reference repos.
- Marks true fresh-clone/source install blocked by GitHub Packages auth issue #69.
- Adds follow-up #75 for the shared core package staging race observed during parallel multi-repo validation.

## Verification

- Sequential `npm test` passed in:
  - `service-lasso-app-node` (4 tests)
  - `service-lasso-app-web` (6 tests)
  - `service-lasso-app-electron` (6 tests)
  - `service-lasso-app-tauri` (6 tests)
  - `service-lasso-app-packager-pkg` (4 tests)
- Sequential `npm run release:verify` passed in all five reference repos.
- Fresh clone of `service-lasso-app-node` succeeded, then `npm ci` failed with GitHub Packages `E401`, confirming blocker #69.
- Parallel multi-repo `npm test` invalidated shared staging concurrency and is tracked in #75.

Updates #58.
