### PR TITLE
ISS-378 define Secrets Broker manifest contract

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -12,7 +12,7 @@ It is meant to make the runtime and service templates usable without forcing ser
 - common top-level fields
 - `actions`
 - `setup`
-- env / dependencies / ports
+- env / broker / dependencies / ports
 - healthcheck direction
 - examples
 - what is currently canonical vs still illustrative
@@ -39,6 +39,7 @@ At a high level it carries:
 - lifecycle/action hints
 - runtime execution settings
 - environment settings
+- explicit Secrets Broker imports/exports/write-back policy
 - dependency hints
 - health expectations
 
@@ -347,6 +348,144 @@ Current direction:
 - avoid depending on uncontrolled host-machine env leakage
 - use `${VAR}` for local/current-service/derived values and legacy `globalenv` compatibility
 - use `${namespace.KEY}` only for explicit Secrets Broker selectors; unresolved or denied broker refs stay unresolved for diagnostics rather than falling back to a bare local name
+
+### `broker`
+
+`broker` is the first-class Secrets Broker manifest contract. It lets a service declare the namespaces and refs it consumes, the values it exports, and which generated secrets it may write back.
+
+Services without a `broker` block keep the existing behavior. There is no implicit migration from `env` or `globalenv` into broker state.
+
+Shape:
+```json
+"broker": {
+  "enabled": true,
+  "namespace": "services/consumer",
+  "imports": [
+    {
+      "namespace": "shared/database",
+      "ref": "database.PASSWORD",
+      "as": "DB_PASSWORD",
+      "required": true
+    }
+  ],
+  "exports": [
+    {
+      "namespace": "services/producer",
+      "ref": "producer.PUBLIC_URL",
+      "source": "${SERVICE_URL}",
+      "required": false
+    }
+  ],
+  "writeback": {
+    "allowedNamespaces": ["services/producer"],
+    "allowedOperations": ["create", "update", "rotate"]
+  }
+}
+```
+
+Fields:
+- `enabled`: optional boolean. `false` can be used to leave a declared broker contract dormant.
+- `namespace`: optional default service namespace. It must be a non-empty broker namespace string such as `services/consumer`.
+- `imports`: optional array of explicit broker refs the service may consume.
+- `imports[].namespace`: namespace authorization boundary for the import.
+- `imports[].ref`: dotted broker selector such as `database.PASSWORD`.
+- `imports[].as`: optional local variable name to materialize the import into.
+- `imports[].required`: optional boolean; required imports should fail closed when absent or denied.
+- `exports`: optional array of values this service publishes to broker namespaces.
+- `exports[].namespace`: namespace authorization boundary for the export.
+- `exports[].ref`: dotted broker selector such as `producer.PUBLIC_URL`.
+- `exports[].source`: local selector or literal value to export, for example `${SERVICE_URL}`.
+- `exports[].required`: optional boolean; required exports should fail closed when the source is unavailable.
+- `writeback.allowedNamespaces`: optional array limiting namespaces this service may write generated secrets into.
+- `writeback.allowedOperations`: optional array of allowed generated-secret operations: `create`, `update`, `rotate`, `delete`.
+
+Selector semantics:
+- `${VAR}` means local/current-service variables only, including derived variables and legacy-compatible values already visible to the service.
+- `${namespace.KEY}` means an explicit broker lookup.
+- Bare names never fall through into broker namespaces.
+- Broker refs must be dotted. This keeps broker access reviewable and prevents accidental secret reads from ordinary env selectors.
+
+Producer example:
+```json
+{
+  "id": "token-producer",
+  "name": "Token Producer",
+  "description": "Generates a service token and publishes it to the broker.",
+  "env": {
+    "PUBLIC_URL": "http://127.0.0.1:${SERVICE_PORT}/"
+  },
+  "broker": {
+    "enabled": true,
+    "namespace": "services/token-producer",
+    "exports": [
+      {
+        "namespace": "services/token-producer",
+        "ref": "token.PUBLIC_URL",
+        "source": "${PUBLIC_URL}",
+        "required": true
+      }
+    ],
+    "writeback": {
+      "allowedNamespaces": ["services/token-producer"],
+      "allowedOperations": ["create", "update", "rotate"]
+    }
+  }
+}
+```
+
+Consumer example:
+```json
+{
+  "id": "token-consumer",
+  "name": "Token Consumer",
+  "description": "Consumes an explicit broker value.",
+  "env": {
+    "TOKEN_ENDPOINT": "${token.PUBLIC_URL}"
+  },
+  "broker": {
+    "enabled": true,
+    "namespace": "services/token-consumer",
+    "imports": [
+      {
+        "namespace": "services/token-producer",
+        "ref": "token.PUBLIC_URL",
+        "as": "TOKEN_ENDPOINT",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+Migration from `globalenv`:
+```json
+{
+  "globalenv": {
+    "DB_PASSWORD": "${DB_PASSWORD}"
+  }
+}
+```
+
+Becomes an explicit broker contract:
+```json
+{
+  "env": {
+    "DB_PASSWORD": "${database.PASSWORD}"
+  },
+  "broker": {
+    "enabled": true,
+    "namespace": "services/api",
+    "imports": [
+      {
+        "namespace": "shared/database",
+        "ref": "database.PASSWORD",
+        "as": "DB_PASSWORD",
+        "required": true
+      }
+    ]
+  }
+}
+```
 
 ### `depend_on`
 Explicit dependencies.

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -131,6 +131,35 @@ export interface ServiceArchiveArtifact {
 
 export type ServiceRole = "service" | "provider";
 
+export interface ServiceBrokerImport {
+  namespace: string;
+  ref: string;
+  as?: string;
+  required?: boolean;
+}
+
+export interface ServiceBrokerExport {
+  namespace: string;
+  ref: string;
+  source: string;
+  required?: boolean;
+}
+
+export type ServiceBrokerWritebackOperation = "create" | "update" | "rotate" | "delete";
+
+export interface ServiceBrokerWritebackPolicy {
+  allowedNamespaces?: string[];
+  allowedOperations?: ServiceBrokerWritebackOperation[];
+}
+
+export interface ServiceBrokerPolicy {
+  enabled?: boolean;
+  namespace?: string;
+  imports?: ServiceBrokerImport[];
+  exports?: ServiceBrokerExport[];
+  writeback?: ServiceBrokerWritebackPolicy;
+}
+
 export interface ServiceManifest {
   id: string;
   name: string;
@@ -143,6 +172,7 @@ export interface ServiceManifest {
   healthcheck?: ServiceHealthcheck;
   env?: Record<string, string>;
   globalenv?: Record<string, string>;
+  broker?: ServiceBrokerPolicy;
   ports?: ServicePortDeclaration;
   portmapping?: ServicePortMappingDeclaration;
   urls?: ServiceEndpoint[];

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1,4 +1,5 @@
 import type {
+  ServiceBrokerWritebackOperation,
   ServiceHookFailurePolicy,
   ServiceHookStep,
   ServiceManifest,
@@ -17,6 +18,9 @@ const updateRunningServicePolicies = new Set(["skip", "require-stopped", "stop-s
 const updateWindowDays = new Set(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 const serviceRoles = new Set(["service", "provider"]);
 const setupRerunPolicies = new Set(["manual", "ifMissing", "always"]);
+const brokerWritebackOperations = new Set(["create", "update", "rotate", "delete"]);
+const brokerNamespacePattern = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.-]*)*$/;
+const brokerRefPattern = /^[A-Za-z][A-Za-z0-9_-]*\.[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 
 function expectNonEmptyString(value: unknown, field: string, manifestPath: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -148,6 +152,34 @@ function readStringMap(value: unknown, field: string, manifestPath: string): Rec
   }
 
   return Object.fromEntries(Object.entries(value as Record<string, string>).map(([key, entry]) => [key.trim(), entry]));
+}
+
+function readNonEmptyStringArray(value: unknown, field: string, manifestPath: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an array of non-empty strings.`);
+  }
+
+  return value.map((entry) => (entry as string).trim());
+}
+
+function expectBrokerNamespace(value: unknown, field: string, manifestPath: string): string {
+  const namespace = expectNonEmptyString(value, field, manifestPath);
+  if (!brokerNamespacePattern.test(namespace)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be a valid broker namespace.`);
+  }
+  return namespace;
+}
+
+function expectBrokerRef(value: unknown, field: string, manifestPath: string): string {
+  const ref = expectNonEmptyString(value, field, manifestPath);
+  if (!brokerRefPattern.test(ref)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be a dotted broker ref like "namespace.KEY".`);
+  }
+  return ref;
 }
 
 function readHookSteps(value: unknown, field: string, manifestPath: string): ServiceHookStep[] | undefined {
@@ -379,6 +411,89 @@ function readUpdateInstallWindow(
     start: expectTimeOfDay(record.start, "updates.installWindow.start", manifestPath),
     end: expectTimeOfDay(record.end, "updates.installWindow.end", manifestPath),
     timezone: typeof record.timezone === "string" ? record.timezone.trim() : undefined,
+  };
+}
+
+function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest["broker"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker" to be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const imports = record.imports;
+  if (imports !== undefined && !Array.isArray(imports)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.imports" to be an array.`);
+  }
+  const exports = record.exports;
+  if (exports !== undefined && !Array.isArray(exports)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.exports" to be an array.`);
+  }
+
+  const writeback = record.writeback;
+  if (writeback !== undefined && (!writeback || typeof writeback !== "object" || Array.isArray(writeback))) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.writeback" to be an object.`);
+  }
+  const writebackRecord = writeback as Record<string, unknown> | undefined;
+  const allowedOperations = readNonEmptyStringArray(
+    writebackRecord?.allowedOperations,
+    "broker.writeback.allowedOperations",
+    manifestPath,
+  );
+  if (allowedOperations?.some((operation) => !brokerWritebackOperations.has(operation))) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "broker.writeback.allowedOperations" to contain create, update, rotate, or delete.`,
+    );
+  }
+  const allowedNamespaces = readNonEmptyStringArray(
+    writebackRecord?.allowedNamespaces,
+    "broker.writeback.allowedNamespaces",
+    manifestPath,
+  );
+  allowedNamespaces?.forEach((namespace) => expectBrokerNamespace(namespace, "broker.writeback.allowedNamespaces", manifestPath));
+
+  return {
+    enabled: expectOptionalBoolean(record.enabled, "broker.enabled", manifestPath),
+    namespace: record.namespace === undefined ? undefined : expectBrokerNamespace(record.namespace, "broker.namespace", manifestPath),
+    imports: Array.isArray(imports)
+      ? imports.map((entry, index) => {
+          const field = `broker.imports[${index}]`;
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+          }
+          const importRecord = entry as Record<string, unknown>;
+          return {
+            namespace: expectBrokerNamespace(importRecord.namespace, `${field}.namespace`, manifestPath),
+            ref: expectBrokerRef(importRecord.ref, `${field}.ref`, manifestPath),
+            as: importRecord.as === undefined ? undefined : expectNonEmptyString(importRecord.as, `${field}.as`, manifestPath),
+            required: expectOptionalBoolean(importRecord.required, `${field}.required`, manifestPath),
+          };
+        })
+      : undefined,
+    exports: Array.isArray(exports)
+      ? exports.map((entry, index) => {
+          const field = `broker.exports[${index}]`;
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+          }
+          const exportRecord = entry as Record<string, unknown>;
+          return {
+            namespace: expectBrokerNamespace(exportRecord.namespace, `${field}.namespace`, manifestPath),
+            ref: expectBrokerRef(exportRecord.ref, `${field}.ref`, manifestPath),
+            source: expectNonEmptyString(exportRecord.source, `${field}.source`, manifestPath),
+            required: expectOptionalBoolean(exportRecord.required, `${field}.required`, manifestPath),
+          };
+        })
+      : undefined,
+    writeback: writebackRecord
+      ? {
+          allowedNamespaces,
+          allowedOperations: allowedOperations as ServiceBrokerWritebackOperation[] | undefined,
+        }
+      : undefined,
   };
 }
 
@@ -746,6 +861,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"urls\" to be an array of { label, url } objects.`);
   }
 
+  const broker = readBrokerPolicy(record.broker, manifestPath);
   const artifact = readArtifact(record.artifact, manifestPath);
   const install = readActionMaterialization(record.install, "install", manifestPath);
   const config = readActionMaterialization(record.config, "config", manifestPath);
@@ -770,6 +886,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     globalenv: rawGlobalEnv
       ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
       : undefined,
+    broker,
     ports: rawPorts
       ? Object.fromEntries(Object.entries(rawPorts as Record<string, number>).map(([key, value]) => [key.trim(), value]))
       : undefined,

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -375,6 +375,116 @@ test("loadServiceManifest accepts bounded globalenv emission maps", async () => 
   }
 });
 
+test("loadServiceManifest accepts bounded broker manifest policy", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "broker-consumer", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "broker-consumer",
+        name: "Broker Consumer",
+        description: "Service with explicit Secrets Broker contract.",
+        broker: {
+          enabled: true,
+          namespace: "services/broker-consumer",
+          imports: [
+            {
+              namespace: "shared/database",
+              ref: "database.PASSWORD",
+              as: "DB_PASSWORD",
+              required: true,
+            },
+          ],
+          exports: [
+            {
+              namespace: "broker-consumer/runtime",
+              ref: "runtime.API_TOKEN",
+              source: "${API_TOKEN}",
+              required: false,
+            },
+          ],
+          writeback: {
+            allowedNamespaces: ["broker-consumer/runtime"],
+            allowedOperations: ["create", "update", "rotate"],
+          },
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.broker, {
+      enabled: true,
+      namespace: "services/broker-consumer",
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+          required: true,
+        },
+      ],
+      exports: [
+        {
+          namespace: "broker-consumer/runtime",
+          ref: "runtime.API_TOKEN",
+          source: "${API_TOKEN}",
+          required: false,
+        },
+      ],
+      writeback: {
+        allowedNamespaces: ["broker-consumer/runtime"],
+        allowedOperations: ["create", "update", "rotate"],
+      },
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects malformed broker manifest policy", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "bad-enabled", {
+      id: "bad-enabled",
+      name: "Bad Enabled",
+      description: "Invalid broker enabled flag.",
+      broker: { enabled: "yes" },
+    });
+    await writeManifest(servicesRoot, "bad-ref", {
+      id: "bad-ref",
+      name: "Bad Ref",
+      description: "Invalid broker import ref.",
+      broker: { imports: [{ namespace: "shared/database", ref: "PASSWORD" }] },
+    });
+    await writeManifest(servicesRoot, "bad-writeback", {
+      id: "bad-writeback",
+      name: "Bad Writeback",
+      description: "Invalid writeback operation.",
+      broker: { writeback: { allowedNamespaces: ["runtime"], allowedOperations: ["read"] } },
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-enabled", "service.json")),
+      /broker\.enabled/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-ref", "service.json")),
+      /broker\.imports\[0\]\.ref/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-writeback", "service.json")),
+      /broker\.writeback\.allowedOperations/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest accepts bounded autostart flags", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const manifestPath = path.join(servicesRoot, "autostart-service", "service.json");


### PR DESCRIPTION
## Summary
- add typed service manifest broker contract for imports, exports, and write-back policy
- validate broker.enabled, namespace, import/export refs, and writeback namespace/operation bounds
- document selector semantics plus producer/consumer and globalenv migration examples
- add manifest discovery tests covering valid and invalid broker shapes

## Validation
- PASS: `npm run build && node --test --test-concurrency=1 tests/manifest-discovery.test.js`
- PASS: `git diff --check`
- PARTIAL/BLOCKED: `npm test -- --runInBand` currently fails in existing install-acquire cwd proof test: `tests/install-acquire.test.js` "start prefers an installed artifact command over a checked-in fixture command" ENOENT for `artifact-cwd.txt`. Project already has `service-lasso/service-lasso#394` for this failure.

Issue: #378
