### PR TITLE
Add provider connection lifecycle API contract

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -151,6 +151,96 @@ The response is safe to log because it contains reference metadata only. The
 facade must never return raw provider secrets, access tokens, refresh tokens,
 API keys, password values, private keys, key material, or recovery material.
 
+## Provider connection lifecycle API
+
+Provider lifecycle actions are stable core API contracts that UI and workflow
+layers can call without embedding provider-specific behavior. The refresh/test
+operations let consumers verify provider reachability and scope posture without
+mutating provider secret payloads. Provider-specific OAuth or token flows may
+still be unavailable in early slices; unavailable flows
+must return actionable `setup-needed` or `provider-unavailable` responses rather
+than dead actions.
+
+```text
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect
+```
+
+Normalized lifecycle statuses are:
+
+- `connected`
+- `expiring`
+- `refresh_failed`
+- `reconnect_required`
+- `revoked`
+- `permission_changed`
+- `disabled`
+- `source_auth_required`
+- `degraded`
+
+Lifecycle responses include safe metadata only:
+
+```json
+{
+  "connectionId": "pc_github_ready",
+  "provider": "github",
+  "action": "test",
+  "status": "connected",
+  "ok": true,
+  "auditEvent": {
+    "id": "audit_provider_ready_001",
+    "workspaceId": "wks_local_demo",
+    "connectionId": "pc_github_ready",
+    "provider": "github",
+    "action": "test",
+    "fromStatus": "connected",
+    "toStatus": "connected",
+    "outcome": "success",
+    "at": "2026-05-08T11:05:00Z",
+    "actorUserId": "usr_01hzy9operator",
+    "safeDetail": "Provider metadata check succeeded; no provider credential values returned."
+  }
+}
+```
+
+Unavailable or setup-required actions return actionable errors without provider
+secret values:
+
+```json
+{
+  "connectionId": "pc_slack_missing",
+  "provider": "slack",
+  "action": "connect",
+  "status": "source_auth_required",
+  "ok": false,
+  "error": {
+    "code": "setup-needed",
+    "message": "Provider connection needs operator setup before it can be used.",
+    "action": "Open the provider setup flow and complete authorization.",
+    "provider": "slack",
+    "retryable": true,
+    "documentationRef": "docs/reference/product-api-facade.md#provider-connection-lifecycle-api"
+  }
+}
+```
+
+Each transition records a safe audit event with `workspaceId`, `connectionId`,
+`provider`, `action`, `fromStatus`, `toStatus`, `outcome`, `at`, `actorUserId`,
+and a `safeDetail`. Audit details may mention missing authorization, changed
+permissions, or unavailable provider support, but must never include access
+tokens, refresh tokens, API keys, provider secrets, key material, or recovery
+material.
+
+Reference lifecycle fixtures cover healthy, missing/setup-required, denied, and
+reconnect-required states in `src/platform/providerConnectionLifecycle.ts`.
+Tests in `tests/provider-connection-lifecycle.test.js` verify status
+normalization, secret-safe error payloads, unavailable action stubs, and safe
+audit transition metadata.
+
 ## ZITADEL session mapping
 
 When ZITADEL is used by a consuming app, Service Lasso maps the OIDC session to

--- a/src/platform/providerConnectionLifecycle.ts
+++ b/src/platform/providerConnectionLifecycle.ts
@@ -1,0 +1,329 @@
+import type { PlatformRequestContext, ProviderConnectionMetadata } from "./facade.js";
+import { assertProviderConnectionMetadataOnly, authorizePlatformResource } from "./facade.js";
+
+export type ProviderConnectionLifecycleStatus =
+  | "connected"
+  | "expiring"
+  | "refresh_failed"
+  | "reconnect_required"
+  | "revoked"
+  | "permission_changed"
+  | "disabled"
+  | "source_auth_required"
+  | "degraded";
+
+export type ProviderConnectionLifecycleAction = "connect" | "reconnect" | "refresh" | "test" | "disable" | "disconnect";
+
+export type ProviderLifecycleErrorCode =
+  | "setup-needed"
+  | "provider-unavailable"
+  | "permission-denied"
+  | "source-auth-required"
+  | "connection-not-found"
+  | "action-not-implemented";
+
+export type ProviderConnectionLifecycleError = {
+  code: ProviderLifecycleErrorCode;
+  message: string;
+  action: string;
+  provider: string;
+  retryable: boolean;
+  documentationRef?: string;
+};
+
+export type ProviderConnectionLifecycleAuditEvent = {
+  id: string;
+  workspaceId: string;
+  connectionId: string;
+  provider: string;
+  action: ProviderConnectionLifecycleAction;
+  fromStatus?: ProviderConnectionLifecycleStatus;
+  toStatus: ProviderConnectionLifecycleStatus;
+  outcome: "success" | "denied" | "unavailable" | "setup-needed";
+  at: string;
+  actorUserId: string;
+  safeDetail: string;
+};
+
+export type ProviderConnectionLifecycleFixture = {
+  connection: ProviderConnectionMetadata;
+  lifecycleStatus: ProviderConnectionLifecycleStatus;
+  expectedAction: ProviderConnectionLifecycleAction;
+  nextActionLabel: string;
+  lastAuditEvent: ProviderConnectionLifecycleAuditEvent;
+  safeError?: ProviderConnectionLifecycleError;
+};
+
+export type ProviderLifecycleActionRequest = {
+  action: ProviderConnectionLifecycleAction;
+  connectionId: string;
+  provider: string;
+  requestedAt: string;
+};
+
+export type ProviderLifecycleActionResponse = {
+  connectionId: string;
+  provider: string;
+  action: ProviderConnectionLifecycleAction;
+  status: ProviderConnectionLifecycleStatus;
+  ok: boolean;
+  auditEvent: ProviderConnectionLifecycleAuditEvent;
+  error?: ProviderConnectionLifecycleError;
+};
+
+export const providerConnectionLifecycleEndpoints = {
+  connect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect",
+  reconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect",
+  refresh: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh",
+  test: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test",
+  disable: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable",
+  disconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect",
+} as const;
+
+const now = "2026-05-08T11:05:00Z";
+
+export const providerConnectionLifecycleFixtures: Record<
+  "healthy" | "missing" | "denied" | "reconnectRequired",
+  ProviderConnectionLifecycleFixture
+> = {
+  healthy: {
+    connection: {
+      id: "pc_github_ready",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "github",
+      kind: "oauth",
+      displayName: "GitHub ready connection",
+      status: "ready",
+      scopes: ["repo:read", "workflow:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/github",
+      secretRef: "provider.github.oauth.client",
+      lastVerifiedAt: now,
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "connected",
+    expectedAction: "test",
+    nextActionLabel: "Test connection",
+    lastAuditEvent: {
+      id: "audit_provider_ready_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_github_ready",
+      provider: "github",
+      action: "test",
+      fromStatus: "connected",
+      toStatus: "connected",
+      outcome: "success",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider metadata check succeeded; no provider credential values returned.",
+    },
+  },
+  missing: {
+    connection: {
+      id: "pc_slack_missing",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "slack",
+      kind: "oauth",
+      displayName: "Slack setup required",
+      status: "needs-auth",
+      scopes: ["channels:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/slack",
+      secretRef: "provider.slack.oauth.client",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "source_auth_required",
+    expectedAction: "connect",
+    nextActionLabel: "Connect provider",
+    safeError: {
+      code: "setup-needed",
+      message: "Provider connection needs operator setup before it can be used.",
+      action: "Open the provider setup flow and complete authorization.",
+      provider: "slack",
+      retryable: true,
+      documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
+    },
+    lastAuditEvent: {
+      id: "audit_provider_missing_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_slack_missing",
+      provider: "slack",
+      action: "connect",
+      toStatus: "source_auth_required",
+      outcome: "setup-needed",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider authorization is not configured; no provider credential values returned.",
+    },
+  },
+  denied: {
+    connection: {
+      id: "pc_stripe_denied",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "stripe",
+      kind: "api-token",
+      displayName: "Stripe denied connection",
+      status: "error",
+      scopes: ["charges:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/stripe",
+      secretRef: "provider.stripe.api.client",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "permission_changed",
+    expectedAction: "reconnect",
+    nextActionLabel: "Reconnect with required scopes",
+    safeError: {
+      code: "permission-denied",
+      message: "Provider rejected the requested scope set.",
+      action: "Reconnect the provider with the required scopes or update workflow requirements.",
+      provider: "stripe",
+      retryable: true,
+      documentationRef: "docs/reference/product-api-facade.md#authorization-boundaries",
+    },
+    lastAuditEvent: {
+      id: "audit_provider_denied_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_stripe_denied",
+      provider: "stripe",
+      action: "test",
+      fromStatus: "connected",
+      toStatus: "permission_changed",
+      outcome: "denied",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider metadata check reported insufficient scope; credential values were not returned.",
+    },
+  },
+  reconnectRequired: {
+    connection: {
+      id: "pc_calendar_reconnect",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "google-calendar",
+      kind: "oauth",
+      displayName: "Calendar reconnect required",
+      status: "needs-auth",
+      scopes: ["calendar:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/google-calendar",
+      secretRef: "provider.google-calendar.oauth.client",
+      lastVerifiedAt: "2026-05-08T09:55:00Z",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "reconnect_required",
+    expectedAction: "reconnect",
+    nextActionLabel: "Reconnect provider",
+    safeError: {
+      code: "source-auth-required",
+      message: "Provider authorization must be refreshed before workflows can use this connection.",
+      action: "Start the reconnect flow and retry the workflow after authorization succeeds.",
+      provider: "google-calendar",
+      retryable: true,
+      documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
+    },
+    lastAuditEvent: {
+      id: "audit_provider_reconnect_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_calendar_reconnect",
+      provider: "google-calendar",
+      action: "refresh",
+      fromStatus: "expiring",
+      toStatus: "reconnect_required",
+      outcome: "unavailable",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider refresh failed with source authorization required; no refresh payload returned.",
+    },
+  },
+};
+
+export function normalizeProviderConnectionLifecycleStatus(input: {
+  metadataStatus?: ProviderConnectionMetadata["status"];
+  sourceState?: string;
+  expiresAt?: string;
+  scopesChanged?: boolean;
+  lastRefreshFailed?: boolean;
+}): ProviderConnectionLifecycleStatus {
+  if (input.metadataStatus === "disabled") return "disabled";
+  if (input.metadataStatus === "revoked") return "revoked";
+  if (input.sourceState === "auth-required" || input.metadataStatus === "needs-auth") return "source_auth_required";
+  if (input.scopesChanged) return "permission_changed";
+  if (input.lastRefreshFailed) return "refresh_failed";
+  if (input.sourceState === "degraded" || input.metadataStatus === "error") return "degraded";
+  if (input.expiresAt && Date.parse(input.expiresAt) <= Date.parse("2026-05-09T00:00:00Z")) return "expiring";
+  return "connected";
+}
+
+export function createProviderLifecycleUnavailableResponse(
+  context: PlatformRequestContext,
+  fixture: ProviderConnectionLifecycleFixture,
+  request: ProviderLifecycleActionRequest,
+): ProviderLifecycleActionResponse {
+  assertProviderConnectionMetadataOnly(fixture.connection);
+  const decision = authorizePlatformResource(context, { kind: "provider-connection", connection: fixture.connection });
+  const safeError = fixture.safeError ?? {
+    code: "action-not-implemented" as const,
+    message: "Provider-specific lifecycle flow is not implemented yet.",
+    action: "Use the provider setup documentation or retry after this provider flow is enabled.",
+    provider: request.provider,
+    retryable: false,
+    documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
+  };
+
+  if (!decision.allowed && decision.reason !== "connection-not-ready") {
+    return {
+      connectionId: request.connectionId,
+      provider: request.provider,
+      action: request.action,
+      status: fixture.lifecycleStatus,
+      ok: false,
+      auditEvent: {
+        ...fixture.lastAuditEvent,
+        id: `${fixture.lastAuditEvent.id}_denied`,
+        action: request.action,
+        outcome: "denied",
+        actorUserId: context.userId,
+        safeDetail: `Lifecycle action denied: ${decision.reason}.`,
+      },
+      error: {
+        code: "permission-denied",
+        message: "Requester is not authorized to use this provider connection.",
+        action: "Request provider-connection:use in the target workspace or switch workspace context.",
+        provider: request.provider,
+        retryable: false,
+        documentationRef: "docs/reference/product-api-facade.md#authorization-boundaries",
+      },
+    };
+  }
+
+  return {
+    connectionId: request.connectionId,
+    provider: request.provider,
+    action: request.action,
+    status: fixture.lifecycleStatus,
+    ok: fixture.lifecycleStatus === "connected",
+    auditEvent: {
+      ...fixture.lastAuditEvent,
+      action: request.action,
+      actorUserId: context.userId,
+    },
+    error: fixture.lifecycleStatus === "connected" ? undefined : safeError,
+  };
+}
+
+const secretLikePayloadPattern = /(sk-[a-z0-9]{8,}|ghp_[a-z0-9]{8,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|correct-horse-battery-staple|raw-provider-secret|refresh-token|access-token|recovery phrase|client_secret=)/i;
+
+export function assertProviderLifecyclePayloadSecretSafe(payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  if (secretLikePayloadPattern.test(serialized)) {
+    throw new Error("Provider lifecycle payload contains secret-like material");
+  }
+}

--- a/tests/provider-connection-lifecycle.test.js
+++ b/tests/provider-connection-lifecycle.test.js
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { mapZitadelSessionToPlatformContext } from "../dist/platform/facade.js";
+import {
+  assertProviderLifecyclePayloadSecretSafe,
+  createProviderLifecycleUnavailableResponse,
+  normalizeProviderConnectionLifecycleStatus,
+  providerConnectionLifecycleEndpoints,
+  providerConnectionLifecycleFixtures,
+} from "../dist/platform/providerConnectionLifecycle.js";
+
+const repoRoot = process.cwd();
+
+const forbiddenSecrets = [
+  "raw-provider-secret",
+  "correct-horse-battery-staple",
+  "access-token-value",
+  "refresh-token-value",
+  "private-key-material",
+  "client_secret=",
+  "recovery phrase",
+];
+
+function operatorContext() {
+  const context = mapZitadelSessionToPlatformContext({
+    issuer: "http://localhost:8080",
+    subject: "zitadel-user-operator",
+  });
+  assert.ok(context);
+  return context;
+}
+
+test("provider lifecycle API exposes stable action endpoints", () => {
+  assert.deepEqual(providerConnectionLifecycleEndpoints, {
+    connect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect",
+    reconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect",
+    refresh: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh",
+    test: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test",
+    disable: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable",
+    disconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect",
+  });
+  assertProviderLifecyclePayloadSecretSafe(providerConnectionLifecycleEndpoints);
+});
+
+test("provider lifecycle fixtures cover healthy missing denied and reconnect-required states", () => {
+  assert.equal(providerConnectionLifecycleFixtures.healthy.lifecycleStatus, "connected");
+  assert.equal(providerConnectionLifecycleFixtures.missing.lifecycleStatus, "source_auth_required");
+  assert.equal(providerConnectionLifecycleFixtures.denied.lifecycleStatus, "permission_changed");
+  assert.equal(providerConnectionLifecycleFixtures.reconnectRequired.lifecycleStatus, "reconnect_required");
+
+  for (const fixture of Object.values(providerConnectionLifecycleFixtures)) {
+    assert.equal(fixture.connection.secretMaterialPresent, false);
+    assert.ok(fixture.connection.secretRef?.startsWith("provider."));
+    assertProviderLifecyclePayloadSecretSafe(fixture);
+  }
+});
+
+test("provider lifecycle status normalization covers connected expiring failure and degraded states", () => {
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "ready" }), "connected");
+  assert.equal(
+    normalizeProviderConnectionLifecycleStatus({ metadataStatus: "ready", expiresAt: "2026-05-08T23:00:00Z" }),
+    "expiring",
+  );
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ lastRefreshFailed: true }), "refresh_failed");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ scopesChanged: true }), "permission_changed");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "needs-auth" }), "source_auth_required");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "revoked" }), "revoked");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "disabled" }), "disabled");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "error" }), "degraded");
+});
+
+test("unimplemented provider-specific lifecycle flows return actionable setup-needed or unavailable errors", () => {
+  const context = operatorContext();
+  const missing = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.missing, {
+    action: "connect",
+    connectionId: "pc_slack_missing",
+    provider: "slack",
+    requestedAt: "2026-05-08T11:05:00Z",
+  });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.status, "source_auth_required");
+  assert.equal(missing.error?.code, "setup-needed");
+  assert.match(missing.error?.action ?? "", /setup flow/i);
+  assert.equal(missing.auditEvent.outcome, "setup-needed");
+
+  const reconnect = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.reconnectRequired, {
+    action: "refresh",
+    connectionId: "pc_calendar_reconnect",
+    provider: "google-calendar",
+    requestedAt: "2026-05-08T11:05:00Z",
+  });
+  assert.equal(reconnect.ok, false);
+  assert.equal(reconnect.status, "reconnect_required");
+  assert.equal(reconnect.error?.code, "source-auth-required");
+  assert.match(reconnect.error?.action ?? "", /reconnect flow/i);
+  assertProviderLifecyclePayloadSecretSafe([missing, reconnect]);
+});
+
+test("provider lifecycle authorization denial is fail-closed and secret-safe", () => {
+  const context = { ...operatorContext(), entitlements: ["workspace:read"] };
+  const denied = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.healthy, {
+    action: "test",
+    connectionId: "pc_github_ready",
+    provider: "github",
+    requestedAt: "2026-05-08T11:05:00Z",
+  });
+
+  assert.equal(denied.ok, false);
+  assert.equal(denied.error?.code, "permission-denied");
+  assert.equal(denied.auditEvent.outcome, "denied");
+  assert.match(denied.auditEvent.safeDetail, /missing-entitlement/);
+  assertProviderLifecyclePayloadSecretSafe(denied);
+});
+
+test("provider lifecycle docs and fixtures stay free of raw secrets key material and recovery material", async () => {
+  const docs = await readFile(path.join(repoRoot, "docs", "reference", "product-api-facade.md"), "utf8");
+  for (const requiredText of [
+    "Provider connection lifecycle API",
+    "connect",
+    "reconnect",
+    "refresh/test",
+    "disconnect",
+    "connected",
+    "refresh_failed",
+    "source_auth_required",
+    "setup-needed",
+    "safe audit event",
+  ]) {
+    assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+
+  const serializedFixtures = JSON.stringify(providerConnectionLifecycleFixtures);
+  for (const secret of forbiddenSecrets) {
+    assert.equal(serializedFixtures.includes(secret), false, `Fixture leaked ${secret}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Added provider connection lifecycle API contract for connect, reconnect, refresh/test, disable, and disconnect actions.
- Added normalized lifecycle statuses: `connected`, `expiring`, `refresh_failed`, `reconnect_required`, `revoked`, `permission_changed`, `disabled`, `source_auth_required`, and `degraded`.
- Added safe healthy/missing/denied/reconnect-required lifecycle fixtures, safe audit transition metadata, and actionable setup-needed/unavailable/permission-denied error payloads.
- Extended Product API Facade docs with lifecycle endpoint shapes, status semantics, safe audit event boundaries, and unavailable-flow behavior.
- Added tests covering lifecycle endpoints, status normalization, unavailable/provider setup stubs, authorization denial, and secret-safe fixture/error payloads.

## Validation

Passed:
- `npm run build`
- `node --test --test-concurrency=1 tests/provider-connection-lifecycle.test.js tests/product-api-facade.test.js` — 12 passed
- `node --test --test-concurrency=1 tests/recovery-e2e.test.js` — 1 passed
- `git diff --check`
- `npm run docs:build`

Full-suite note:
- `npm test` was run twice and both runs reached the new #408 tests successfully, but each run hit an unrelated transient existing E2E/provider test failure; each failing test passed when rerun directly:
  - first run: `tests/provider-execution.test.js` failed in full suite, then passed directly (9/9)
  - second run: `tests/recovery-e2e.test.js` failed in full suite, then passed directly (1/1)

## Secret-safety notes

- Lifecycle fixtures and responses carry metadata, broker/source references, and safe audit text only.
- Tests assert lifecycle payloads reject/avoid raw provider secrets, access/refresh token values, private-key material, client secret strings, and recovery material.

Closes #408
