### PR TITLE
Promote develop to main after npm verify retry

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -84,4 +84,14 @@ jobs:
         env:
           SERVICE_LASSO_VERIFY_PACKAGE_VERSION: ${{ steps.publish_version.outputs.version }}
           SERVICE_LASSO_VERIFY_PACKAGE_REGISTRY: https://registry.npmjs.org
-        run: npm run verify:package-consumer
+        run: |
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            if npm run verify:package-consumer; then
+              exit 0
+            fi
+
+            echo "Published package is not visible from npm yet; retry ${attempt}/12 after registry propagation delay."
+            sleep 10
+          done
+
+          npm run verify:package-consumer


### PR DESCRIPTION
## Summary
- re-promote current `develop` to `main` after adding npm publish verification retry/backoff
- includes completed release-readiness closure work and the npm registry propagation fix from PR #118

## Expected post-merge verification
- `Release Artifact` workflow publishes a timestamped GitHub release using `yyyy.m.d-<shortsha>`
- `Publish Package` workflow publishes and verifies `@service-lasso/service-lasso` on npmjs

This is the final release-readiness promotion pass.
