### PR TITLE
Promote develop to main after readiness race fix

### DIFF
--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -150,7 +150,13 @@ export async function runDemoSmoke(options = {}) {
       assertCondition(result.status === 200, `Expected echo-service ${action} to return 200.`);
     }
 
-    const echoHealth = await getJson(`${runtime.apiServer.url}/api/services/echo-service/health`);
+    const echoHealth = await waitFor(async () => {
+      const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/health`);
+      if (result.body.health.healthy === true) {
+        return result;
+      }
+      return null;
+    });
     const echoLogs = await waitFor(async () => {
       const result = await getJson(`${runtime.apiServer.url}/api/services/echo-service/logs`);
       if (result.body.logs.entries.length > 0) {


### PR DESCRIPTION
## Summary
- re-promote current `develop` to `main` after fixing the demo Echo health readiness race found by the previous main publish workflow
- includes all completed release-readiness work plus PR #116

## Expected post-merge verification
- `release-artifact` workflow publishes a timestamped GitHub release
- `publish-package` workflow publishes/verifies `@service-lasso/service-lasso` on npmjs

Closes #58 after main workflows pass and evidence is recorded.
