### PR TITLE
promote: publish authored docs sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Relevant repos:
 | [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) | Echo Service harness used to test lifecycle, UI/API, logs, state, SQLite, and failure behavior |
 | [`service-lasso/lasso-node`](https://github.com/service-lasso/lasso-node), [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python), [`service-lasso/lasso-java`](https://github.com/service-lasso/lasso-java) | release-backed runtime provider services |
 | [`service-lasso/lasso-localcert`](https://github.com/service-lasso/lasso-localcert), [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx), [`service-lasso/lasso-traefik`](https://github.com/service-lasso/lasso-traefik) | release-backed baseline infrastructure services |
-| [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel), [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) | optional release-backed service repos that consumers can add to their own `services/` folder |
+| [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel), [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) | app-owned add-on service repos that consumers can add to their own `services/` folder |
 
 ## Requirements
 
@@ -78,7 +78,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 
 Additional manifests such as `@java`, `@python`, and `node-sample-service` exist for provider and fixture coverage. They are not part of the default baseline start command.
 
-Optional service repos such as [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel) and [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) can be added by committing their released `service.json` into your app's `services/` folder. ZITADEL is intentionally not in this baseline because it requires app-owned PostgreSQL and `ZITADEL_MASTERKEY` configuration before start. Dagu is intentionally optional because workflow orchestration and workflow files are app-specific.
+App-owned add-on service repos such as [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel) and [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) can be added by committing their released `service.json` into your app's `services/` folder. ZITADEL is not in the core baseline because it requires app-owned PostgreSQL and `ZITADEL_MASTERKEY` configuration before start. Dagu is app-owned because workflow orchestration and workflow files are app-specific.
 
 ## Services Folder Contract
 

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -35,8 +35,8 @@ Current related repos:
 | [`service-lasso/lasso-localcert`](https://github.com/service-lasso/lasso-localcert) | release-backed local certificate provider |
 | [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) | release-backed NGINX service used by the baseline Traefik setup |
 | [`service-lasso/lasso-traefik`](https://github.com/service-lasso/lasso-traefik) | release-backed Traefik edge/router service |
-| [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel) | optional release-backed ZITADEL service repo for app-owned identity setups |
-| [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) | optional release-backed Dagu workflow service repo |
+| [`service-lasso/lasso-zitadel`](https://github.com/service-lasso/lasso-zitadel) | app-owned ZITADEL service repo for identity setups |
+| [`service-lasso/lasso-dagu`](https://github.com/service-lasso/lasso-dagu) | app-owned Dagu service repo for workflow orchestration setups |
 | [`service-lasso/service-template`](https://github.com/service-lasso/service-template) | template for creating new release-backed `lasso-*` service repos |
 | [`service-lasso/service-lasso-app-node`](https://github.com/service-lasso/service-lasso-app-node) | Node host reference app template using Service Lasso |
 | [`service-lasso/service-lasso-app-web`](https://github.com/service-lasso/service-lasso-app-web) | web host reference app template using Service Lasso |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ The preferred runtime-root model is:
 Use this short list as the public documentation map:
 
 - [Introduction](INTRODUCTION.md): what Service Lasso is, what this repo owns, and where related repos fit.
-- [Service Catalog](service-catalog.md): available core services, optional services, and reference apps.
+- [Service Catalog](service-catalog.md): available core services, app-owned add-on services, and reference apps.
 - [Quick Start](quick-start.md): clone the repo, install dependencies, start the baseline services, open the useful URLs, and stop cleanly.
 - [Service Authoring Overview](service-authoring/overview.md): ordered process for planning, manifesting, releasing, wiring, and validating a service.
 - [service.json Reference](reference/service-json-reference.md): canonical manifest fields, artifact metadata, health checks, actions, env, dependencies, and update policy.

--- a/docs/development/dagu-service-plan.md
+++ b/docs/development/dagu-service-plan.md
@@ -12,7 +12,7 @@ OpenSpec binding: `SPEC-002`, `AC-4U`, `AC-4Y`
 
 ## Decision
 
-Dagu is delivered as an optional release-backed service repo, not as a default core baseline service.
+Dagu is delivered as an app-owned add-on release-backed service repo, not as a default core baseline service.
 
 Repo:
 

--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -4,7 +4,7 @@ This is the canonical handoff for creating a new release-backed [`service-lasso/
 
 For the recommended step-by-step authoring order, start with [Service Authoring Overview](../service-authoring/overview.md). This page is the detailed implementation handoff for step 3, creating the release-backed service repo.
 
-Use this guide when an agent or contributor needs to create a service from scratch, update an existing service repo, or decide how a consuming app should pin a service manifest.
+Use this guide when an agent or contributor needs to create a service from [`service-lasso/service-template`](https://github.com/service-lasso/service-template), update an existing service repo, or decide how a consuming app should pin a service manifest.
 
 ## Outcome
 
@@ -42,11 +42,11 @@ Choose the closest pattern before writing files.
 | Provider | The service supplies a runtime/tool to other services and should not run as a daemon. | `role: "provider"` plus `artifact` and `globalenv` |
 | Managed binary | The service owns and runs its executable. | `artifact`, platform `command`, `ports`, `healthcheck` |
 | Provider-backed app | The service runs through another provider such as `@node`, `@python`, or `@java`. | `execservice`, `executable`, `args`, `depend_on` |
-| Optional app service | Consumers opt in by copying its released manifest. | `enabled: false` when unsafe to start without app config |
+| App-owned add-on service | Consumers opt in by copying its released manifest. | `enabled: false` when unsafe to start without app config |
 
 ## Required Repo Shape
 
-Every `lasso-*` service repo should start with this shape:
+Every `lasso-*` service repo should start from [`service-lasso/service-template`](https://github.com/service-lasso/service-template), which provides this expected shape:
 
 ```text
 lasso-foo/
@@ -248,7 +248,7 @@ Default baseline services currently are:
 - `echo-service`
 - `@serviceadmin`
 
-Optional provider/service manifests such as `@python`, `@java`, `zitadel`, and `dagu` should not be added to default baseline start unless the app has the needed config and dependencies.
+Non-baseline provider and app-owned manifests such as `@python`, `@java`, `zitadel`, and `dagu` should not be added to default baseline start unless the app has the needed config and dependencies.
 
 ## Consumer Integration
 

--- a/docs/development/runtime-provider-release-services-delivery-plan.md
+++ b/docs/development/runtime-provider-release-services-delivery-plan.md
@@ -30,8 +30,8 @@ It separates current truth from target delivery so the repo does not imply relea
 | --- | --- | --- | --- | --- |
 | `@node` | [`service-lasso/lasso-node`](https://github.com/service-lasso/lasso-node) | release-backed provider in the current core baseline | yes, repo release exists | Core manifest pins `2026.4.27-eca215a`, acquires exact Node `v24.15.0`, and skips provider daemon launch. |
 | `@localcert` | [`service-lasso/lasso-localcert`](https://github.com/service-lasso/lasso-localcert) | release-backed provider in the current core baseline | yes, repo release exists | Core manifest pins `2026.4.27-591ed28`, acquires local cert material, exports certificate globals, and skips provider daemon launch. |
-| `@python` | [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) | optional release-backed provider in core | yes, Windows-only repo release exists | Core manifest pins `2026.4.27-63f915c` and can acquire official Python.org Windows embeddable `3.11.5`; Linux/macOS remain deferred. |
-| `@java` | [`service-lasso/lasso-java`](https://github.com/service-lasso/lasso-java) | optional release-backed provider in core | yes, repo release exists | Core manifest pins `2026.4.27-b313cb0` and can acquire Eclipse Temurin JRE `17.0.18+8` across Windows/Linux/macOS. |
+| `@python` | [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) | non-baseline release-backed provider in core | yes, Windows-only repo release exists | Core manifest pins `2026.4.27-63f915c` and can acquire official Python.org Windows embeddable `3.11.5`; Linux/macOS remain deferred. |
+| `@java` | [`service-lasso/lasso-java`](https://github.com/service-lasso/lasso-java) | non-baseline release-backed provider in core | yes, repo release exists | Core manifest pins `2026.4.27-b313cb0` and can acquire Eclipse Temurin JRE `17.0.18+8` across Windows/Linux/macOS. |
 | `@traefik` | [`service-lasso/lasso-traefik`](https://github.com/service-lasso/lasso-traefik) | release-backed managed router service depending on local `@localcert` and `@nginx` utility manifests | yes | Current verified release is `2026.4.27-bbc7f15`. |
 | `@nginx` | [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) | release-backed managed NGINX dependency in the current core baseline | yes, repo release exists | Core manifest pins `2026.4.27-712c75f`, acquires NGINX Open Source `1.30.0`, and starts it before Traefik. |
 
@@ -279,7 +279,7 @@ Integration order:
 Baseline rule:
 
 - `@node` is part of the current default baseline, so release-backed `@node` changes affect the clean-clone baseline contract. Core should use Node `v24.15.0`, not Node `v25.9.0`.
-- `@python` and `@java` are not part of the current default baseline, so they should remain optional unless a consuming baseline service requires them. If included later, core should use Python `3.11.5` and Java `17.0.18+8`, not Python `3.14.4` or Java `21.0.10+7`.
+- `@python` and `@java` are not part of the current default baseline, so they should remain non-baseline providers unless a consuming baseline service requires them. If included later, core should use Python `3.11.5` and Java `17.0.18+8`, not Python `3.14.4` or Java `21.0.10+7`.
 - `@traefik` is already release-backed and remains part of the default baseline.
 - `@nginx` is part of the current default baseline because `@traefik` depends on it; it is a managed service rather than a provider marker.
 

--- a/docs/development/serviceadmin-integration-validation.md
+++ b/docs/development/serviceadmin-integration-validation.md
@@ -6,7 +6,7 @@ unlisted: true
 
 This document tracks the bounded validation work for `ISS-034` / `TASK-034`.
 
-The goal is not "finish `lasso-@serviceadmin`" in one jump. The goal is to prove the current `service-lasso` runtime can satisfy the first real consumer-facing contracts that the admin UI already expects, then make the remaining gaps explicit.
+The goal is not "finish `lasso-serviceadmin`" in one jump. The goal is to prove the current `service-lasso` runtime can satisfy the first real consumer-facing contracts that the admin UI already expects, then make the remaining gaps explicit.
 
 ## Scope
 
@@ -31,13 +31,13 @@ Out of scope for this slice:
 2. Add runtime-owned live log info and chunk-read routes.
    status: done
 
-3. Validate the current `lasso-@serviceadmin` logs contract against the runtime.
+3. Validate the current `lasso-serviceadmin` logs contract against the runtime.
    status: done
 
 4. Add a bounded runtime-backed dashboard adapter for the current dashboard / services / service-detail consumer model.
    status: done
 
-5. Validate the current `lasso-@serviceadmin` consumer against the bounded runtime adapter routes.
+5. Validate the current `lasso-serviceadmin` consumer against the bounded runtime adapter routes.
    status: done
 
 6. Record any remaining consumer-model gaps as explicit follow-up work before calling the integration slice complete.
@@ -53,7 +53,7 @@ Current bounded live-smoke checklist:
 2. Start at least one real managed demo service so the admin consumer sees non-empty runtime data.
    status: done
 
-3. Build and serve `lasso-@serviceadmin` with `VITE_SERVICE_LASSO_API_BASE_URL` pointed at the live runtime.
+3. Build and serve `lasso-serviceadmin` with `VITE_SERVICE_LASSO_API_BASE_URL` pointed at the live runtime.
    status: done
 
 4. Confirm the served admin app loads against the live runtime stack and record the concrete evidence.
@@ -86,14 +86,14 @@ What that proves:
 
 ### Verified
 
-- `lasso-@serviceadmin` builds successfully with the current codebase.
+- `lasso-serviceadmin` builds successfully with the current codebase.
 - The logs provider contract shape matches the runtime routes that now exist.
 - The runtime now exposes bounded dashboard adapter routes for the current admin summary/services/detail model.
-- `lasso-@serviceadmin` now uses the bounded runtime dashboard adapter routes when `VITE_SERVICE_LASSO_API_BASE_URL` is configured, while still preserving the local stub fallback when the runtime API is absent.
-- `lasso-@serviceadmin` unit tests now pass with the encoded log-query expectations and the new runtime dashboard adapter coverage.
+- `lasso-serviceadmin` now uses the bounded runtime dashboard adapter routes when `VITE_SERVICE_LASSO_API_BASE_URL` is configured, while still preserving the local stub fallback when the runtime API is absent.
+- `lasso-serviceadmin` unit tests now pass with the encoded log-query expectations and the new runtime dashboard adapter coverage.
 - Live local smoke passed against the real stack:
   - `service-lasso` runtime on `http://127.0.0.1:18081`
-  - `lasso-@serviceadmin` preview on `http://127.0.0.1:17700`
+  - `lasso-serviceadmin` preview on `http://127.0.0.1:17700`
   - runtime `/api/health` returned `ok`
   - runtime `/api/dashboard` reported `4` services and `2` running services
   - runtime `/api/dashboard/services/echo-service` reported `echo-service` as `running`

--- a/docs/development/zitadel-service-plan.md
+++ b/docs/development/zitadel-service-plan.md
@@ -12,7 +12,7 @@ OpenSpec binding: `SPEC-002`, `AC-4U`, `AC-4Y`
 
 ## Decision
 
-ZITADEL is delivered as an optional release-backed service repo, not as a default core baseline service.
+ZITADEL is delivered as an app-owned add-on release-backed service repo, not as a default core baseline service.
 
 Repo:
 

--- a/docs/reference/SERVICE-CONFIG-TYPES.md
+++ b/docs/reference/SERVICE-CONFIG-TYPES.md
@@ -9,7 +9,7 @@ This document groups the general `service.json` config/service patterns currentl
 ## 1. Runtime / execution type
 
 ### Direct binary application
-A bundled executable runs directly.
+A packaged executable runs directly.
 
 Examples:
 - @nginx
@@ -33,7 +33,7 @@ Uses a Java runtime via `execservice: "@java"`.
 
 Current core status:
 - `@java` exists as a release-backed provider manifest and can be acquired from [`service-lasso/lasso-java`](https://github.com/service-lasso/lasso-java).
-- release-backed JRE redistribution is deferred until the project chooses a vendor, license, platform, and update strategy.
+- release-backed JRE redistribution uses the `lasso-java` provider release and its documented upstream/runtime version.
 
 ### Python application
 Uses a Python runtime via `execservice: "@python"`.

--- a/docs/service-authoring/01-plan-service.md
+++ b/docs/service-authoring/01-plan-service.md
@@ -29,7 +29,7 @@ Pick one shape before writing `service.json`:
 | Provider | The service supplies a runtime or tool to other services and should not run as a daemon. | `role: "provider"`, `artifact`, `globalenv` |
 | Managed daemon | The service owns and runs its executable. | `artifact`, platform command, `ports`, `healthcheck` |
 | Provider-backed app | The service runs through another provider such as `@node`, `@python`, or `@java`. | `execservice`, `executable`, `args`, `depend_on` |
-| Optional app service | Consumers opt in and must configure it first. | `enabled: false`, explicit env/config notes |
+| App-owned add-on service | Consumers opt in and must configure it first. | `enabled: false`, explicit env/config notes |
 
 For exact manifest fields, use the [service.json Reference](../reference/service-json-reference.md).
 

--- a/docs/service-authoring/04-wire-consumers.md
+++ b/docs/service-authoring/04-wire-consumers.md
@@ -30,7 +30,7 @@ The folder name must match the manifest `id`.
 
 ## What the Manifest Must Contain
 
-The consuming app should not need a separate `release-source.json` or hidden metadata file. The service manifest must already contain enough information for Service Lasso to acquire the service archive from GitHub releases.
+The consuming app should only need the service manifest. That `service.json` must already contain enough information for Service Lasso to acquire the service archive from GitHub releases.
 
 For bundled release outputs, the packaging step runs Service Lasso package/acquire first and includes the downloaded service archives in the release artifact. At runtime, the bundled output should not need to download those services again.
 

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -8,7 +8,7 @@ import ServiceCatalog from "./src/components/ServiceCatalog";
 # Service Catalog
 
 Use this page to find the canonical Service Lasso service repos. Each service
-card links to the source repo and can load that repo's live `README.md` into the
+row links to the source repo and can load that repo's live `README.md` into the
 viewer without copying the README into this docs repo.
 
 The catalog table is populated from `docs/static/data/service-catalog.json`.


### PR DESCRIPTION
Promotes #324 / #325 to main so the live docs receive the stale wording and navigation sweep.

## Verification
- npm run docs:build passed on promotion branch.
- git diff --check passed.