### PR TITLE
docs: remove local path from schema reference

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -5,7 +5,7 @@ sidebar_label: service.json Union Schema
 
 # Complete service.json Union Schema
 
-Full union analysis reference for `service.json` across `C:\projects\service-lasso`.
+Reference shape for the current Service Lasso `service.json` contract.
 
 ## Schema review
 


### PR DESCRIPTION
Closes #242.

Summary:
- replaces the local workspace sentence in the service.json union schema doc with current Service Lasso contract wording

Verification:
- rg check for removed sentence returned no matches
- npm run docs:build
- git diff --check