### PR TITLE
docs: remove planned services sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -76,15 +76,6 @@ const sidebars = {
         "development/reference-app-poc-matrix",
       ],
     },
-    {
-      type: "category",
-      label: "Planned Services",
-      collapsed: true,
-      items: [
-        "development/zitadel-service-plan",
-        "development/dagu-service-plan",
-      ],
-    },
   ],
 };
 


### PR DESCRIPTION
## Summary
- remove the obsolete `Planned Services` category from the docs sidebar
- leave the underlying plan pages untouched so this is only a navigation cleanup

## Verification
- npm run docs:build
- git diff --check
- rg "Planned Services|planned services|Planned services" docs

Fixes #270