### PR TITLE
promote: publish service catalog nav cleanup

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -12,12 +12,9 @@ const sidebars = {
       label: "Introduction",
     },
     {
-      type: "category",
+      type: "doc",
+      id: "service-catalog",
       label: "Service Catalog",
-      collapsed: false,
-      items: [
-        "service-catalog",
-      ],
     },
     {
       type: "doc",


### PR DESCRIPTION
## Summary
- promote the Service Catalog sidebar cleanup to `main`
- publishes Service Catalog as a single direct docs link

Refs #294.

## Verification
- `npm run docs:build`
- `git diff --check origin/main..HEAD`