### PR TITLE
docs: order service authoring process

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Start with these docs when you need more detail:
 
 - [Docs site source](docs/README.md)
 - [Clean clone scenario validation](docs/development/clean-clone-scenario-validation.md)
-- [Create a new lasso service](docs/development/new-lasso-service-guide.md)
+- [Service authoring overview](docs/service-authoring/overview.md)
 - [Baseline service inventory](docs/development/baseline-service-inventory.md)
 
 Build the local documentation site:

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -73,6 +73,6 @@ Bundled application artifacts are produced by running the Service Lasso package 
 
 For a new user validating the project, start with [Clean Clone Scenario Validation](development/clean-clone-scenario-validation.md).
 
-For a service author, start with [Create a New Lasso Service](development/new-lasso-service-guide.md).
+For a service author, start with [Service Authoring Overview](service-authoring/overview.md).
 
 For manifest details, start with [service.json Reference](reference/service-json-reference.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ Use this short list as the current high-value documentation map:
 - [Introduction](INTRODUCTION.md): what Service Lasso is, what this repo owns, and where related repos fit.
 - [Clean Clone Scenario Validation](development/clean-clone-scenario-validation.md): copy-paste validation runbook for a fresh clone that starts the baseline services.
 - [Baseline Service Inventory](development/baseline-service-inventory.md): the baseline `services/` set that Service Lasso should acquire, configure, and start.
-- [Create a New Lasso Service](development/new-lasso-service-guide.md): agent-ready guide for creating a release-backed `service-lasso/lasso-*` service repo.
+- [Service Authoring Overview](service-authoring/overview.md): ordered process for planning, manifesting, releasing, wiring, and validating a service.
 - [service.json Reference](reference/service-json-reference.md): canonical manifest fields, artifact metadata, health checks, actions, env, dependencies, and update policy.
 - [Complete service.json Union Schema](reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md): detailed manifest shape reference.
 - [Service Config Types](reference/SERVICE-CONFIG-TYPES.md): service pattern taxonomy for providers, apps, infrastructure services, health checks, env, and dependency graphs.
@@ -98,7 +98,7 @@ Keep docs in individual service repos when they describe:
 
 ## Service authoring entrypoint
 
-Use [Create a New Lasso Service](development/new-lasso-service-guide.md) when creating or reviewing a new service repo.
+Use [Service Authoring Overview](service-authoring/overview.md) when creating or reviewing a new service repo. It links to the numbered authoring process and the detailed [Create a New Lasso Service](development/new-lasso-service-guide.md) handoff.
 
 That guide is the canonical handoff for:
 

--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -2,6 +2,8 @@
 
 This is the canonical handoff for creating a new release-backed `service-lasso/lasso-*` service repo.
 
+For the recommended step-by-step authoring order, start with [Service Authoring Overview](../service-authoring/overview.md). This page is the detailed implementation handoff for step 3, creating the release-backed service repo.
+
 Use this guide when an agent or contributor needs to create a service from scratch, update an existing service repo, or decide how a consuming app should pin a service manifest.
 
 ## Outcome
@@ -301,6 +303,7 @@ Use this checklist before handing off:
 
 ## Related Docs
 
+- [Service Authoring Overview](../service-authoring/overview.md)
 - [service.json Reference](../reference/service-json-reference.md)
 - [Service Config Types](../reference/SERVICE-CONFIG-TYPES.md)
 - [Runtime Provider Release Services Delivery Plan](runtime-provider-release-services-delivery-plan.md)

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -103,8 +103,8 @@ const config = {
               to: "/",
             },
             {
-              label: "Create a Lasso Service",
-              to: "/development/new-lasso-service-guide",
+              label: "Service Authoring",
+              to: "/service-authoring/overview",
             },
           ],
         },

--- a/docs/reference-apps.md
+++ b/docs/reference-apps.md
@@ -49,4 +49,4 @@ the app needs a desktop shell. Choose one of the packager templates when the
 main product decision is executable distribution rather than UI shape.
 
 If you are building a new service rather than a host app, start with the
-[service authoring guide](development/new-lasso-service-guide.md) instead.
+[Service Authoring Overview](service-authoring/overview.md) instead.

--- a/docs/service-authoring/01-plan-service.md
+++ b/docs/service-authoring/01-plan-service.md
@@ -1,0 +1,55 @@
+---
+id: 01-plan-service
+title: 1. Plan the Service
+---
+
+# 1. Plan the Service
+
+Start by deciding what the service is, who owns it, and how Service Lasso should treat it. Do this before creating release artifacts or writing a detailed manifest.
+
+## Decide Ownership
+
+Use these naming rules consistently:
+
+| Decision | Rule | Example |
+| --- | --- | --- |
+| Core-owned service | service ID starts with `@` | `@node`, `@nginx`, `@serviceadmin` |
+| App-owned service | service ID does not use `@` | `echo-service`, `worker-api` |
+| GitHub repo | use `service-lasso/lasso-<name>` for shared service repos | `service-lasso/lasso-nginx` |
+| Service folder | folder matches the service ID exactly | `services/@nginx/service.json` |
+
+Only use `@` for core-owned Service Lasso services and providers.
+
+## Choose the Service Shape
+
+Pick one shape before writing `service.json`:
+
+| Shape | Use when | Common fields |
+| --- | --- | --- |
+| Provider | The service supplies a runtime or tool to other services and should not run as a daemon. | `role: "provider"`, `artifact`, `globalenv` |
+| Managed daemon | The service owns and runs its executable. | `artifact`, platform command, `ports`, `healthcheck` |
+| Provider-backed app | The service runs through another provider such as `@node`, `@python`, or `@java`. | `execservice`, `executable`, `args`, `depend_on` |
+| Optional app service | Consumers opt in and must configure it first. | `enabled: false`, explicit env/config notes |
+
+For more examples, use [Service Config Types](../reference/SERVICE-CONFIG-TYPES.md).
+
+## Define the Consumer Contract
+
+Record these decisions before implementation:
+
+- Which apps or templates should include this service?
+- Which ports and URLs does the service expose?
+- Which env variables does it require or export?
+- Which services must start before it?
+- Which healthcheck proves it is ready?
+- Which upstream runtime/tool version is being packaged?
+- Which platforms are supported by the first release?
+
+## Exit Criteria
+
+Move to step 2 only when:
+
+- service ID and ownership are settled
+- service shape is selected
+- runtime/tool version and platform support are known
+- dependencies, ports, env, and health intent are clear

--- a/docs/service-authoring/02-write-service-json.md
+++ b/docs/service-authoring/02-write-service-json.md
@@ -1,0 +1,73 @@
+---
+id: 02-write-service-json
+title: 2. Write service.json
+---
+
+# 2. Write `service.json`
+
+`service.json` is the only manifest Service Lasso should need to acquire, configure, start, monitor, and update a service.
+
+## Minimum Manifest Contract
+
+Every release-backed service manifest should define:
+
+- `id`
+- `name`
+- `description`
+- `version`
+- `enabled`
+- `artifact.kind: "archive"`
+- `artifact.source.type: "github-release"`
+- `artifact.source.repo`
+- `artifact.source.tag`
+- `artifact.platforms.<platform>.assetName`
+- `artifact.platforms.<platform>.archiveType`
+- `artifact.platforms.<platform>.command` when the archive exposes an executable
+
+Use [service.json Reference](../reference/service-json-reference.md) for field-level detail.
+
+## Add Runtime Behavior
+
+Managed services usually also need:
+
+- `ports` for named service ports
+- `urls` for operator-facing links
+- `healthcheck` for process, HTTP, TCP, file, or variable readiness
+- `env` for service-local runtime values
+- `globalenv` for values other services can consume
+- `depend_on` for startup ordering
+- `install.files` or `config.files` when Service Lasso must write config files
+
+Provider services usually need:
+
+- `role: "provider"`
+- `globalenv` entries that expose installed tool paths
+- a cheap probe/version command where useful
+- no long-running daemon healthcheck unless the provider truly starts a process
+
+## Pin the Release
+
+The manifest must point to a real release asset:
+
+```json
+{
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-example",
+      "tag": "2026.4.29-abc1234"
+    }
+  }
+}
+```
+
+The release tag uses `yyyy.m.d-<shortsha>`. Artifact names should include the exact upstream service, runtime, framework, or tool version.
+
+## Exit Criteria
+
+Move to step 3 only when:
+
+- `service.json` can identify the exact GitHub release asset to download
+- commands, env, dependencies, ports, and health checks match the planned service shape
+- the manifest can be copied into `services/<service-id>/service.json` without needing a second hidden metadata file

--- a/docs/service-authoring/03-create-release-repo.md
+++ b/docs/service-authoring/03-create-release-repo.md
@@ -1,0 +1,52 @@
+---
+id: 03-create-release-repo
+title: 3. Create the Release Repo
+---
+
+# 3. Create the Release Repo
+
+Each shared Service Lasso service should live in its own release-backed repo, usually named `service-lasso/lasso-<name>`.
+
+## Required Repo Shape
+
+Start with this shape unless the service has a strong reason to differ:
+
+```text
+lasso-example/
+  .github/
+    workflows/
+      release.yml
+  scripts/
+    package.mjs
+    verify-release.mjs
+  service.json
+  README.md
+  LICENSE
+  package.json
+```
+
+Add service-owned runtime source or assets only when the service builds its own wrapper. Provider repos often package upstream archives instead.
+
+## Release Outputs
+
+The release workflow should create:
+
+- a GitHub release tagged `yyyy.m.d-<shortsha>`
+- platform archives for each supported operating system
+- asset names that include the exact upstream version
+- `SHA256SUMS.txt` when practical
+- a released `service.json` that points at those assets
+
+## Reuse the Full Handoff
+
+Use [Create a New Lasso Service](../development/new-lasso-service-guide.md) as the detailed implementation handoff for this step. That guide includes naming rules, examples, release workflow expectations, packaging checks, and consuming-app guidance.
+
+## Exit Criteria
+
+Move to step 4 only when:
+
+- the service repo exists
+- packaging can be run locally
+- CI can create release assets
+- `service.json` in the repo points to the released artifacts
+- release verification proves the archive layout matches the manifest commands

--- a/docs/service-authoring/04-wire-consumers.md
+++ b/docs/service-authoring/04-wire-consumers.md
@@ -1,0 +1,48 @@
+---
+id: 04-wire-consumers
+title: 4. Wire Consumers
+---
+
+# 4. Wire Consumers
+
+After a service has a release-backed manifest, consuming projects opt in by committing that manifest under their `services/` folder.
+
+## Consumer Layout
+
+Use this layout:
+
+```text
+consumer-app/
+  services/
+    <service-id>/
+      service.json
+```
+
+Examples:
+
+```text
+services/@node/service.json
+services/@serviceadmin/service.json
+services/echo-service/service.json
+```
+
+The folder name must match the manifest `id`.
+
+## What the Manifest Must Contain
+
+The consuming app should not need a separate `release-source.json` or hidden metadata file. The service manifest must already contain enough information for Service Lasso to acquire the service archive from GitHub releases.
+
+For bundled release outputs, the packaging step runs Service Lasso package/acquire first and includes the downloaded service archives in the release artifact. At runtime, the bundled output should not need to download those services again.
+
+## Baseline and Reference Apps
+
+Core baseline services live in this repo's `services/` folder. Reference apps should include the services they demonstrate, commonly including `echo-service` and `@serviceadmin`.
+
+## Exit Criteria
+
+Move to step 5 only when:
+
+- each consumer has `services/<service-id>/service.json`
+- manifests point at real service repo releases
+- dependency services are included in the consumer when needed
+- bundled outputs are configured to include acquired archives when the artifact is meant to run without downloads

--- a/docs/service-authoring/05-validate-release.md
+++ b/docs/service-authoring/05-validate-release.md
@@ -1,0 +1,50 @@
+---
+id: 05-validate-release
+title: 5. Validate and Release
+---
+
+# 5. Validate and Release
+
+Validation proves the service works through Service Lasso, not just that a repo built an archive.
+
+## Required Checks
+
+Run checks that prove:
+
+- Service Lasso can read the consumer `services/<service-id>/service.json`
+- Service Lasso can download or reuse the referenced archive
+- the archive extracts on each supported platform
+- configured commands resolve to real files
+- dependencies start in order
+- health checks report the expected state
+- logs and env outputs are visible where the service contract promises them
+- update checks can compare the pinned version with newer release metadata when update behavior is in scope
+
+## Release Evidence
+
+For each service repo release, record:
+
+- release tag
+- asset names
+- upstream runtime/tool version packaged
+- supported platforms
+- local verification command output
+- CI run URL
+- any deferred platform or behavior gaps
+
+For each consuming app, record:
+
+- default download-on-start behavior
+- bundled/no-download artifact behavior where applicable
+- Service Admin visibility when the app includes `@serviceadmin`
+
+## Exit Criteria
+
+The service is ready only when:
+
+- release assets exist and match `service.json`
+- Service Lasso acquisition succeeds
+- start/stop/health behavior is verified for managed services
+- provider services expose expected env/globalenv values
+- consuming apps include the right manifests
+- documentation names the exact repo, release, and artifact expectations

--- a/docs/service-authoring/overview.md
+++ b/docs/service-authoring/overview.md
@@ -1,0 +1,41 @@
+---
+title: Service Authoring Overview
+---
+
+# Service Authoring Overview
+
+Service authoring is the process for creating a Service Lasso service that can be installed, started, monitored, updated, and reused from another project.
+
+Use this section when you are creating a new `service-lasso/lasso-*` service repo, updating an existing service repo, or adding a released service to an app or template.
+
+## Outcome
+
+A finished service has:
+
+- a clear service type and ownership decision
+- one canonical `service.json`
+- release artifacts attached to a GitHub release
+- checks that prove Service Lasso can acquire and use the service
+- a pinned manifest in each consuming app or core baseline folder
+
+## Follow This Order
+
+1. [Plan the Service](01-plan-service.md): decide whether the service is core-owned, app-owned, a provider, a managed daemon, or provider-backed.
+2. [Write `service.json`](02-write-service-json.md): define identity, artifacts, commands, env, dependencies, ports, health, and update policy.
+3. [Create the Release Repo](03-create-release-repo.md): build the dedicated `lasso-*` repo, package artifacts, and publish release assets.
+4. [Wire Consumers](04-wire-consumers.md): copy the released manifest into each app or baseline `services/<id>/service.json`.
+5. [Validate and Release](05-validate-release.md): prove acquisition, startup, health, updates, and release outputs before calling the service ready.
+
+## When to Use Reference Docs
+
+The numbered pages are the process. Reference docs are for detail while doing a step:
+
+- [service.json Reference](../reference/service-json-reference.md) for exact manifest fields.
+- [Service Config Types](../reference/SERVICE-CONFIG-TYPES.md) for service shape examples.
+- [Complete service.json Union Schema](../reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md) for exhaustive schema review.
+- [Runtime Provider Release Services Delivery Plan](../development/runtime-provider-release-services-delivery-plan.md) for current core provider release versions.
+- [Create a New Lasso Service](../development/new-lasso-service-guide.md) for the full repo creation handoff.
+
+## Rule of Thumb
+
+If someone clones a consuming app, Service Lasso should be able to read that app's `services/<id>/service.json`, download the referenced release artifact when needed, and run or expose the service according to the manifest. If that is not true yet, the service is not ready.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -35,11 +35,48 @@ const sidebars = {
       label: "Service Authoring",
       collapsed: false,
       items: [
-        "development/new-lasso-service-guide",
-        "reference/service-json-reference",
-        "reference/SERVICE-CONFIG-TYPES",
-        "reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA",
-        "development/runtime-provider-release-services-delivery-plan",
+        {
+          type: "doc",
+          id: "service-authoring/overview",
+          label: "Overview",
+        },
+        {
+          type: "doc",
+          id: "service-authoring/01-plan-service",
+          label: "1. Plan the Service",
+        },
+        {
+          type: "doc",
+          id: "service-authoring/02-write-service-json",
+          label: "2. Write service.json",
+        },
+        {
+          type: "doc",
+          id: "service-authoring/03-create-release-repo",
+          label: "3. Create the Release Repo",
+        },
+        {
+          type: "doc",
+          id: "service-authoring/04-wire-consumers",
+          label: "4. Wire Consumers",
+        },
+        {
+          type: "doc",
+          id: "service-authoring/05-validate-release",
+          label: "5. Validate and Release",
+        },
+        {
+          type: "category",
+          label: "References",
+          collapsed: true,
+          items: [
+            "development/new-lasso-service-guide",
+            "reference/service-json-reference",
+            "reference/SERVICE-CONFIG-TYPES",
+            "reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA",
+            "development/runtime-provider-release-services-delivery-plan",
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- add a Service Authoring overview page
- add numbered process pages for planning, manifest authoring, release repo creation, consumer wiring, and validation
- reorganize the sidebar so process pages come before reference material
- update README, introduction, footer, and reference-app links to point at the new overview

Closes #284.

## Verification
- `npm run docs:build`
- `git diff --check`
- source checks for old footer entry and new ordered sidebar IDs