### PR TITLE
promote: publish service-template release repo docs

### DIFF
--- a/docs/service-authoring/03-create-release-repo.md
+++ b/docs/service-authoring/03-create-release-repo.md
@@ -7,9 +7,13 @@ title: 3. Create the Release Repo
 
 Each shared Service Lasso service should live in its own release-backed repo, usually named [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories).
 
+Start from [`service-lasso/service-template`](https://github.com/service-lasso/service-template). Use it as a GitHub template or clone it into the new `lasso-*` repo, then replace the sample service details with the real service manifest, packaging script, README, and release verification.
+
+The template is the contract baseline. Do not rebuild the release workflow and repo layout from memory unless the service has a specific reason to diverge.
+
 ## Required Repo Shape
 
-Start with this shape unless the service has a strong reason to differ:
+The template provides this expected shape:
 
 ```text
 lasso-example/
@@ -26,6 +30,17 @@ lasso-example/
 ```
 
 Add service-owned runtime source or assets only when the service builds its own wrapper. Provider repos often package upstream archives instead.
+
+## Template Customization Checklist
+
+After creating the repo from the template:
+
+- rename the repo and package metadata to the target `lasso-*` service
+- replace the sample `service.json` with the real service manifest
+- update `scripts/package.mjs` to produce the exact release assets the manifest references
+- update `scripts/verify-release.mjs` so CI proves the archive layout and manifest commands match
+- update `README.md` with service purpose, supported versions, required env, ports, health checks, and release artifact names
+- keep the `yyyy.m.d-<shortsha>` release version pattern from the template workflow
 
 ## Release Outputs
 

--- a/docs/service-authoring/overview.md
+++ b/docs/service-authoring/overview.md
@@ -22,7 +22,7 @@ A finished service has:
 
 1. [Plan the Service](01-plan-service.md): decide whether the service is core-owned, app-owned, a provider, a managed daemon, or provider-backed.
 2. [Write `service.json`](02-write-service-json.md): define identity, artifacts, commands, env, dependencies, ports, health, and update policy.
-3. [Create the Release Repo](03-create-release-repo.md): build the dedicated `lasso-*` repo, package artifacts, and publish release assets.
+3. [Create the Release Repo](03-create-release-repo.md): create the dedicated `lasso-*` repo from [`service-lasso/service-template`](https://github.com/service-lasso/service-template), package artifacts, and publish release assets.
 4. [Wire Consumers](04-wire-consumers.md): copy the released manifest into each app or baseline `services/<id>/service.json`.
 5. [Validate and Release](05-validate-release.md): prove acquisition, startup, health, updates, and release outputs before calling the service ready.
 


### PR DESCRIPTION
Promotes #319 / #320 to main so the live docs clearly tell service authors to start release repos from service-lasso/service-template.

## Verification
- npm run docs:build passed on promotion branch.
- git diff --check passed.