### PR TITLE
Add broker consumption fixtures

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -530,6 +530,13 @@ Migration from `globalenv`:
 
 Legacy `globalenv` remains a compatibility path for bounded provider/tool values that are already safe to share. New cross-service secret flow should move to explicit broker imports/exports so values are bucketed as current-service, app-level, explicitly shared, or truly global instead of ambiently merged into every launched process.
 
+Ordinary services should consume broker values through service-local `env` names or through an explicit CLI/adapter resolution step. Keep the manifest reviewable:
+- map each secret to a concrete env key, for example `"DB_PASSWORD": "${database.PASSWORD}"`
+- declare the same dotted ref in `broker.imports[]`; undeclared dotted refs are denied instead of falling back to ambient/global lookup
+- do not print resolved values in normal logs, diagnostics, issue comments, or support bundles
+- prefer env mapping for long-running processes; use CLI-style resolution only for controlled setup/adapter paths that do not echo arguments or outputs containing raw secrets
+- missing, denied, or source-auth-required refs should fail with actionable diagnostics that name the ref and reason without including the secret value
+
 Becomes an explicit broker contract:
 ```json
 {

--- a/src/runtime/execution/commandline.ts
+++ b/src/runtime/execution/commandline.ts
@@ -1,5 +1,5 @@
 import type { DiscoveredService } from "../../contracts/service.js";
-import { resolveServiceText } from "../operator/variables.js";
+import { resolveServiceText, type ServiceTextResolutionOptions } from "../operator/variables.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
 
 export function selectPlatformCommandline(
@@ -60,11 +60,12 @@ export function resolveExecutionArgs(
   executionPlan: ProviderExecutionPlan,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
+  options: ServiceTextResolutionOptions = {},
 ): string[] {
   const commandline = selectPlatformCommandline(service.manifest.commandline);
   if (!commandline) {
-    return executionPlan.args;
+    return executionPlan.args.map((arg) => resolveServiceText(arg, service, sharedGlobalEnv, resolvedPorts, options));
   }
 
-  return parseCommandlineArgs(resolveServiceText(commandline, service, sharedGlobalEnv, resolvedPorts));
+  return parseCommandlineArgs(resolveServiceText(commandline, service, sharedGlobalEnv, resolvedPorts, options));
 }

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -4,7 +4,7 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { resolveExecutionArgs, selectPlatformCommandline } from "./commandline.js";
-import { buildServiceVariables } from "../operator/variables.js";
+import { buildServiceVariables, type ServiceVariableResolutionOptions } from "../operator/variables.js";
 import { archiveRuntimeLogs, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
 
@@ -41,6 +41,7 @@ interface StartProcessOptions {
   sharedGlobalEnv?: Record<string, string>;
   resolvedPorts?: Record<string, number>;
   secureEnv?: Record<string, string>;
+  variableResolution?: ServiceVariableResolutionOptions;
   onExit?: (payload: {
     service: DiscoveredService;
     exitCode: number | null;
@@ -182,9 +183,10 @@ function buildProcessEnvironment(
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
   secureEnv: Record<string, string> = {},
+  variableResolution: ServiceVariableResolutionOptions = {},
 ): NodeJS.ProcessEnv {
   const serviceVariables = Object.fromEntries(
-    buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
+    buildServiceVariables(service, sharedGlobalEnv, resolvedPorts, variableResolution).variables.map((entry) => [entry.key, entry.value]),
   );
 
   return {
@@ -200,7 +202,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv, onExit } = options;
+  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv, variableResolution, onExit } = options;
   const serviceId = service.manifest.id;
 
   const priorFinalizer = managedProcessFinalizers.get(serviceId);
@@ -217,7 +219,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
   const args = resolveCommandRootArgs(
     service,
     executionPlan,
-    resolveExecutionArgs(service, executionPlan, sharedGlobalEnv, resolvedPorts),
+    resolveExecutionArgs(service, executionPlan, sharedGlobalEnv, resolvedPorts, variableResolution),
   );
   const command = buildCommandString(executable, args);
   const startedAt = new Date().toISOString();
@@ -225,7 +227,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const child = spawn(executable, args, {
     cwd: workingDirectory,
-    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv),
+    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts, secureEnv, variableResolution),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
   });

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -5,7 +5,7 @@ import { mintScopedBrokerIdentity, revokeServiceScopedBrokerIdentities } from ".
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
-import { collectRuntimeGlobalEnv } from "../operator/variables.js";
+import { collectRuntimeGlobalEnv, type ServiceVariableResolutionOptions } from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
 import { createDirectExecutionPlan } from "../providers/direct.js";
 import { resolveProviderExecution } from "../providers/resolveProvider.js";
@@ -71,6 +71,10 @@ function applyProcessLaunchMetrics(
     totalRunDurationMs,
     lastRunDurationMs,
   };
+}
+
+export interface ServiceLifecycleActionOptions {
+  variableResolution?: ServiceVariableResolutionOptions;
 }
 
 function applyState(
@@ -207,6 +211,7 @@ export async function configService(
 export async function startService(
   service: DiscoveredService,
   registry?: ServiceRegistry,
+  options: ServiceLifecycleActionOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
@@ -255,7 +260,7 @@ export async function startService(
       }
 
       if (!dependencyState.running) {
-        const dependencyResult = await startService(dependency, registry);
+        const dependencyResult = await startService(dependency, registry, options);
         await writeServiceState(dependency, dependencyResult.state);
       }
     }
@@ -275,6 +280,7 @@ export async function startService(
     sharedGlobalEnv,
     resolvedPorts,
     secureEnv: scopedBrokerIdentity?.env,
+    variableResolution: options.variableResolution,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -389,6 +395,7 @@ export async function stopService(service: DiscoveredService): Promise<Lifecycle
 export async function restartService(
   service: DiscoveredService,
   registry?: ServiceRegistry,
+  options: ServiceLifecycleActionOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
@@ -426,6 +433,7 @@ export async function restartService(
     sharedGlobalEnv,
     resolvedPorts,
     secureEnv: scopedBrokerIdentity?.env,
+    variableResolution: options.variableResolution,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;

--- a/tests/broker-consumption-fixtures.test.js
+++ b/tests/broker-consumption-fixtures.test.js
@@ -1,0 +1,175 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
+import { installService, configService, startService, stopService } from "../dist/runtime/lifecycle/actions.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { buildServiceVariables, resolveServiceText } from "../dist/runtime/operator/variables.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function waitFor(predicate, timeoutMs = 1_500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function prepareRegistry(servicesRoot) {
+  const discovered = await discoverServices(servicesRoot);
+  const registry = createServiceRegistry(discovered);
+  return { discovered, registry };
+}
+
+test("ordinary service consumes Secrets Broker imports through resolved env without logging raw values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-env-e2e-");
+  const rawSecret = "ordinary-service-db-password";
+
+  try {
+    const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "ordinary-broker-env-consumer", {
+      readyFileAfterMs: 10,
+      captureEnvKeys: ["DB_PASSWORD", "API_TOKEN", "BROKER_BACKED_URL"],
+      stdoutLines: ["ordinary broker env consumer started"],
+      stderrLines: ["ordinary broker env consumer diagnostics are scrubbed"],
+      env: {
+        DB_PASSWORD: "${database.PASSWORD}",
+        API_TOKEN: "${services.API_TOKEN}",
+        BROKER_BACKED_URL: "postgres://service:${database.PASSWORD}@localhost/app",
+      },
+      broker: {
+        enabled: true,
+        namespace: "services/ordinary-broker-env-consumer",
+        buckets: [
+          { namespace: "services/ordinary-broker-env-consumer", kind: "service" },
+          { namespace: "shared/database", kind: "shared" },
+        ],
+        imports: [
+          { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
+          { namespace: "services/ordinary-broker-env-consumer", ref: "services.API_TOKEN", as: "API_TOKEN", required: true },
+        ],
+      },
+    });
+    const { registry } = await prepareRegistry(servicesRoot);
+    const service = registry.getById("ordinary-broker-env-consumer");
+    assert.ok(service);
+
+    await installService(service, registry);
+    await configService(service, registry);
+    const started = await startService(service, registry, {
+      variableResolution: {
+        brokerValues: {
+          "database.PASSWORD": rawSecret,
+          "services.API_TOKEN": "ordinary-service-api-token",
+        },
+      },
+    });
+
+    try {
+      const snapshotPath = path.join(serviceRoot, "runtime", "env.json");
+      await waitFor(async () => {
+        try {
+          await readFile(snapshotPath, "utf8");
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const snapshot = JSON.parse(await readFile(snapshotPath, "utf8"));
+      assert.equal(snapshot.DB_PASSWORD, rawSecret);
+      assert.equal(snapshot.API_TOKEN, "ordinary-service-api-token");
+      assert.equal(snapshot.BROKER_BACKED_URL, `postgres://service:${rawSecret}@localhost/app`);
+    } finally {
+      await stopService(service);
+    }
+
+    const stdout = await readFile(started.state.runtime.logs.stdoutPath, "utf8");
+    const stderr = await readFile(started.state.runtime.logs.stderrPath, "utf8");
+    const combined = await readFile(started.state.runtime.logs.logPath, "utf8");
+    assert.equal(stdout.includes(rawSecret), false);
+    assert.equal(stderr.includes(rawSecret), false);
+    assert.equal(combined.includes(rawSecret), false);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI-style broker resolution fixture reports missing denied and source-auth refs without leaking values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-cli-fixture-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "ordinary-broker-cli-consumer", {
+      env: {
+        CLI_TOKEN: "${cli.TOKEN}",
+        LOCAL_ONLY: "local-value",
+        MISSING_REF: "${cli.MISSING}",
+        DENIED_REF: "${cli.DENIED}",
+        SOURCE_REF: "${source.NEEDS_AUTH}",
+      },
+      broker: {
+        enabled: true,
+        namespace: "services/ordinary-broker-cli-consumer",
+        imports: [
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.TOKEN", as: "CLI_TOKEN", required: true },
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.MISSING", as: "MISSING_REF" },
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.DENIED", as: "DENIED_REF" },
+          { namespace: "external/source", ref: "source.NEEDS_AUTH", as: "SOURCE_REF" },
+        ],
+      },
+    });
+    const { registry } = await prepareRegistry(servicesRoot);
+    const service = registry.getById("ordinary-broker-cli-consumer");
+    assert.ok(service);
+
+    const diagnostics = [];
+    const resolved = resolveServiceText(
+      "secretsbroker-resolve cli.TOKEN -> ${cli.TOKEN}; local=${LOCAL_ONLY}; denied=${cli.DENIED}; source=${source.NEEDS_AUTH}",
+      service,
+      {},
+      {},
+      {
+        brokerValues: {
+          "cli.TOKEN": "cli-token-value",
+          "cli.DENIED": "must-not-leak-denied",
+          "source.NEEDS_AUTH": "must-not-leak-source",
+        },
+        deniedBrokerRefs: ["cli.DENIED"],
+        sourceAuthRequiredBrokerRefs: ["source.NEEDS_AUTH"],
+        diagnostics,
+      },
+    );
+
+    assert.equal(resolved, "secretsbroker-resolve cli.TOKEN -> cli-token-value; local=local-value; denied=${cli.DENIED}; source=${source.NEEDS_AUTH}");
+    assert.equal(resolved.includes("must-not-leak-denied"), false);
+    assert.equal(resolved.includes("must-not-leak-source"), false);
+    assert.deepEqual(diagnostics, [
+      { selector: "cli.DENIED", kind: "broker", reason: "denied-broker" },
+      { selector: "source.NEEDS_AUTH", kind: "broker", reason: "source-auth-required" },
+    ]);
+
+    const payload = buildServiceVariables(service, {}, {}, {
+      brokerValues: { "cli.TOKEN": "cli-token-value", "cli.DENIED": "must-not-leak-denied" },
+      deniedBrokerRefs: ["cli.DENIED"],
+      sourceAuthRequiredBrokerRefs: ["source.NEEDS_AUTH"],
+    });
+    const serialized = JSON.stringify(payload);
+    assert.equal(serialized.includes("must-not-leak-denied"), false);
+    assert.equal(serialized.includes("must-not-leak-source"), false);
+    assert.deepEqual(payload.diagnostics.map((entry) => entry.reason), [
+      "missing-broker",
+      "denied-broker",
+      "source-auth-required",
+    ]);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add ordinary-service broker consumption fixtures covering env-var injection and CLI-style resolution diagnostics.
- Allow lifecycle-managed process starts/restarts to pass explicit broker variable resolution into env and command/arg resolution paths.
- Document service-author patterns for broker-backed env mapping and controlled CLI/adapter resolution without leaking raw secret values.

## Validation

- `npm run build && node --test --test-concurrency=1 tests/broker-consumption-fixtures.test.js tests/variable-selector-planning.test.js`
- `git diff --check`
- `npm test`

## Process

- Selected after #402 completed and Dagu #1 remained Blocked / Human Needed.
- Please independently validate before merge; I will not merge without an explicit validation verdict.

Closes #403.
