### PR TITLE
#401 Add scoped broker launch identity

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -310,6 +310,16 @@ This keeps `install` and `config` explicit (as discussed), but removes unnecessa
 }
 ```
 
+### Runtime broker identity
+
+When `broker.writeback` is present, the runtime mints a per-launch scoped broker credential and injects it through reserved process environment keys:
+
+- `SERVICE_LASSO_BROKER_IDENTITY_ID`
+- `SERVICE_LASSO_BROKER_CREDENTIAL`
+- `SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT`
+
+The raw credential is launch-only authority: it is not stored in lifecycle state or logs. Persisted lifecycle metadata is limited to non-secret identity/audit fields and revocation/expiry timestamps.
+
 ## Union skeleton (keys only)
 
 ```json

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -433,6 +433,14 @@ Fields:
 - `writeback.generatedSecrets[].operation`: optional operation for this capture: `create`, `update`, `rotate`, or `delete`.
 - `writeback.generatedSecrets[].required`: optional boolean; required captures should fail closed when the source cannot be resolved.
 
+Launch-time writeback identity:
+- Services with `broker.writeback` declared receive a short-lived per-launch broker credential from the runtime.
+- The credential is scoped to the service id plus `writeback.allowedNamespaces`, `writeback.allowedRefs`, and `writeback.allowedOperations`.
+- Runtime injects the credential through reserved process env keys: `SERVICE_LASSO_BROKER_IDENTITY_ID`, `SERVICE_LASSO_BROKER_CREDENTIAL`, and `SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT`.
+- Lifecycle state may persist non-secret identity metadata for audit (`id`, service id, issued/expires/revoked timestamps, scope, audit reason), but must not persist the raw credential value.
+- Stop/restart revokes active launch credentials; expiry also denies later writeback attempts.
+- Broker writeback audit records should use the launched service identity and the optional `writeback.auditReason`.
+
 Selector semantics:
 - `${VAR}` means local/current-service variables only, including derived variables and legacy-compatible values already visible to the service.
 - `${namespace.KEY}` means an explicit broker lookup.

--- a/src/runtime/broker/identity.ts
+++ b/src/runtime/broker/identity.ts
@@ -1,0 +1,217 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type { DiscoveredService, ServiceBrokerWritebackOperation } from "../../contracts/service.js";
+
+export const BROKER_IDENTITY_ID_ENV = "SERVICE_LASSO_BROKER_IDENTITY_ID";
+export const BROKER_CREDENTIAL_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL";
+export const BROKER_CREDENTIAL_EXPIRES_AT_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT";
+
+const DEFAULT_CREDENTIAL_TTL_MS = 60 * 60 * 1000;
+
+export interface ScopedBrokerIdentityScope {
+  namespaces: string[];
+  operations: ServiceBrokerWritebackOperation[];
+  refs: string[];
+}
+
+export interface ScopedBrokerIdentityAuditContext {
+  serviceId: string;
+  identityId: string;
+  issuedAt: string;
+  expiresAt: string;
+  reason: string | null;
+}
+
+export interface ScopedBrokerIdentityMetadata {
+  id: string;
+  serviceId: string;
+  issuedAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  scope: ScopedBrokerIdentityScope;
+  audit: ScopedBrokerIdentityAuditContext;
+}
+
+export interface ScopedBrokerCredential {
+  token: string;
+  env: Record<string, string>;
+  metadata: ScopedBrokerIdentityMetadata;
+}
+
+interface ScopedBrokerCredentialRecord {
+  tokenHash: string;
+  metadata: ScopedBrokerIdentityMetadata;
+}
+
+export interface ScopedBrokerWritebackRequest {
+  serviceId: string;
+  namespace: string;
+  ref: string;
+  operation: ServiceBrokerWritebackOperation;
+  now?: Date;
+}
+
+export interface ScopedBrokerWritebackDecision {
+  ok: boolean;
+  reason: "allowed" | "unknown-credential" | "service-mismatch" | "expired" | "revoked" | "namespace-denied" | "ref-denied" | "operation-denied";
+  audit: ScopedBrokerIdentityAuditContext | null;
+  identity: ScopedBrokerIdentityMetadata | null;
+}
+
+const scopedCredentials = new Map<string, ScopedBrokerCredentialRecord>();
+const serviceIdentityIds = new Map<string, Set<string>>();
+
+function hashCredential(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function cloneMetadata(metadata: ScopedBrokerIdentityMetadata): ScopedBrokerIdentityMetadata {
+  return {
+    id: metadata.id,
+    serviceId: metadata.serviceId,
+    issuedAt: metadata.issuedAt,
+    expiresAt: metadata.expiresAt,
+    revokedAt: metadata.revokedAt,
+    scope: {
+      namespaces: [...metadata.scope.namespaces],
+      operations: [...metadata.scope.operations],
+      refs: [...metadata.scope.refs],
+    },
+    audit: { ...metadata.audit },
+  };
+}
+
+function rememberServiceIdentity(serviceId: string, identityId: string): void {
+  const identities = serviceIdentityIds.get(serviceId) ?? new Set<string>();
+  identities.add(identityId);
+  serviceIdentityIds.set(serviceId, identities);
+}
+
+export function serviceNeedsScopedBrokerIdentity(service: DiscoveredService): boolean {
+  return service.manifest.broker?.writeback !== undefined;
+}
+
+export function mintScopedBrokerIdentity(
+  service: DiscoveredService,
+  options: { now?: Date; ttlMs?: number } = {},
+): ScopedBrokerCredential | null {
+  const writeback = service.manifest.broker?.writeback;
+  if (!writeback) {
+    return null;
+  }
+
+  const now = options.now ?? new Date();
+  const ttlMs = options.ttlMs ?? DEFAULT_CREDENTIAL_TTL_MS;
+  const issuedAt = now.toISOString();
+  const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
+  const identityId = randomUUID();
+  const token = `slb_${randomBytes(32).toString("base64url")}`;
+  const allowedOperations = writeback.allowedOperations ?? ["create", "update", "rotate", "delete"];
+  const metadata: ScopedBrokerIdentityMetadata = {
+    id: identityId,
+    serviceId: service.manifest.id,
+    issuedAt,
+    expiresAt,
+    revokedAt: null,
+    scope: {
+      namespaces: [...(writeback.allowedNamespaces ?? [])],
+      operations: [...allowedOperations],
+      refs: [...(writeback.allowedRefs ?? [])],
+    },
+    audit: {
+      serviceId: service.manifest.id,
+      identityId,
+      issuedAt,
+      expiresAt,
+      reason: writeback.auditReason ?? null,
+    },
+  };
+
+  scopedCredentials.set(identityId, {
+    tokenHash: hashCredential(token),
+    metadata,
+  });
+  rememberServiceIdentity(service.manifest.id, identityId);
+
+  return {
+    token,
+    metadata: cloneMetadata(metadata),
+    env: {
+      [BROKER_IDENTITY_ID_ENV]: identityId,
+      [BROKER_CREDENTIAL_ENV]: token,
+      [BROKER_CREDENTIAL_EXPIRES_AT_ENV]: expiresAt,
+    },
+  };
+}
+
+export function revokeScopedBrokerIdentity(identityId: string, options: { now?: Date } = {}): ScopedBrokerIdentityMetadata | null {
+  const record = scopedCredentials.get(identityId);
+  if (!record) {
+    return null;
+  }
+
+  record.metadata.revokedAt = (options.now ?? new Date()).toISOString();
+  return cloneMetadata(record.metadata);
+}
+
+export function revokeServiceScopedBrokerIdentities(serviceId: string, options: { now?: Date } = {}): ScopedBrokerIdentityMetadata[] {
+  const identities = serviceIdentityIds.get(serviceId);
+  if (!identities) {
+    return [];
+  }
+
+  return [...identities]
+    .map((identityId) => revokeScopedBrokerIdentity(identityId, options))
+    .filter((metadata): metadata is ScopedBrokerIdentityMetadata => metadata !== null);
+}
+
+function findCredentialRecord(token: string): ScopedBrokerCredentialRecord | null {
+  const tokenHash = hashCredential(token);
+  for (const record of scopedCredentials.values()) {
+    if (record.tokenHash === tokenHash) {
+      return record;
+    }
+  }
+  return null;
+}
+
+function isDeniedBySet(scopeValues: string[], value: string): boolean {
+  return scopeValues.length > 0 && !scopeValues.includes(value);
+}
+
+export function authorizeScopedBrokerWriteback(
+  token: string,
+  request: ScopedBrokerWritebackRequest,
+): ScopedBrokerWritebackDecision {
+  const record = findCredentialRecord(token);
+  if (!record) {
+    return { ok: false, reason: "unknown-credential", audit: null, identity: null };
+  }
+
+  const metadata = record.metadata;
+  const identity = cloneMetadata(metadata);
+  if (metadata.serviceId !== request.serviceId) {
+    return { ok: false, reason: "service-mismatch", audit: metadata.audit, identity };
+  }
+  if (metadata.revokedAt) {
+    return { ok: false, reason: "revoked", audit: metadata.audit, identity };
+  }
+  if ((request.now ?? new Date()).getTime() >= Date.parse(metadata.expiresAt)) {
+    return { ok: false, reason: "expired", audit: metadata.audit, identity };
+  }
+  if (isDeniedBySet(metadata.scope.namespaces, request.namespace)) {
+    return { ok: false, reason: "namespace-denied", audit: metadata.audit, identity };
+  }
+  if (isDeniedBySet(metadata.scope.refs, request.ref)) {
+    return { ok: false, reason: "ref-denied", audit: metadata.audit, identity };
+  }
+  if (isDeniedBySet(metadata.scope.operations, request.operation)) {
+    return { ok: false, reason: "operation-denied", audit: metadata.audit, identity };
+  }
+
+  return { ok: true, reason: "allowed", audit: metadata.audit, identity };
+}
+
+export function resetScopedBrokerIdentities(): void {
+  scopedCredentials.clear();
+  serviceIdentityIds.clear();
+}

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -40,6 +40,7 @@ interface StartProcessOptions {
   executionPlan: ProviderExecutionPlan;
   sharedGlobalEnv?: Record<string, string>;
   resolvedPorts?: Record<string, number>;
+  secureEnv?: Record<string, string>;
   onExit?: (payload: {
     service: DiscoveredService;
     exitCode: number | null;
@@ -180,6 +181,7 @@ function buildProcessEnvironment(
   executionPlan: ProviderExecutionPlan,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
+  secureEnv: Record<string, string> = {},
 ): NodeJS.ProcessEnv {
   const serviceVariables = Object.fromEntries(
     buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
@@ -189,6 +191,7 @@ function buildProcessEnvironment(
     ...process.env,
     ...executionPlan.providerEnv,
     ...serviceVariables,
+    ...secureEnv,
   };
 }
 
@@ -197,7 +200,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
+  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv, onExit } = options;
   const serviceId = service.manifest.id;
 
   const priorFinalizer = managedProcessFinalizers.get(serviceId);
@@ -222,7 +225,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const child = spawn(executable, args, {
     cwd: workingDirectory,
-    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts),
+    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
   });

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,6 +1,7 @@
 import type { DiscoveredService } from "../../contracts/service.js";
 import { LifecycleStateError } from "../../server/errors.js";
 import { startManagedProcess, stopManagedProcess } from "../execution/supervisor.js";
+import { mintScopedBrokerIdentity, revokeServiceScopedBrokerIdentities } from "../broker/identity.js";
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
@@ -108,6 +109,8 @@ async function persistProcessExit(
   exitCode: number | null,
 ): Promise<void> {
   const finishedAt = new Date().toISOString();
+  const revokedIdentities = revokeServiceScopedBrokerIdentities(service.manifest.id, { now: new Date(finishedAt) });
+  const revokedIdentity = revokedIdentities.at(-1) ?? getLifecycleState(service.manifest.id).runtime.brokerIdentity;
   const termination = (exitCode ?? getLifecycleState(service.manifest.id).runtime.exitCode ?? 0) === 0 ? "exited" : "crashed";
   const state = updateRuntimeState(service.manifest.id, (current) => ({
     ...current,
@@ -119,6 +122,7 @@ async function persistProcessExit(
       exitCode: exitCode ?? current.runtime.exitCode,
       lastTermination: termination,
       metrics: applyRunCompletionMetrics(current, finishedAt, termination),
+      brokerIdentity: revokedIdentity,
     },
   }));
 
@@ -258,6 +262,8 @@ export async function startService(
   }
 
   const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  revokeServiceScopedBrokerIdentities(serviceId);
+  const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
   const resolvedPorts = Object.keys(current.runtime.ports).length > 0
     ? current.runtime.ports
     : registry
@@ -268,6 +274,7 @@ export async function startService(
     executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
+    secureEnv: scopedBrokerIdentity?.env,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -296,12 +303,15 @@ export async function startService(
         stderrPath: handle.logs.stderrPath,
       },
       metrics: applyProcessLaunchMetrics(state, "start", handle.startedAt),
+      brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
     },
   }));
 
   const readiness = await waitForServiceReadiness(service, sharedGlobalEnv);
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
+    const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId);
+    const revokedIdentity = revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
     return applyState(
       serviceId,
       "start",
@@ -316,6 +326,7 @@ export async function startService(
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
             metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
+            brokerIdentity: revokedIdentity,
           },
         },
         message: readiness.message,
@@ -338,6 +349,7 @@ export async function startService(
         provider: executionPlan.provider,
         providerServiceId: executionPlan.providerServiceId,
         lastTermination: null,
+        brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
       },
     },
     message: readiness.message,
@@ -353,6 +365,8 @@ export async function stopService(service: DiscoveredService): Promise<Lifecycle
 
   const stopped = await stopManagedProcess(serviceId);
   const finishedAt = new Date().toISOString();
+  const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId, { now: new Date(finishedAt) });
+  const revokedIdentity = revokedIdentities.at(-1) ?? current.runtime.brokerIdentity;
 
   return applyState(serviceId, "stop", (state) => ({
     nextState: {
@@ -365,6 +379,7 @@ export async function stopService(service: DiscoveredService): Promise<Lifecycle
         exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
         lastTermination: "stopped",
         metrics: applyRunCompletionMetrics(state, finishedAt, "stopped"),
+        brokerIdentity: revokedIdentity,
       },
     },
     message: "Stop completed.",
@@ -396,8 +411,10 @@ export async function restartService(
   if (current.running) {
     await stopManagedProcess(serviceId);
   }
+  revokeServiceScopedBrokerIdentities(serviceId);
 
   const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
   const resolvedPorts = Object.keys(current.runtime.ports).length > 0
     ? current.runtime.ports
     : registry
@@ -408,6 +425,7 @@ export async function restartService(
     executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
+    secureEnv: scopedBrokerIdentity?.env,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -436,12 +454,15 @@ export async function restartService(
         stderrPath: handle.logs.stderrPath,
       },
       metrics: applyProcessLaunchMetrics(state, "restart", handle.startedAt),
+      brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
     },
   }));
 
   const readiness = await waitForServiceReadiness(service, sharedGlobalEnv);
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
+    const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId);
+    const revokedIdentity = revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
     const failedResult = applyState(
       serviceId,
       "restart",
@@ -456,6 +477,7 @@ export async function restartService(
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
             metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
+            brokerIdentity: revokedIdentity,
           },
         },
         message: readiness.message,
@@ -486,6 +508,7 @@ export async function restartService(
         provider: executionPlan.provider,
         providerServiceId: executionPlan.providerServiceId,
         lastTermination: null,
+        brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
       },
     },
     message: readiness.message.replace(/^Start/, "Restart"),

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -2,6 +2,26 @@ import type { ServiceLifecycleState } from "./types.js";
 
 const lifecycleState = new Map<string, ServiceLifecycleState>();
 
+function cloneBrokerIdentity(identity: ServiceLifecycleState["runtime"]["brokerIdentity"]): ServiceLifecycleState["runtime"]["brokerIdentity"] {
+  if (!identity) {
+    return null;
+  }
+
+  return {
+    id: identity.id,
+    serviceId: identity.serviceId,
+    issuedAt: identity.issuedAt,
+    expiresAt: identity.expiresAt,
+    revokedAt: identity.revokedAt,
+    scope: {
+      namespaces: [...identity.scope.namespaces],
+      operations: [...identity.scope.operations],
+      refs: [...identity.scope.refs],
+    },
+    audit: { ...identity.audit },
+  };
+}
+
 function createInitialState(): ServiceLifecycleState {
   return {
     installed: false,
@@ -58,6 +78,7 @@ function createInitialState(): ServiceLifecycleState {
         totalRunDurationMs: 0,
         lastRunDurationMs: null,
       },
+      brokerIdentity: null,
     },
   };
 }
@@ -137,6 +158,7 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
         totalRunDurationMs: current.runtime.metrics.totalRunDurationMs,
         lastRunDurationMs: current.runtime.metrics.lastRunDurationMs,
       },
+      brokerIdentity: cloneBrokerIdentity(current.runtime.brokerIdentity),
     },
   };
 }
@@ -210,6 +232,7 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
         totalRunDurationMs: nextState.runtime.metrics.totalRunDurationMs,
         lastRunDurationMs: nextState.runtime.metrics.lastRunDurationMs,
       },
+      brokerIdentity: cloneBrokerIdentity(nextState.runtime.brokerIdentity),
     },
   };
 

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -1,4 +1,5 @@
 import type { ProviderKind } from "../providers/types.js";
+import type { ScopedBrokerIdentityMetadata } from "../broker/identity.js";
 
 export type LifecycleAction = "install" | "config" | "setup" | "start" | "stop" | "restart";
 
@@ -76,6 +77,7 @@ export interface ServiceRuntimeState {
     stderrPath: string | null;
   };
   metrics: ServiceRuntimeMetricsState;
+  brokerIdentity: ScopedBrokerIdentityMetadata | null;
 }
 
 export interface ServiceLifecycleState {

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -3,6 +3,7 @@ import { hasManagedProcess } from "../execution/supervisor.js";
 import { getLifecycleState, setLifecycleState } from "../lifecycle/store.js";
 import type { LifecycleAction, ServiceLifecycleState, ServiceSetupStepRunState, SetupStepStatus } from "../lifecycle/types.js";
 import type { ProviderKind } from "../providers/types.js";
+import type { ServiceBrokerWritebackOperation } from "../../contracts/service.js";
 import { readStoredState } from "./readState.js";
 import { resolveServiceRootPath } from "./paths.js";
 
@@ -56,6 +57,7 @@ interface StoredRuntimeState {
     totalRunDurationMs?: number;
     lastRunDurationMs?: number | null;
   };
+  brokerIdentity?: ServiceLifecycleState["runtime"]["brokerIdentity"];
   lastAction?: LifecycleAction | null;
   actionHistory?: LifecycleAction[];
 }
@@ -71,6 +73,57 @@ interface StoredSetupState {
 
 function isLifecycleAction(value: unknown): value is LifecycleAction {
   return value === "install" || value === "config" || value === "setup" || value === "start" || value === "stop" || value === "restart";
+}
+
+
+function isWritebackOperation(value: unknown): value is ServiceBrokerWritebackOperation {
+  return value === "create" || value === "update" || value === "rotate" || value === "delete";
+}
+
+function parseBrokerIdentity(value: unknown): ServiceLifecycleState["runtime"]["brokerIdentity"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as ServiceLifecycleState["runtime"]["brokerIdentity"];
+  if (
+    !record ||
+    typeof record.id !== "string" ||
+    typeof record.serviceId !== "string" ||
+    typeof record.issuedAt !== "string" ||
+    typeof record.expiresAt !== "string" ||
+    !record.scope ||
+    !Array.isArray(record.scope.namespaces) ||
+    !Array.isArray(record.scope.operations) ||
+    !Array.isArray(record.scope.refs) ||
+    !record.audit ||
+    typeof record.audit.serviceId !== "string" ||
+    typeof record.audit.identityId !== "string" ||
+    typeof record.audit.issuedAt !== "string" ||
+    typeof record.audit.expiresAt !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    id: record.id,
+    serviceId: record.serviceId,
+    issuedAt: record.issuedAt,
+    expiresAt: record.expiresAt,
+    revokedAt: typeof record.revokedAt === "string" ? record.revokedAt : null,
+    scope: {
+      namespaces: record.scope.namespaces.filter((entry): entry is string => typeof entry === "string"),
+      operations: record.scope.operations.filter(isWritebackOperation),
+      refs: record.scope.refs.filter((entry): entry is string => typeof entry === "string"),
+    },
+    audit: {
+      serviceId: record.audit.serviceId,
+      identityId: record.audit.identityId,
+      issuedAt: record.audit.issuedAt,
+      expiresAt: record.audit.expiresAt,
+      reason: typeof record.audit.reason === "string" ? record.audit.reason : null,
+    },
+  };
 }
 
 function isProviderKind(value: unknown): value is ProviderKind {
@@ -257,6 +310,7 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
         lastRunDurationMs:
           typeof runtime?.metrics?.lastRunDurationMs === "number" ? runtime.metrics.lastRunDurationMs : null,
       },
+      brokerIdentity: parseBrokerIdentity(runtime?.brokerIdentity),
     },
   };
 }

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -84,6 +84,7 @@ export async function writeServiceState(
           ports: lifecycle.runtime.ports,
           logs: lifecycle.runtime.logs,
           metrics: lifecycle.runtime.metrics,
+          brokerIdentity: lifecycle.runtime.brokerIdentity,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,
         },

--- a/tests/broker-scoped-identity.test.js
+++ b/tests/broker-scoped-identity.test.js
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import {
+  authorizeScopedBrokerWriteback,
+  BROKER_CREDENTIAL_ENV,
+  BROKER_CREDENTIAL_EXPIRES_AT_ENV,
+  BROKER_IDENTITY_ID_ENV,
+  mintScopedBrokerIdentity,
+  resetScopedBrokerIdentities,
+} from "../dist/runtime/broker/identity.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { readStoredState } from "../dist/runtime/state/readState.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+function fixtureService() {
+  return {
+    manifestPath: path.join(process.cwd(), "services", "writer", "service.json"),
+    serviceRoot: path.join(process.cwd(), "services", "writer"),
+    manifest: {
+      id: "writer",
+      name: "Writer",
+      description: "Broker writeback identity test fixture.",
+      broker: {
+        writeback: {
+          allowedNamespaces: ["services/writer"],
+          allowedOperations: ["create", "rotate"],
+          allowedRefs: ["writer.API_TOKEN"],
+          auditReason: "test writeback",
+        },
+      },
+    },
+  };
+}
+
+async function postJson(url) {
+  const response = await fetch(url, { method: "POST" });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function waitFor(predicate, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+test("scoped broker credentials allow only the launched service writeback scope", () => {
+  resetScopedBrokerIdentities();
+  const issuedAt = new Date("2026-05-08T06:00:00.000Z");
+  const credential = mintScopedBrokerIdentity(fixtureService(), { now: issuedAt, ttlMs: 1_000 });
+  assert.ok(credential);
+
+  const allowed = authorizeScopedBrokerWriteback(credential.token, {
+    serviceId: "writer",
+    namespace: "services/writer",
+    ref: "writer.API_TOKEN",
+    operation: "create",
+    now: new Date("2026-05-08T06:00:00.500Z"),
+  });
+  assert.equal(allowed.ok, true);
+  assert.equal(allowed.reason, "allowed");
+  assert.equal(allowed.audit?.serviceId, "writer");
+  assert.equal(allowed.audit?.identityId, credential.metadata.id);
+  assert.equal(allowed.audit?.reason, "test writeback");
+
+  assert.equal(
+    authorizeScopedBrokerWriteback(credential.token, {
+      serviceId: "other-service",
+      namespace: "services/writer",
+      ref: "writer.API_TOKEN",
+      operation: "create",
+      now: new Date("2026-05-08T06:00:00.500Z"),
+    }).reason,
+    "service-mismatch",
+  );
+  assert.equal(
+    authorizeScopedBrokerWriteback(credential.token, {
+      serviceId: "writer",
+      namespace: "shared/database",
+      ref: "writer.API_TOKEN",
+      operation: "create",
+      now: new Date("2026-05-08T06:00:00.500Z"),
+    }).reason,
+    "namespace-denied",
+  );
+  assert.equal(
+    authorizeScopedBrokerWriteback(credential.token, {
+      serviceId: "writer",
+      namespace: "services/writer",
+      ref: "writer.OTHER_TOKEN",
+      operation: "create",
+      now: new Date("2026-05-08T06:00:00.500Z"),
+    }).reason,
+    "ref-denied",
+  );
+  assert.equal(
+    authorizeScopedBrokerWriteback(credential.token, {
+      serviceId: "writer",
+      namespace: "services/writer",
+      ref: "writer.API_TOKEN",
+      operation: "delete",
+      now: new Date("2026-05-08T06:00:00.500Z"),
+    }).reason,
+    "operation-denied",
+  );
+  assert.equal(
+    authorizeScopedBrokerWriteback(credential.token, {
+      serviceId: "writer",
+      namespace: "services/writer",
+      ref: "writer.API_TOKEN",
+      operation: "create",
+      now: new Date("2026-05-08T06:00:01.000Z"),
+    }).reason,
+    "expired",
+  );
+  assert.equal(JSON.stringify(credential.metadata).includes(credential.token), false);
+});
+
+test("runtime injects scoped broker credential without persisting or logging raw authority", async () => {
+  resetLifecycleState();
+  resetScopedBrokerIdentities();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-identity-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "writer", {
+    captureEnvKeys: [BROKER_IDENTITY_ID_ENV, BROKER_CREDENTIAL_ENV, BROKER_CREDENTIAL_EXPIRES_AT_ENV],
+    broker: {
+      writeback: {
+        allowedNamespaces: ["services/writer"],
+        allowedOperations: ["create", "rotate"],
+        allowedRefs: ["writer.API_TOKEN"],
+        auditReason: "capture writer token",
+      },
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/writer/install`);
+    await postJson(`${apiServer.url}/api/services/writer/config`);
+    const start = await postJson(`${apiServer.url}/api/services/writer/start`);
+    assert.equal(start.status, 200);
+    assert.equal(start.body.state.running, true);
+    assert.equal(typeof start.body.state.runtime.brokerIdentity.id, "string");
+    assert.equal(start.body.state.runtime.brokerIdentity.serviceId, "writer");
+
+    const envPath = path.join(serviceRoot, "runtime", "env.json");
+    await waitFor(async () => {
+      try {
+        const env = JSON.parse(await readFile(envPath, "utf8"));
+        return typeof env[BROKER_CREDENTIAL_ENV] === "string";
+      } catch {
+        return false;
+      }
+    });
+
+    const env = JSON.parse(await readFile(envPath, "utf8"));
+    assert.equal(env[BROKER_IDENTITY_ID_ENV], start.body.state.runtime.brokerIdentity.id);
+    assert.equal(typeof env[BROKER_CREDENTIAL_ENV], "string");
+    assert.equal(typeof env[BROKER_CREDENTIAL_EXPIRES_AT_ENV], "string");
+
+    const decision = authorizeScopedBrokerWriteback(env[BROKER_CREDENTIAL_ENV], {
+      serviceId: "writer",
+      namespace: "services/writer",
+      ref: "writer.API_TOKEN",
+      operation: "rotate",
+    });
+    assert.equal(decision.ok, true);
+    assert.equal(decision.audit?.serviceId, "writer");
+
+    const storedRunning = await readStoredState(serviceRoot);
+    assert.equal(JSON.stringify(start.body).includes(env[BROKER_CREDENTIAL_ENV]), false);
+    assert.equal(JSON.stringify(storedRunning.runtime).includes(env[BROKER_CREDENTIAL_ENV]), false);
+
+    const stop = await postJson(`${apiServer.url}/api/services/writer/stop`);
+    assert.equal(stop.status, 200);
+    assert.equal(stop.body.state.running, false);
+    assert.equal(typeof stop.body.state.runtime.brokerIdentity.revokedAt, "string");
+    assert.equal(
+      authorizeScopedBrokerWriteback(env[BROKER_CREDENTIAL_ENV], {
+        serviceId: "writer",
+        namespace: "services/writer",
+        ref: "writer.API_TOKEN",
+        operation: "rotate",
+      }).reason,
+      "revoked",
+    );
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    resetScopedBrokerIdentities();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -76,6 +76,7 @@ export async function writeExecutableFixtureService(
     config = undefined,
     setup = undefined,
     role = undefined,
+    broker = undefined,
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -196,6 +197,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     install,
     config,
     setup,
+    broker,
     healthcheck: healthcheck === null ? undefined : healthcheck,
   });
 


### PR DESCRIPTION
## Summary
- add runtime-scoped broker identity issuance for services declaring `broker.writeback`
- inject launch credentials through reserved process env keys while persisting only non-secret identity/audit metadata
- authorize writeback attempts by service id, namespace, ref, operation, expiry, and revocation state
- revoke scoped launch credentials on stop/restart/process exit paths where practical
- document the launch identity contract and add focused tests

## Validation
- `npm test` — 184/184 passing
- `git diff --check` — clean

## Scope boundaries
- Does not implement #402 selector plan cache
- Does not implement broad #403 end-to-end CLI fixture coverage beyond focused lifecycle identity tests
- No Service Admin or Dagu coupling