### PR TITLE
ISS-158: Run release-backed baseline artifacts

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -95,6 +95,9 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-136` | `done` | Add CLI and API surfaces for recovery, doctor, and hook results | `SPEC-002`, `AC-4AA` | GitHub issue: `#136`. PR `#153` merged; adds `recovery status`, `recovery doctor`, `GET /api/recovery`, `GET /api/services/:id/recovery`, and `POST /api/services/:id/recovery/doctor`. |
 | `ISS-137` | `done` | Surface recovery, doctor, and upgrade hook status in Service Admin UI | `SPEC-002`, `AC-4AA` | GitHub issue: `#137`. Service Admin PR `service-lasso/lasso-serviceadmin#13` merged recovery status badges, dashboard warnings, service-detail recovery card, and manual doctor action wiring. |
 | `ISS-138` | `done` | Add end-to-end recovery and hook verification with Echo Service scenarios | `SPEC-002`, `AC-4AA` | GitHub issue: `#138`. PR `#156` merged deterministic Echo-style recovery/hook E2E verification plus `npm run verify:recovery-hooks`. |
+| `ISS-158` | `done` | Fix checked-in baseline start so release-backed Echo and Service Admin stay running | `SPEC-002`, `AC-4Z` | GitHub issue: `#158`. Direct checked-in-manifest proof invalidated the claim, then the runtime was fixed to prefer installed artifact commands and run artifact-relative commands from the extracted artifact root. Echo Service and Service Admin now acquire release artifacts and remain running/healthy. |
+| `ISS-159` | `todo` | Clarify and enforce `@node` local provider behavior in baseline start | `SPEC-002`, `AC-4Y`, `AC-4Z` | GitHub issue: `#159`. `@node` is local/no-download but currently runs `node --version` as if it were a long-running service, leaving a false unhealthy/running state after baseline start. |
+| `ISS-160` | `todo` | Replace stale clean-clone baseline evaluation with direct current evidence | `SPEC-002`, `AC-4Z` | GitHub issue: `#160`. The clean-clone evaluation doc still needs final refresh once `#159` lands so it can report the fully verified baseline-start outcome without stale partial-era text. |
 
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
@@ -186,6 +189,9 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `TASK-136` | `done` | `ISS-136` | Add recovery CLI and API surfaces | `SPEC-002`, `AC-4AA` | PR `#153` merged; targeted API/CLI tests and `npm test` prove recovery status and manual doctor execution persist and read `.state/recovery.json`. |
 | `TASK-137` | `done` | `ISS-137` | Add Service Admin recovery status | `SPEC-002`, `AC-4AA` | Service Admin PR `#13` merged; `npm test`, `npm run build`, and `npm run lint` passed locally with recovery API shape/unit coverage. |
 | `TASK-138` | `done` | `ISS-138` | Add recovery and hook end-to-end verification | `SPEC-002`, `AC-4AA` | PR `#156` merged; targeted E2E, `npm run verify:recovery-hooks`, and `npm test` prove Echo-style monitor restart, doctor, update hooks, API, CLI, and persisted recovery state agreement. |
+| `TASK-158` | `done` | `ISS-158` | Prefer installed artifact commands for release-backed baseline services | `SPEC-002`, `AC-4Z` | Targeted tests prove installed artifact commands override fixture commands and run from the extracted artifact root. Direct checked-in-manifest proof shows `@traefik`, `echo-service`, and `service-admin` acquired release artifacts and remained running/healthy; `@node` remains tracked separately under `#159`. |
+| `TASK-159` | `todo` | `ISS-159` | Make `@node` baseline provider behavior explicit and non-false | `SPEC-002`, `AC-4Y`, `AC-4Z` | Pending. |
+| `TASK-160` | `todo` | `ISS-160` | Refresh clean-clone baseline evaluation after direct proof | `SPEC-002`, `AC-4Z` | Pending final refresh after `#159` closes. |
 
 ## Next Recommended Item
-Recovery, doctor, and upgrade-hook feature chain is complete. Reassess the next readiness gap from the broader backlog.
+Finish `ISS-159` so the baseline start result treats `@node` honestly as a local/no-download provider instead of a failed long-running service, then close `ISS-160` with the final clean-clone evidence refresh.

--- a/docs/development/clean-clone-baseline-start-evaluation.md
+++ b/docs/development/clean-clone-baseline-start-evaluation.md
@@ -2,9 +2,9 @@
 
 Date: 2026-04-24
 
-Latest update: 2026-04-25
+Latest update: 2026-04-27
 
-Linked issues: `#95`, `#96`, `#97`, `#98`, `#99`
+Linked issues: `#95`, `#96`, `#97`, `#98`, `#99`, `#102`, `#158`, `#159`, `#160`
 
 OpenSpec binding: `SPEC-002`, `AC-4Z`
 
@@ -33,7 +33,11 @@ As of 2026-04-25, the core CLI has a bounded baseline bootstrap command that ins
 
 `@traefik` now points at the canonical `service-lasso/lasso-traefik@2026.4.25-5301df9` release artifact. The command can acquire, configure, and start Traefik as a real release-backed baseline service.
 
-## Evidence
+Issue `#158` fixed the release-backed command execution gap for `echo-service` and `service-admin`: after install, direct execution now prefers the acquired artifact command over any checked-in fixture command, and artifact-relative commands run from the extracted artifact root.
+
+The remaining baseline-start gap is `#159`: `@node` is intentionally local/no-download, but the current checked-in manifest still behaves like a short-lived command service (`node --version`) rather than a long-running managed service or explicitly skipped provider validation.
+
+## Historical Evidence
 
 Clean-clone command evaluated:
 
@@ -76,9 +80,29 @@ Missing from the expected clean-clone baseline:
 
 Issue `#97` added the baseline manifest IDs to the core services root. Issue `#102` turns `@traefik` from a disabled placeholder into a release-backed Traefik service artifact from `service-lasso/lasso-traefik`. Issue `#93` adds `@java` as a bounded local/no-download provider outside the starter baseline.
 
-Current `services/echo-service/service.json` is a local fixture manifest. It does not currently prove the expected release-backed download path from `service-lasso/lasso-echoservice`.
+Current `services/echo-service/service.json` carries both a local fixture fallback and release artifact metadata. Install/acquire uses the release-backed artifact metadata from `service-lasso/lasso-echoservice`.
 
-Current `services/@node/service.json` is a local runtime/provider fixture. It does not currently document whether `@node` is intentionally no-download/local or a release-backed runtime service.
+Current `services/@node/service.json` is a local/no-download runtime/provider fixture. Its final baseline-start state still needs to be made explicit under `#159`.
+
+## 2026-04-27 Direct Checked-In Manifest Proof
+
+Command shape exercised against tracked `services/` manifests copied to a temporary services root:
+
+```powershell
+npm run build
+node dist/cli.js start --services-root <tracked-services-copy> --workspace-root <temp-workspace> --port <temp-port> --json
+```
+
+Observed after issue `#158` fix:
+
+| Service | Installed | Configured | Running | Healthy | Artifact source |
+| --- | --- | --- | --- | --- | --- |
+| `@traefik` | yes | yes | yes | yes | `service-lasso/lasso-traefik@2026.4.25-5301df9` |
+| `echo-service` | yes | yes | yes | yes | `service-lasso/lasso-echoservice@2026.4.20-a417abd` |
+| `service-admin` | yes | yes | yes | yes | `service-lasso/lasso-serviceadmin@2026.4.18-170a1af` |
+| `@node` | yes | yes | no | no | local/no-download provider; tracked under `#159` |
+
+This directly verifies that release-backed `@traefik`, `echo-service`, and `service-admin` are acquired from their configured GitHub releases and remain running/healthy after the baseline start path. It does not yet close the `@node` provider-state gap.
 
 ## Current CLI/API Capability
 
@@ -107,8 +131,9 @@ Current implemented capability:
 
 Current missing capability:
 
-- the deterministic baseline-start smoke still uses fixtures for `@node`, `echo-service`, and `service-admin`; fully live reference-app lifecycle proof is now covered by `npm run verify:reference-app-lifecycle` from issue `#89`.
-- deterministic live reference-app lifecycle proof passed on 2026-04-25 for all five canonical reference apps through `npm run verify:reference-app-lifecycle`.
+- the deterministic baseline-start smoke still uses fixtures for `@node`, `echo-service`, and `service-admin`; direct checked-in-manifest proof now covers release-backed `echo-service` and `service-admin` after `#158`
+- `@node` local/no-download provider behavior still needs an explicit non-false final state under `#159`
+- deterministic live reference-app lifecycle proof passed on 2026-04-25 for all five canonical reference apps through `npm run verify:reference-app-lifecycle`
 
 ## Gap Issues
 
@@ -119,6 +144,9 @@ The clean-clone baseline start use case is split into these implementation-grade
 - `#98`: add a bootstrap start command for baseline service install/config/start.
 - `#99`: add deterministic clean-clone baseline start smoke verification.
 - `#102`: create the canonical release-backed `@traefik` service repo/artifact and include it in the baseline release-backed proof.
+- `#158`: fix checked-in baseline start so release-backed Echo Service and Service Admin start from acquired artifacts and remain running.
+- `#159`: clarify and enforce `@node` local provider behavior in baseline start.
+- `#160`: replace stale clean-clone baseline evaluation with final direct current evidence.
 
 ## Completion Target
 

--- a/scripts/baseline-start-smoke.mjs
+++ b/scripts/baseline-start-smoke.mjs
@@ -12,7 +12,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function waitForJson(url, timeoutMs = 30_000) {
+async function waitForJson(url, timeoutMs = 120_000) {
   const startedAt = Date.now();
   let lastError = null;
 
@@ -33,7 +33,7 @@ async function waitForJson(url, timeoutMs = 30_000) {
   throw lastError ?? new Error(`Timed out waiting for ${url}`);
 }
 
-async function waitForCliSummary(cli, timeoutMs = 5_000) {
+async function waitForCliSummary(cli, timeoutMs = 30_000) {
   const startedAt = Date.now();
   let lastError = null;
 

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -164,6 +164,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
   const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
   const serviceId = service.manifest.id;
+  const commandRoot = executionPlan.commandRoot ?? service.serviceRoot;
 
   const priorFinalizer = managedProcessFinalizers.get(serviceId);
   if (priorFinalizer) {
@@ -181,7 +182,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
   const { paths: logPaths, streams: logStreams } = await prepareRuntimeLogStreams(service.serviceRoot);
 
   const child = spawn(executable, args, {
-    cwd: service.serviceRoot,
+    cwd: commandRoot,
     env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -136,6 +136,23 @@ function resolveExecutable(service: DiscoveredService, executionPlan: ProviderEx
   return executable;
 }
 
+function isPathInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function resolveWorkingDirectory(service: DiscoveredService, executionPlan: ProviderExecutionPlan, executable: string): string {
+  if (!executionPlan.commandRoot) {
+    return service.serviceRoot;
+  }
+
+  // Archive executables often consume Service-Lasso-materialized config from the service root,
+  // while plain launchers such as `node` need artifact-relative payload args.
+  return path.isAbsolute(executable) && isPathInside(executionPlan.commandRoot, executable)
+    ? service.serviceRoot
+    : executionPlan.commandRoot;
+}
+
 function buildCommandString(executable: string, args: string[]): string {
   return [executable, ...args].join(" ");
 }
@@ -164,7 +181,6 @@ export function hasManagedProcess(serviceId: string): boolean {
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
   const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
   const serviceId = service.manifest.id;
-  const commandRoot = executionPlan.commandRoot ?? service.serviceRoot;
 
   const priorFinalizer = managedProcessFinalizers.get(serviceId);
   if (priorFinalizer) {
@@ -176,13 +192,14 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
   }
 
   const executable = resolveExecutable(service, executionPlan);
+  const workingDirectory = resolveWorkingDirectory(service, executionPlan, executable);
   const args = executionPlan.args;
   const command = buildCommandString(executable, args);
   const startedAt = new Date().toISOString();
   const { paths: logPaths, streams: logStreams } = await prepareRuntimeLogStreams(service.serviceRoot);
 
   const child = spawn(executable, args, {
-    cwd: commandRoot,
+    cwd: workingDirectory,
     env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,

--- a/src/runtime/providers/direct.ts
+++ b/src/runtime/providers/direct.ts
@@ -9,8 +9,11 @@ export function createDirectExecutionPlan(
     extractedPath: string | null;
   },
 ): ProviderExecutionPlan {
-  const executable = manifest.executable ?? installedArtifact?.command ?? manifest.id;
-  const args = manifest.args ?? (manifest.executable ? [] : installedArtifact?.args ?? []);
+  const executable = installedArtifact?.command ?? manifest.executable ?? manifest.id;
+  const args = installedArtifact?.command ? installedArtifact.args : manifest.args ?? [];
+  const commandRoot = installedArtifact?.command
+    ? installedArtifact.extractedPath
+    : null;
 
   return {
     provider: "direct",
@@ -19,6 +22,6 @@ export function createDirectExecutionPlan(
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
     providerEnv: {},
-    commandRoot: manifest.executable ? null : installedArtifact?.extractedPath ?? null,
+    commandRoot,
   };
 }

--- a/tests/install-acquire.test.js
+++ b/tests/install-acquire.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import AdmZip from "adm-zip";
 import { startApiServer } from "../dist/server/index.js";
@@ -34,6 +34,42 @@ function createZipWithRuntimeScript() {
     ].join("\n"), "utf8"),
   );
   return zip.toBuffer();
+}
+
+function createZipWithObservableRuntimeScript() {
+  const zip = new AdmZip();
+  zip.addFile(
+    "runtime/downloaded-service.mjs",
+    Buffer.from([
+      'import { writeFileSync } from "node:fs";',
+      'import path from "node:path";',
+      'writeFileSync(path.join(process.cwd(), "artifact-cwd.txt"), process.cwd());',
+      'const heartbeat = setInterval(() => {}, 1000);',
+      'process.on("SIGTERM", () => { clearInterval(heartbeat); process.exit(0); });',
+      'console.log("observable-artifact-started");',
+    ].join("\n"), "utf8"),
+  );
+  return zip.toBuffer();
+}
+
+async function waitFor(readinessCheck, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await readinessCheck();
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw lastError ?? new Error(`Condition not met within ${timeoutMs}ms`);
 }
 
 async function startFakeGitHubReleaseServer(assetName, assetBytes, options = {}) {
@@ -181,6 +217,42 @@ test("start can use the installed artifact command when the manifest has no chec
     assert.match(start.body.state.runtime.command, /node|node\.exe/i);
     assert.equal(stop.status, 200);
     assert.equal(stop.body.state.running, false);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("start prefers an installed artifact command over a checked-in fixture command", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, createZipWithObservableRuntimeScript());
+  await writeManifest(servicesRoot, "downloaded-service", {
+    ...createReleaseBackedManifest(releaseServer, assetName, "Service should run from the installed artifact."),
+    executable: process.execPath,
+    args: ["./runtime/local-fixture-should-not-run.mjs"],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const config = await postJson(`${apiServer.url}/api/services/downloaded-service/config`);
+    const start = await postJson(`${apiServer.url}/api/services/downloaded-service/start`);
+    const extractedPath = install.body.state.installArtifacts.artifact.extractedPath;
+    const cwdProofPath = path.join(extractedPath, "artifact-cwd.txt");
+    const cwdProof = await waitFor(() => readFile(cwdProofPath, "utf8"));
+    const stop = await postJson(`${apiServer.url}/api/services/downloaded-service/stop`);
+
+    assert.equal(config.status, 200);
+    assert.equal(start.status, 200);
+    assert.equal(start.body.state.running, true);
+    assert.equal(cwdProof, extractedPath);
+    assert.match(start.body.state.runtime.command, /downloaded-service\.mjs/);
+    assert.doesNotMatch(start.body.state.runtime.command, /local-fixture-should-not-run/);
+    assert.equal(stop.status, 200);
   } finally {
     await apiServer.stop();
     await releaseServer.stop();


### PR DESCRIPTION
## Summary
- fixes direct execution so installed release artifact commands take precedence over checked-in fixture commands
- runs artifact-relative commands from the extracted artifact root
- adds regression coverage proving artifact commands override local fixture commands
- records direct checked-in-manifest proof for release-backed `@traefik`, `echo-service`, and `service-admin`

## Linked Issue
Closes #158

## Verification
- `npm run build`
- `node --test --test-concurrency=1 tests/install-acquire.test.js tests/provider-execution.test.js`
- direct checked-in-manifest baseline proof: `@traefik`, `echo-service`, and `service-admin` acquired release artifacts and remained running/healthy
- `npm test` passed 153/153

## Residual Gap
- `@node` local/no-download provider final state remains tracked under #159
- final stale-doc cleanup remains tracked under #160