### PR TITLE
docs: add service catalog navbar link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -76,6 +76,11 @@ const config = {
           label: "Docs",
         },
         {
+          to: "/service-catalog",
+          label: "Service Catalog",
+          position: "left",
+        },
+        {
           href: "https://github.com/service-lasso/service-lasso",
           label: "GitHub",
           position: "right",


### PR DESCRIPTION
## Summary
- Fixes #254.
- Adds Service Catalog as a left-side top navbar item beside Docs.
- Points the item to the existing `/service-catalog` page.

## Verification
- npm run docs:build passed.
- git diff --check passed.
- Generated docs HTML shows Docs followed by Service Catalog with href `/service-lasso/service-catalog`.
