### PR TITLE
promote: publish planned services sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -70,7 +70,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Optional Services",
+      label: "Planned Services",
       collapsed: true,
       items: [
         "development/zitadel-service-plan",


### PR DESCRIPTION
## Summary
- Promotes the docs sidebar taxonomy fix from develop to main.
- Removes the released "Optional Services" navigation label in favor of "Planned Services".

## Verification
- PR #249 checks passed: Build docs and baseline-start-smoke.
- Local docs build passed before merge.
- Local search found no remaining "Optional Services" references.
