### PR TITLE
docs: rename planned services sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -70,7 +70,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Optional Services",
+      label: "Planned Services",
       collapsed: true,
       items: [
         "development/zitadel-service-plan",


### PR DESCRIPTION
## Summary
- Fixes #248
- Renames the Docusaurus sidebar group from "Optional Services" to "Planned Services".

## Verification
- rg for "Optional Services", "optional services", and "Optional services" returned no matches.
- npm run docs:build passed.
- git diff --check passed.
