### PR TITLE
ISS-392 add per-OS release assets

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -43,6 +43,24 @@ jobs:
           SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
         run: npm run release:verify
 
+      - name: Validate staged release asset policy
+        run: |
+          TAG_NAME="${{ steps.release_version.outputs.version }}"
+          ASSET_NAMES=(
+            "${{ steps.release_version.outputs.artifact_name }}.tar.gz"
+            "${{ steps.release_version.outputs.bundled_artifact_name }}.tar.gz"
+            "${{ steps.release_version.outputs.artifact_name }}-win32.zip"
+            "${{ steps.release_version.outputs.artifact_name }}-linux.tar.gz"
+            "${{ steps.release_version.outputs.artifact_name }}-darwin.tar.gz"
+            "${{ steps.release_version.outputs.bundled_artifact_name }}-win32.zip"
+            "${{ steps.release_version.outputs.bundled_artifact_name }}-linux.tar.gz"
+            "${{ steps.release_version.outputs.bundled_artifact_name }}-darwin.tar.gz"
+          )
+          for asset_name in "${ASSET_NAMES[@]}"; do
+            test -f "artifacts/${asset_name}"
+          done
+          node scripts/check-release-assets.mjs "$TAG_NAME" "${ASSET_NAMES[@]}"
+
       - name: Upload staged artifact folder
         uses: actions/upload-artifact@v6
         with:
@@ -67,13 +85,40 @@ jobs:
           name: ${{ steps.release_version.outputs.bundled_artifact_name }}-archive
           path: artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}.tar.gz
 
+      - name: Upload per-OS release archives
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.version }}-per-os-release-archives
+          path: |
+            artifacts/${{ steps.release_version.outputs.artifact_name }}-win32.zip
+            artifacts/${{ steps.release_version.outputs.artifact_name }}-linux.tar.gz
+            artifacts/${{ steps.release_version.outputs.artifact_name }}-darwin.tar.gz
+            artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-win32.zip
+            artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-linux.tar.gz
+            artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-darwin.tar.gz
+
       - name: Create or update GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           TAG_NAME="${{ steps.release_version.outputs.version }}"
-          ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
-          BUNDLED_ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}.tar.gz"
+          RELEASE_ASSETS=(
+            "artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
+            "artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}.tar.gz"
+            "artifacts/${{ steps.release_version.outputs.artifact_name }}-win32.zip"
+            "artifacts/${{ steps.release_version.outputs.artifact_name }}-linux.tar.gz"
+            "artifacts/${{ steps.release_version.outputs.artifact_name }}-darwin.tar.gz"
+            "artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-win32.zip"
+            "artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-linux.tar.gz"
+            "artifacts/${{ steps.release_version.outputs.bundled_artifact_name }}-darwin.tar.gz"
+          )
           gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --target "${GITHUB_SHA}" --title "$TAG_NAME" --notes "Bounded runtime artifact release for service-lasso."
-          gh release upload "$TAG_NAME" "$ARCHIVE_PATH" --clobber
-          gh release upload "$TAG_NAME" "$BUNDLED_ARCHIVE_PATH" --clobber
+          gh release upload "$TAG_NAME" "${RELEASE_ASSETS[@]}" --clobber
+
+      - name: Verify GitHub release asset policy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          TAG_NAME="${{ steps.release_version.outputs.version }}"
+          mapfile -t RELEASE_ASSET_NAMES < <(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')
+          node scripts/check-release-assets.mjs "$TAG_NAME" "${RELEASE_ASSET_NAMES[@]}"

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import AdmZip from "adm-zip";
+import { SUPPORTED_RELEASE_PLATFORMS } from "./release-asset-policy.mjs";
 import { getReleaseVersion, readRootPackageJson, RELEASE_VERSION_ENV } from "./release-version-lib.mjs";
 
 export const RELEASE_FILES = [
@@ -245,11 +247,38 @@ export function runNpmCommand(args, options = {}) {
   return runCommand(comspec, ["/d", "/s", "/c", commandLine], options);
 }
 
-export async function createReleaseArchive(outputRoot, artifactName) {
-  const archivePath = path.join(outputRoot, `${artifactName}.tar.gz`);
+export async function createReleaseArchive(outputRoot, artifactName, archiveName = `${artifactName}.tar.gz`) {
+  const archivePath = path.join(outputRoot, archiveName);
   await rm(archivePath, { force: true });
   await runCommand("tar", ["-czf", archivePath, "-C", outputRoot, artifactName]);
   return archivePath;
+}
+
+export async function createReleaseZipArchive(outputRoot, artifactName, archiveName = `${artifactName}.zip`) {
+  const archivePath = path.join(outputRoot, archiveName);
+  await rm(archivePath, { force: true });
+
+  const archive = new AdmZip();
+  archive.addLocalFolder(path.join(outputRoot, artifactName), artifactName);
+  archive.writeZip(archivePath);
+
+  return archivePath;
+}
+
+export async function createPlatformReleaseArchives(outputRoot, artifactName) {
+  const archives = [];
+
+  for (const platform of SUPPORTED_RELEASE_PLATFORMS) {
+    const archiveName = platform === "win32" ? `${artifactName}-${platform}.zip` : `${artifactName}-${platform}.tar.gz`;
+    const archivePath =
+      platform === "win32"
+        ? await createReleaseZipArchive(outputRoot, artifactName, archiveName)
+        : await createReleaseArchive(outputRoot, artifactName, archiveName);
+
+    archives.push({ platform, archiveName, archivePath });
+  }
+
+  return archives;
 }
 
 export async function stageReleaseArtifact({
@@ -280,11 +309,13 @@ export async function stageReleaseArtifact({
     version: resolvedVersion,
   });
   const archivePath = await createReleaseArchive(outputRoot, artifactName);
+  const platformArchives = await createPlatformReleaseArchives(outputRoot, artifactName);
 
   return {
     artifactName,
     artifactRoot,
     archivePath,
+    platformArchives,
     manifest,
   };
 }
@@ -336,11 +367,13 @@ export async function stageBundledReleaseArtifact({
     ],
   });
   const archivePath = await createReleaseArchive(outputRoot, artifactName);
+  const platformArchives = await createPlatformReleaseArchives(outputRoot, artifactName);
 
   return {
     artifactName,
     artifactRoot,
     archivePath,
+    platformArchives,
     manifest,
   };
 }

--- a/scripts/release-artifact.mjs
+++ b/scripts/release-artifact.mjs
@@ -11,7 +11,13 @@ console.log("[service-lasso] staged bounded release artifact");
 console.log(`- artifact: ${result.artifactName}`);
 console.log(`- folder: ${result.artifactRoot}`);
 console.log(`- archive: ${result.archivePath}`);
+for (const platformArchive of result.platformArchives) {
+  console.log(`- ${platformArchive.platform} archive: ${platformArchive.archivePath}`);
+}
 console.log("[service-lasso] staged bundled release artifact");
 console.log(`- artifact: ${bundled.artifactName}`);
 console.log(`- folder: ${bundled.artifactRoot}`);
 console.log(`- archive: ${bundled.archivePath}`);
+for (const platformArchive of bundled.platformArchives) {
+  console.log(`- ${platformArchive.platform} archive: ${platformArchive.archivePath}`);
+}

--- a/tests/release-artifact.test.js
+++ b/tests/release-artifact.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { rm } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import {
   createTemporaryOutputRoot,
   stageReleaseArtifact,
@@ -23,6 +23,17 @@ test("bounded release artifact can be staged and verified", async () => {
     assert.match(staged.artifactName, /^service-lasso-[0-9A-Za-z.-]+$/);
     assert.equal(staged.manifest.entrypoints.runtime, "dist/index.js");
     assert.equal(staged.manifest.entrypoints.corePackage, "packages/core/index.js");
+    assert.deepEqual(
+      staged.platformArchives.map((archive) => archive.archiveName),
+      [
+        `${staged.artifactName}-win32.zip`,
+        `${staged.artifactName}-linux.tar.gz`,
+        `${staged.artifactName}-darwin.tar.gz`,
+      ],
+    );
+    for (const archive of staged.platformArchives) {
+      await stat(archive.archivePath);
+    }
 
     const verified = await verifyStagedArtifact({
       repoRoot,


### PR DESCRIPTION
Closes #392

## Summary
- Stages explicit Windows/Linux/macOS release archives for both generic and bundled Service Lasso runtime artifacts using the existing release asset policy names.
- Updates the release workflow to validate the staged asset set, upload all eight required assets to the GitHub release, and verify the release asset policy after upload.
- Extends release artifact tests to assert per-OS archive names and file creation.

## Validation
- `npm run build` — passed
- `node --test --test-concurrency=1 tests/release-artifact.test.js tests/release-versioning.test.js` — 3 passed
- `SERVICE_LASSO_RELEASE_VERSION=2026.5.8-policytest npm run release:verify` — passed
- `node scripts/check-release-assets.mjs 2026.5.8-policytest ...all eight expected assets...` — passed
- `node scripts/check-release-assets.mjs --expected 2026.5.8-policytest` — listed all eight policy assets
- `git diff --check` — passed

## Notes
- Full `npm test` was not used as the primary gate because #394 tracks a known deterministic existing `tests/install-acquire.test.js` failure on Windows outside this release asset policy scope.
