### PR TITLE
ISS-394 resolve artifact command args from install root

### DIFF
--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { createWriteStream, type WriteStream } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
-import { resolveExecutionArgs } from "./commandline.js";
+import { resolveExecutionArgs, selectPlatformCommandline } from "./commandline.js";
 import { buildServiceVariables } from "../operator/variables.js";
 import { archiveRuntimeLogs, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
@@ -141,6 +141,36 @@ function resolveWorkingDirectory(service: DiscoveredService, _executionPlan: Pro
   return service.serviceRoot;
 }
 
+function resolveCommandRootArgument(commandRoot: string, arg: string): string {
+  if (path.isAbsolute(arg)) {
+    return arg;
+  }
+
+  if (arg.startsWith(".")) {
+    return path.resolve(commandRoot, arg);
+  }
+
+  const equalsIndex = arg.indexOf("=");
+  if (equalsIndex > 0) {
+    const option = arg.slice(0, equalsIndex + 1);
+    const value = arg.slice(equalsIndex + 1);
+    if (value.startsWith(".") && !path.isAbsolute(value)) {
+      return `${option}${path.resolve(commandRoot, value)}`;
+    }
+  }
+
+  return arg;
+}
+
+function resolveCommandRootArgs(service: DiscoveredService, executionPlan: ProviderExecutionPlan, args: string[]): string[] {
+  const commandRoot = executionPlan.commandRoot;
+  if (!commandRoot || selectPlatformCommandline(service.manifest.commandline)) {
+    return args;
+  }
+
+  return args.map((arg) => resolveCommandRootArgument(commandRoot, arg));
+}
+
 function buildCommandString(executable: string, args: string[]): string {
   return [executable, ...args].join(" ");
 }
@@ -181,7 +211,11 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const executable = resolveExecutable(service, executionPlan);
   const workingDirectory = resolveWorkingDirectory(service, executionPlan, executable);
-  const args = resolveExecutionArgs(service, executionPlan, sharedGlobalEnv, resolvedPorts);
+  const args = resolveCommandRootArgs(
+    service,
+    executionPlan,
+    resolveExecutionArgs(service, executionPlan, sharedGlobalEnv, resolvedPorts),
+  );
   const command = buildCommandString(executable, args);
   const startedAt = new Date().toISOString();
   const { paths: logPaths, streams: logStreams } = await prepareRuntimeLogStreams(service.serviceRoot);

--- a/tests/install-acquire.test.js
+++ b/tests/install-acquire.test.js
@@ -242,14 +242,15 @@ test("start prefers an installed artifact command over a checked-in fixture comm
     const config = await postJson(`${apiServer.url}/api/services/downloaded-service/config`);
     const start = await postJson(`${apiServer.url}/api/services/downloaded-service/start`);
     const extractedPath = install.body.state.installArtifacts.artifact.extractedPath;
-    const cwdProofPath = path.join(extractedPath, "artifact-cwd.txt");
+    const cwdProofPath = path.join(servicesRoot, "downloaded-service", "artifact-cwd.txt");
     const cwdProof = await waitFor(() => readFile(cwdProofPath, "utf8"));
     const stop = await postJson(`${apiServer.url}/api/services/downloaded-service/stop`);
 
     assert.equal(config.status, 200);
     assert.equal(start.status, 200);
     assert.equal(start.body.state.running, true);
-    assert.equal(cwdProof, extractedPath);
+    assert.equal(path.resolve(cwdProof), path.resolve(servicesRoot, "downloaded-service"));
+    assert.equal(start.body.state.runtime.command.includes(path.join(extractedPath, "runtime", "downloaded-service.mjs")), true);
     assert.match(start.body.state.runtime.command, /downloaded-service\.mjs/);
     assert.doesNotMatch(start.body.state.runtime.command, /local-fixture-should-not-run/);
     assert.equal(stop.status, 200);


### PR DESCRIPTION
Closes #394

## Summary
- Confirmed the install-acquire failure was reproducible on Windows before the fix.
- Preserves the existing lifecycle contract that managed processes run from the service root working directory.
- Resolves relative/path-like installed artifact command args against the artifact extraction root so artifact-owned runtime entrypoints like `./runtime/downloaded-service.mjs` launch correctly even while cwd remains the service root.
- Updates the install-acquire regression test to assert both: artifact command wins over the checked-in fixture, and cwd remains the service root.

## Validation
- Reproduced before fix: `node --test --test-concurrency=1 tests/install-acquire.test.js` failed on `start prefers an installed artifact command over a checked-in fixture command` with missing `artifact-cwd.txt`.
- `npm run build` — passed
- `node --test --test-concurrency=1 tests/install-acquire.test.js tests/commandline-execution.test.js` — 9 passed
- `npm test` — 179 passed
- `git diff --check` — passed
