### PR TITLE
promote: publish operations nav removal

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,17 +71,6 @@ const sidebars = {
       ],
     },
     {
-      type: "category",
-      label: "Operations",
-      collapsed: true,
-      items: [
-        "development/service-update-management-plan",
-        "development/service-recovery-doctor-upgrade-hooks-plan",
-        "development/serviceadmin-integration-validation",
-        "windows-containment-tiers",
-      ],
-    },
-    {
       type: "doc",
       id: "reference-apps",
       label: "Reference Apps",


### PR DESCRIPTION
## Summary
- promote the docs sidebar cleanup that removes `Operations` from navigation

Refs #299.

## Verification
- `npm run docs:build`
- `git diff --check origin/main..HEAD`