### PR TITLE
#400 Add broker import writeback contract

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -236,7 +236,18 @@ This keeps `install` and `config` explicit (as discussed), but removes unnecessa
       ],
       "writeback": {
         "allowedNamespaces": ["services/<service-id>"],
-        "allowedOperations": ["create", "update", "rotate", "delete"]
+        "allowedOperations": ["create", "update", "rotate", "delete"],
+        "allowedRefs": ["service.KEY"],
+        "allowOverwrite": false,
+        "auditReason": "capture generated service secret",
+        "generatedSecrets": [
+          {
+            "ref": "service.KEY",
+            "source": "${LOCAL_ENV}",
+            "operation": "create",
+            "required": false
+          }
+        ]
       }
     },
     "depend_on": [

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -389,7 +389,18 @@ Shape:
   ],
   "writeback": {
     "allowedNamespaces": ["services/producer"],
-    "allowedOperations": ["create", "update", "rotate"]
+    "allowedOperations": ["create", "update", "rotate"],
+    "allowedRefs": ["producer.API_TOKEN"],
+    "allowOverwrite": false,
+    "auditReason": "capture generated service token",
+    "generatedSecrets": [
+      {
+        "ref": "producer.API_TOKEN",
+        "source": "${API_TOKEN}",
+        "operation": "create",
+        "required": true
+      }
+    ]
   }
 }
 ```
@@ -413,13 +424,21 @@ Fields:
 - `exports[].required`: optional boolean; required exports should fail closed when the source is unavailable.
 - `writeback.allowedNamespaces`: optional array limiting namespaces this service may write generated secrets into.
 - `writeback.allowedOperations`: optional array of allowed generated-secret operations: `create`, `update`, `rotate`, `delete`.
+- `writeback.allowedRefs`: optional array limiting generated-secret refs within the allowed namespaces.
+- `writeback.allowOverwrite`: optional boolean; defaults should be treated as no overwrite unless a broker implementation explicitly opts in.
+- `writeback.auditReason`: optional non-empty operator/audit reason attached to generated-secret capture.
+- `writeback.generatedSecrets`: optional array declaring generated values that may be captured from service-local variables and written back through the broker.
+- `writeback.generatedSecrets[].ref`: dotted broker ref that must also have a matching `exports[].ref`.
+- `writeback.generatedSecrets[].source`: local selector or literal source, for example `${API_TOKEN}`. Sources are resolved from service-local variables; raw secret values must not be logged.
+- `writeback.generatedSecrets[].operation`: optional operation for this capture: `create`, `update`, `rotate`, or `delete`.
+- `writeback.generatedSecrets[].required`: optional boolean; required captures should fail closed when the source cannot be resolved.
 
 Selector semantics:
 - `${VAR}` means local/current-service variables only, including derived variables and legacy-compatible values already visible to the service.
 - `${namespace.KEY}` means an explicit broker lookup.
 - Bare names never fall through into broker namespaces.
 - Broker refs must be dotted. This keeps broker access reviewable and prevents accidental secret reads from ordinary env selectors.
-- Duplicate bucket namespaces, duplicate import refs, duplicate `imports[].as` names, and duplicate export namespace/ref pairs are invalid.
+- Duplicate bucket namespaces, duplicate import refs, duplicate `imports[].as` names, duplicate export namespace/ref pairs, duplicate writeback refs, and duplicate generated-secret refs are invalid.
 - `imports[].as` may intentionally line up with an `env` key only when that env value is exactly the same dotted broker selector, for example `"DB_PASSWORD": "${database.PASSWORD}"`. It must not collide with `globalenv` output names.
 
 Producer example:
@@ -447,7 +466,18 @@ Producer example:
     ],
     "writeback": {
       "allowedNamespaces": ["services/token-producer"],
-      "allowedOperations": ["create", "update", "rotate"]
+      "allowedOperations": ["create", "update", "rotate"],
+      "allowedRefs": ["token.PUBLIC_URL"],
+      "allowOverwrite": false,
+      "auditReason": "publish generated token endpoint",
+      "generatedSecrets": [
+        {
+          "ref": "token.PUBLIC_URL",
+          "source": "${PUBLIC_URL}",
+          "operation": "create",
+          "required": true
+        }
+      ]
     }
   }
 }

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -4,12 +4,17 @@
   "description": "Tracked provider-backed sample service used to prove real @node execution through the core runtime.",
   "version": "0.1.0",
   "enabled": true,
-  "depend_on": ["@node"],
+  "depend_on": [
+    "@node"
+  ],
   "execservice": "@node",
-  "args": ["runtime/server.mjs"],
+  "args": [
+    "runtime/server.mjs"
+  ],
   "env": {
     "NODE_SAMPLE_ENV_PATH": "./.state/provider-env.json",
-    "NODE_SAMPLE_PORT": "${SERVICE_PORT}"
+    "NODE_SAMPLE_PORT": "${SERVICE_PORT}",
+    "NODE_SAMPLE_API_TOKEN": "${sample.API_TOKEN}"
   },
   "ports": {
     "service": 4020
@@ -23,5 +28,57 @@
   ],
   "healthcheck": {
     "type": "process"
+  },
+  "broker": {
+    "enabled": true,
+    "namespace": "services/node-sample-service",
+    "buckets": [
+      {
+        "namespace": "services/node-sample-service",
+        "kind": "service"
+      },
+      {
+        "namespace": "shared/sample",
+        "kind": "shared"
+      }
+    ],
+    "imports": [
+      {
+        "namespace": "shared/sample",
+        "ref": "sample.API_TOKEN",
+        "as": "NODE_SAMPLE_API_TOKEN",
+        "required": false
+      }
+    ],
+    "writeback": {
+      "allowedNamespaces": [
+        "services/node-sample-service"
+      ],
+      "allowedOperations": [
+        "create",
+        "rotate"
+      ],
+      "allowedRefs": [
+        "sample.GENERATED_TOKEN"
+      ],
+      "allowOverwrite": false,
+      "auditReason": "sample service generated token capture",
+      "generatedSecrets": [
+        {
+          "ref": "sample.GENERATED_TOKEN",
+          "source": "${NODE_SAMPLE_API_TOKEN}",
+          "operation": "create",
+          "required": false
+        }
+      ]
+    },
+    "exports": [
+      {
+        "namespace": "services/node-sample-service",
+        "ref": "sample.GENERATED_TOKEN",
+        "source": "${NODE_SAMPLE_API_TOKEN}",
+        "required": false
+      }
+    ]
   }
 }

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -146,6 +146,13 @@ export interface ServiceBrokerImport {
   required?: boolean;
 }
 
+export interface ServiceBrokerWritebackCapture {
+  ref: string;
+  source: string;
+  operation?: ServiceBrokerWritebackOperation;
+  required?: boolean;
+}
+
 export interface ServiceBrokerExport {
   namespace: string;
   ref: string;
@@ -158,6 +165,10 @@ export type ServiceBrokerWritebackOperation = "create" | "update" | "rotate" | "
 export interface ServiceBrokerWritebackPolicy {
   allowedNamespaces?: string[];
   allowedOperations?: ServiceBrokerWritebackOperation[];
+  allowedRefs?: string[];
+  allowOverwrite?: boolean;
+  auditReason?: string;
+  generatedSecrets?: ServiceBrokerWritebackCapture[];
 }
 
 export interface ServiceBrokerPolicy {

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -470,6 +470,40 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
     manifestPath,
   );
   allowedNamespaces?.forEach((namespace) => expectBrokerNamespace(namespace, "broker.writeback.allowedNamespaces", manifestPath));
+  const allowedRefs = readNonEmptyStringArray(writebackRecord?.allowedRefs, "broker.writeback.allowedRefs", manifestPath);
+  allowedRefs?.forEach((ref) => expectBrokerRef(ref, "broker.writeback.allowedRefs", manifestPath));
+  validateUniqueEntries(allowedRefs ?? [], "broker.writeback.allowedRefs", manifestPath);
+  const allowOverwrite = expectOptionalBoolean(writebackRecord?.allowOverwrite, "broker.writeback.allowOverwrite", manifestPath);
+  const auditReason =
+    writebackRecord?.auditReason === undefined
+      ? undefined
+      : expectNonEmptyString(writebackRecord.auditReason, "broker.writeback.auditReason", manifestPath);
+  const generatedSecrets = writebackRecord?.generatedSecrets;
+  if (generatedSecrets !== undefined && !Array.isArray(generatedSecrets)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.writeback.generatedSecrets" to be an array.`);
+  }
+  const parsedGeneratedSecrets = Array.isArray(generatedSecrets)
+    ? generatedSecrets.map((entry, index) => {
+        const field = `broker.writeback.generatedSecrets[${index}]`;
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+        }
+        const captureRecord = entry as Record<string, unknown>;
+        const operation = captureRecord.operation;
+        if (operation !== undefined && (typeof operation !== "string" || !brokerWritebackOperations.has(operation))) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "${field}.operation" to contain create, update, rotate, or delete.`,
+          );
+        }
+        return {
+          ref: expectBrokerRef(captureRecord.ref, `${field}.ref`, manifestPath),
+          source: expectNonEmptyString(captureRecord.source, `${field}.source`, manifestPath),
+          ...(operation === undefined ? {} : { operation: operation as ServiceBrokerWritebackOperation }),
+          required: expectOptionalBoolean(captureRecord.required, `${field}.required`, manifestPath),
+        };
+      })
+    : undefined;
+  validateUniqueEntries(parsedGeneratedSecrets?.map((entry) => entry.ref) ?? [], "broker.writeback.generatedSecrets.ref", manifestPath);
 
   const parsedBuckets = Array.isArray(buckets)
     ? buckets.map((entry, index) => {
@@ -531,6 +565,10 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
       ? {
           allowedNamespaces,
           allowedOperations: allowedOperations as ServiceBrokerWritebackOperation[] | undefined,
+          allowedRefs,
+          allowOverwrite,
+          auditReason,
+          generatedSecrets: parsedGeneratedSecrets,
         }
       : undefined,
   };
@@ -557,6 +595,32 @@ function validateBrokerCollisions(
     "broker.exports namespace/ref",
     manifestPath,
   );
+  const allowedWritebackNamespaces = new Set(broker.writeback?.allowedNamespaces ?? []);
+  const allowedWritebackRefs = new Set(broker.writeback?.allowedRefs ?? []);
+  const allowedWritebackOperations = new Set(broker.writeback?.allowedOperations ?? []);
+  for (const entry of broker.writeback?.generatedSecrets ?? []) {
+    const exportEntry = (broker.exports ?? []).find((candidate) => candidate.ref === entry.ref);
+    if (!exportEntry) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" must have a matching broker.exports entry.`,
+      );
+    }
+    if (allowedWritebackNamespaces.size > 0 && !allowedWritebackNamespaces.has(exportEntry.namespace)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" targets namespace "${exportEntry.namespace}" outside broker.writeback.allowedNamespaces.`,
+      );
+    }
+    if (allowedWritebackRefs.size > 0 && !allowedWritebackRefs.has(entry.ref)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" is outside broker.writeback.allowedRefs.`,
+      );
+    }
+    if (entry.operation && allowedWritebackOperations.size > 0 && !allowedWritebackOperations.has(entry.operation)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" uses operation "${entry.operation}" outside broker.writeback.allowedOperations.`,
+      );
+    }
+  }
 
   const envKeys = new Set(Object.keys(env ?? {}));
   const globalKeys = new Set(Object.keys(globalenv ?? {}));

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -24,7 +24,7 @@ export interface ServiceSelectorPlan {
   brokerRefs: string[];
 }
 
-export type ServiceSelectorDiagnosticReason = "unresolved-local" | "missing-broker";
+export type ServiceSelectorDiagnosticReason = "unresolved-local" | "missing-broker" | "denied-broker" | "source-auth-required";
 
 export interface ServiceSelectorDiagnostic {
   selector: string;
@@ -35,6 +35,9 @@ export interface ServiceSelectorDiagnostic {
 export interface ServiceTextResolutionOptions {
   brokerValues?: Record<string, string>;
   diagnostics?: ServiceSelectorDiagnostic[];
+  allowedBrokerRefs?: Set<string> | string[];
+  deniedBrokerRefs?: Set<string> | string[];
+  sourceAuthRequiredBrokerRefs?: Set<string> | string[];
 }
 
 export interface ServiceVariableResolutionOptions extends ServiceTextResolutionOptions {}
@@ -133,6 +136,13 @@ function mergeSelectorPlans(plans: ServiceSelectorPlan[]): ServiceSelectorPlan {
   };
 }
 
+function hasRef(refs: Set<string> | string[] | undefined, ref: string): boolean {
+  if (!refs) {
+    return false;
+  }
+  return Array.isArray(refs) ? refs.includes(ref) : refs.has(ref);
+}
+
 function replaceVariableSelectors(
   value: string,
   variables: ServiceVariableEntry[],
@@ -141,6 +151,18 @@ function replaceVariableSelectors(
   return value.replace(/\$\{([^}]+)\}/g, (match, key) => {
     const ref = createSelectorRef(key);
     if (ref.kind === "broker") {
+      if (options.allowedBrokerRefs && !hasRef(options.allowedBrokerRefs, ref.selector)) {
+        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+        return match;
+      }
+      if (hasRef(options.deniedBrokerRefs, ref.selector)) {
+        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+        return match;
+      }
+      if (hasRef(options.sourceAuthRequiredBrokerRefs, ref.selector)) {
+        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "source-auth-required" });
+        return match;
+      }
       const brokerValue = options.brokerValues?.[ref.selector];
       if (brokerValue !== undefined) {
         return brokerValue;
@@ -226,18 +248,30 @@ export function buildServiceVariables(
   ];
 
   const manifestDiagnostics: ServiceSelectorDiagnostic[] = [];
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
+  const allowedBrokerRefs = declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined;
+  const brokerResolutionOptions: ServiceTextResolutionOptions = {
+    ...options,
+    allowedBrokerRefs,
+    diagnostics: manifestDiagnostics,
+  };
   const manifestVariables = rawManifestVariables.map((entry) => ({
     ...entry,
-    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables], {
-      diagnostics: manifestDiagnostics,
-      brokerValues: options.brokerValues,
-    }),
+    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables], brokerResolutionOptions),
   }));
 
   const manifestVariableKeys = new Set(manifestVariables.map((entry) => entry.key));
   const brokerImportVariables = (service.manifest.broker?.imports ?? [])
     .filter((entry) => entry.as && !manifestVariableKeys.has(entry.as))
     .flatMap((entry): ServiceVariableEntry[] => {
+      if (hasRef(options.deniedBrokerRefs, entry.ref)) {
+        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "denied-broker" });
+        return [];
+      }
+      if (hasRef(options.sourceAuthRequiredBrokerRefs, entry.ref)) {
+        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "source-auth-required" });
+        return [];
+      }
       const brokerValue = options.brokerValues?.[entry.ref];
       if (brokerValue === undefined) {
         manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "missing-broker" });
@@ -289,7 +323,12 @@ export function resolveServiceText(
   resolvedPorts: Record<string, number> = {},
   options: ServiceTextResolutionOptions = {},
 ): string {
-  return replaceVariableSelectors(value, buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables, options);
+  const variablesPayload = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts, options);
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
+  return replaceVariableSelectors(value, variablesPayload.variables, {
+    ...options,
+    allowedBrokerRefs: declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined,
+  });
 }
 
 export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<string, string> {

--- a/src/runtime/setup/materialize.ts
+++ b/src/runtime/setup/materialize.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import type { DiscoveredService, ServiceActionMaterialization } from "../../contracts/service.js";
-import { resolveServiceText } from "../operator/variables.js";
+import { resolveServiceText, type ServiceTextResolutionOptions } from "../operator/variables.js";
 
 export interface MaterializedArtifactResult {
   files: string[];
@@ -39,13 +39,14 @@ async function materializeFiles(
   definition: ServiceActionMaterialization | undefined,
   sharedGlobalEnv: Record<string, string>,
   resolvedPorts: Record<string, number>,
+  options: ServiceTextResolutionOptions = {},
 ): Promise<MaterializedArtifactResult> {
   const files = definition?.files ?? [];
   const materializedPaths: string[] = [];
 
   for (const file of files) {
-    const renderedRelativePath = resolveServiceText(file.path, service, sharedGlobalEnv, resolvedPorts);
-    const renderedContent = resolveServiceText(file.content, service, sharedGlobalEnv, resolvedPorts);
+    const renderedRelativePath = resolveServiceText(file.path, service, sharedGlobalEnv, resolvedPorts, options);
+    const renderedContent = resolveServiceText(file.content, service, sharedGlobalEnv, resolvedPorts, options);
     const { absolutePath, relativePath } = resolveArtifactPath(service.serviceRoot, renderedRelativePath);
     await mkdir(path.dirname(absolutePath), { recursive: true });
     await writeFile(absolutePath, renderedContent, "utf8");
@@ -62,14 +63,16 @@ export async function materializeInstallArtifacts(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
+  options: ServiceTextResolutionOptions = {},
 ): Promise<MaterializedArtifactResult> {
-  return materializeFiles(service, service.manifest.install, sharedGlobalEnv, resolvedPorts);
+  return materializeFiles(service, service.manifest.install, sharedGlobalEnv, resolvedPorts, options);
 }
 
 export async function materializeConfigArtifacts(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
+  options: ServiceTextResolutionOptions = {},
 ): Promise<MaterializedArtifactResult> {
-  return materializeFiles(service, service.manifest.config, sharedGlobalEnv, resolvedPorts);
+  return materializeFiles(service, service.manifest.config, sharedGlobalEnv, resolvedPorts, options);
 }

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -420,6 +420,17 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
           writeback: {
             allowedNamespaces: ["broker-consumer/runtime"],
             allowedOperations: ["create", "update", "rotate"],
+            allowedRefs: ["runtime.API_TOKEN"],
+            allowOverwrite: false,
+            auditReason: "capture generated runtime token",
+            generatedSecrets: [
+              {
+                ref: "runtime.API_TOKEN",
+                source: "${API_TOKEN}",
+                operation: "create",
+                required: true,
+              },
+            ],
           },
         },
       }),
@@ -460,6 +471,17 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
       writeback: {
         allowedNamespaces: ["broker-consumer/runtime"],
         allowedOperations: ["create", "update", "rotate"],
+        allowedRefs: ["runtime.API_TOKEN"],
+        allowOverwrite: false,
+        auditReason: "capture generated runtime token",
+        generatedSecrets: [
+          {
+            ref: "runtime.API_TOKEN",
+            source: "${API_TOKEN}",
+            operation: "create",
+            required: true,
+          },
+        ],
       },
     });
   } finally {
@@ -509,6 +531,43 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
         imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
       },
     });
+    await writeManifest(servicesRoot, "writeback-denied-ref", {
+      id: "writeback-denied-ref",
+      name: "Writeback Denied Ref",
+      description: "Writeback capture outside allowed refs.",
+      broker: {
+        exports: [{ namespace: "runtime", ref: "runtime.API_TOKEN", source: "${API_TOKEN}" }],
+        writeback: {
+          allowedNamespaces: ["runtime"],
+          allowedRefs: ["runtime.OTHER_TOKEN"],
+          generatedSecrets: [{ ref: "runtime.API_TOKEN", source: "${API_TOKEN}" }],
+        },
+      },
+    });
+    await writeManifest(servicesRoot, "writeback-no-export", {
+      id: "writeback-no-export",
+      name: "Writeback No Export",
+      description: "Writeback capture without export contract.",
+      broker: {
+        writeback: {
+          allowedNamespaces: ["runtime"],
+          generatedSecrets: [{ ref: "runtime.API_TOKEN", source: "${API_TOKEN}" }],
+        },
+      },
+    });
+    await writeManifest(servicesRoot, "writeback-denied-operation", {
+      id: "writeback-denied-operation",
+      name: "Writeback Denied Operation",
+      description: "Writeback capture outside allowed operations.",
+      broker: {
+        exports: [{ namespace: "runtime", ref: "runtime.API_TOKEN", source: "${API_TOKEN}" }],
+        writeback: {
+          allowedNamespaces: ["runtime"],
+          allowedOperations: ["create"],
+          generatedSecrets: [{ ref: "runtime.API_TOKEN", source: "${API_TOKEN}", operation: "rotate" }],
+        },
+      },
+    });
 
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "bad-enabled", "service.json")),
@@ -529,6 +588,18 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "env-import-collision", "service.json")),
       /collides with env\.DB_PASSWORD/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "writeback-denied-ref", "service.json")),
+      /outside broker\.writeback\.allowedRefs/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "writeback-no-export", "service.json")),
+      /must have a matching broker\.exports entry/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "writeback-denied-operation", "service.json")),
+      /outside broker\.writeback\.allowedOperations/i,
     );
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import os from "node:os";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import {
   buildServiceVariables,
   compileServiceMaterializationSelectorPlan,
@@ -8,6 +10,7 @@ import {
   resolveServiceText,
   resolveServiceVariable,
 } from "../dist/runtime/operator/variables.js";
+import { materializeConfigArtifacts } from "../dist/runtime/setup/materialize.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 
 function fixtureService(overrides = {}) {
@@ -100,6 +103,53 @@ test("broker imports materialize to service-specific env names", () => {
   assert.equal(byKey.API_TOKEN.value, "resolved-token");
 });
 
+test("broker selectors require explicit imports and report denied/source auth diagnostics without leaking values", () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      DECLARED: "${database.PASSWORD}",
+      UNDECLARED: "${vault.API_TOKEN}",
+      DENIED: "${database.DENIED}",
+      NEEDS_AUTH: "${database.SOURCE_AUTH}",
+    },
+    broker: {
+      imports: [
+        { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" },
+        { namespace: "shared/database", ref: "database.DENIED", as: "DENIED_PASSWORD" },
+        { namespace: "shared/database", ref: "database.SOURCE_AUTH", as: "AUTH_PASSWORD" },
+      ],
+    },
+  });
+
+  const payload = buildServiceVariables(service, {}, {}, {
+    brokerValues: {
+      "database.PASSWORD": "resolved-password",
+      "vault.API_TOKEN": "should-not-leak",
+      "database.DENIED": "denied-secret",
+      "database.SOURCE_AUTH": "auth-secret",
+    },
+    deniedBrokerRefs: ["database.DENIED"],
+    sourceAuthRequiredBrokerRefs: ["database.SOURCE_AUTH"],
+  });
+  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry.value]));
+
+  assert.equal(byKey.DECLARED, "resolved-password");
+  assert.equal(byKey.UNDECLARED, "${vault.API_TOKEN}");
+  assert.equal(byKey.DENIED, "${database.DENIED}");
+  assert.equal(byKey.NEEDS_AUTH, "${database.SOURCE_AUTH}");
+  const serializedPayload = JSON.stringify(payload);
+  assert.equal(serializedPayload.includes("should-not-leak"), false);
+  assert.equal(serializedPayload.includes("denied-secret"), false);
+  assert.equal(serializedPayload.includes("auth-secret"), false);
+  assert.deepEqual(payload.diagnostics, [
+    { selector: "vault.API_TOKEN", kind: "broker", reason: "denied-broker" },
+    { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
+    { selector: "database.SOURCE_AUTH", kind: "broker", reason: "source-auth-required" },
+    { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
+    { selector: "database.SOURCE_AUTH", kind: "broker", reason: "source-auth-required" },
+  ]);
+});
+
 test("bare selectors do not fall back into broker namespaces", () => {
   resetLifecycleState();
   const service = fixtureService({ env: { LOCAL_SECRET: "${API_KEY}" } });
@@ -130,6 +180,55 @@ test("explicit broker selectors resolve only from broker values and report missi
 
   assert.equal(resolved, "token=resolved-secret; missing=${secretsbroker.MISSING}; local=local");
   assert.deepEqual(diagnostics, [{ selector: "secretsbroker.MISSING", kind: "broker", reason: "missing-broker" }]);
+});
+
+test("config materialization resolves declared broker imports without leaking denied values", async () => {
+  resetLifecycleState();
+  const serviceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-broker-config-"));
+  const service = {
+    manifestPath: path.join(serviceRoot, "service.json"),
+    serviceRoot,
+    manifest: {
+      id: "config-consumer",
+      name: "Config Consumer",
+      description: "Materializes broker imports into config.",
+      env: {
+        DB_PASSWORD: "${database.PASSWORD}",
+        DENIED_PASSWORD: "${database.DENIED}",
+      },
+      broker: {
+        imports: [
+          { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
+          { namespace: "shared/database", ref: "database.DENIED", as: "DENIED_PASSWORD" },
+        ],
+      },
+      config: {
+        files: [
+          {
+            path: "runtime/config.json",
+            content: "{\n  \"password\": \"${database.PASSWORD}\",\n  \"denied\": \"${database.DENIED}\"\n}\n",
+          },
+        ],
+      },
+    },
+  };
+
+  try {
+    await materializeConfigArtifacts(service, {}, {}, {
+      brokerValues: {
+        "database.PASSWORD": "resolved-password",
+        "database.DENIED": "denied-secret",
+      },
+      deniedBrokerRefs: ["database.DENIED"],
+    });
+
+    const content = await readFile(path.join(serviceRoot, "runtime", "config.json"), "utf8");
+    assert.match(content, /resolved-password/);
+    assert.match(content, /\$\{database\.DENIED\}/);
+    assert.equal(content.includes("denied-secret"), false);
+  } finally {
+    await rm(serviceRoot, { recursive: true, force: true });
+  }
 });
 
 test("materialization selector plan covers env, globalenv, install, and config templates", () => {


### PR DESCRIPTION
## Summary
- expand the service broker writeback contract with explicit allowed refs, overwrite/audit metadata, and generated-secret capture declarations
- enforce explicit broker imports during variable/config materialization, surfacing missing/denied/source-auth-required diagnostics without materializing denied raw secret values
- update docs/schema references, node-sample-service, and validation tests for broker imports/writeback

## Validation
- `npm test` — 182/182 passing
- `git diff --check` — clean

## Scope boundaries
- Does not implement launch-time scoped identity (#401)
- Does not implement selector plan cache (#402)
- Does not add the full CLI/env fixture suite (#403)