### PR TITLE
docs: make service catalog a direct link

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -12,12 +12,9 @@ const sidebars = {
       label: "Introduction",
     },
     {
-      type: "category",
+      type: "doc",
+      id: "service-catalog",
       label: "Service Catalog",
-      collapsed: false,
-      items: [
-        "service-catalog",
-      ],
     },
     {
       type: "doc",


### PR DESCRIPTION
## Summary
- replace the one-item `Service Catalog` sidebar category with a direct doc link

Closes #294.

## Verification
- `npm run docs:build`
- `git diff --check`
- inspected `docs/sidebars.js` structure