### PR TITLE
ISS-098 Add baseline start command

### DIFF
--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -120,3 +120,4 @@ Classify verification honestly as direct proof, partial proof, or surrogate-only
 - The first runtime slice should stay intentionally bounded: prove a runnable standalone core before widening into full donor parity or broad manifest redesign.
 - Donor material under `ref/` remains useful evidence and reference input, but implemented behavior must now move into tracked repo source with direct verification.
 - The tracked fixture set may evolve from static manifest-only samples into runnable harness services when that improves direct verification for runtime hardening and later supervision work.
+- 2026-04-25: `#98` adds `service-lasso start` as the documented baseline bootstrap command. It directly verifies dependency-aware install/config/start sequencing and rerun idempotency with fixture services, while the real `@traefik` baseline remains deferred to `#102`.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Start the bounded API runtime:
 service-lasso
 ```
 
+Bootstrap the documented baseline inventory and leave the API running:
+
+```bash
+service-lasso start --services-root ./services --workspace-root ./workspace
+```
+
+`service-lasso start` is the clean-clone baseline command name for `#98`. It installs, configures, and starts the baseline services in dependency order, then starts the core API for Service Admin and app consumers. The current baseline is `@traefik`, `@node`, `echo-service`, and `service-admin`; disabled services such as the current `@traefik` placeholder are reported as skipped/deferred until their release-backed service repo exists.
+
 Acquire/install a service from manifest-owned `artifact` metadata without starting it:
 
 ```bash

--- a/docs/development/clean-clone-baseline-start-evaluation.md
+++ b/docs/development/clean-clone-baseline-start-evaluation.md
@@ -2,6 +2,8 @@
 
 Date: 2026-04-24
 
+Latest update: 2026-04-25
+
 Linked issues: `#95`, `#96`, `#97`, `#98`, `#99`
 
 OpenSpec binding: `SPEC-002`, `AC-4Z`
@@ -19,9 +21,17 @@ Expected baseline services:
 
 ## Current Answer
 
-No.
+Partial.
 
-As of this evaluation, a clean clone does not have a single working start path that downloads, configures, and starts `@traefik`, `@node`, `echo-service`, and `service-admin`.
+The documented command name is now:
+
+```powershell
+service-lasso start --services-root ./services --workspace-root ./workspace
+```
+
+As of 2026-04-25, the core CLI has a bounded baseline bootstrap command that installs, configures, and starts the baseline inventory in dependency order, then leaves the API running.
+
+Remaining gap: `@traefik` is still an intentionally disabled placeholder until `#102` creates the canonical release-backed Traefik service repo/artifact. The command reports disabled baseline services as skipped/deferred instead of pretending they started.
 
 ## Evidence
 
@@ -75,6 +85,7 @@ Current CLI commands:
 
 - `service-lasso`
 - `service-lasso serve`
+- `service-lasso start`
 - `service-lasso install <serviceId>`
 - `service-lasso help`
 - `service-lasso --version`
@@ -85,9 +96,15 @@ Current capability:
 - The CLI can acquire/install one service from manifest-owned artifact metadata.
 - The API can run `startAll` after services are installed and configured.
 
+Current implemented capability:
+
+- `service-lasso start` discovers the baseline services, installs/configures/starts enabled services in dependency order, reports skipped disabled services, and leaves the API running.
+- `tests/bootstrap-start.test.js` proves install/config/start sequencing and rerun idempotency against a four-service baseline fixture.
+
 Current missing capability:
 
-- There is no single user-facing clean-clone command that discovers the baseline, downloads required release artifacts, installs services, configures services, starts services in dependency order, and leaves the API running.
+- a deterministic clean-clone smoke that runs the built CLI command end to end from a fresh checkout is still tracked by `#99`.
+- release-backed Traefik acquisition/start remains blocked on `#102`.
 
 ## Gap Issues
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
 import { startRuntimeApp } from "./runtime/app.js";
+import { bootstrapBaselineServices, type BootstrapBaselineResult } from "./runtime/cli/bootstrap.js";
 import { installServiceFromCli } from "./runtime/cli/install.js";
 import { resolveRuntimeVersion } from "./runtime/version.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "help" | "version";
+  command: "serve" | "install" | "start" | "help" | "version";
   serviceId?: string;
   port?: number;
   servicesRoot?: string;
@@ -18,12 +19,14 @@ function usageText(): string {
     "Usage:",
     "  service-lasso",
     "  service-lasso serve [--port <number>] [--services-root <path>] [--workspace-root <path>]",
+    "  service-lasso start [--port <number>] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso install <serviceId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso help",
     "  service-lasso --version",
     "",
     "Notes:",
     "  - Running without a command starts the bounded core API runtime.",
+    "  - The start command installs/configures/starts the baseline services, then leaves the API running.",
     "  - The install command acquires and installs a service from manifest-owned artifact metadata without starting it.",
   ].join("\n");
 }
@@ -52,7 +55,7 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     return { command: "version", json: false };
   }
 
-  const command = commandToken === "serve" || commandToken === "install" ? commandToken : null;
+  const command = commandToken === "serve" || commandToken === "install" || commandToken === "start" ? commandToken : null;
   if (!command) {
     throw new Error(`Unknown command: ${commandToken}`);
   }
@@ -93,8 +96,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--port": {
-        if (command !== "serve") {
-          throw new Error("--port is only supported for the serve command.");
+        if (command !== "serve" && command !== "start") {
+          throw new Error("--port is only supported for the serve and start commands.");
         }
         const value = remaining.shift();
         if (!value) {
@@ -104,8 +107,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install") {
-          throw new Error("--json is only supported for the install command.");
+        if (command !== "install" && command !== "start") {
+          throw new Error("--json is only supported for the install and start commands.");
         }
         parsed.json = true;
         break;
@@ -116,6 +119,37 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
   }
 
   return parsed;
+}
+
+function printBootstrapResult(
+  result: BootstrapBaselineResult,
+  app: Awaited<ReturnType<typeof startRuntimeApp>>,
+  asJson: boolean,
+): void {
+  const payload = {
+    servicesRoot: result.servicesRoot,
+    workspaceRoot: result.workspaceRoot,
+    apiUrl: app.apiServer.url,
+    requestedServiceIds: result.requestedServiceIds,
+    serviceOrder: result.serviceOrder,
+    services: result.services,
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log("[service-lasso] baseline start completed");
+  console.log(`- api: ${app.apiServer.url}`);
+  console.log(`- servicesRoot: ${result.servicesRoot}`);
+  console.log(`- workspaceRoot: ${result.workspaceRoot}`);
+  for (const service of result.services) {
+    const actionSummary = service.actions
+      .map((action) => `${action.action}:${action.status}`)
+      .join(", ") || "no actions";
+    console.log(`- ${service.serviceId}: ${service.status} (${actionSummary})`);
+  }
 }
 
 function printInstallResult(result: Awaited<ReturnType<typeof installServiceFromCli>>, asJson: boolean): void {
@@ -160,6 +194,22 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printInstallResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "start") {
+    const bootstrap = await bootstrapBaselineServices({
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+    });
+    const app = await startRuntimeApp({
+      port: parsed.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080),
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+    });
+    printBootstrapResult(bootstrap, app, parsed.json);
     return;
   }
 

--- a/src/runtime/cli/bootstrap.ts
+++ b/src/runtime/cli/bootstrap.ts
@@ -1,0 +1,170 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import { hasManagedProcess } from "../execution/supervisor.js";
+import { configService, installService, startService } from "../lifecycle/actions.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "../lifecycle/types.js";
+import { DependencyGraph, createServiceRegistry } from "../manager/DependencyGraph.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { discoverServices } from "../discovery/discoverServices.js";
+import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
+import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
+import { writeServiceState } from "../state/writeState.js";
+
+export const DEFAULT_BASELINE_SERVICE_IDS = ["@traefik", "@node", "echo-service", "service-admin"] as const;
+
+export type BaselineServiceStatus = "completed" | "skipped";
+
+export interface BaselineActionSummary {
+  action: LifecycleAction;
+  status: "completed" | "skipped";
+  message: string;
+}
+
+export interface BaselineServiceSummary {
+  serviceId: string;
+  status: BaselineServiceStatus;
+  enabled: boolean;
+  actions: BaselineActionSummary[];
+  state: ServiceLifecycleState;
+  message: string;
+}
+
+export interface BootstrapBaselineOptions extends RuntimeConfigOptions {
+  serviceIds?: readonly string[];
+}
+
+export interface BootstrapBaselineResult {
+  servicesRoot: string;
+  workspaceRoot: string;
+  requestedServiceIds: string[];
+  serviceOrder: string[];
+  services: BaselineServiceSummary[];
+  registry: ServiceRegistry;
+}
+
+function formatActionFailure(serviceId: string, action: LifecycleAction, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Baseline bootstrap failed for service "${serviceId}" during "${action}": ${detail}`);
+}
+
+function shouldStartService(service: DiscoveredService, state: ServiceLifecycleState): boolean {
+  return Boolean(service.manifest.execservice || service.manifest.executable || state.installArtifacts.artifact?.command);
+}
+
+async function runLifecycleAction(
+  service: DiscoveredService,
+  registry: ServiceRegistry,
+  action: LifecycleAction,
+): Promise<LifecycleActionResult> {
+  try {
+    if (action === "install") {
+      return await installService(service, registry);
+    }
+
+    if (action === "config") {
+      return await configService(service, registry);
+    }
+
+    if (action === "start") {
+      return await startService(service, registry);
+    }
+  } catch (error) {
+    throw formatActionFailure(service.manifest.id, action, error);
+  }
+
+  throw new Error(`Unsupported baseline bootstrap action: ${action}`);
+}
+
+function resolveBaselineOrder(registry: ServiceRegistry, requestedServiceIds: readonly string[]): string[] {
+  const available = new Set(registry.list().map((service) => service.manifest.id));
+
+  for (const serviceId of requestedServiceIds) {
+    if (!available.has(serviceId)) {
+      const hint = [...available].sort().join(", ");
+      throw new Error(`Baseline bootstrap requires service "${serviceId}", but it was not discovered. Available services: ${hint}.`);
+    }
+  }
+
+  return new DependencyGraph(registry)
+    .getGlobalStartupOrder()
+    .filter((serviceId) => requestedServiceIds.includes(serviceId));
+}
+
+export async function bootstrapBaselineServices(options: BootstrapBaselineOptions = {}): Promise<BootstrapBaselineResult> {
+  const runtimeConfig = await ensureRuntimeConfig(resolveRuntimeConfig(options));
+  const discovered = await discoverServices(runtimeConfig.servicesRoot);
+  await rehydrateDiscoveredServices(discovered);
+  const registry = createServiceRegistry(discovered);
+  const requestedServiceIds = [...(options.serviceIds ?? DEFAULT_BASELINE_SERVICE_IDS)];
+  const serviceOrder = resolveBaselineOrder(registry, requestedServiceIds);
+  const summaries: BaselineServiceSummary[] = [];
+
+  for (const serviceId of serviceOrder) {
+    const service = registry.getById(serviceId);
+    if (!service) {
+      throw new Error(`Baseline bootstrap internal error: service "${serviceId}" disappeared after discovery.`);
+    }
+
+    if (service.manifest.enabled === false) {
+      summaries.push({
+        serviceId,
+        status: "skipped",
+        enabled: false,
+        actions: [],
+        state: getLifecycleState(serviceId),
+        message: `Skipped disabled baseline service "${serviceId}".`,
+      });
+      continue;
+    }
+
+    const actions: BaselineActionSummary[] = [];
+    let state = getLifecycleState(serviceId);
+
+    if (state.installed) {
+      actions.push({ action: "install", status: "skipped", message: "Already installed." });
+    } else {
+      const result = await runLifecycleAction(service, registry, "install");
+      await writeServiceState(service, result.state);
+      state = result.state;
+      actions.push({ action: "install", status: "completed", message: result.message });
+    }
+
+    if (state.configured) {
+      actions.push({ action: "config", status: "skipped", message: "Already configured." });
+    } else {
+      const result = await runLifecycleAction(service, registry, "config");
+      await writeServiceState(service, result.state);
+      state = result.state;
+      actions.push({ action: "config", status: "completed", message: result.message });
+    }
+
+    if (state.running || hasManagedProcess(serviceId)) {
+      actions.push({ action: "start", status: "skipped", message: "Already running." });
+    } else if (!shouldStartService(service, state)) {
+      actions.push({ action: "start", status: "skipped", message: "No executable or artifact command is configured." });
+    } else {
+      const result = await runLifecycleAction(service, registry, "start");
+      await writeServiceState(service, result.state);
+      state = result.state;
+      actions.push({ action: "start", status: "completed", message: result.message });
+    }
+
+    summaries.push({
+      serviceId,
+      status: "completed",
+      enabled: true,
+      actions,
+      state,
+      message: `Baseline service "${serviceId}" processed.`,
+    });
+  }
+
+  return {
+    servicesRoot: runtimeConfig.servicesRoot,
+    workspaceRoot: runtimeConfig.workspaceRoot,
+    requestedServiceIds,
+    serviceOrder,
+    services: summaries,
+    registry,
+  };
+}

--- a/tests/bootstrap-start.test.js
+++ b/tests/bootstrap-start.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rm } from "node:fs/promises";
+import { bootstrapBaselineServices } from "../dist/runtime/cli/bootstrap.js";
+import { stopAllManagedProcesses } from "../dist/runtime/execution/supervisor.js";
+import { getLifecycleState, resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+test("bootstrapBaselineServices installs, configures, and starts baseline services in dependency order", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-baseline-start-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "@traefik", {
+      install: { files: [{ path: "./runtime/install.txt", content: "installed ${SERVICE_ID}\n" }] },
+      config: { files: [{ path: "./runtime/config.txt", content: "configured ${SERVICE_ID}\n" }] },
+    });
+    await writeExecutableFixtureService(servicesRoot, "@node");
+    await writeExecutableFixtureService(servicesRoot, "echo-service", {
+      depend_on: ["@node", "@traefik"],
+    });
+    await writeExecutableFixtureService(servicesRoot, "service-admin", {
+      depend_on: ["@node"],
+    });
+
+    const result = await bootstrapBaselineServices({
+      servicesRoot,
+      workspaceRoot,
+      version: "test-version",
+    });
+
+    assert.deepEqual(result.requestedServiceIds, ["@traefik", "@node", "echo-service", "service-admin"]);
+    assert.deepEqual(result.serviceOrder, ["@node", "@traefik", "echo-service", "service-admin"]);
+    assert.equal(result.services.length, 4);
+
+    for (const service of result.services) {
+      assert.equal(service.status, "completed");
+      assert.deepEqual(
+        service.actions.map((action) => `${action.action}:${action.status}`),
+        ["install:completed", "config:completed", "start:completed"],
+      );
+      const state = getLifecycleState(service.serviceId);
+      assert.equal(state.installed, true, `${service.serviceId} installed`);
+      assert.equal(state.configured, true, `${service.serviceId} configured`);
+      assert.equal(state.running, true, `${service.serviceId} running`);
+    }
+
+    const rerun = await bootstrapBaselineServices({
+      servicesRoot,
+      workspaceRoot,
+      version: "test-version",
+    });
+
+    for (const service of rerun.services) {
+      assert.deepEqual(
+        service.actions.map((action) => `${action.action}:${action.status}`),
+        ["install:skipped", "config:skipped", "start:skipped"],
+      );
+    }
+  } finally {
+    await stopAllManagedProcesses();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #98.\n\nSummary:\n- documents service-lasso start as the clean-clone baseline bootstrap command\n- adds a baseline bootstrap engine that installs/configures/starts enabled services in dependency order and skips disabled baseline placeholders explicitly\n- wires the CLI start command to bootstrap services and then leave the API running\n- adds regression coverage for dependency-aware baseline install/config/start and rerun idempotency\n\nTraceability:\n- SPEC-002 AC-4I, AC-4U, AC-4X, AC-4Z\n\nValidation:\n- npm run build && node --test --test-concurrency=1 tests/bootstrap-start.test.js\n- npm test\n\nResidual gap:\n- @traefik is still disabled/deferred until #102 creates the release-backed Traefik service repo/artifact.\n- Fresh clean-clone command smoke remains #99.