### PR TITLE
docs: make service catalog filterable table

### DIFF
--- a/docs/src/components/ServiceCatalog.jsx
+++ b/docs/src/components/ServiceCatalog.jsx
@@ -235,19 +235,38 @@ function readmeDocument(service, markdown, sourceUrl) {
 
 export default function ServiceCatalog() {
   const [activeService, setActiveService] = useState(null);
+  const [query, setQuery] = useState("");
+  const [groupFilter, setGroupFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
   const [viewer, setViewer] = useState({
     status: "idle",
     srcDoc: "",
     error: "",
   });
 
-  const groupedServices = useMemo(() => {
-    return services.reduce((groups, service) => {
-      groups[service.group] = groups[service.group] || [];
-      groups[service.group].push(service);
-      return groups;
-    }, {});
+  const groupOptions = useMemo(() => {
+    return Array.from(new Set(services.map((service) => service.group))).sort();
   }, []);
+
+  const statusOptions = useMemo(() => {
+    return Array.from(new Set(services.map((service) => service.status))).sort();
+  }, []);
+
+  const filteredServices = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return services.filter((service) => {
+      const matchesQuery =
+        !normalizedQuery ||
+        [service.id, service.name, service.repo, service.group, service.status, service.summary]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedQuery);
+      const matchesGroup = groupFilter === "all" || service.group === groupFilter;
+      const matchesStatus = statusFilter === "all" || service.status === statusFilter;
+      return matchesQuery && matchesGroup && matchesStatus;
+    });
+  }, [groupFilter, query, statusFilter]);
 
   async function openReadme(service) {
     setActiveService(service);
@@ -286,39 +305,117 @@ export default function ServiceCatalog() {
     <div className="serviceCatalog">
       <div className="serviceCatalog__intro">
         <p>
-          This catalog points to the canonical service repos. Use the README button
-          to load the live upstream README in-page without copying that content
-          into the Service Lasso docs repo.
+          This catalog points to the canonical service repos. Filter the table
+          by service, repo, group, or status, then use the README action to load
+          the live upstream README in-page without copying that content into the
+          Service Lasso docs repo.
         </p>
       </div>
 
-      {Object.entries(groupedServices).map(([group, entries]) => (
-        <section className="serviceCatalog__group" key={group}>
-          <h2>{group}</h2>
-          <div className="serviceCatalog__grid">
-            {entries.map((service) => (
-              <article className="serviceCatalog__card" key={service.id}>
-                <div className="serviceCatalog__cardHeader">
-                  <div>
-                    <h3>{service.id}</h3>
-                    <p>{service.name}</p>
-                  </div>
-                  <span>{service.status}</span>
-                </div>
-                <p>{service.summary}</p>
-                <div className="serviceCatalog__actions">
-                  <a href={githubUrl(service.repo)} target="_blank" rel="noreferrer">
-                    Open repo
-                  </a>
-                  <button type="button" onClick={() => openReadme(service)}>
-                    Read README
-                  </button>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-      ))}
+      <section className="serviceCatalog__tableShell">
+        <div className="serviceCatalog__toolbar" aria-label="Service catalog filters">
+          <label className="serviceCatalog__search">
+            <span>Search services</span>
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter by service, repo, or summary..."
+            />
+          </label>
+
+          <label>
+            <span>Group</span>
+            <select value={groupFilter} onChange={(event) => setGroupFilter(event.target.value)}>
+              <option value="all">All groups</option>
+              {groupOptions.map((group) => (
+                <option key={group} value={group}>
+                  {group}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>Status</span>
+            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+              <option value="all">All statuses</option>
+              {statusOptions.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            type="button"
+            className="serviceCatalog__reset"
+            onClick={() => {
+              setQuery("");
+              setGroupFilter("all");
+              setStatusFilter("all");
+            }}
+          >
+            Reset
+          </button>
+        </div>
+
+        <div className="serviceCatalog__tableMeta">
+          Showing {filteredServices.length} of {services.length} services
+        </div>
+
+        <div className="serviceCatalog__tableScroller">
+          <table className="serviceCatalog__table">
+            <thead>
+              <tr>
+                <th scope="col">Service</th>
+                <th scope="col">Group</th>
+                <th scope="col">Status</th>
+                <th scope="col">Repository</th>
+                <th scope="col">Summary</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredServices.map((service) => (
+                <tr key={service.id}>
+                  <th scope="row">
+                    <span className="serviceCatalog__serviceId">{service.id}</span>
+                    <span className="serviceCatalog__serviceName">{service.name}</span>
+                  </th>
+                  <td>{service.group}</td>
+                  <td>
+                    <span className="serviceCatalog__status">{service.status}</span>
+                  </td>
+                  <td>
+                    <a href={githubUrl(service.repo)} target="_blank" rel="noreferrer">
+                      {service.repo}
+                    </a>
+                  </td>
+                  <td>{service.summary}</td>
+                  <td>
+                    <div className="serviceCatalog__actions">
+                      <a href={githubUrl(service.repo)} target="_blank" rel="noreferrer">
+                        Open repo
+                      </a>
+                      <button type="button" onClick={() => openReadme(service)}>
+                        Read README
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {filteredServices.length === 0 ? (
+            <div className="serviceCatalog__noResults">
+              No services match the current filters.
+            </div>
+          ) : null}
+        </div>
+      </section>
 
       <section className="serviceCatalog__viewer" aria-live="polite">
         <div className="serviceCatalog__viewerHeader">

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -38,53 +38,135 @@
   margin: 0;
 }
 
-.serviceCatalog__group {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.serviceCatalog__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-}
-
-.serviceCatalog__card {
-  display: flex;
-  min-height: 230px;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1.1rem;
-  border: 1px solid #d9e8e6;
-  border-radius: 20px;
+.serviceCatalog__tableShell {
+  overflow: hidden;
+  border: 1px solid #d7e8e6;
+  border-radius: 22px;
   background: #ffffff;
-  box-shadow: 0 14px 36px rgba(20, 56, 63, 0.08);
+  box-shadow: 0 18px 44px rgba(17, 48, 56, 0.1);
 }
 
-.serviceCatalog__cardHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
+.serviceCatalog__toolbar {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1fr) minmax(10rem, 0.35fr) minmax(10rem, 0.3fr) auto;
+  gap: 0.85rem;
+  align-items: end;
+  padding: 1rem;
+  border-bottom: 1px solid #d7e8e6;
+  background:
+    radial-gradient(circle at top left, rgba(23, 92, 98, 0.12), transparent 28rem),
+    #f8fcfb;
 }
 
-.serviceCatalog__cardHeader h3,
-.serviceCatalog__cardHeader p {
+.serviceCatalog__toolbar label {
+  display: grid;
+  gap: 0.35rem;
+  color: #31535a;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.serviceCatalog__toolbar input,
+.serviceCatalog__toolbar select {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #b7d5d0;
+  border-radius: 12px;
+  background: #ffffff;
+  color: #17383b;
+  font: inherit;
+}
+
+.serviceCatalog__search input {
+  min-width: 0;
+}
+
+.serviceCatalog__reset {
+  min-height: 2.5rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid #b7d5d0;
+  border-radius: 12px;
+  background: #eef8f6;
+  color: #0f5867;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+.serviceCatalog__reset:hover {
+  background: #e1f2ee;
+}
+
+.serviceCatalog__tableMeta {
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid #e3efed;
+  color: #49656b;
+  font-size: 0.9rem;
+}
+
+.serviceCatalog__tableScroller {
+  overflow-x: auto;
+}
+
+.serviceCatalog__table {
+  width: 100%;
+  min-width: 980px;
   margin: 0;
+  border-collapse: collapse;
 }
 
-.serviceCatalog__cardHeader h3 {
+.serviceCatalog__table th,
+.serviceCatalog__table td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid #e3efed;
+  vertical-align: top;
+  text-align: left;
+}
+
+.serviceCatalog__table thead th {
+  background: #f5fbfa;
+  color: #31535a;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.serviceCatalog__table tbody tr:hover {
+  background: #fbfefd;
+}
+
+.serviceCatalog__serviceId,
+.serviceCatalog__serviceName {
+  display: block;
+}
+
+.serviceCatalog__serviceId {
   color: #103d49;
+  font-weight: 800;
 }
 
-.serviceCatalog__cardHeader span {
-  padding: 0.2rem 0.55rem;
+.serviceCatalog__serviceName {
+  margin-top: 0.15rem;
+  color: #49656b;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.serviceCatalog__status {
+  display: inline-flex;
+  padding: 0.22rem 0.58rem;
   border-radius: 999px;
   background: #e4f3ef;
   color: #0d5d51;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: 800;
+}
+
+.serviceCatalog__noResults {
+  padding: 2rem;
+  color: #49656b;
+  text-align: center;
 }
 
 .serviceCatalog__actions {
@@ -159,4 +241,10 @@
   width: 100%;
   min-height: 720px;
   border: 0;
+}
+
+@media (max-width: 760px) {
+  .serviceCatalog__toolbar {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes #257.
- Refactors the Service Catalog from grouped cards into a filterable table.
- Adds text search, group filter, status filter, reset, result count, empty-results messaging, and row actions.
- Keeps Open repo and live README viewer behavior.

## Verification
- npm run docs:build passed.
- git diff --check passed.
- Generated service-catalog.html contains Search services, group/status filters, table markup, lasso-echoservice, Read README actions, and empty-results text.

## Notes
- Used shadcn-admin task-table UX as a visual/pattern reference only; no third-party table code was copied into this repo.
