### PR TITLE
promote: publish schema wording cleanup

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -5,7 +5,7 @@ sidebar_label: service.json Union Schema
 
 # Complete service.json Union Schema
 
-Full union analysis reference for `service.json` across `C:\projects\service-lasso`.
+Reference shape for the current Service Lasso `service.json` contract.
 
 ## Schema review
 


### PR DESCRIPTION
Promotes #242 from develop to main so the public docs no longer show the local workspace sentence in the service.json schema reference.

Included:
- PR #243 / issue #242
- docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md wording cleanup

Verification already passed:
- rg check for removed sentence
- npm run docs:build
- git diff --check
- PR docs build
- PR baseline-start-smoke