### PR TITLE
docs: fix service.json union schema title

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -1,4 +1,9 @@
-# SERVICE-JSON-COMPLETE-UNION-SCHEMA
+---
+title: Complete service.json Union Schema
+sidebar_label: service.json Union Schema
+---
+
+# Complete service.json Union Schema
 
 Full union analysis reference for `service.json` across `C:\projects\service-lasso`.
 


### PR DESCRIPTION
Closes #227

## Summary
- Adds Docusaurus frontmatter to the service.json union schema reference page.
- Changes the page H1 from `SERVICE-JSON-COMPLETE-UNION-SCHEMA` to `Complete service.json Union Schema`.
- Sets the sidebar label to `service.json Union Schema` while keeping the existing file path and route stable.

## Verification
- `npm run docs:build`
- `git diff --check`
- Generated HTML confirms the page title, breadcrumb, H1, and sidebar label are readable.