### PR TITLE
docs: review planned service inventory

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -68,6 +68,7 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-080` | `done` | Publish Service Lasso to public npm registry | `SPEC-002`, `AC-4S`, `AC-4X` | GitHub issue: `#80`. Publish workflow run `24876054960` published `@service-lasso/service-lasso@2026.4.24-a663bb0` to public npmjs and verified the registry-installed CLI. Local unauthenticated `npm view`, clean temp `npm install`, and `npm run verify:package-consumer` also passed against `registry.npmjs.org`. |
 | `ISS-083` | `done` | Fix managed log stream finalization race in CI | `SPEC-002`, `AC-4J`, `AC-4X` | GitHub issue: `#83`. Managed-process finalization now waits for child `close` so stdout/stderr streams finish before runtime log streams are flushed and ended. |
 | `ISS-089` | `ready` | Add deterministic live reference-app lifecycle smoke | `SPEC-002`, `AC-4X` | GitHub issue: `#89`. Add a repeatable fresh-clone/source-host smoke for all canonical reference apps that proves host shell, Service Admin route, runtime service list, and Echo Service install/config/start/stop with deterministic child-process cleanup. |
+| `ISS-091` | `ready` | Align reference-app baseline service inventories with docs | `SPEC-002`, `AC-4W`, `AC-4X` | GitHub issue: `#91`. Docs and `service-template` say app/reference repos should carry `echo-service`, `service-admin`, `@node`, and `@traefik`; current canonical reference apps only carry `echo-service` and `service-admin`. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Current preferred runtime-root model:
 - `docs/development/core-runtime-autonomous-task-list.md` - comprehensive ordered execution list for finishing donor migration slices, consumer validation, and post-core rollout
 - `docs/development/core-runtime-package-architecture.md` - bounded core package-boundary plan and the current sibling-repo template rollout for reference apps
 - `docs/development/reference-app-and-service-distribution-remediation-plan.md` - corrective plan for reference-app naming, canonical `service.json` release/install metadata, and bundled versus download/install behavior
+- `docs/development/planned-services-review.md` - current planned-service inventory review and reference-app baseline gaps
 - `docs/development/reference-app-service-distribution-task-list.md` - governed execution order for the four active distribution-remediation workstreams
 - `docs/development/core-runtime-release-artifact.md` - exact definition of the current bounded downloadable runtime artifact and what files it ships
 - `docs/development/core-runtime-publishable-package.md` - exact definition of the current bounded self-contained publishable `@service-lasso/service-lasso` package payload and how it is verified/published

--- a/docs/development/planned-services-review.md
+++ b/docs/development/planned-services-review.md
@@ -1,0 +1,94 @@
+# Planned Services Review
+
+This review records the service inventory currently implied by the core docs, `service-template`, and canonical reference app repos.
+
+Date: 2026-04-24
+
+Linked issue: `#91`
+
+## Summary
+
+The current planned baseline service inventory is not fully aligned across repos.
+
+Docs and `service-template` identify this baseline for app/reference repos:
+
+- `services/echo-service/service.json`
+- `services/service-admin/service.json`
+- `services/@node/service.json`
+- `services/@traefik/service.json`
+
+Current canonical reference app repos only include:
+
+- `services/echo-service/service.json`
+- `services/service-admin/service.json`
+
+This is a real gap because `service-template/services/service-admin/service.json` declares `depend_on: ["@node", "@traefik"]`, while the app repos that include `service-admin` do not carry those dependency manifests.
+
+## Service Status
+
+| Service | Role | Current status | Gap |
+| --- | --- | --- | --- |
+| `echo-service` | Real managed harness/service for install, lifecycle, logs, state, SQLite, HTTP/TCP health, and UI validation. | Implemented and released in `service-lasso/lasso-echoservice`; used by core and all reference apps. | No baseline gap. |
+| `service-admin` | Operator/admin UI entry for app hosts. | Implemented in `service-lasso/lasso-serviceadmin`; all reference apps include `services/service-admin/service.json`. | Dependency inventory is incomplete if `@node` / `@traefik` remain declared dependencies. |
+| `@node` | Runtime/provider utility service for Node-backed services and Service Admin dependency modeling. | Implemented as a bounded provider path in core; manifest exists in core `services/@node/service.json` and `service-template/services/@node/service.json`. | Missing from all canonical reference app `services/` inventories. |
+| `@python` | Runtime/provider utility service for Python-backed services. | Manifest exists in core `services/@python/service.json`; docs mention provider planning. | Not part of the current starter baseline, but should be explicitly classified as optional/future for app inventories. |
+| `@traefik` | Edge/router utility service for local routing and Service Admin dependency modeling. | Manifest exists in `service-template/services/@traefik/service.json`; docs list it in starter baseline. | Missing from core `services/` and all canonical reference app `services/` inventories; no dedicated implementation/release proof exists yet. |
+| `@archive` | Future utility/archive provider based on donor/reference docs. | Discussed in service-template reference material only. | Future/deferred; not current baseline. |
+| `@localcert` | Future local certificate/bootstrap utility based on donor/reference docs. | Discussed in service-template reference material only. | Future/deferred; not current baseline. |
+
+## Repo Inventory Snapshot
+
+Core repo currently has:
+
+- `services/echo-service/service.json`
+- `services/@node/service.json`
+- `services/@python/service.json`
+- `services/node-sample-service/service.json`
+
+`service-template` currently has:
+
+- root `service.json`
+- `services/echo-service/service.json`
+- `services/service-admin/service.json`
+- `services/@node/service.json`
+- `services/@traefik/service.json`
+
+Each canonical reference app currently has:
+
+- `services/echo-service/service.json`
+- `services/service-admin/service.json`
+
+Affected reference apps:
+
+- `service-lasso-app-node`
+- `service-lasso-app-web`
+- `service-lasso-app-electron`
+- `service-lasso-app-tauri`
+- `service-lasso-app-packager-pkg`
+
+## Recommendation
+
+Resolve issue `#91` before claiming the planned service inventory is complete.
+
+Preferred direction:
+
+- add `services/@node/service.json` and `services/@traefik/service.json` to each canonical reference app if they remain the documented Service Admin baseline dependencies
+- add validation that the reference app service inventory includes the documented baseline
+- run `npm test` and `npm run release:verify` in each changed reference app
+- update core docs and `service-template` docs with evidence
+
+If `@traefik` is not actually required for the near-term app hosts, then update docs and `service-template` to classify `@traefik` as future/deferred rather than a baseline dependency.
+
+## Remaining Planned Services
+
+Current baseline to finish:
+
+- `@node`
+- `@traefik`
+
+Future/deferred donor-aligned utility services:
+
+- `@archive`
+- `@localcert`
+- `@python` beyond the current bounded manifest/provider planning
+


### PR DESCRIPTION
## Intent
Record a review of planned services across the core docs, service-template, and canonical reference apps.

## Change
- Adds `docs/development/planned-services-review.md`.
- Links the review from `docs/README.md`.
- Adds `ISS-091` to the governed backlog.

## Findings
Docs and `service-template` define a baseline inventory of:
- `echo-service`
- `service-admin`
- `@node`
- `@traefik`

Current canonical reference apps only carry:
- `echo-service`
- `service-admin`

This is now tracked as #91.

## Verification
- `git diff --check`
- Scanned core docs, `service-template`, core `services/`, and all five canonical reference app `services/` inventories.

Refs #91