### PR TITLE
#399 Add canonical Secrets Broker namespace buckets

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -204,6 +204,41 @@ This keeps `install` and `config` explicit (as discussed), but removes unnecessa
     "globalenv": {
       "<GLOBAL_ENV_KEY>": "<value>"
     },
+    "broker": {
+      "enabled": true,
+      "namespace": "services/<service-id>",
+      "buckets": [
+        {
+          "namespace": "services/<service-id>",
+          "kind": "service",
+          "description": "private current-service values"
+        },
+        {
+          "namespace": "shared/<bucket>",
+          "kind": "shared"
+        }
+      ],
+      "imports": [
+        {
+          "namespace": "shared/<bucket>",
+          "ref": "bucket.KEY",
+          "as": "PROCESS_ENV_NAME",
+          "required": true
+        }
+      ],
+      "exports": [
+        {
+          "namespace": "services/<service-id>",
+          "ref": "service.KEY",
+          "source": "${LOCAL_ENV}",
+          "required": false
+        }
+      ],
+      "writeback": {
+        "allowedNamespaces": ["services/<service-id>"],
+        "allowedOperations": ["create", "update", "rotate", "delete"]
+      }
+    },
     "depend_on": [
       "<dependency-service-id>"
     ],

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -360,6 +360,17 @@ Shape:
 "broker": {
   "enabled": true,
   "namespace": "services/consumer",
+  "buckets": [
+    {
+      "namespace": "services/consumer",
+      "kind": "service",
+      "description": "private values for this service"
+    },
+    {
+      "namespace": "shared/database",
+      "kind": "shared"
+    }
+  ],
   "imports": [
     {
       "namespace": "shared/database",
@@ -386,10 +397,14 @@ Shape:
 Fields:
 - `enabled`: optional boolean. `false` can be used to leave a declared broker contract dormant.
 - `namespace`: optional default service namespace. It must be a non-empty broker namespace string such as `services/consumer`.
+- `buckets`: optional array declaring the namespace buckets this manifest participates in. Bucket namespaces must be unique.
+- `buckets[].namespace`: a namespace boundary such as `services/consumer`, `apps/reference`, `shared/database`, or `global`.
+- `buckets[].kind`: optional bucket kind: `service`, `app`, `shared`, or `global`.
+- `buckets[].description`: optional human-readable note for review/audit.
 - `imports`: optional array of explicit broker refs the service may consume.
 - `imports[].namespace`: namespace authorization boundary for the import.
 - `imports[].ref`: dotted broker selector such as `database.PASSWORD`.
-- `imports[].as`: optional local variable name to materialize the import into.
+- `imports[].as`: optional local variable name to materialize the import into. This stays service-specific, so a ref such as `${database.PASSWORD}` can become `DB_PASSWORD` for one process and `PGPASSWORD` for another.
 - `imports[].required`: optional boolean; required imports should fail closed when absent or denied.
 - `exports`: optional array of values this service publishes to broker namespaces.
 - `exports[].namespace`: namespace authorization boundary for the export.
@@ -404,6 +419,8 @@ Selector semantics:
 - `${namespace.KEY}` means an explicit broker lookup.
 - Bare names never fall through into broker namespaces.
 - Broker refs must be dotted. This keeps broker access reviewable and prevents accidental secret reads from ordinary env selectors.
+- Duplicate bucket namespaces, duplicate import refs, duplicate `imports[].as` names, and duplicate export namespace/ref pairs are invalid.
+- `imports[].as` may intentionally line up with an `env` key only when that env value is exactly the same dotted broker selector, for example `"DB_PASSWORD": "${database.PASSWORD}"`. It must not collide with `globalenv` output names.
 
 Producer example:
 ```json
@@ -417,6 +434,9 @@ Producer example:
   "broker": {
     "enabled": true,
     "namespace": "services/token-producer",
+    "buckets": [
+      { "namespace": "services/token-producer", "kind": "service" }
+    ],
     "exports": [
       {
         "namespace": "services/token-producer",
@@ -445,6 +465,10 @@ Consumer example:
   "broker": {
     "enabled": true,
     "namespace": "services/token-consumer",
+    "buckets": [
+      { "namespace": "services/token-consumer", "kind": "service" },
+      { "namespace": "services/token-producer", "kind": "shared" }
+    ],
     "imports": [
       {
         "namespace": "services/token-producer",
@@ -466,6 +490,8 @@ Migration from `globalenv`:
 }
 ```
 
+Legacy `globalenv` remains a compatibility path for bounded provider/tool values that are already safe to share. New cross-service secret flow should move to explicit broker imports/exports so values are bucketed as current-service, app-level, explicitly shared, or truly global instead of ambiently merged into every launched process.
+
 Becomes an explicit broker contract:
 ```json
 {
@@ -475,6 +501,10 @@ Becomes an explicit broker contract:
   "broker": {
     "enabled": true,
     "namespace": "services/api",
+    "buckets": [
+      { "namespace": "services/api", "kind": "service" },
+      { "namespace": "shared/database", "kind": "shared" }
+    ],
     "imports": [
       {
         "namespace": "shared/database",

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -131,6 +131,14 @@ export interface ServiceArchiveArtifact {
 
 export type ServiceRole = "service" | "provider";
 
+export type ServiceBrokerBucketKind = "service" | "app" | "shared" | "global";
+
+export interface ServiceBrokerBucket {
+  namespace: string;
+  kind?: ServiceBrokerBucketKind;
+  description?: string;
+}
+
 export interface ServiceBrokerImport {
   namespace: string;
   ref: string;
@@ -155,6 +163,7 @@ export interface ServiceBrokerWritebackPolicy {
 export interface ServiceBrokerPolicy {
   enabled?: boolean;
   namespace?: string;
+  buckets?: ServiceBrokerBucket[];
   imports?: ServiceBrokerImport[];
   exports?: ServiceBrokerExport[];
   writeback?: ServiceBrokerWritebackPolicy;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1,4 +1,5 @@
 import type {
+  ServiceBrokerBucketKind,
   ServiceBrokerWritebackOperation,
   ServiceHookFailurePolicy,
   ServiceHookStep,
@@ -19,6 +20,7 @@ const updateWindowDays = new Set(["mon", "tue", "wed", "thu", "fri", "sat", "sun
 const serviceRoles = new Set(["service", "provider"]);
 const setupRerunPolicies = new Set(["manual", "ifMissing", "always"]);
 const brokerWritebackOperations = new Set(["create", "update", "rotate", "delete"]);
+const brokerBucketKinds = new Set(["service", "app", "shared", "global"]);
 const brokerNamespacePattern = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.-]*)*$/;
 const brokerRefPattern = /^[A-Za-z][A-Za-z0-9_-]*\.[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 
@@ -414,6 +416,16 @@ function readUpdateInstallWindow(
   };
 }
 
+function validateUniqueEntries(values: string[], field: string, manifestPath: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: duplicate ${field} entry "${value}".`);
+    }
+    seen.add(value);
+  }
+}
+
 function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest["broker"] | undefined {
   if (value === undefined) {
     return undefined;
@@ -424,6 +436,10 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
   }
 
   const record = value as Record<string, unknown>;
+  const buckets = record.buckets;
+  if (buckets !== undefined && !Array.isArray(buckets)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.buckets" to be an array.`);
+  }
   const imports = record.imports;
   if (imports !== undefined && !Array.isArray(imports)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.imports" to be an array.`);
@@ -455,9 +471,32 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
   );
   allowedNamespaces?.forEach((namespace) => expectBrokerNamespace(namespace, "broker.writeback.allowedNamespaces", manifestPath));
 
+  const parsedBuckets = Array.isArray(buckets)
+    ? buckets.map((entry, index) => {
+        const field = `broker.buckets[${index}]`;
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+        }
+        const bucketRecord = entry as Record<string, unknown>;
+        const kind = bucketRecord.kind;
+        if (kind !== undefined && (typeof kind !== "string" || !brokerBucketKinds.has(kind))) {
+          throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}.kind" to be one of service, app, shared, or global.`);
+        }
+        return {
+          namespace: expectBrokerNamespace(bucketRecord.namespace, `${field}.namespace`, manifestPath),
+          ...(kind === undefined ? {} : { kind: kind as ServiceBrokerBucketKind }),
+          ...(bucketRecord.description === undefined
+            ? {}
+            : { description: expectNonEmptyString(bucketRecord.description, `${field}.description`, manifestPath) }),
+        };
+      })
+    : undefined;
+  validateUniqueEntries(parsedBuckets?.map((entry) => entry.namespace) ?? [], "broker.buckets.namespace", manifestPath);
+
   return {
     enabled: expectOptionalBoolean(record.enabled, "broker.enabled", manifestPath),
     namespace: record.namespace === undefined ? undefined : expectBrokerNamespace(record.namespace, "broker.namespace", manifestPath),
+    buckets: parsedBuckets,
     imports: Array.isArray(imports)
       ? imports.map((entry, index) => {
           const field = `broker.imports[${index}]`;
@@ -495,6 +534,44 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
         }
       : undefined,
   };
+}
+
+function validateBrokerCollisions(
+  broker: ServiceManifest["broker"],
+  env: Record<string, string> | undefined,
+  globalenv: Record<string, string> | undefined,
+  manifestPath: string,
+): void {
+  if (!broker) {
+    return;
+  }
+
+  validateUniqueEntries((broker.imports ?? []).map((entry) => entry.ref), "broker.imports.ref", manifestPath);
+  validateUniqueEntries(
+    (broker.imports ?? []).flatMap((entry) => (entry.as ? [entry.as] : [])),
+    "broker.imports.as",
+    manifestPath,
+  );
+  validateUniqueEntries(
+    (broker.exports ?? []).map((entry) => `${entry.namespace}:${entry.ref}`),
+    "broker.exports namespace/ref",
+    manifestPath,
+  );
+
+  const envKeys = new Set(Object.keys(env ?? {}));
+  const globalKeys = new Set(Object.keys(globalenv ?? {}));
+  for (const entry of broker.imports ?? []) {
+    if (entry.as && globalKeys.has(entry.as)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.imports.as "${entry.as}" collides with legacy globalenv output; map it through service-local env instead.`,
+      );
+    }
+    if (entry.as && envKeys.has(entry.as) && env?.[entry.as] !== `\${${entry.ref}}`) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.imports.as "${entry.as}" collides with env.${entry.as}; env values for broker imports must be exactly "\${${entry.ref}}".`,
+      );
+    }
+  }
 }
 
 function readUpdatePolicy(
@@ -862,6 +939,11 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   }
 
   const broker = readBrokerPolicy(record.broker, manifestPath);
+  const env = rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined;
+  const globalenv = rawGlobalEnv
+    ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
+    : undefined;
+  validateBrokerCollisions(broker, env, globalenv, manifestPath);
   const artifact = readArtifact(record.artifact, manifestPath);
   const install = readActionMaterialization(record.install, "install", manifestPath);
   const config = readActionMaterialization(record.config, "config", manifestPath);
@@ -882,10 +964,8 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     autostart: typeof record.autostart === "boolean" ? record.autostart : undefined,
     depend_on: dependOn?.map((dependency) => dependency.trim()),
     healthcheck,
-    env: rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined,
-    globalenv: rawGlobalEnv
-      ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
-      : undefined,
+    env,
+    globalenv,
     broker,
     ports: rawPorts
       ? Object.fromEntries(Object.entries(rawPorts as Record<string, number>).map(([key, value]) => [key.trim(), value]))

--- a/src/runtime/operator/dashboard.ts
+++ b/src/runtime/operator/dashboard.ts
@@ -166,17 +166,21 @@ function buildDashboardLinks(endpoints: DashboardEndpointResponse[]): DashboardS
     }));
 }
 
-function mapVariableScope(scope: "manifest" | "derived" | "global"): "global" | "service" {
+function mapVariableScope(scope: "manifest" | "derived" | "global" | "broker"): "global" | "service" {
   return scope === "global" ? "global" : "service";
 }
 
-function mapVariableSource(scope: "manifest" | "derived" | "global"): string {
+function mapVariableSource(scope: "manifest" | "derived" | "global" | "broker"): string {
   if (scope === "manifest") {
     return "service.json";
   }
 
   if (scope === "global") {
     return "globalenv";
+  }
+
+  if (scope === "broker") {
+    return "broker.imports";
   }
 
   return "runtime";

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 export interface ServiceVariableEntry {
   key: string;
   value: string;
-  scope: "manifest" | "derived" | "global";
+  scope: "manifest" | "derived" | "global" | "broker";
 }
 
 export type ServiceSelectorKind = "local" | "broker";
@@ -36,6 +36,8 @@ export interface ServiceTextResolutionOptions {
   brokerValues?: Record<string, string>;
   diagnostics?: ServiceSelectorDiagnostic[];
 }
+
+export interface ServiceVariableResolutionOptions extends ServiceTextResolutionOptions {}
 
 export interface ServiceVariablesPayload {
   serviceId: string;
@@ -159,6 +161,7 @@ export function buildServiceVariables(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
+  options: ServiceVariableResolutionOptions = {},
 ): ServiceVariablesPayload {
   const statePaths = getServiceStatePaths(service.serviceRoot);
   const installArtifact = getLifecycleState(service.manifest.id).installArtifacts.artifact;
@@ -227,12 +230,25 @@ export function buildServiceVariables(
     ...entry,
     value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables], {
       diagnostics: manifestDiagnostics,
+      brokerValues: options.brokerValues,
     }),
   }));
 
+  const manifestVariableKeys = new Set(manifestVariables.map((entry) => entry.key));
+  const brokerImportVariables = (service.manifest.broker?.imports ?? [])
+    .filter((entry) => entry.as && !manifestVariableKeys.has(entry.as))
+    .flatMap((entry): ServiceVariableEntry[] => {
+      const brokerValue = options.brokerValues?.[entry.ref];
+      if (brokerValue === undefined) {
+        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "missing-broker" });
+        return [];
+      }
+      return [{ key: entry.as as string, value: brokerValue, scope: "broker" }];
+    });
+
   return {
     serviceId: service.manifest.id,
-    variables: [...manifestVariables, ...globalVariables, ...derivedVariables],
+    variables: [...manifestVariables, ...brokerImportVariables, ...globalVariables, ...derivedVariables],
     selectorPlan: compileServiceSelectorPlan(service.manifest.env ?? {}),
     diagnostics: manifestDiagnostics,
   };
@@ -259,6 +275,8 @@ export function compileServiceMaterializationSelectorPlan(service: DiscoveredSer
   return mergeSelectorPlans([
     compileServiceSelectorPlan(service.manifest.env ?? {}),
     compileServiceSelectorPlan(service.manifest.globalenv ?? {}),
+    compileServiceSelectorPlan((service.manifest.broker?.imports ?? []).map((entry) => `\${${entry.ref}}`)),
+    compileServiceSelectorPlan((service.manifest.broker?.exports ?? []).flatMap((entry) => [`\${${entry.ref}}`, entry.source])),
     compileServiceSelectorPlan(installFiles.flatMap((file) => [file.path, file.content])),
     compileServiceSelectorPlan(configFiles.flatMap((file) => [file.path, file.content])),
   ]);

--- a/src/server/routes/variables.ts
+++ b/src/server/routes/variables.ts
@@ -1,7 +1,7 @@
 export interface ServiceVariablesResponse {
   variables: {
     serviceId: string;
-    variables: { key: string; value: string; scope: "manifest" | "derived" | "global" }[];
+    variables: { key: string; value: string; scope: "manifest" | "derived" | "global" | "broker" }[];
   };
 }
 

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -390,6 +390,17 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
         broker: {
           enabled: true,
           namespace: "services/broker-consumer",
+          buckets: [
+            {
+              namespace: "services/broker-consumer",
+              kind: "service",
+              description: "Current-service private values.",
+            },
+            {
+              namespace: "shared/database",
+              kind: "shared",
+            },
+          ],
           imports: [
             {
               namespace: "shared/database",
@@ -419,6 +430,17 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
     assert.deepEqual(manifest.broker, {
       enabled: true,
       namespace: "services/broker-consumer",
+      buckets: [
+        {
+          namespace: "services/broker-consumer",
+          kind: "service",
+          description: "Current-service private values.",
+        },
+        {
+          namespace: "shared/database",
+          kind: "shared",
+        },
+      ],
       imports: [
         {
           namespace: "shared/database",
@@ -467,6 +489,26 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
       description: "Invalid writeback operation.",
       broker: { writeback: { allowedNamespaces: ["runtime"], allowedOperations: ["read"] } },
     });
+    await writeManifest(servicesRoot, "duplicate-import", {
+      id: "duplicate-import",
+      name: "Duplicate Import",
+      description: "Duplicate broker import env mapping.",
+      broker: {
+        imports: [
+          { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" },
+          { namespace: "shared/database", ref: "database.USER", as: "DB_PASSWORD" },
+        ],
+      },
+    });
+    await writeManifest(servicesRoot, "env-import-collision", {
+      id: "env-import-collision",
+      name: "Env Import Collision",
+      description: "Broker import collides with unrelated local env.",
+      env: { DB_PASSWORD: "literal" },
+      broker: {
+        imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
+      },
+    });
 
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "bad-enabled", "service.json")),
@@ -479,6 +521,14 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "bad-writeback", "service.json")),
       /broker\.writeback\.allowedOperations/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "duplicate-import", "service.json")),
+      /broker\.imports\.as/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "env-import-collision", "service.json")),
+      /collides with env\.DB_PASSWORD/i,
     );
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -64,6 +64,42 @@ test("service variable resolution preserves local precedence and legacy globalen
   assert.equal(byKey.FROM_GLOBAL, "C:/tools/legacy");
 });
 
+test("broker imports materialize to service-specific env names", () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      FROM_SELECTOR: "${database.PASSWORD}",
+    },
+    broker: {
+      enabled: true,
+      namespace: "services/consumer",
+      buckets: [
+        { namespace: "services/consumer", kind: "service" },
+        { namespace: "shared/database", kind: "shared" },
+      ],
+      imports: [
+        { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
+        { namespace: "services/consumer", ref: "consumer.API_TOKEN", as: "API_TOKEN" },
+      ],
+    },
+  });
+
+  const payload = buildServiceVariables(service, {}, {}, {
+    brokerValues: {
+      "database.PASSWORD": "resolved-password",
+      "consumer.API_TOKEN": "resolved-token",
+    },
+  });
+  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry]));
+
+  assert.deepEqual(payload.diagnostics, []);
+  assert.equal(byKey.FROM_SELECTOR.value, "resolved-password");
+  assert.equal(byKey.FROM_SELECTOR.scope, "manifest");
+  assert.equal(byKey.DB_PASSWORD.value, "resolved-password");
+  assert.equal(byKey.DB_PASSWORD.scope, "broker");
+  assert.equal(byKey.API_TOKEN.value, "resolved-token");
+});
+
 test("bare selectors do not fall back into broker namespaces", () => {
   resetLifecycleState();
   const service = fixtureService({ env: { LOCAL_SECRET: "${API_KEY}" } });
@@ -100,14 +136,25 @@ test("materialization selector plan covers env, globalenv, install, and config t
   const service = fixtureService({
     env: { LOCAL_SECRET_REF: "${secretsbroker.API_KEY}" },
     globalenv: { TOOL_HOME: "${SERVICE_ROOT}/tool" },
+    broker: {
+      imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
+      exports: [{ namespace: "consumer/runtime", ref: "consumer.PUBLIC_URL", source: "${PUBLIC_URL}" }],
+    },
     install: { files: [{ path: "generated/${SERVICE_ID}.txt", content: "${vault.shared.token}" }] },
     config: { files: [{ path: "config/${secretsbroker.CONFIG_NAME}.json", content: "${LOCAL_SECRET_REF}" }] },
   });
 
   const plan = compileServiceMaterializationSelectorPlan(service);
 
-  assert.deepEqual(plan.brokerRefs, ["secretsbroker.API_KEY", "vault.shared.token", "secretsbroker.CONFIG_NAME"]);
+  assert.deepEqual(plan.brokerRefs, [
+    "secretsbroker.API_KEY",
+    "database.PASSWORD",
+    "consumer.PUBLIC_URL",
+    "vault.shared.token",
+    "secretsbroker.CONFIG_NAME",
+  ]);
   assert.ok(plan.localRefs.includes("SERVICE_ROOT"));
+  assert.ok(plan.localRefs.includes("PUBLIC_URL"));
   assert.ok(plan.localRefs.includes("SERVICE_ID"));
   assert.ok(plan.localRefs.includes("LOCAL_SECRET_REF"));
 });


### PR DESCRIPTION
## Summary
- add broker namespace bucket declarations (`service`, `app`, `shared`, `global`) to the service manifest contract
- materialize explicit broker imports to service-specific env names while preserving dotted selector semantics
- validate duplicate/colliding broker namespaces, refs, import env aliases, export refs, and unsafe `globalenv`/env collisions
- document bucket examples and the compatibility migration path from legacy `globalenv`

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/variable-selector-planning.test.js tests/manifest-discovery.test.js`
- `npm run build && node --test --test-concurrency=1 tests/variable-selector-planning.test.js tests/manifest-discovery.test.js tests/operator-data.test.js` → 44/44 pass
- `git diff --check`
- `npm test` → 180/180 pass

Closes #399