### PR TITLE
promote: publish repo link docs

### DIFF
--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -10,7 +10,7 @@ The core idea is simple: an app commits a `services/` folder, each service folde
 
 ## What this repo owns
 
-This `service-lasso/service-lasso` repo owns:
+The [`service-lasso/service-lasso`](https://github.com/service-lasso/service-lasso) repo owns:
 
 - the Service Lasso CLI and runtime API
 - the canonical `service.json` contract documentation
@@ -19,7 +19,7 @@ This `service-lasso/service-lasso` repo owns:
 - Docusaurus docs for runtime, operator, and service-authoring behavior
 - validation scripts for clean-clone and reference-app scenarios
 
-It does not own every service implementation. Each release-backed service should live in its own `service-lasso/lasso-*` repo and publish its own GitHub release artifacts.
+It does not own every service implementation. Each release-backed service should live in its own [`service-lasso/lasso-*`](https://github.com/service-lasso?q=lasso-&type=repositories) repo and publish its own GitHub release artifacts.
 
 ## Related repos
 

--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -1,6 +1,6 @@
 # Create a New Lasso Service
 
-This is the canonical handoff for creating a new release-backed `service-lasso/lasso-*` service repo.
+This is the canonical handoff for creating a new release-backed [`service-lasso/lasso-*`](https://github.com/service-lasso?q=lasso-&type=repositories) service repo.
 
 For the recommended step-by-step authoring order, start with [Service Authoring Overview](../service-authoring/overview.md). This page is the detailed implementation handoff for step 3, creating the release-backed service repo.
 
@@ -10,7 +10,7 @@ Use this guide when an agent or contributor needs to create a service from scrat
 
 A complete service delivery produces:
 
-- a dedicated GitHub repo such as `service-lasso/lasso-foo`
+- a dedicated GitHub repo in the [`service-lasso`](https://github.com/service-lasso) org, such as `lasso-foo`
 - a released `service.json`
 - platform archives attached to a timestamped GitHub release
 - `SHA256SUMS.txt` when practical
@@ -23,7 +23,7 @@ Repo names and service IDs are related, but they are not the same field.
 
 | Thing | Rule | Example |
 | --- | --- | --- |
-| GitHub repo | `service-lasso/lasso-<name>` | [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) |
+| GitHub repo | [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories) | [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) |
 | Core-owned service ID | `@<name>` | `@nginx` |
 | Non-core app/service ID | no `@` prefix unless the app owns that convention | `echo-service` |
 | Service folder | must match the service ID | `services/@nginx/service.json` |
@@ -288,7 +288,7 @@ Use this checklist before handing off:
 
 - GitHub issue exists with spec binding and acceptance criteria.
 - Branch starts from the correct target branch.
-- Repo name is `service-lasso/lasso-<name>`.
+- Repo name follows the [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories) pattern.
 - Service ID follows the prefix rule.
 - `service.json` has artifact download metadata in the manifest itself.
 - Release workflow creates `yyyy.m.d-<shortsha>` releases from protected-branch pushes.

--- a/docs/service-authoring/01-plan-service.md
+++ b/docs/service-authoring/01-plan-service.md
@@ -15,7 +15,7 @@ Use these naming rules consistently:
 | --- | --- | --- |
 | Core-owned service | service ID starts with `@` | `@node`, `@nginx`, `@serviceadmin` |
 | App-owned service | service ID does not use `@` | `echo-service`, `worker-api` |
-| GitHub repo | use `service-lasso/lasso-<name>` for shared service repos | `service-lasso/lasso-nginx` |
+| GitHub repo | use [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories) for shared service repos | [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) |
 | Service folder | folder matches the service ID exactly | `services/@nginx/service.json` |
 
 Only use `@` for core-owned Service Lasso services and providers.

--- a/docs/service-authoring/03-create-release-repo.md
+++ b/docs/service-authoring/03-create-release-repo.md
@@ -5,7 +5,7 @@ title: 3. Create the Release Repo
 
 # 3. Create the Release Repo
 
-Each shared Service Lasso service should live in its own release-backed repo, usually named `service-lasso/lasso-<name>`.
+Each shared Service Lasso service should live in its own release-backed repo, usually named [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories).
 
 ## Required Repo Shape
 

--- a/docs/service-authoring/overview.md
+++ b/docs/service-authoring/overview.md
@@ -6,7 +6,7 @@ title: Service Authoring Overview
 
 Service authoring is the process for creating a Service Lasso service that can be installed, started, monitored, updated, and reused from another project.
 
-Use this section when you are creating a new `service-lasso/lasso-*` service repo, updating an existing service repo, or adding a released service to an app or template.
+Use this section when you are creating a new [`service-lasso/lasso-*`](https://github.com/service-lasso?q=lasso-&type=repositories) service repo, updating an existing service repo, or adding a released service to an app or template.
 
 ## Outcome
 


### PR DESCRIPTION
## Summary
- promote repo-reference link cleanup to `main`
- makes remaining prose repo references clickable in public docs

Refs #309.

## Verification
- `npm run docs:build`
- `git diff --check origin/main..HEAD`