### PR TITLE
Retry npm publish verification

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -84,4 +84,14 @@ jobs:
         env:
           SERVICE_LASSO_VERIFY_PACKAGE_VERSION: ${{ steps.publish_version.outputs.version }}
           SERVICE_LASSO_VERIFY_PACKAGE_REGISTRY: https://registry.npmjs.org
-        run: npm run verify:package-consumer
+        run: |
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            if npm run verify:package-consumer; then
+              exit 0
+            fi
+
+            echo "Published package is not visible from npm yet; retry ${attempt}/12 after registry propagation delay."
+            sleep 10
+          done
+
+          npm run verify:package-consumer


### PR DESCRIPTION
## Summary
- add retry/backoff around post-publish npm package verification
- prevents main publish workflow false negatives while npm registry indexes a just-published version

## Verification
- `npm test`
- confirmed `npm view @service-lasso/service-lasso@2026.4.25-7e74784` succeeds after the failed workflow, proving the prior failure was registry propagation latency

Part of #58
