### PR TITLE
Add selector plan cache invalidation

### DIFF
--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -24,6 +24,26 @@ export interface ServiceSelectorPlan {
   brokerRefs: string[];
 }
 
+export interface ServiceSelectorPlanCacheStats {
+  planHits: number;
+  planMisses: number;
+  planInvalidations: number;
+  templateHits: number;
+  templateMisses: number;
+  planEntries: number;
+  templateEntries: number;
+}
+
+interface CompiledServiceSelectorTemplate {
+  tokens: Array<string | { raw: string; ref: ServiceSelectorRef }>;
+  selectors: ServiceSelectorRef[];
+}
+
+interface CachedSelectorPlan {
+  fingerprint: string;
+  plan: ServiceSelectorPlan;
+}
+
 export type ServiceSelectorDiagnosticReason = "unresolved-local" | "missing-broker" | "denied-broker" | "source-auth-required";
 
 export interface ServiceSelectorDiagnostic {
@@ -47,6 +67,34 @@ export interface ServiceVariablesPayload {
   variables: ServiceVariableEntry[];
   selectorPlan: ServiceSelectorPlan;
   diagnostics: ServiceSelectorDiagnostic[];
+}
+
+const compiledTemplateCache = new Map<string, CompiledServiceSelectorTemplate>();
+const selectorPlanCache = new Map<string, CachedSelectorPlan>();
+const selectorPlanCacheStats = {
+  planHits: 0,
+  planMisses: 0,
+  planInvalidations: 0,
+  templateHits: 0,
+  templateMisses: 0,
+};
+
+export function resetServiceSelectorPlanCache(): void {
+  compiledTemplateCache.clear();
+  selectorPlanCache.clear();
+  selectorPlanCacheStats.planHits = 0;
+  selectorPlanCacheStats.planMisses = 0;
+  selectorPlanCacheStats.planInvalidations = 0;
+  selectorPlanCacheStats.templateHits = 0;
+  selectorPlanCacheStats.templateMisses = 0;
+}
+
+export function getServiceSelectorPlanCacheStats(): ServiceSelectorPlanCacheStats {
+  return {
+    ...selectorPlanCacheStats,
+    planEntries: selectorPlanCache.size,
+    templateEntries: compiledTemplateCache.size,
+  };
 }
 
 function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVariableEntry[] {
@@ -101,13 +149,82 @@ function createSelectorRef(selector: string): ServiceSelectorRef {
   };
 }
 
+function compileServiceSelectorTemplate(value: string): CompiledServiceSelectorTemplate {
+  const cached = compiledTemplateCache.get(value);
+  if (cached) {
+    selectorPlanCacheStats.templateHits += 1;
+    return cached;
+  }
+
+  selectorPlanCacheStats.templateMisses += 1;
+  const tokens: CompiledServiceSelectorTemplate["tokens"] = [];
+  const selectors = new Map<string, ServiceSelectorRef>();
+  const selectorPattern = /\$\{([^}]+)\}/g;
+  let cursor = 0;
+
+  for (const match of value.matchAll(selectorPattern)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > cursor) {
+      tokens.push(value.slice(cursor, matchIndex));
+    }
+
+    const raw = match[0];
+    const ref = createSelectorRef(match[1]);
+    tokens.push({ raw, ref });
+    selectors.set(ref.selector, ref);
+    cursor = matchIndex + raw.length;
+  }
+
+  if (cursor < value.length) {
+    tokens.push(value.slice(cursor));
+  }
+
+  const compiled = { tokens, selectors: [...selectors.values()] };
+  compiledTemplateCache.set(value, compiled);
+  return compiled;
+}
+
+function fingerprintSelectorValues(values: string[] | Record<string, string>): string {
+  if (Array.isArray(values)) {
+    return JSON.stringify({ kind: "array", values });
+  }
+
+  return JSON.stringify({
+    kind: "record",
+    values: Object.keys(values)
+      .sort()
+      .map((key) => [key, values[key]]),
+  });
+}
+
+export function compileCachedServiceSelectorPlan(
+  cacheKey: string,
+  values: string[] | Record<string, string>,
+): ServiceSelectorPlan {
+  const fingerprint = fingerprintSelectorValues(values);
+  const cached = selectorPlanCache.get(cacheKey);
+
+  if (cached?.fingerprint === fingerprint) {
+    selectorPlanCacheStats.planHits += 1;
+    return cached.plan;
+  }
+
+  if (cached) {
+    selectorPlanCacheStats.planInvalidations += 1;
+  }
+
+  selectorPlanCacheStats.planMisses += 1;
+  const plan = compileServiceSelectorPlan(values);
+  selectorPlanCache.set(cacheKey, { fingerprint, plan });
+  return plan;
+}
+
 export function compileServiceSelectorPlan(values: string[] | Record<string, string>): ServiceSelectorPlan {
   const texts = Array.isArray(values) ? values : Object.values(values);
   const selectors = new Map<string, ServiceSelectorRef>();
 
   for (const text of texts) {
-    for (const match of text.matchAll(/\$\{([^}]+)\}/g)) {
-      const ref = createSelectorRef(match[1]);
+    for (const ref of compileServiceSelectorTemplate(text).selectors) {
       selectors.set(ref.selector, ref);
     }
   }
@@ -148,35 +265,42 @@ function replaceVariableSelectors(
   variables: ServiceVariableEntry[],
   options: ServiceTextResolutionOptions = {},
 ): string {
-  return value.replace(/\$\{([^}]+)\}/g, (match, key) => {
-    const ref = createSelectorRef(key);
-    if (ref.kind === "broker") {
-      if (options.allowedBrokerRefs && !hasRef(options.allowedBrokerRefs, ref.selector)) {
-        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
-        return match;
+  const compiled = compileServiceSelectorTemplate(value);
+  return compiled.tokens
+    .map((token) => {
+      if (typeof token === "string") {
+        return token;
       }
-      if (hasRef(options.deniedBrokerRefs, ref.selector)) {
-        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
-        return match;
-      }
-      if (hasRef(options.sourceAuthRequiredBrokerRefs, ref.selector)) {
-        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "source-auth-required" });
-        return match;
-      }
-      const brokerValue = options.brokerValues?.[ref.selector];
-      if (brokerValue !== undefined) {
-        return brokerValue;
-      }
-      options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "missing-broker" });
-      return match;
-    }
 
-    const entry = variables.find((candidate) => candidate.key === ref.key);
-    if (!entry) {
-      options.diagnostics?.push({ selector: ref.selector, kind: "local", reason: "unresolved-local" });
-    }
-    return entry ? entry.value : match;
-  });
+      const { raw, ref } = token;
+      if (ref.kind === "broker") {
+        if (options.allowedBrokerRefs && !hasRef(options.allowedBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+          return raw;
+        }
+        if (hasRef(options.deniedBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+          return raw;
+        }
+        if (hasRef(options.sourceAuthRequiredBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "source-auth-required" });
+          return raw;
+        }
+        const brokerValue = options.brokerValues?.[ref.selector];
+        if (brokerValue !== undefined) {
+          return brokerValue;
+        }
+        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "missing-broker" });
+        return raw;
+      }
+
+      const entry = variables.find((candidate) => candidate.key === ref.key);
+      if (!entry) {
+        options.diagnostics?.push({ selector: ref.selector, kind: "local", reason: "unresolved-local" });
+      }
+      return entry ? entry.value : raw;
+    })
+    .join("");
 }
 
 export function buildServiceVariables(
@@ -283,7 +407,10 @@ export function buildServiceVariables(
   return {
     serviceId: service.manifest.id,
     variables: [...manifestVariables, ...brokerImportVariables, ...globalVariables, ...derivedVariables],
-    selectorPlan: compileServiceSelectorPlan(service.manifest.env ?? {}),
+    selectorPlan: compileCachedServiceSelectorPlan(
+      `service:${service.manifestPath}:${service.manifest.id}:env`,
+      service.manifest.env ?? {},
+    ),
     diagnostics: manifestDiagnostics,
   };
 }
@@ -305,15 +432,51 @@ export function collectServiceGlobalEnv(
 export function compileServiceMaterializationSelectorPlan(service: DiscoveredService): ServiceSelectorPlan {
   const installFiles = service.manifest.install?.files ?? [];
   const configFiles = service.manifest.config?.files ?? [];
+  const cacheKey = `service:${service.manifestPath}:${service.manifest.id}:materialization`;
+  const fingerprintValues = {
+    env: JSON.stringify(service.manifest.env ?? {}),
+    globalenv: JSON.stringify(service.manifest.globalenv ?? {}),
+    imports: JSON.stringify(service.manifest.broker?.imports ?? []),
+    exports: JSON.stringify(service.manifest.broker?.exports ?? []),
+    install: JSON.stringify(installFiles),
+    config: JSON.stringify(configFiles),
+  };
+  const fingerprint = fingerprintSelectorValues(fingerprintValues);
+  const cached = selectorPlanCache.get(cacheKey);
 
-  return mergeSelectorPlans([
-    compileServiceSelectorPlan(service.manifest.env ?? {}),
-    compileServiceSelectorPlan(service.manifest.globalenv ?? {}),
-    compileServiceSelectorPlan((service.manifest.broker?.imports ?? []).map((entry) => `\${${entry.ref}}`)),
-    compileServiceSelectorPlan((service.manifest.broker?.exports ?? []).flatMap((entry) => [`\${${entry.ref}}`, entry.source])),
-    compileServiceSelectorPlan(installFiles.flatMap((file) => [file.path, file.content])),
-    compileServiceSelectorPlan(configFiles.flatMap((file) => [file.path, file.content])),
+  if (cached?.fingerprint === fingerprint) {
+    selectorPlanCacheStats.planHits += 1;
+    return cached.plan;
+  }
+
+  if (cached) {
+    selectorPlanCacheStats.planInvalidations += 1;
+  }
+
+  selectorPlanCacheStats.planMisses += 1;
+  const plan = mergeSelectorPlans([
+    compileCachedServiceSelectorPlan(`${cacheKey}:env`, service.manifest.env ?? {}),
+    compileCachedServiceSelectorPlan(`${cacheKey}:globalenv`, service.manifest.globalenv ?? {}),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:broker-imports`,
+      (service.manifest.broker?.imports ?? []).map((entry) => `\${${entry.ref}}`),
+    ),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:broker-exports`,
+      (service.manifest.broker?.exports ?? []).flatMap((entry) => [`\${${entry.ref}}`, entry.source]),
+    ),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:install`,
+      installFiles.flatMap((file) => [file.path, file.content]),
+    ),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:config`,
+      configFiles.flatMap((file) => [file.path, file.content]),
+    ),
   ]);
+
+  selectorPlanCache.set(cacheKey, { fingerprint, plan });
+  return plan;
 }
 
 export function resolveServiceText(

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -5,8 +5,11 @@ import os from "node:os";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import {
   buildServiceVariables,
+  compileCachedServiceSelectorPlan,
   compileServiceMaterializationSelectorPlan,
   compileServiceSelectorPlan,
+  getServiceSelectorPlanCacheStats,
+  resetServiceSelectorPlanCache,
   resolveServiceText,
   resolveServiceVariable,
 } from "../dist/runtime/operator/variables.js";
@@ -256,4 +259,90 @@ test("materialization selector plan covers env, globalenv, install, and config t
   assert.ok(plan.localRefs.includes("PUBLIC_URL"));
   assert.ok(plan.localRefs.includes("SERVICE_ID"));
   assert.ok(plan.localRefs.includes("LOCAL_SECRET_REF"));
+});
+
+test("selector planning cache reuses unchanged plans and invalidates when values change", () => {
+  resetServiceSelectorPlanCache();
+
+  const first = compileCachedServiceSelectorPlan("service:consumer:env", {
+    LOCAL: "${SERVICE_ROOT}",
+    SECRET: "${database.PASSWORD}:${database.PASSWORD}",
+  });
+  const second = compileCachedServiceSelectorPlan("service:consumer:env", {
+    SECRET: "${database.PASSWORD}:${database.PASSWORD}",
+    LOCAL: "${SERVICE_ROOT}",
+  });
+  const changed = compileCachedServiceSelectorPlan("service:consumer:env", {
+    LOCAL: "${SERVICE_ROOT}",
+    SECRET: "${vault.API_TOKEN}",
+  });
+
+  assert.equal(second, first);
+  assert.notEqual(changed, first);
+  assert.deepEqual(second.brokerRefs, ["database.PASSWORD"]);
+  assert.deepEqual(changed.brokerRefs, ["vault.API_TOKEN"]);
+  assert.deepEqual(getServiceSelectorPlanCacheStats(), {
+    planHits: 1,
+    planMisses: 2,
+    planInvalidations: 1,
+    templateHits: 1,
+    templateMisses: 3,
+    planEntries: 1,
+    templateEntries: 3,
+  });
+});
+
+test("materialization selector plan cache invalidates on broker policy and config changes", () => {
+  resetServiceSelectorPlanCache();
+  const service = fixtureService({
+    env: { LOCAL_SECRET_REF: "${secretsbroker.API_KEY}" },
+    broker: {
+      imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
+    },
+    config: { files: [{ path: "config/${SERVICE_ID}.json", content: "${database.PASSWORD}" }] },
+  });
+
+  const first = compileServiceMaterializationSelectorPlan(service);
+  const second = compileServiceMaterializationSelectorPlan(service);
+
+  service.manifest.broker.imports = [
+    { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" },
+    { namespace: "shared/database", ref: "database.USER", as: "DB_USER" },
+  ];
+  const withBrokerPolicyChange = compileServiceMaterializationSelectorPlan(service);
+
+  service.manifest.config.files[0].content = "${database.PASSWORD}:${database.USER}:${vault.extra.token}";
+  const withConfigChange = compileServiceMaterializationSelectorPlan(service);
+
+  assert.equal(second, first);
+  assert.notEqual(withBrokerPolicyChange, first);
+  assert.notEqual(withConfigChange, withBrokerPolicyChange);
+  assert.deepEqual(withBrokerPolicyChange.brokerRefs, ["secretsbroker.API_KEY", "database.PASSWORD", "database.USER"]);
+  assert.deepEqual(withConfigChange.brokerRefs, [
+    "secretsbroker.API_KEY",
+    "database.PASSWORD",
+    "database.USER",
+    "vault.extra.token",
+  ]);
+
+  const stats = getServiceSelectorPlanCacheStats();
+  assert.equal(stats.planHits >= 1, true);
+  assert.equal(stats.planInvalidations >= 2, true);
+});
+
+test("compiled selector templates are reused during repeated text resolution", () => {
+  resetServiceSelectorPlanCache();
+  const service = fixtureService({
+    env: {
+      LOCAL_ONLY: "local",
+      FROM_LOCAL: "${LOCAL_ONLY}:${LOCAL_ONLY}",
+    },
+  });
+
+  const first = resolveServiceText("value=${FROM_LOCAL}", service);
+  const second = resolveServiceText("value=${FROM_LOCAL}", service);
+
+  assert.equal(first, "value=local:local");
+  assert.equal(second, "value=local:local");
+  assert.equal(getServiceSelectorPlanCacheStats().templateHits > 0, true);
 });


### PR DESCRIPTION
## Summary
- Add an in-memory parse-once/resolve-many selector template cache and keyed selector plan cache.
- Cache service env selector plans and materialization selector plans by service manifest path/id with fingerprint invalidation.
- Preserve local/broker selector behavior while adding cache stats/reset exports for tests and operator introspection.
- Extend selector planning tests for duplicate refs, broker refs, denied/missing refs, materialization invalidation, and repeated text resolution reuse.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/variable-selector-planning.test.js` → 11/11 passing
- `npm test` → 191/191 passing
- `git diff --check`

## Process note
Holding this PR for explicit independent validation before merge, per Max/MegaMind validation hold requirement after #401/#406 process misses.

Closes #402
