### PR TITLE
ISS-387 document release asset policy gap

### DIFF
--- a/docs/release-asset-policy.md
+++ b/docs/release-asset-policy.md
@@ -1,0 +1,74 @@
+# Service Lasso release asset policy
+
+Status: baseline  
+Created: 2026-05-08  
+Scope: `service-lasso/service-lasso` GitHub release assets
+
+## Expected assets
+
+A Service Lasso core release tag `<version>` should publish both generic runtime archives and per-OS runtime bundle assets.
+
+Required release assets:
+
+```text
+service-lasso-<version>.tar.gz
+service-lasso-bundled-<version>.tar.gz
+service-lasso-<version>-win32.zip
+service-lasso-<version>-linux.tar.gz
+service-lasso-<version>-darwin.tar.gz
+service-lasso-bundled-<version>-win32.zip
+service-lasso-bundled-<version>-linux.tar.gz
+service-lasso-bundled-<version>-darwin.tar.gz
+```
+
+The generic archives remain useful as source/runtime staging outputs. The per-OS archives are the consumer-facing bundle set that proves Windows, Linux, and macOS release packaging is represented explicitly on the GitHub release.
+
+## Validation helper
+
+List expected assets for a release tag:
+
+```bash
+node scripts/check-release-assets.mjs --expected 2026.5.2-92235c2
+```
+
+Compare actual asset names against policy:
+
+```bash
+node scripts/check-release-assets.mjs 2026.5.2-92235c2 \
+  service-lasso-2026.5.2-92235c2.tar.gz \
+  service-lasso-bundled-2026.5.2-92235c2.tar.gz
+```
+
+The command exits non-zero when required assets are missing or unexpected names are present.
+
+## Investigation: `2026.5.2-92235c2`
+
+Release `2026.5.2-92235c2` currently has only these assets:
+
+```text
+service-lasso-2026.5.2-92235c2.tar.gz
+service-lasso-bundled-2026.5.2-92235c2.tar.gz
+```
+
+Missing required assets:
+
+```text
+service-lasso-2026.5.2-92235c2-win32.zip
+service-lasso-2026.5.2-92235c2-linux.tar.gz
+service-lasso-2026.5.2-92235c2-darwin.tar.gz
+service-lasso-bundled-2026.5.2-92235c2-win32.zip
+service-lasso-bundled-2026.5.2-92235c2-linux.tar.gz
+service-lasso-bundled-2026.5.2-92235c2-darwin.tar.gz
+```
+
+Root cause: `.github/workflows/release-artifact.yml` runs a single Ubuntu job, stages only `service-lasso-<version>.tar.gz` and `service-lasso-bundled-<version>.tar.gz`, and its release step uploads only those two archive paths. The successful workflow run for commit `92235c22835480e5638084031106d298fdcaf165` (`25256316836`) shows `gh release upload` invoked only for `ARCHIVE_PATH` and `BUNDLED_ARCHIVE_PATH`.
+
+This affects the current release pipeline generally. It is not isolated to the `2026.5.2-92235c2` release: the workflow has no OS matrix and no release-asset policy gate for the per-OS bundle names above.
+
+## Required pipeline follow-up
+
+Before the next Service Lasso core release is considered complete, add a release workflow fix that:
+
+1. builds/stages Windows, Linux, and macOS release bundle assets with the names in this policy;
+2. uploads those assets to the GitHub release; and
+3. runs a release-asset policy check before or immediately after upload so missing OS bundles fail the release job.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "docs:start": "docusaurus start docs",
     "docs:build": "docusaurus build docs",
     "docs:serve": "docusaurus serve docs",
-    "docs:clear": "docusaurus clear docs"
+    "docs:clear": "docusaurus clear docs",
+    "release:assets:expected": "node scripts/check-release-assets.mjs --expected",
+    "release:assets:check": "node scripts/check-release-assets.mjs"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/scripts/check-release-assets.mjs
+++ b/scripts/check-release-assets.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { compareReleaseAssets, getExpectedReleaseAssetNames } from "./release-asset-policy.mjs";
+
+function usage() {
+  console.error("Usage: node scripts/check-release-assets.mjs <version> <asset-name> [asset-name ...]");
+  console.error("       node scripts/check-release-assets.mjs --expected <version>");
+}
+
+const args = process.argv.slice(2);
+
+if (args[0] === "--expected") {
+  const version = args[1];
+  if (!version) {
+    usage();
+    process.exit(2);
+  }
+
+  for (const assetName of getExpectedReleaseAssetNames(version)) {
+    console.log(assetName);
+  }
+  process.exit(0);
+}
+
+const [version, ...assetNames] = args;
+if (!version || assetNames.length === 0) {
+  usage();
+  process.exit(2);
+}
+
+const comparison = compareReleaseAssets(version, assetNames);
+
+console.log(`Release asset policy check for ${version}`);
+console.log("");
+console.log("Expected assets:");
+for (const name of comparison.expected) {
+  console.log(`- ${name}`);
+}
+console.log("");
+console.log("Actual assets:");
+for (const name of comparison.actual) {
+  console.log(`- ${name}`);
+}
+
+if (comparison.missing.length > 0) {
+  console.error("");
+  console.error("Missing required assets:");
+  for (const name of comparison.missing) {
+    console.error(`- ${name}`);
+  }
+}
+
+if (comparison.unexpected.length > 0) {
+  console.error("");
+  console.error("Unexpected assets:");
+  for (const name of comparison.unexpected) {
+    console.error(`- ${name}`);
+  }
+}
+
+if (comparison.missing.length > 0 || comparison.unexpected.length > 0) {
+  process.exit(1);
+}
+
+console.log("");
+console.log("Release asset policy check passed.");

--- a/scripts/release-asset-policy.mjs
+++ b/scripts/release-asset-policy.mjs
@@ -1,0 +1,35 @@
+export const SUPPORTED_RELEASE_PLATFORMS = ["win32", "linux", "darwin"];
+
+export function getExpectedReleaseAssetNames(version) {
+  if (!version || typeof version !== "string") {
+    throw new Error("A release version/tag is required to compute expected release asset names.");
+  }
+
+  return [
+    `service-lasso-${version}.tar.gz`,
+    `service-lasso-bundled-${version}.tar.gz`,
+    ...SUPPORTED_RELEASE_PLATFORMS.map((platform) =>
+      platform === "win32" ? `service-lasso-${version}-${platform}.zip` : `service-lasso-${version}-${platform}.tar.gz`,
+    ),
+    ...SUPPORTED_RELEASE_PLATFORMS.map((platform) =>
+      platform === "win32"
+        ? `service-lasso-bundled-${version}-${platform}.zip`
+        : `service-lasso-bundled-${version}-${platform}.tar.gz`,
+    ),
+  ];
+}
+
+export function compareReleaseAssets(version, actualAssetNames) {
+  const expected = getExpectedReleaseAssetNames(version);
+  const actual = [...new Set(actualAssetNames)].sort();
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+
+  return {
+    version,
+    expected,
+    actual,
+    missing: expected.filter((name) => !actualSet.has(name)),
+    unexpected: actual.filter((name) => !expectedSet.has(name)),
+  };
+}


### PR DESCRIPTION
## Summary
- documented the expected `service-lasso/service-lasso` release asset policy for generic and per-OS assets
- added a reusable asset-name policy helper and CLI check
- recorded the root cause for `2026.5.2-92235c2`: the release workflow uploads only the two generic archives and has no OS matrix/policy gate
- created follow-up fix issue #392 for the actual release workflow implementation

## Evidence
- `gh release view 2026.5.2-92235c2 --repo service-lasso/service-lasso --json targetCommitish,tagName,assets`
- `gh run list --repo service-lasso/service-lasso --commit 92235c22835480e5638084031106d298fdcaf165 --json databaseId,workflowName,displayTitle,event,status,conclusion,createdAt,updatedAt,url --limit 20`
- `gh run view 25256316836 --repo service-lasso/service-lasso --log` showed `gh release upload` only for `ARCHIVE_PATH` and `BUNDLED_ARCHIVE_PATH`
- `node scripts/check-release-assets.mjs --expected 2026.5.2-92235c2`
- `node scripts/check-release-assets.mjs 2026.5.2-92235c2 service-lasso-2026.5.2-92235c2.tar.gz service-lasso-bundled-2026.5.2-92235c2.tar.gz` exits non-zero and lists the six missing per-OS assets
- `npm run typecheck`
- `git diff --check`

## Follow-up
- #392 should implement the per-OS bundle build/upload workflow and enforce the asset policy during release.

Closes #387.