### PR TITLE
ISS-379 add broker-aware selector planning

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -310,6 +310,9 @@ Practical rule:
 Current core behavior:
 - Service Lasso selects `commandline[process.platform]`, falling back to `commandline.default`.
 - `${...}` selectors are resolved with the same service variables used for env/config materialization.
+- Selector planning classifies `${VAR}` as local/current-service/derived/legacy-compatible lookup and `${namespace.KEY}` as an explicit broker lookup.
+- Bare names never fall through into broker namespaces; broker lookups must use dotted selectors.
+- Repeated dotted broker selectors are deduplicated before a broker resolver is called.
 - The resolved commandline is parsed into process arguments and overrides `args` during `start` and `restart`.
 - `commandline` is the arguments payload after the executable; it does not include the executable itself.
 - Keep `args` as the fallback when no platform/default commandline is declared.
@@ -342,6 +345,8 @@ Example:
 Current direction:
 - service env should be explicit
 - avoid depending on uncontrolled host-machine env leakage
+- use `${VAR}` for local/current-service/derived values and legacy `globalenv` compatibility
+- use `${namespace.KEY}` only for explicit Secrets Broker selectors; unresolved or denied broker refs stay unresolved for diagnostics rather than falling back to a bare local name
 
 ### `depend_on`
 Explicit dependencies.

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -9,9 +9,39 @@ export interface ServiceVariableEntry {
   scope: "manifest" | "derived" | "global";
 }
 
+export type ServiceSelectorKind = "local" | "broker";
+
+export interface ServiceSelectorRef {
+  selector: string;
+  kind: ServiceSelectorKind;
+  namespace?: string;
+  key: string;
+}
+
+export interface ServiceSelectorPlan {
+  selectors: ServiceSelectorRef[];
+  localRefs: string[];
+  brokerRefs: string[];
+}
+
+export type ServiceSelectorDiagnosticReason = "unresolved-local" | "missing-broker";
+
+export interface ServiceSelectorDiagnostic {
+  selector: string;
+  kind: ServiceSelectorKind;
+  reason: ServiceSelectorDiagnosticReason;
+}
+
+export interface ServiceTextResolutionOptions {
+  brokerValues?: Record<string, string>;
+  diagnostics?: ServiceSelectorDiagnostic[];
+}
+
 export interface ServiceVariablesPayload {
   serviceId: string;
   variables: ServiceVariableEntry[];
+  selectorPlan: ServiceSelectorPlan;
+  diagnostics: ServiceSelectorDiagnostic[];
 }
 
 function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVariableEntry[] {
@@ -37,10 +67,90 @@ function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVaria
   return entries;
 }
 
-function replaceVariableSelectors(value: string, variables: ServiceVariableEntry[]): string {
+function normalizeVariableSelector(selector: string): string {
+  const trimmed = selector.trim();
+  const match = trimmed.match(/^\$\{(.+)\}$/);
+  return (match?.[1] ?? trimmed).trim();
+}
+
+function isBrokerSelector(selector: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9_-]*\.[A-Za-z0-9_.-]+$/.test(selector.trim());
+}
+
+function createSelectorRef(selector: string): ServiceSelectorRef {
+  const normalizedSelector = normalizeVariableSelector(selector);
+  if (isBrokerSelector(normalizedSelector)) {
+    const dotIndex = normalizedSelector.indexOf(".");
+    return {
+      selector: normalizedSelector,
+      kind: "broker",
+      namespace: normalizedSelector.slice(0, dotIndex),
+      key: normalizedSelector.slice(dotIndex + 1),
+    };
+  }
+
+  return {
+    selector: normalizedSelector,
+    kind: "local",
+    key: normalizedSelector,
+  };
+}
+
+export function compileServiceSelectorPlan(values: string[] | Record<string, string>): ServiceSelectorPlan {
+  const texts = Array.isArray(values) ? values : Object.values(values);
+  const selectors = new Map<string, ServiceSelectorRef>();
+
+  for (const text of texts) {
+    for (const match of text.matchAll(/\$\{([^}]+)\}/g)) {
+      const ref = createSelectorRef(match[1]);
+      selectors.set(ref.selector, ref);
+    }
+  }
+
+  const orderedSelectors = [...selectors.values()];
+  return {
+    selectors: orderedSelectors,
+    localRefs: orderedSelectors.filter((selector) => selector.kind === "local").map((selector) => selector.key),
+    brokerRefs: orderedSelectors.filter((selector) => selector.kind === "broker").map((selector) => selector.selector),
+  };
+}
+
+function mergeSelectorPlans(plans: ServiceSelectorPlan[]): ServiceSelectorPlan {
+  const selectors = new Map<string, ServiceSelectorRef>();
+  for (const plan of plans) {
+    for (const selector of plan.selectors) {
+      selectors.set(selector.selector, selector);
+    }
+  }
+
+  const orderedSelectors = [...selectors.values()];
+  return {
+    selectors: orderedSelectors,
+    localRefs: orderedSelectors.filter((selector) => selector.kind === "local").map((selector) => selector.key),
+    brokerRefs: orderedSelectors.filter((selector) => selector.kind === "broker").map((selector) => selector.selector),
+  };
+}
+
+function replaceVariableSelectors(
+  value: string,
+  variables: ServiceVariableEntry[],
+  options: ServiceTextResolutionOptions = {},
+): string {
   return value.replace(/\$\{([^}]+)\}/g, (match, key) => {
-    const normalizedKey = normalizeVariableSelector(key);
-    const entry = variables.find((candidate) => candidate.key === normalizedKey);
+    const ref = createSelectorRef(key);
+    if (ref.kind === "broker") {
+      const brokerValue = options.brokerValues?.[ref.selector];
+      if (brokerValue !== undefined) {
+        return brokerValue;
+      }
+      options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "missing-broker" });
+      return match;
+    }
+
+    const entry = variables.find((candidate) => candidate.key === ref.key);
+    if (!entry) {
+      options.diagnostics?.push({ selector: ref.selector, kind: "local", reason: "unresolved-local" });
+    }
     return entry ? entry.value : match;
   });
 }
@@ -112,21 +222,20 @@ export function buildServiceVariables(
     ...buildPortVariables(resolvedPorts),
   ];
 
+  const manifestDiagnostics: ServiceSelectorDiagnostic[] = [];
   const manifestVariables = rawManifestVariables.map((entry) => ({
     ...entry,
-    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables]),
+    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables], {
+      diagnostics: manifestDiagnostics,
+    }),
   }));
 
   return {
     serviceId: service.manifest.id,
     variables: [...manifestVariables, ...globalVariables, ...derivedVariables],
+    selectorPlan: compileServiceSelectorPlan(service.manifest.env ?? {}),
+    diagnostics: manifestDiagnostics,
   };
-}
-
-function normalizeVariableSelector(selector: string): string {
-  const trimmed = selector.trim();
-  const match = trimmed.match(/^\$\{(.+)\}$/);
-  return (match?.[1] ?? trimmed).trim();
 }
 
 export function collectServiceGlobalEnv(
@@ -134,7 +243,8 @@ export function collectServiceGlobalEnv(
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): Record<string, string> {
-  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables;
+  const variablesPayload = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts);
+  const variables = variablesPayload.variables;
   const configuredGlobalEnv = service.manifest.globalenv ?? {};
 
   return Object.fromEntries(
@@ -142,13 +252,26 @@ export function collectServiceGlobalEnv(
   );
 }
 
+export function compileServiceMaterializationSelectorPlan(service: DiscoveredService): ServiceSelectorPlan {
+  const installFiles = service.manifest.install?.files ?? [];
+  const configFiles = service.manifest.config?.files ?? [];
+
+  return mergeSelectorPlans([
+    compileServiceSelectorPlan(service.manifest.env ?? {}),
+    compileServiceSelectorPlan(service.manifest.globalenv ?? {}),
+    compileServiceSelectorPlan(installFiles.flatMap((file) => [file.path, file.content])),
+    compileServiceSelectorPlan(configFiles.flatMap((file) => [file.path, file.content])),
+  ]);
+}
+
 export function resolveServiceText(
   value: string,
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
-  resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
+  resolvedPorts: Record<string, number> = {},
+  options: ServiceTextResolutionOptions = {},
 ): string {
-  return replaceVariableSelectors(value, buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables);
+  return replaceVariableSelectors(value, buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables, options);
 }
 
 export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<string, string> {
@@ -169,6 +292,9 @@ export function resolveServiceVariable(
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): ServiceVariableEntry | undefined {
-  const key = normalizeVariableSelector(selector);
-  return buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.find((entry) => entry.key === key);
+  const ref = createSelectorRef(selector);
+  if (ref.kind === "broker") {
+    return undefined;
+  }
+  return buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.find((entry) => entry.key === ref.key);
 }

--- a/src/runtime/setup/materialize.ts
+++ b/src/runtime/setup/materialize.ts
@@ -1,19 +1,11 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import type { DiscoveredService, ServiceActionMaterialization } from "../../contracts/service.js";
-import { buildServiceVariables } from "../operator/variables.js";
+import { resolveServiceText } from "../operator/variables.js";
 
 export interface MaterializedArtifactResult {
   files: string[];
   updatedAt: string;
-}
-
-function renderTemplate(source: string, variables: ReturnType<typeof buildServiceVariables>["variables"]): string {
-  return source.replace(/\$\{([^}]+)\}/g, (match, selector) => {
-    const key = selector.trim();
-    const resolved = variables.find((entry) => entry.key === key);
-    return resolved ? resolved.value : match;
-  });
 }
 
 function resolveArtifactPath(serviceRoot: string, relativePath: string): { absolutePath: string; relativePath: string } {
@@ -49,12 +41,11 @@ async function materializeFiles(
   resolvedPorts: Record<string, number>,
 ): Promise<MaterializedArtifactResult> {
   const files = definition?.files ?? [];
-  const variables = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables;
   const materializedPaths: string[] = [];
 
   for (const file of files) {
-    const renderedRelativePath = renderTemplate(file.path, variables);
-    const renderedContent = renderTemplate(file.content, variables);
+    const renderedRelativePath = resolveServiceText(file.path, service, sharedGlobalEnv, resolvedPorts);
+    const renderedContent = resolveServiceText(file.content, service, sharedGlobalEnv, resolvedPorts);
     const { absolutePath, relativePath } = resolveArtifactPath(service.serviceRoot, renderedRelativePath);
     await mkdir(path.dirname(absolutePath), { recursive: true });
     await writeFile(absolutePath, renderedContent, "utf8");

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  buildServiceVariables,
+  compileServiceMaterializationSelectorPlan,
+  compileServiceSelectorPlan,
+  resolveServiceText,
+  resolveServiceVariable,
+} from "../dist/runtime/operator/variables.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+
+function fixtureService(overrides = {}) {
+  return {
+    manifestPath: path.join(process.cwd(), "services", "consumer", "service.json"),
+    serviceRoot: path.join(process.cwd(), "services", "consumer"),
+    manifest: {
+      id: "consumer",
+      name: "Consumer",
+      description: "Selector planning test service",
+      env: {},
+      ...overrides,
+    },
+  };
+}
+
+test("selector planning classifies local and broker selectors and deduplicates broker refs", () => {
+  const plan = compileServiceSelectorPlan({
+    local: "${SERVICE_ROOT}:${LOCAL_ONLY}",
+    secret: "${secretsbroker.API_KEY}:${secretsbroker.API_KEY}:${vault.database.password}",
+  });
+
+  assert.deepEqual(plan.localRefs, ["SERVICE_ROOT", "LOCAL_ONLY"]);
+  assert.deepEqual(plan.brokerRefs, ["secretsbroker.API_KEY", "vault.database.password"]);
+  assert.deepEqual(
+    plan.selectors.map((selector) => [selector.selector, selector.kind, selector.namespace ?? null, selector.key]),
+    [
+      ["SERVICE_ROOT", "local", null, "SERVICE_ROOT"],
+      ["LOCAL_ONLY", "local", null, "LOCAL_ONLY"],
+      ["secretsbroker.API_KEY", "broker", "secretsbroker", "API_KEY"],
+      ["vault.database.password", "broker", "vault", "database.password"],
+    ],
+  );
+});
+
+test("service variable resolution preserves local precedence and legacy globalenv compatibility", () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      LOCAL_ONLY: "local",
+      SHARED_VALUE: "local-wins",
+      FROM_DERIVED: "${SERVICE_ID}:${SERVICE_PORT}",
+      FROM_GLOBAL: "${LEGACY_TOOL_HOME}",
+    },
+    ports: { service: 4310 },
+  });
+
+  const payload = buildServiceVariables(service, { SHARED_VALUE: "global", LEGACY_TOOL_HOME: "C:/tools/legacy" });
+  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry.value]));
+
+  assert.equal(byKey.LOCAL_ONLY, "local");
+  assert.equal(resolveServiceVariable(service, "${SHARED_VALUE}", { SHARED_VALUE: "global" })?.value, "local-wins");
+  assert.equal(byKey.FROM_DERIVED, "consumer:4310");
+  assert.equal(byKey.FROM_GLOBAL, "C:/tools/legacy");
+});
+
+test("bare selectors do not fall back into broker namespaces", () => {
+  resetLifecycleState();
+  const service = fixtureService({ env: { LOCAL_SECRET: "${API_KEY}" } });
+  const diagnostics = [];
+  const resolved = resolveServiceText("token=${API_KEY}", service, {}, {}, {
+    brokerValues: { "secretsbroker.API_KEY": "resolved-secret" },
+    diagnostics,
+  });
+
+  assert.equal(resolved, "token=${API_KEY}");
+  assert.deepEqual(diagnostics, [{ selector: "API_KEY", kind: "local", reason: "unresolved-local" }]);
+});
+
+test("explicit broker selectors resolve only from broker values and report missing refs", () => {
+  resetLifecycleState();
+  const service = fixtureService({ env: { LOCAL_ONLY: "local" } });
+  const diagnostics = [];
+  const resolved = resolveServiceText(
+    "token=${secretsbroker.API_KEY}; missing=${secretsbroker.MISSING}; local=${LOCAL_ONLY}",
+    service,
+    {},
+    {},
+    {
+      brokerValues: { "secretsbroker.API_KEY": "resolved-secret" },
+      diagnostics,
+    },
+  );
+
+  assert.equal(resolved, "token=resolved-secret; missing=${secretsbroker.MISSING}; local=local");
+  assert.deepEqual(diagnostics, [{ selector: "secretsbroker.MISSING", kind: "broker", reason: "missing-broker" }]);
+});
+
+test("materialization selector plan covers env, globalenv, install, and config templates", () => {
+  const service = fixtureService({
+    env: { LOCAL_SECRET_REF: "${secretsbroker.API_KEY}" },
+    globalenv: { TOOL_HOME: "${SERVICE_ROOT}/tool" },
+    install: { files: [{ path: "generated/${SERVICE_ID}.txt", content: "${vault.shared.token}" }] },
+    config: { files: [{ path: "config/${secretsbroker.CONFIG_NAME}.json", content: "${LOCAL_SECRET_REF}" }] },
+  });
+
+  const plan = compileServiceMaterializationSelectorPlan(service);
+
+  assert.deepEqual(plan.brokerRefs, ["secretsbroker.API_KEY", "vault.shared.token", "secretsbroker.CONFIG_NAME"]);
+  assert.ok(plan.localRefs.includes("SERVICE_ROOT"));
+  assert.ok(plan.localRefs.includes("SERVICE_ID"));
+  assert.ok(plan.localRefs.includes("LOCAL_SECRET_REF"));
+});


### PR DESCRIPTION
## Summary
- adds selector planning for Service Lasso templates, classifying `${VAR}` as local/current-service/derived/legacy-compatible and `${namespace.KEY}` as an explicit broker ref
- deduplicates broker refs into a selector plan for batch lookup boundaries
- adds broker/local diagnostics for unresolved local refs and missing broker refs without leaking values
- routes install/config materialization through the shared selector resolver
- documents selector semantics and no bare-name broker fallback
- adds focused selector-planning tests for precedence, legacy globalenv compatibility, unresolved refs, duplicate broker refs, explicit broker lookup, and no bare broker fallback

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/variable-selector-planning.test.js tests/operator-data.test.js tests/setup-lifecycle.test.js`
- `git diff --check`

## Validation note
- Full `npm test` was attempted but an existing install-acquire artifact-command proof test failed: `tests/install-acquire.test.js` / `start prefers an installed artifact command over a checked-in fixture command` (`ENOENT` for `.state/extracted/current/artifact-cwd.txt`). Tracked separately in #394.

Closes #379.