### PR TITLE
Add product API facade contract

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -1,0 +1,199 @@
+---
+title: Product API Facade Contract
+sidebar_label: Product API Facade
+---
+
+# Product API Facade Contract
+
+The product API facade owns Service Lasso account metadata that is broader than
+runtime service state: users, workspaces, linked identities, provider connection
+metadata, roles/entitlements, and authorization decisions for Secrets Broker and
+workflow/run resolution.
+
+This contract is metadata-only. Provider secret payloads, OAuth access tokens,
+refresh tokens, API keys, private keys, password values, portable master keys,
+and recovery material must not be stored or returned by the facade. Store secret
+material behind a Secrets Broker or source-backend reference and return only the
+safe reference metadata needed to authorize and diagnose access.
+
+## Data model
+
+### `users`
+
+A user is the internal product principal.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable internal user id such as `usr_...`. |
+| `displayName` / `email` | Display metadata copied from a verified identity claim where available. |
+| `status` | `active`, `disabled`, or `pending`. Disabled users fail authorization. |
+| `linkedIdentityIds` | Links to external identities that can authenticate as this user. |
+| `createdAt` / `updatedAt` | Audit timestamps. |
+
+### `workspaces`
+
+A workspace scopes users, provider connections, broker authorization, and
+workflow/run ownership.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable internal workspace id such as `wks_...`. |
+| `slug` / `displayName` | Operator-facing metadata. |
+| `status` | `active`, `suspended`, or `archived`. Suspended/archived workspaces fail mutating actions. |
+| `ownerUserId` | Internal owner user id. |
+| `createdAt` / `updatedAt` | Audit timestamps. |
+
+### `linked_identities`
+
+A linked identity maps an external identity provider subject to an internal user
+and one or more workspaces.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable link id. |
+| `provider` | `zitadel`, `github`, `google`, `telegram`, `custom-oidc`, or another registered provider. |
+| `issuer` | OIDC issuer or provider authority. |
+| `subject` | Provider subject id. |
+| `userId` | Internal user id. |
+| `workspaceIds` | Workspaces this identity can enter after role checks. |
+| `claims` | Safe claim metadata only: email, preferred username, groups. |
+| `createdAt` / `lastSeenAt` | Audit timestamps. |
+
+### `provider_connections`
+
+A provider connection is safe metadata for a third-party or service provider
+integration. It must be clearly split from secret payloads.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable connection id such as `pc_...`. |
+| `workspaceId` / `ownerUserId` | Ownership and authorization scope. |
+| `provider` | Provider key, for example `github`, `stripe`, or `vault`. |
+| `kind` | `oauth`, `api-token`, `webhook`, `secrets-broker-source`, or `custom`. |
+| `displayName` | Operator-facing label. |
+| `status` | `ready`, `needs-auth`, `revoked`, `disabled`, or `error`. |
+| `scopes` | Granted/expected provider scopes as labels. |
+| `brokerNamespace` / `secretRef` | Pointer to secret material, never the value itself. |
+| `lastVerifiedAt` | Last successful metadata/auth check. |
+| `secretMaterialPresent` | Must be `false` in facade responses. A true value is a contract violation. |
+| `createdAt` / `updatedAt` | Audit timestamps. |
+
+Forbidden fields in facade provider connection payloads include `secret`,
+`accessToken`, `refreshToken`, `apiKey`, `privateKey`, `password`,
+`credential`, `keyMaterial`, and `recoveryMaterial`.
+
+### `roles` and entitlements
+
+Roles are workspace-scoped bundles of entitlements. The first concrete
+entitlements are:
+
+- `workspace:read`
+- `workspace:admin`
+- `provider-connection:read`
+- `provider-connection:write`
+- `provider-connection:use`
+- `secrets-broker:resolve`
+- `workflow:run`
+
+Secrets Broker resolution requires `secrets-broker:resolve` in the same
+workspace as the requested broker namespace. Workflow/run resolution requires
+`workflow:run`; if a workflow uses provider connection metadata, it also
+requires `provider-connection:use` for each referenced connection.
+
+## Provider connection metadata API
+
+The facade exposes CRUD for metadata only:
+
+```text
+GET   /api/platform/workspaces/{workspaceId}/provider-connections
+POST  /api/platform/workspaces/{workspaceId}/provider-connections
+GET   /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
+PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
+```
+
+### Create request
+
+```json
+{
+  "workspaceId": "wks_local_demo",
+  "ownerUserId": "usr_01hzy9operator",
+  "provider": "github",
+  "kind": "oauth",
+  "displayName": "GitHub Actions metadata connection",
+  "scopes": ["repo:read", "workflow:read"],
+  "brokerNamespace": "workspaces/local-demo/provider-connections/github",
+  "secretRef": "provider.github.oauth.client"
+}
+```
+
+### Response
+
+```json
+{
+  "id": "pc_github_actions",
+  "workspaceId": "wks_local_demo",
+  "ownerUserId": "usr_01hzy9operator",
+  "provider": "github",
+  "kind": "oauth",
+  "displayName": "GitHub Actions metadata connection",
+  "status": "ready",
+  "scopes": ["repo:read", "workflow:read"],
+  "brokerNamespace": "workspaces/local-demo/provider-connections/github",
+  "secretRef": "provider.github.oauth.client",
+  "lastVerifiedAt": "2026-05-08T10:05:00Z",
+  "secretMaterialPresent": false,
+  "createdAt": "2026-05-08T10:00:00Z",
+  "updatedAt": "2026-05-08T10:05:00Z"
+}
+```
+
+The response is safe to log because it contains reference metadata only. The
+facade must never return raw provider secrets, access tokens, refresh tokens,
+API keys, password values, private keys, key material, or recovery material.
+
+## ZITADEL session mapping
+
+When ZITADEL is used by a consuming app, Service Lasso maps the OIDC session to
+internal context as follows:
+
+1. Match `issuer` + `subject` to a `linked_identities` record with
+   `provider: "zitadel"`.
+2. Resolve the internal `userId` and allowed `workspaceIds` from that record.
+3. Select the active workspace from request routing or the user's default
+   workspace.
+4. Load roles for that workspace and flatten them to entitlements.
+5. Produce a request context containing `userId`, `workspaceId`,
+   `linkedIdentityId`, and entitlements.
+6. Fail closed if the linked identity, workspace, user, or required entitlement
+   is missing.
+
+ZITADEL remains app-owned. This facade contract describes how an authenticated
+ZITADEL subject enters Service Lasso account/workspace authorization; it does
+not make ZITADEL part of the Service Lasso core baseline.
+
+## Authorization boundaries
+
+Authorization is workspace-scoped and fail-closed:
+
+- Provider connection read/write/use checks must compare the request workspace to
+  the connection `workspaceId`.
+- Secrets Broker checks must compare the request workspace to the broker
+  namespace owner and require `secrets-broker:resolve`.
+- Workflow/run checks must require `workflow:run`, then require
+  `provider-connection:use` for each provider connection referenced by the run.
+- Connections with status `needs-auth`, `revoked`, `disabled`, or `error` cannot
+  be used for broker or workflow authorization.
+- Denied authorization responses may include metadata reasons such as
+  `workspace-mismatch`, `missing-entitlement`, or `connection-not-ready`, but
+  must not include provider secret values or key material.
+
+## Test fixtures
+
+The TypeScript contract lives in `src/platform/facade.ts`. Tests in
+`tests/product-api-facade.test.js` verify:
+
+- required facade model and endpoint concepts exist,
+- ZITADEL session context maps to internal user/workspace context,
+- provider connection metadata is split from secret payloads,
+- Secrets Broker and workflow authorization boundaries are testable, and
+- sensitive strings are rejected or absent from fixture/API shapes.

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -1,0 +1,283 @@
+export type PlatformUserStatus = "active" | "disabled" | "pending";
+export type PlatformWorkspaceStatus = "active" | "suspended" | "archived";
+export type LinkedIdentityProvider = "zitadel" | "github" | "google" | "telegram" | "custom-oidc";
+export type ProviderConnectionKind = "oauth" | "api-token" | "webhook" | "secrets-broker-source" | "custom";
+export type ProviderConnectionStatus = "ready" | "needs-auth" | "revoked" | "disabled" | "error";
+export type PlatformEntitlement =
+  | "workspace:read"
+  | "workspace:admin"
+  | "provider-connection:read"
+  | "provider-connection:write"
+  | "provider-connection:use"
+  | "secrets-broker:resolve"
+  | "workflow:run";
+
+export type PlatformRole = {
+  id: string;
+  workspaceId: string;
+  name: "owner" | "admin" | "developer" | "operator" | "viewer" | string;
+  entitlements: PlatformEntitlement[];
+};
+
+export type PlatformUser = {
+  id: string;
+  displayName: string;
+  email?: string;
+  status: PlatformUserStatus;
+  linkedIdentityIds: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlatformWorkspace = {
+  id: string;
+  slug: string;
+  displayName: string;
+  status: PlatformWorkspaceStatus;
+  ownerUserId: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LinkedIdentity = {
+  id: string;
+  provider: LinkedIdentityProvider;
+  issuer: string;
+  subject: string;
+  userId: string;
+  workspaceIds: string[];
+  claims: {
+    email?: string;
+    preferredUsername?: string;
+    groups?: string[];
+  };
+  createdAt: string;
+  lastSeenAt?: string;
+};
+
+export type ProviderConnectionMetadata = {
+  id: string;
+  workspaceId: string;
+  ownerUserId: string;
+  provider: string;
+  kind: ProviderConnectionKind;
+  displayName: string;
+  status: ProviderConnectionStatus;
+  scopes: string[];
+  brokerNamespace?: string;
+  secretRef?: string;
+  lastVerifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  // Metadata only. Secret payloads, access tokens, refresh tokens, API keys,
+  // private keys, and recovery material must live behind a broker/source ref.
+  secretMaterialPresent: boolean;
+};
+
+export type CreateProviderConnectionMetadataRequest = {
+  workspaceId: string;
+  ownerUserId: string;
+  provider: string;
+  kind: ProviderConnectionKind;
+  displayName: string;
+  scopes?: string[];
+  brokerNamespace?: string;
+  secretRef?: string;
+};
+
+export type UpdateProviderConnectionMetadataRequest = Partial<
+  Pick<
+    ProviderConnectionMetadata,
+    | "displayName"
+    | "status"
+    | "scopes"
+    | "brokerNamespace"
+    | "secretRef"
+    | "lastVerifiedAt"
+  >
+>;
+
+export type ZitadelSessionContext = {
+  issuer: string;
+  subject: string;
+  email?: string;
+  preferredUsername?: string;
+  groups?: string[];
+};
+
+export type PlatformRequestContext = {
+  userId: string;
+  workspaceId: string;
+  linkedIdentityId: string;
+  entitlements: PlatformEntitlement[];
+};
+
+export type AuthorizationResource =
+  | { kind: "provider-connection"; connection: ProviderConnectionMetadata }
+  | { kind: "secrets-broker-ref"; workspaceId: string; brokerNamespace: string; ref: string }
+  | { kind: "workflow-run"; workspaceId: string; workflowId: string; requiredProviderConnectionIds?: string[] };
+
+export type AuthorizationDecision = {
+  allowed: boolean;
+  reason: "allowed" | "missing-entitlement" | "workspace-mismatch" | "connection-not-ready";
+  requiredEntitlements: PlatformEntitlement[];
+};
+
+export const providerConnectionMetadataEndpoints = {
+  list: "GET /api/platform/workspaces/{workspaceId}/provider-connections",
+  create: "POST /api/platform/workspaces/{workspaceId}/provider-connections",
+  read: "GET /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+  update: "PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+} as const;
+
+export const examplePlatformFacadeState = {
+  users: [
+    {
+      id: "usr_01hzy9operator",
+      displayName: "Operator Example",
+      email: "operator@example.test",
+      status: "active",
+      linkedIdentityIds: ["lid_zitadel_operator"],
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:00:00Z",
+    },
+  ],
+  workspaces: [
+    {
+      id: "wks_local_demo",
+      slug: "local-demo",
+      displayName: "Local demo workspace",
+      status: "active",
+      ownerUserId: "usr_01hzy9operator",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:00:00Z",
+    },
+  ],
+  linkedIdentities: [
+    {
+      id: "lid_zitadel_operator",
+      provider: "zitadel",
+      issuer: "http://localhost:8080",
+      subject: "zitadel-user-operator",
+      userId: "usr_01hzy9operator",
+      workspaceIds: ["wks_local_demo"],
+      claims: {
+        email: "operator@example.test",
+        preferredUsername: "operator",
+        groups: ["service-lasso-operators"],
+      },
+      createdAt: "2026-05-08T10:00:00Z",
+      lastSeenAt: "2026-05-08T10:05:00Z",
+    },
+  ],
+  roles: [
+    {
+      id: "role_local_operator",
+      workspaceId: "wks_local_demo",
+      name: "operator",
+      entitlements: [
+        "workspace:read",
+        "provider-connection:read",
+        "provider-connection:use",
+        "secrets-broker:resolve",
+        "workflow:run",
+      ],
+    },
+  ],
+  providerConnections: [
+    {
+      id: "pc_github_actions",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "github",
+      kind: "oauth",
+      displayName: "GitHub Actions metadata connection",
+      status: "ready",
+      scopes: ["repo:read", "workflow:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/github",
+      secretRef: "provider.github.oauth.client",
+      lastVerifiedAt: "2026-05-08T10:05:00Z",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:05:00Z",
+      secretMaterialPresent: false,
+    },
+  ],
+} as const satisfies {
+  users: PlatformUser[];
+  workspaces: PlatformWorkspace[];
+  linkedIdentities: LinkedIdentity[];
+  roles: PlatformRole[];
+  providerConnections: ProviderConnectionMetadata[];
+};
+
+export function mapZitadelSessionToPlatformContext(
+  session: ZitadelSessionContext,
+  state = examplePlatformFacadeState,
+): PlatformRequestContext | undefined {
+  const identity = state.linkedIdentities.find(
+    (linkedIdentity) => linkedIdentity.provider === "zitadel" && linkedIdentity.issuer === session.issuer && linkedIdentity.subject === session.subject,
+  );
+  if (!identity) return undefined;
+
+  const workspaceId = identity.workspaceIds[0];
+  if (!workspaceId) return undefined;
+
+  const entitlements = state.roles
+    .filter((role) => role.workspaceId === workspaceId)
+    .flatMap((role) => role.entitlements);
+
+  return {
+    userId: identity.userId,
+    workspaceId,
+    linkedIdentityId: identity.id,
+    entitlements: [...new Set(entitlements)],
+  };
+}
+
+export function authorizePlatformResource(
+  context: PlatformRequestContext,
+  resource: AuthorizationResource,
+): AuthorizationDecision {
+  const requiredEntitlements = requiredEntitlementsForResource(resource);
+  const workspaceId = "connection" in resource ? resource.connection.workspaceId : resource.workspaceId;
+
+  if (workspaceId !== context.workspaceId) {
+    return { allowed: false, reason: "workspace-mismatch", requiredEntitlements };
+  }
+
+  if (!requiredEntitlements.every((entitlement) => context.entitlements.includes(entitlement))) {
+    return { allowed: false, reason: "missing-entitlement", requiredEntitlements };
+  }
+
+  if (resource.kind === "provider-connection" && resource.connection.status !== "ready") {
+    return { allowed: false, reason: "connection-not-ready", requiredEntitlements };
+  }
+
+  return { allowed: true, reason: "allowed", requiredEntitlements };
+}
+
+function requiredEntitlementsForResource(resource: AuthorizationResource): PlatformEntitlement[] {
+  if (resource.kind === "provider-connection") return ["provider-connection:use"];
+  if (resource.kind === "secrets-broker-ref") return ["secrets-broker:resolve"];
+  return ["workflow:run", "provider-connection:use"];
+}
+
+const secretLikeFieldPattern = /(secret|token|apiKey|api_key|privateKey|private_key|password|credential|recoveryMaterial|recovery_material|keyMaterial|key_material)$/i;
+const secretLikeValuePattern = /(sk-[a-z0-9]{8,}|ghp_[a-z0-9]{8,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|correct-horse-battery-staple|raw-provider-secret|refresh-token|access-token|recovery phrase)/i;
+
+export function assertProviderConnectionMetadataOnly(connection: ProviderConnectionMetadata): void {
+  const entries = Object.entries(connection) as Array<[string, unknown]>;
+  for (const [key, value] of entries) {
+    if (key === "secretRef" || key === "secretMaterialPresent") continue;
+    if (secretLikeFieldPattern.test(key)) {
+      throw new Error(`Provider connection metadata must not include secret-like field ${key}`);
+    }
+    if (typeof value === "string" && secretLikeValuePattern.test(value)) {
+      throw new Error(`Provider connection metadata must not include secret-like value in ${key}`);
+    }
+  }
+
+  if (connection.secretMaterialPresent) {
+    throw new Error("Provider connection metadata must not carry raw secret material");
+  }
+}

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  assertProviderConnectionMetadataOnly,
+  authorizePlatformResource,
+  examplePlatformFacadeState,
+  mapZitadelSessionToPlatformContext,
+  providerConnectionMetadataEndpoints,
+} from "../dist/platform/facade.js";
+
+const repoRoot = process.cwd();
+
+const forbiddenSecrets = [
+  "raw-provider-secret",
+  "correct-horse-battery-staple",
+  "access-token-value",
+  "refresh-token-value",
+  "private-key-material",
+  "recovery phrase",
+];
+
+test("platform facade fixture defines users workspaces linked identities provider connections and roles", () => {
+  assert.equal(examplePlatformFacadeState.users.length, 1);
+  assert.equal(examplePlatformFacadeState.workspaces.length, 1);
+  assert.equal(examplePlatformFacadeState.linkedIdentities.length, 1);
+  assert.equal(examplePlatformFacadeState.providerConnections.length, 1);
+  assert.equal(examplePlatformFacadeState.roles.length, 1);
+
+  const connection = examplePlatformFacadeState.providerConnections[0];
+  assert.equal(connection.workspaceId, examplePlatformFacadeState.workspaces[0].id);
+  assert.equal(connection.ownerUserId, examplePlatformFacadeState.users[0].id);
+  assert.equal(connection.secretMaterialPresent, false);
+  assert.equal(connection.secretRef, "provider.github.oauth.client");
+  assert.equal(connection.status, "ready");
+  assert.doesNotThrow(() => assertProviderConnectionMetadataOnly(connection));
+});
+
+test("provider connection metadata API exposes CRUD endpoints without secret payload endpoints", () => {
+  assert.deepEqual(providerConnectionMetadataEndpoints, {
+    list: "GET /api/platform/workspaces/{workspaceId}/provider-connections",
+    create: "POST /api/platform/workspaces/{workspaceId}/provider-connections",
+    read: "GET /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+    update: "PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+  });
+
+  const serializedEndpoints = JSON.stringify(providerConnectionMetadataEndpoints);
+  assert.equal(serializedEndpoints.includes("secret-value"), false);
+  assert.equal(serializedEndpoints.includes("token-value"), false);
+});
+
+test("ZITADEL session context maps to internal user workspace and entitlements", () => {
+  const context = mapZitadelSessionToPlatformContext({
+    issuer: "http://localhost:8080",
+    subject: "zitadel-user-operator",
+    email: "operator@example.test",
+  });
+
+  assert.ok(context);
+  assert.equal(context.userId, "usr_01hzy9operator");
+  assert.equal(context.workspaceId, "wks_local_demo");
+  assert.equal(context.linkedIdentityId, "lid_zitadel_operator");
+  assert.ok(context.entitlements.includes("secrets-broker:resolve"));
+  assert.ok(context.entitlements.includes("workflow:run"));
+
+  assert.equal(
+    mapZitadelSessionToPlatformContext({
+      issuer: "http://localhost:8080",
+      subject: "unknown-user",
+    }),
+    undefined,
+  );
+});
+
+test("authorization boundaries fail closed for workspace mismatch missing entitlement and connection readiness", () => {
+  const context = mapZitadelSessionToPlatformContext({
+    issuer: "http://localhost:8080",
+    subject: "zitadel-user-operator",
+  });
+  assert.ok(context);
+
+  const connection = examplePlatformFacadeState.providerConnections[0];
+  assert.deepEqual(authorizePlatformResource(context, { kind: "provider-connection", connection }), {
+    allowed: true,
+    reason: "allowed",
+    requiredEntitlements: ["provider-connection:use"],
+  });
+
+  assert.equal(
+    authorizePlatformResource(
+      { ...context, workspaceId: "wks_other" },
+      { kind: "provider-connection", connection },
+    ).reason,
+    "workspace-mismatch",
+  );
+
+  assert.equal(
+    authorizePlatformResource(
+      { ...context, entitlements: ["workspace:read"] },
+      { kind: "secrets-broker-ref", workspaceId: context.workspaceId, brokerNamespace: "workspaces/local-demo/provider-connections/github", ref: "provider.github.oauth.client" },
+    ).reason,
+    "missing-entitlement",
+  );
+
+  assert.equal(
+    authorizePlatformResource(context, {
+      kind: "provider-connection",
+      connection: { ...connection, status: "needs-auth" },
+    }).reason,
+    "connection-not-ready",
+  );
+});
+
+test("provider connection metadata rejects raw secret and recovery material fields", () => {
+  const connection = examplePlatformFacadeState.providerConnections[0];
+  assert.throws(
+    () => assertProviderConnectionMetadataOnly({ ...connection, secretMaterialPresent: true }),
+    /raw secret material/,
+  );
+  assert.throws(
+    () =>
+      assertProviderConnectionMetadataOnly({
+        ...connection,
+        displayName: "raw-provider-secret",
+      }),
+    /secret-like value/,
+  );
+  assert.throws(
+    () =>
+      assertProviderConnectionMetadataOnly({
+        ...connection,
+        // Contract guard for accidental expansion outside the typed shape.
+        accessToken: "access-token-value",
+      }),
+    /secret-like field accessToken/,
+  );
+});
+
+test("product facade docs and fixture stay metadata-only", async () => {
+  const docs = await readFile(path.join(repoRoot, "docs", "reference", "product-api-facade.md"), "utf8");
+  const fixture = JSON.stringify(examplePlatformFacadeState);
+
+  for (const requiredText of [
+    "users",
+    "workspaces",
+    "linked_identities",
+    "provider_connections",
+    "roles/entitlements",
+    "GET   /api/platform/workspaces/{workspaceId}/provider-connections",
+    "ZITADEL session mapping",
+    "Secrets Broker checks",
+    "must not be stored or returned by the facade",
+  ]) {
+    assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+
+  for (const secret of forbiddenSecrets) {
+    assert.equal(fixture.includes(secret), false, `Fixture leaked ${secret}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Added the first concrete product/API facade contract for users, workspaces, linked identities, provider connection metadata, roles/entitlements, ZITADEL request-context mapping, and broker/workflow authorization decisions.
- Added a metadata-only TypeScript contract and fixture in `src/platform/facade.ts`.
- Added reference docs for the provider connection metadata CRUD API and explicit secret-payload boundaries.
- Added tests proving ZITADEL context mapping, authorization fail-closed behavior, provider connection metadata shape, and absence/rejection of raw provider secrets or recovery/key material.

## Validation

- `npm run build` — passed
- `node --test --test-concurrency=1 tests/product-api-facade.test.js` — 6 passed
- `npm test` — 199 passed
- `git diff --check` — passed
- `npm run docs:build` — passed

## Secret-safety notes

- Provider connection records contain metadata and broker/source references only.
- The contract explicitly rejects secret-like fields/values outside `secretRef` metadata.
- Tests include sensitive-string guards for raw provider secrets, access/refresh token values, private key material, and recovery material.

Closes #407
