### PR TITLE
#406 Add ZITADEL consumer integration contract

### DIFF
--- a/docs/reference-apps.md
+++ b/docs/reference-apps.md
@@ -37,6 +37,12 @@ Every reference app should make the same core integration story obvious:
 - Service Lasso can discover and manage the app's services.
 - Echo Service and Service Admin are available as baseline integration targets.
 
+Optional identity stacks follow the same app-owned rule. For example, an app that
+opts into local SSO commits its own ZITADEL and PostgreSQL service manifests,
+owns the database and OIDC client setup, and supplies secrets through its own
+secret policy. See the [ZITADEL Consumer Integration](reference/zitadel-consumer-integration.md)
+contract and fixture for the concrete `services/zitadel/service.json` pattern.
+
 ## How To Decide
 
 Start with `service-lasso-app-node` if you are still deciding. It is the

--- a/docs/reference/zitadel-consumer-integration.md
+++ b/docs/reference/zitadel-consumer-integration.md
@@ -1,0 +1,106 @@
+---
+title: ZITADEL Consumer Integration
+sidebar_label: ZITADEL Consumer Integration
+---
+
+# ZITADEL Consumer Integration
+
+ZITADEL is an optional, app-owned identity service. Service Lasso can acquire,
+configure, start, stop, and health-check the `service-lasso/lasso-zitadel`
+release artifact, but the consuming app owns the decision to include ZITADEL,
+the database, domain, issuer, client registrations, redirect URIs, and secret
+lifecycle.
+
+Do not add ZITADEL to the core baseline just because an app needs SSO. Commit it
+inside that app's `services/` inventory instead.
+
+## Reference fixture
+
+A concrete committed pattern lives at:
+
+```text
+fixtures/zitadel-consumer-app/services/postgres/service.json
+fixtures/zitadel-consumer-app/services/zitadel/service.json
+```
+
+The fixture models an app-owned stack with:
+
+- `postgres`: local PostgreSQL service that owns the `zitadel` database.
+- `zitadel`: release-backed ZITADEL service that depends on `postgres`.
+- broker import `identity.ZITADEL_MASTERKEY` from namespace `services/zitadel`.
+- external local issuer `http://localhost:${HTTP_PORT}/`.
+- console URL `http://localhost:${HTTP_PORT}/ui/console/`.
+- health URL `http://127.0.0.1:${HTTP_PORT}/debug/ready`.
+
+Copy the pattern into a reference app or product repo when that app opts into
+local SSO. Keep the service inventory committed so reviewers can see that the
+app, not the Service Lasso baseline, owns the identity dependency.
+
+## Required app-owned inputs
+
+The consuming app must supply these before `zitadel/start`:
+
+| Input | Owner | Notes |
+| --- | --- | --- |
+| PostgreSQL dependency | App | Commit or otherwise provide a `postgres` service and start it before ZITADEL. The fixture uses `depend_on: ["postgres"]`. |
+| `ZITADEL_DATABASE_POSTGRES_DSN` | App | The fixture builds `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/zitadel?sslmode=disable` from the sibling PostgreSQL service. Production apps should use their own database, credentials, TLS posture, and retention policy. |
+| `ZITADEL_MASTERKEY` | App secret owner | Stable exactly-32-byte key. Store it in the app-owned Secrets Broker namespace, not in `service.json`, source control, logs, issue comments, or support bundles. |
+| External domain and port | App | The local fixture uses `localhost` and `HTTP_PORT`. Packaged apps must set the externally visible host/port that users and OIDC clients will actually use. |
+| Issuer URL | App | Must remain stable for OIDC clients. The fixture emits `ZITADEL_ISSUER=http://localhost:${HTTP_PORT}/`. |
+| Redirect URIs | App | Register exact redirect URIs for each consuming client, for example `http://localhost:3000/auth/callback` for a local web app. |
+| Client setup | App/ZITADEL admin | Create the project/application/client in ZITADEL and store client IDs/secrets according to the consuming app's secret policy. |
+
+## Service Lasso-owned behavior
+
+Service Lasso owns the bounded runtime mechanics:
+
+1. Discover the committed app-owned `services/zitadel/service.json`.
+2. Resolve declared ports and local selectors.
+3. Acquire the `service-lasso/lasso-zitadel` release artifact during install.
+4. Materialize install/config files declared by the manifest.
+5. Inject resolved env, including the broker-provided master key, only at process
+   launch.
+6. Start the process with `start-from-init --masterkeyFromEnv --tlsMode disabled`
+   for the local fixture contract.
+7. Report readiness through `/debug/ready`.
+
+Service Lasso does not own ZITADEL org/project/client administration, user
+lifecycle, cross-instance trust, public TLS, or production database operations in
+this slice.
+
+## Smoke and blocked prerequisites
+
+The fixture is intentionally safe to validate without starting a real identity
+stack:
+
+```bash
+npm run build
+node --test --test-concurrency=1 tests/zitadel-consumer-contract.test.js
+```
+
+That test proves the committed fixture manifests are loadable, app-owned,
+non-baseline, dependency-linked, broker-backed for `ZITADEL_MASTERKEY`, and
+documented.
+
+A full acquisition/config/start smoke is valid only after the app supplies:
+
+1. a reachable PostgreSQL service/database for ZITADEL,
+2. the app-owned `identity.ZITADEL_MASTERKEY` broker secret with exactly 32
+   bytes,
+3. stable local external domain/port values,
+4. the expected client redirect URIs.
+
+Once those prerequisites exist in a real app workspace, the operator flow is:
+
+```text
+POST /api/services/postgres/install
+POST /api/services/postgres/config
+POST /api/services/postgres/start
+POST /api/services/zitadel/install
+POST /api/services/zitadel/config
+POST /api/services/zitadel/start
+GET  /api/services/zitadel/health
+```
+
+If any prerequisite is missing, fail closed and report the missing input. Do not
+silently fall back to a generated master key or a default database.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,6 +68,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/zitadel-consumer-integration",
+          label: "ZITADEL Consumer Integration",
+        },
+        {
+          type: "doc",
           id: "development/new-lasso-service-guide",
           label: "Service Repo Handoff",
         },

--- a/fixtures/zitadel-consumer-app/services/postgres/service.json
+++ b/fixtures/zitadel-consumer-app/services/postgres/service.json
@@ -1,0 +1,79 @@
+{
+  "id": "postgres",
+  "name": "PostgreSQL for ZITADEL",
+  "description": "App-owned PostgreSQL dependency used by the ZITADEL consumer integration fixture.",
+  "version": "15.17",
+  "enabled": true,
+  "ports": {
+    "service": 18532
+  },
+  "env": {
+    "POSTGRES_HOST": "127.0.0.1",
+    "POSTGRES_PORT": "${SERVICE_PORT}",
+    "POSTGRES_USER": "zitadel",
+    "POSTGRES_PASSWORD": "zitadel-local-dev-only",
+    "POSTGRES_DATABASES": "zitadel",
+    "POSTGRES_DATA_DIR": "${SERVICE_ROOT}/runtime/data",
+    "PGPASSWORD": "${POSTGRES_PASSWORD}"
+  },
+  "globalenv": {
+    "POSTGRES_HOST": "${POSTGRES_HOST}",
+    "POSTGRES_PORT": "${POSTGRES_PORT}",
+    "POSTGRES_USER": "${POSTGRES_USER}",
+    "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+    "POSTGRES_DATABASE": "zitadel"
+  },
+  "urls": [
+    {
+      "label": "tcp",
+      "url": "postgresql://${POSTGRES_USER}:***@${POSTGRES_HOST}:${POSTGRES_PORT}/zitadel",
+      "kind": "local"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-postgres",
+      "channel": "latest"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-postgres-15.17-win32.zip",
+        "archiveType": "zip",
+        "command": "node",
+        "args": ["./lasso-postgres.mjs"]
+      },
+      "darwin": {
+        "assetName": "lasso-postgres-15.17-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "node",
+        "args": ["./lasso-postgres.mjs"]
+      },
+      "linux": {
+        "assetName": "lasso-postgres-15.17-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "node",
+        "args": ["./lasso-postgres.mjs"]
+      }
+    }
+  },
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/data/.keep",
+        "content": ""
+      },
+      {
+        "path": "./runtime/.keep",
+        "content": ""
+      }
+    ]
+  },
+  "healthcheck": {
+    "type": "tcp",
+    "address": "${POSTGRES_HOST}:${POSTGRES_PORT}",
+    "retries": 80,
+    "interval": 250
+  }
+}

--- a/fixtures/zitadel-consumer-app/services/zitadel/service.json
+++ b/fixtures/zitadel-consumer-app/services/zitadel/service.json
@@ -1,0 +1,111 @@
+{
+  "id": "zitadel",
+  "name": "ZITADEL",
+  "description": "App-owned ZITADEL identity service fixture wired to an app-owned PostgreSQL dependency and broker-backed master key.",
+  "version": "v4.14.0",
+  "enabled": true,
+  "depend_on": ["postgres"],
+  "ports": {
+    "http": 18084
+  },
+  "commandline": {
+    "win32": " start-from-init --masterkeyFromEnv --tlsMode disabled",
+    "darwin": " start-from-init --masterkeyFromEnv --tlsMode disabled",
+    "linux": " start-from-init --masterkeyFromEnv --tlsMode disabled",
+    "default": " start-from-init --masterkeyFromEnv --tlsMode disabled"
+  },
+  "env": {
+    "ZITADEL_PORT": "${HTTP_PORT}",
+    "ZITADEL_EXTERNALPORT": "${HTTP_PORT}",
+    "ZITADEL_EXTERNALDOMAIN": "localhost",
+    "ZITADEL_EXTERNALSECURE": "false",
+    "ZITADEL_TLS_ENABLED": "false",
+    "ZITADEL_DATABASE_POSTGRES_DSN": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/zitadel?sslmode=disable",
+    "ZITADEL_MASTERKEY": "${identity.ZITADEL_MASTERKEY}"
+  },
+  "globalenv": {
+    "ZITADEL_HTTP_PORT": "${HTTP_PORT}",
+    "ZITADEL_URL": "http://localhost:${HTTP_PORT}/",
+    "ZITADEL_ISSUER": "http://localhost:${HTTP_PORT}/",
+    "ZITADEL_HEALTH_URL": "http://127.0.0.1:${HTTP_PORT}/debug/ready"
+  },
+  "broker": {
+    "enabled": true,
+    "namespace": "services/zitadel",
+    "buckets": [
+      {
+        "namespace": "services/zitadel",
+        "kind": "service",
+        "description": "App-owned ZITADEL secrets, including the stable 32-byte master key."
+      }
+    ],
+    "imports": [
+      {
+        "namespace": "services/zitadel",
+        "ref": "identity.ZITADEL_MASTERKEY",
+        "as": "ZITADEL_MASTERKEY",
+        "required": true
+      }
+    ]
+  },
+  "urls": [
+    {
+      "label": "console",
+      "url": "http://localhost:${HTTP_PORT}/ui/console/",
+      "kind": "local"
+    },
+    {
+      "label": "issuer",
+      "url": "http://localhost:${HTTP_PORT}/",
+      "kind": "local"
+    },
+    {
+      "label": "health",
+      "url": "http://127.0.0.1:${HTTP_PORT}/debug/ready",
+      "kind": "local"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-zitadel",
+      "channel": "latest"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-zitadel-v4.14.0-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\zitadel.exe",
+        "args": ["--version"]
+      },
+      "linux": {
+        "assetName": "lasso-zitadel-v4.14.0-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./zitadel",
+        "args": ["--version"]
+      },
+      "darwin": {
+        "assetName": "lasso-zitadel-v4.14.0-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./zitadel",
+        "args": ["--version"]
+      }
+    }
+  },
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/ZITADEL-CONSUMER-CONTRACT.md",
+        "content": "# ZITADEL consumer contract\n\nThis app-owned service depends on the sibling `postgres` service and a broker-backed `identity.ZITADEL_MASTERKEY` secret. Provide a stable exactly-32-byte master key before start; changing it after initialisation breaks encrypted ZITADEL state.\n\nExpected local issuer: http://localhost:${HTTP_PORT}/\n\nRegister each consuming app client in ZITADEL with explicit redirect URIs owned by the app, for example http://localhost:3000/auth/callback in local development.\n"
+      }
+    ]
+  },
+  "healthcheck": {
+    "type": "http",
+    "url": "http://127.0.0.1:${HTTP_PORT}/debug/ready",
+    "expected_status": 200,
+    "retries": 80,
+    "interval": 500
+  }
+}

--- a/tests/zitadel-consumer-contract.test.js
+++ b/tests/zitadel-consumer-contract.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { compileServiceSelectorPlan } from "../dist/runtime/operator/variables.js";
+
+const repoRoot = process.cwd();
+const fixtureRoot = path.join(repoRoot, "fixtures", "zitadel-consumer-app");
+const servicesRoot = path.join(fixtureRoot, "services");
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(repoRoot, relativePath), "utf8"));
+}
+
+test("ZITADEL consumer fixture declares an app-owned PostgreSQL-backed identity stack", async () => {
+  const services = await discoverServices(servicesRoot);
+  const byId = new Map(services.map((service) => [service.manifest.id, service.manifest]));
+
+  assert.deepEqual([...byId.keys()].sort(), ["postgres", "zitadel"]);
+  assert.equal(byId.get("postgres")?.artifact?.source?.repo, "service-lasso/lasso-postgres");
+  assert.equal(byId.get("zitadel")?.artifact?.source?.repo, "service-lasso/lasso-zitadel");
+  assert.deepEqual(byId.get("zitadel")?.depend_on, ["postgres"]);
+  assert.equal(byId.get("zitadel")?.enabled, true);
+  assert.equal(byId.get("zitadel")?.env?.ZITADEL_EXTERNALDOMAIN, "localhost");
+  assert.equal(byId.get("zitadel")?.env?.ZITADEL_EXTERNALSECURE, "false");
+  assert.match(byId.get("zitadel")?.env?.ZITADEL_DATABASE_POSTGRES_DSN ?? "", /^postgresql:\/\//);
+  assert.match(byId.get("zitadel")?.globalenv?.ZITADEL_ISSUER ?? "", /^http:\/\/localhost:/);
+});
+
+test("ZITADEL master key is broker-backed and no raw master key is committed", async () => {
+  const manifest = await readJson("fixtures/zitadel-consumer-app/services/zitadel/service.json");
+  const manifestText = await readFile(path.join(repoRoot, "fixtures", "zitadel-consumer-app", "services", "zitadel", "service.json"), "utf8");
+
+  assert.equal(manifest.env.ZITADEL_MASTERKEY, "${identity.ZITADEL_MASTERKEY}");
+  assert.deepEqual(manifest.broker.imports, [
+    {
+      namespace: "services/zitadel",
+      ref: "identity.ZITADEL_MASTERKEY",
+      as: "ZITADEL_MASTERKEY",
+      required: true,
+    },
+  ]);
+  assert.equal(manifestText.includes("<exactly-32-byte-master-key>"), false);
+  assert.equal(/ZITADEL_MASTERKEY"\s*:\s*"[A-Za-z0-9_-]{32,}"/.test(manifestText), false);
+
+  const selectorPlan = compileServiceSelectorPlan(manifest.env);
+  assert.deepEqual(selectorPlan.brokerRefs, ["identity.ZITADEL_MASTERKEY"]);
+});
+
+test("core baseline remains free of optional ZITADEL", async () => {
+  const coreServices = await discoverServices(path.join(repoRoot, "services"));
+  const coreIds = new Set(coreServices.map((service) => service.manifest.id));
+
+  assert.equal(coreIds.has("zitadel"), false);
+  assert.equal(coreIds.has("postgres"), false);
+});
+
+test("ZITADEL consumer docs name the required app-owned contract fields", async () => {
+  const docs = await readFile(path.join(repoRoot, "docs", "reference", "zitadel-consumer-integration.md"), "utf8");
+
+  for (const requiredText of [
+    "fixtures/zitadel-consumer-app/services/zitadel/service.json",
+    "ZITADEL_DATABASE_POSTGRES_DSN",
+    "ZITADEL_MASTERKEY",
+    "PostgreSQL dependency",
+    "Issuer URL",
+    "Redirect URIs",
+    "Client setup",
+    "Do not add ZITADEL to the core baseline",
+    "fail closed",
+  ]) {
+    assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a committed app-owned `fixtures/zitadel-consumer-app` pattern with PostgreSQL and ZITADEL service manifests.
- Document the ZITADEL consumer contract, including PostgreSQL dependency wiring, `ZITADEL_MASTERKEY`, issuer/domain/port, redirect URI/client setup, and blocked-prerequisite smoke guidance.
- Add a focused contract test proving the fixture is loadable, optional/non-baseline, broker-backed for the master key, and documented.

Closes #406

## Validation
- `npm run build` ✅
- `node --test --test-concurrency=1 tests/zitadel-consumer-contract.test.js tests/manifest-discovery.test.js` ✅ 26/26 passing
- `npm test` ✅ 188/188 passing on rerun. First full run had an unrelated flaky `recovery-e2e` assertion, and `node --test --test-concurrency=1 tests/recovery-e2e.test.js` passed immediately after.
- `npm run docs:build` ✅
- `git diff --check` ✅
