### PR TITLE
Release: promote develop after ISS-210 CI fix

### DIFF
--- a/tests/recovery-e2e.test.js
+++ b/tests/recovery-e2e.test.js
@@ -284,16 +284,20 @@ test("recovery E2E keeps API, CLI, state, monitor restart, doctor, and hooks in 
     const apiHookEvents = apiHookRecovery.body.recovery.events.filter((event) => event.kind === "hook");
     assert.deepEqual(apiHookEvents.map((event) => event.kind), ["hook", "hook"]);
 
-    const cliHookRecovery = JSON.parse(await runCli([
-      "recovery",
-      "status",
-      "echo-hook",
-      "--services-root",
-      servicesRoot,
-      "--workspace-root",
-      workspaceRoot,
-      "--json",
-    ]));
+    const cliHookRecovery = await waitFor(async () => {
+      const recovery = JSON.parse(await runCli([
+        "recovery",
+        "status",
+        "echo-hook",
+        "--services-root",
+        servicesRoot,
+        "--workspace-root",
+        workspaceRoot,
+        "--json",
+      ]));
+      const events = recovery.services[0].recovery.events.filter((event) => event.kind === "hook");
+      return events.map((event) => event.phase).join(",") === "preUpgrade,postUpgrade" ? recovery : null;
+    });
     const cliHookEvents = cliHookRecovery.services[0].recovery.events.filter((event) => event.kind === "hook");
     assert.deepEqual(cliHookEvents.map((event) => event.phase), ["preUpgrade", "postUpgrade"]);
   } finally {


### PR DESCRIPTION
## Summary
- promote the release-artifact CI hardening from `develop` to `main`
- includes Dagu service docs/governance from the earlier ISS-210 promotion plus the recovery E2E race fix

## Validation
- PR #211 baseline-start-smoke passed
- PR #213 baseline-start-smoke passed
- `npm test` in `C:\projects\service-lasso\lasso-dagu`
- `lasso-dagu` release workflow `25010221397` passed and published `2026.4.27-a43c829`
- `node --test --test-concurrency=1 tests/recovery-e2e.test.js`
- `npm run build`
- `git diff --check`

Closes #210