### PR TITLE
Wait for demo echo health readiness

### DIFF
--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -150,7 +150,13 @@ export async function runDemoSmoke(options = {}) {
       assertCondition(result.status === 200, `Expected echo-service ${action} to return 200.`);
     }
 
-    const echoHealth = await getJson(`${runtime.apiServer.url}/api/services/echo-service/health`);
+    const echoHealth = await waitFor(async () => {
+      const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/health`);
+      if (result.body.health.healthy === true) {
+        return result;
+      }
+      return null;
+    });
     const echoLogs = await waitFor(async () => {
       const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/logs`);
       if (result.body.logs.entries.length > 0) {


### PR DESCRIPTION
## Summary
- fix the Linux CI race where demo smoke checked Echo health before it reported healthy
- wait for Echo health to become healthy, matching the existing wait pattern for logs

## Verification
- `npm run build && node --test --test-concurrency=1 tests/demo-instance.test.js`
- `npm test`

Part of #58
