### PR TITLE
docs: remove operations from nav

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,17 +71,6 @@ const sidebars = {
       ],
     },
     {
-      type: "category",
-      label: "Operations",
-      collapsed: true,
-      items: [
-        "development/service-update-management-plan",
-        "development/service-recovery-doctor-upgrade-hooks-plan",
-        "development/serviceadmin-integration-validation",
-        "windows-containment-tiers",
-      ],
-    },
-    {
       type: "doc",
       id: "reference-apps",
       label: "Reference Apps",


### PR DESCRIPTION
## Summary
- remove the `Operations` category from the docs sidebar navigation
- keep underlying operations docs available through direct/content links

Closes #299.

## Verification
- `npm run docs:build`
- `git diff --check`
- confirmed `Operations` is absent from `docs/sidebars.js`