### PR TITLE
promote: release docs title fix

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -1,4 +1,9 @@
-# SERVICE-JSON-COMPLETE-UNION-SCHEMA
+---
+title: Complete service.json Union Schema
+sidebar_label: service.json Union Schema
+---
+
+# Complete service.json Union Schema
 
 Full union analysis reference for `service.json` across `C:\projects\service-lasso`.
 


### PR DESCRIPTION
## Summary
- Promotes the service.json union schema docs title fix from `develop` to `main`.
- Publishes the updated Docusaurus page/sidebar title to the public docs site.

## Included change
- `#228` / `#227`: human-facing title/sidebar label changed from `SERVICE-JSON-COMPLETE-UNION-SCHEMA` to readable service.json union schema labels.

## Verification before promotion
- `npm run docs:build`
- `git diff --check`
- PR #228 CI passed: Build docs and baseline-start-smoke