### PR TITLE
promote: publish service catalog navbar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -76,6 +76,11 @@ const config = {
           label: "Docs",
         },
         {
+          to: "/service-catalog",
+          label: "Service Catalog",
+          position: "left",
+        },
+        {
           href: "https://github.com/service-lasso/service-lasso",
           label: "GitHub",
           position: "right",

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -1,0 +1,14 @@
+---
+title: Service Catalog
+description: Canonical Service Lasso service repos and live README previews.
+---
+
+import ServiceCatalog from "./src/components/ServiceCatalog";
+
+# Service Catalog
+
+Use this page to find the canonical Service Lasso service repos. Each service
+card links to the source repo and can load that repo's live `README.md` into the
+viewer without copying the README into this docs repo.
+
+<ServiceCatalog />

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -13,6 +13,14 @@ const sidebars = {
     },
     {
       type: "category",
+      label: "Service Catalog",
+      collapsed: false,
+      items: [
+        "service-catalog",
+      ],
+    },
+    {
+      type: "category",
       label: "Getting Started",
       collapsed: false,
       items: [

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -70,7 +70,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Optional Services",
+      label: "Planned Services",
       collapsed: true,
       items: [
         "development/zitadel-service-plan",

--- a/docs/src/components/ServiceCatalog.jsx
+++ b/docs/src/components/ServiceCatalog.jsx
@@ -1,0 +1,360 @@
+import React, {useMemo, useState} from "react";
+
+const services = [
+  {
+    id: "@node",
+    name: "Node Runtime Provider",
+    repo: "service-lasso/lasso-node",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Release-backed Node provider used by the baseline and by services that execute through execservice.",
+  },
+  {
+    id: "@localcert",
+    name: "Local Certificate Provider",
+    repo: "service-lasso/lasso-localcert",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Core certificate utility used by the Traefik baseline to produce local certificate outputs.",
+  },
+  {
+    id: "@nginx",
+    name: "NGINX Service",
+    repo: "service-lasso/lasso-nginx",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Managed NGINX Open Source service started before Traefik in the default baseline.",
+  },
+  {
+    id: "@traefik",
+    name: "Traefik Edge Router",
+    repo: "service-lasso/lasso-traefik",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Release-backed edge/router service with local certificate and NGINX dependencies.",
+  },
+  {
+    id: "echo-service",
+    name: "Echo Service",
+    repo: "service-lasso/lasso-echoservice",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Harness service for lifecycle, UI/API, health, logs, state, SQLite, and failure testing.",
+  },
+  {
+    id: "@serviceadmin",
+    name: "Service Admin",
+    repo: "service-lasso/lasso-serviceadmin",
+    group: "Baseline Core",
+    status: "Available",
+    summary:
+      "Browser-based operator UI served as a managed Service Lasso service.",
+  },
+  {
+    id: "@python",
+    name: "Python Runtime Provider",
+    repo: "service-lasso/lasso-python",
+    group: "Runtime Providers",
+    status: "Available",
+    summary:
+      "Release-backed Python provider for consumers that need Python-backed local services.",
+  },
+  {
+    id: "@java",
+    name: "Java Runtime Provider",
+    repo: "service-lasso/lasso-java",
+    group: "Runtime Providers",
+    status: "Available",
+    summary:
+      "Release-backed Java provider for consumers that need Java-backed local services.",
+  },
+  {
+    id: "zitadel",
+    name: "ZITADEL",
+    repo: "service-lasso/lasso-zitadel",
+    group: "App-Owned Services",
+    status: "Available",
+    summary:
+      "Release-backed identity service for apps that own the required database, domain, and secret configuration.",
+  },
+  {
+    id: "dagu",
+    name: "Dagu",
+    repo: "service-lasso/lasso-dagu",
+    group: "App-Owned Services",
+    status: "Available",
+    summary:
+      "Release-backed workflow service for apps that own their workflow definitions and orchestration contract.",
+  },
+];
+
+const githubUrl = (repo) => `https://github.com/${repo}`;
+const readmeUrls = (repo) => [
+  `https://raw.githubusercontent.com/${repo}/main/README.md`,
+  `https://raw.githubusercontent.com/${repo}/master/README.md`,
+];
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function renderInlineMarkdown(value) {
+  return escapeHtml(value)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+}
+
+function markdownToHtml(markdown) {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const html = [];
+  let inCode = false;
+  let inList = false;
+  let codeLines = [];
+
+  const closeList = () => {
+    if (inList) {
+      html.push("</ul>");
+      inList = false;
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      if (inCode) {
+        html.push(`<pre><code>${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+        codeLines = [];
+        inCode = false;
+      } else {
+        closeList();
+        inCode = true;
+      }
+      continue;
+    }
+
+    if (inCode) {
+      codeLines.push(line);
+      continue;
+    }
+
+    if (!line.trim()) {
+      closeList();
+      continue;
+    }
+
+    const heading = /^(#{1,4})\s+(.+)$/.exec(line);
+    if (heading) {
+      closeList();
+      const level = heading[1].length;
+      html.push(`<h${level}>${renderInlineMarkdown(heading[2])}</h${level}>`);
+      continue;
+    }
+
+    const listItem = /^[-*]\s+(.+)$/.exec(line);
+    if (listItem) {
+      if (!inList) {
+        html.push("<ul>");
+        inList = true;
+      }
+      html.push(`<li>${renderInlineMarkdown(listItem[1])}</li>`);
+      continue;
+    }
+
+    closeList();
+    html.push(`<p>${renderInlineMarkdown(line)}</p>`);
+  }
+
+  closeList();
+
+  if (inCode) {
+    html.push(`<pre><code>${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+  }
+
+  return html.join("\n");
+}
+
+function readmeDocument(service, markdown, sourceUrl) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <base target="_blank" />
+  <style>
+    :root { color-scheme: light; }
+    body {
+      margin: 0;
+      padding: 24px;
+      color: #172026;
+      background: #ffffff;
+      font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    h1, h2, h3, h4 { color: #0f2f3f; line-height: 1.2; margin: 1.2em 0 0.45em; }
+    h1:first-child { margin-top: 0; }
+    a { color: #0b6b7b; }
+    code {
+      padding: 0.12rem 0.28rem;
+      border-radius: 5px;
+      background: #edf5f5;
+      color: #16323a;
+    }
+    pre {
+      overflow: auto;
+      padding: 16px;
+      border-radius: 12px;
+      background: #102027;
+      color: #f3fbfb;
+    }
+    pre code { padding: 0; background: transparent; color: inherit; }
+    .source {
+      margin: 0 0 18px;
+      padding: 12px 14px;
+      border: 1px solid #d4e4e2;
+      border-radius: 12px;
+      background: #f5fbfa;
+    }
+  </style>
+</head>
+<body>
+  <div class="source">
+    Live README loaded from <a href="${escapeHtml(sourceUrl)}">${escapeHtml(service.repo)}</a>.
+  </div>
+  ${markdownToHtml(markdown)}
+</body>
+</html>`;
+}
+
+export default function ServiceCatalog() {
+  const [activeService, setActiveService] = useState(null);
+  const [viewer, setViewer] = useState({
+    status: "idle",
+    srcDoc: "",
+    error: "",
+  });
+
+  const groupedServices = useMemo(() => {
+    return services.reduce((groups, service) => {
+      groups[service.group] = groups[service.group] || [];
+      groups[service.group].push(service);
+      return groups;
+    }, {});
+  }, []);
+
+  async function openReadme(service) {
+    setActiveService(service);
+    setViewer({status: "loading", srcDoc: "", error: ""});
+
+    for (const url of readmeUrls(service.repo)) {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          continue;
+        }
+        const markdown = await response.text();
+        setViewer({
+          status: "ready",
+          srcDoc: readmeDocument(service, markdown, url),
+          error: "",
+        });
+        return;
+      } catch (error) {
+        setViewer({
+          status: "error",
+          srcDoc: "",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    setViewer({
+      status: "error",
+      srcDoc: "",
+      error: `No README.md could be loaded from ${service.repo}.`,
+    });
+  }
+
+  return (
+    <div className="serviceCatalog">
+      <div className="serviceCatalog__intro">
+        <p>
+          This catalog points to the canonical service repos. Use the README button
+          to load the live upstream README in-page without copying that content
+          into the Service Lasso docs repo.
+        </p>
+      </div>
+
+      {Object.entries(groupedServices).map(([group, entries]) => (
+        <section className="serviceCatalog__group" key={group}>
+          <h2>{group}</h2>
+          <div className="serviceCatalog__grid">
+            {entries.map((service) => (
+              <article className="serviceCatalog__card" key={service.id}>
+                <div className="serviceCatalog__cardHeader">
+                  <div>
+                    <h3>{service.id}</h3>
+                    <p>{service.name}</p>
+                  </div>
+                  <span>{service.status}</span>
+                </div>
+                <p>{service.summary}</p>
+                <div className="serviceCatalog__actions">
+                  <a href={githubUrl(service.repo)} target="_blank" rel="noreferrer">
+                    Open repo
+                  </a>
+                  <button type="button" onClick={() => openReadme(service)}>
+                    Read README
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <section className="serviceCatalog__viewer" aria-live="polite">
+        <div className="serviceCatalog__viewerHeader">
+          <div>
+            <h2>README Viewer</h2>
+            <p>
+              {activeService
+                ? `${activeService.id} from ${activeService.repo}`
+                : "Choose a service README to preview it here."}
+            </p>
+          </div>
+          {activeService ? (
+            <a href={githubUrl(activeService.repo)} target="_blank" rel="noreferrer">
+              Open on GitHub
+            </a>
+          ) : null}
+        </div>
+
+        {viewer.status === "idle" ? (
+          <div className="serviceCatalog__empty">No README selected yet.</div>
+        ) : null}
+        {viewer.status === "loading" ? (
+          <div className="serviceCatalog__empty">Loading live README...</div>
+        ) : null}
+        {viewer.status === "error" ? (
+          <div className="serviceCatalog__error">{viewer.error}</div>
+        ) : null}
+        {viewer.status === "ready" ? (
+          <iframe
+            className="serviceCatalog__iframe"
+            title={`${activeService.id} README`}
+            sandbox="allow-popups allow-popups-to-escape-sandbox"
+            srcDoc={viewer.srcDoc}
+          />
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -19,3 +19,144 @@
 .navbar__title {
   letter-spacing: 0.01em;
 }
+
+.serviceCatalog {
+  display: grid;
+  gap: 2rem;
+}
+
+.serviceCatalog__intro {
+  padding: 1rem 1.2rem;
+  border: 1px solid #d7e8e6;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top left, rgba(23, 92, 98, 0.16), transparent 34rem),
+    linear-gradient(135deg, #f7fbfa, #eef8f6);
+}
+
+.serviceCatalog__intro p {
+  margin: 0;
+}
+
+.serviceCatalog__group {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.serviceCatalog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.serviceCatalog__card {
+  display: flex;
+  min-height: 230px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem;
+  border: 1px solid #d9e8e6;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 14px 36px rgba(20, 56, 63, 0.08);
+}
+
+.serviceCatalog__cardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.serviceCatalog__cardHeader h3,
+.serviceCatalog__cardHeader p {
+  margin: 0;
+}
+
+.serviceCatalog__cardHeader h3 {
+  color: #103d49;
+}
+
+.serviceCatalog__cardHeader span {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #e4f3ef;
+  color: #0d5d51;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.serviceCatalog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.serviceCatalog__actions a,
+.serviceCatalog__actions button,
+.serviceCatalog__viewerHeader a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid #b7d5d0;
+  border-radius: 999px;
+  background: #f8fcfb;
+  color: #0f5867;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.serviceCatalog__actions button {
+  cursor: pointer;
+  font: inherit;
+}
+
+.serviceCatalog__actions a:hover,
+.serviceCatalog__actions button:hover,
+.serviceCatalog__viewerHeader a:hover {
+  background: #e8f7f4;
+  text-decoration: none;
+}
+
+.serviceCatalog__viewer {
+  overflow: hidden;
+  border: 1px solid #d7e8e6;
+  border-radius: 22px;
+  background: #ffffff;
+  box-shadow: 0 18px 44px rgba(17, 48, 56, 0.1);
+}
+
+.serviceCatalog__viewerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid #d7e8e6;
+  background: #f7fbfa;
+}
+
+.serviceCatalog__viewerHeader h2,
+.serviceCatalog__viewerHeader p {
+  margin: 0;
+}
+
+.serviceCatalog__empty,
+.serviceCatalog__error {
+  padding: 2rem;
+  color: #49656b;
+}
+
+.serviceCatalog__error {
+  color: #8c2d22;
+}
+
+.serviceCatalog__iframe {
+  display: block;
+  width: 100%;
+  min-height: 720px;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- Promotes the Service Catalog top-navbar link from develop to main.
- Publishes the navbar item beside Docs on the public docs site.

## Verification
- PR #255 checks passed: Build docs and baseline-start-smoke.
- Local `npm run docs:build` and `git diff --check` passed before merge.
- Generated HTML showed Docs followed by Service Catalog with href `/service-lasso/service-catalog`.
