### PR TITLE
fix: serialize recovery history appends

### DIFF
--- a/src/runtime/recovery/history.ts
+++ b/src/runtime/recovery/history.ts
@@ -70,6 +70,8 @@ export interface ServiceRecoveryHistoryState {
   events: ServiceRecoveryHistoryEvent[];
 }
 
+const recoveryHistoryAppendQueues = new Map<string, Promise<void>>();
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -195,7 +197,7 @@ export async function writeServiceRecoveryHistory(
   return nextState;
 }
 
-export async function appendServiceRecoveryHistoryEvents(
+async function appendServiceRecoveryHistoryEventsWithoutQueue(
   service: DiscoveredService,
   events: ServiceRecoveryHistoryEvent[],
   limit = DEFAULT_RECOVERY_HISTORY_LIMIT,
@@ -217,4 +219,27 @@ export async function appendServiceRecoveryHistoryEvents(
       })),
     ].slice(-Math.max(1, limit)),
   });
+}
+
+export async function appendServiceRecoveryHistoryEvents(
+  service: DiscoveredService,
+  events: ServiceRecoveryHistoryEvent[],
+  limit = DEFAULT_RECOVERY_HISTORY_LIMIT,
+): Promise<ServiceRecoveryHistoryState> {
+  const paths = getServiceStatePaths(service.serviceRoot);
+  const previousAppend = recoveryHistoryAppendQueues.get(paths.recovery) ?? Promise.resolve();
+  const appendOperation = previousAppend
+    .catch(() => undefined)
+    .then(() => appendServiceRecoveryHistoryEventsWithoutQueue(service, events, limit));
+
+  const settledAppend = appendOperation.then(() => undefined, () => undefined);
+  recoveryHistoryAppendQueues.set(paths.recovery, settledAppend);
+
+  try {
+    return await appendOperation;
+  } finally {
+    if (recoveryHistoryAppendQueues.get(paths.recovery) === settledAppend) {
+      recoveryHistoryAppendQueues.delete(paths.recovery);
+    }
+  }
 }

--- a/tests/recovery-history.test.js
+++ b/tests/recovery-history.test.js
@@ -52,3 +52,39 @@ test("recovery history rehydrates persisted events and enforces retention", asyn
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("recovery history preserves concurrent appends for the same service", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-recovery-history-concurrent-");
+
+  try {
+    const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "history-concurrent-service");
+    const service = {
+      serviceRoot,
+      manifest: {
+        id: "history-concurrent-service",
+      },
+    };
+
+    await Promise.all(Array.from({ length: 12 }, (_, index) => appendServiceRecoveryHistoryEvents(service, [
+      {
+        kind: "monitor",
+        serviceId: "history-concurrent-service",
+        action: "skip",
+        reason: "not_running",
+        message: `event-${index}`,
+        at: `2026-04-27T00:00:${String(index).padStart(2, "0")}.000Z`,
+      },
+    ], 20)));
+
+    const rehydrated = await readServiceRecoveryHistory(service);
+
+    assert.equal(rehydrated.serviceId, "history-concurrent-service");
+    assert.equal(rehydrated.events.length, 12);
+    assert.deepEqual(
+      rehydrated.events.map((event) => event.message).sort(),
+      Array.from({ length: 12 }, (_, index) => `event-${index}`).sort(),
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- serialize recovery history appends per recovery file to prevent read-modify-write races
- add regression coverage for concurrent recovery history appends

## Verification
- npm test
- npm run docs:build
- git diff --check

Fixes #262