### PR TITLE
Add workflow package catalog contract

### DIFF
--- a/docs/reference/workflow-package-catalog.md
+++ b/docs/reference/workflow-package-catalog.md
@@ -1,0 +1,180 @@
+---
+title: Workflow Package Catalog
+sidebar_label: Workflow Package Catalog
+---
+
+# Workflow Package Catalog
+
+Service Lasso workflow packages are Git-managed units of workflow metadata. The
+catalog lets UI and workflow layers list, validate, and display official/core and
+custom workflow repositories without reading raw secrets.
+
+The first catalog contract lives in `src/platform/workflowCatalog.ts` and uses a
+`workflow-package.json` metadata file per package.
+
+## Package sources
+
+### Official/core packages
+
+Official/core packages are maintained by Service Lasso and use the `official.*`
+namespace. They can be updated by pulling a new repository ref, but consuming
+installations must not edit official package content in place.
+
+Examples:
+
+- package id: `official.core.maintenance`
+- workflow id: `official.core.maintenance/backup-check`
+- config path: `official/core-maintenance/defaults.yaml`
+- tool id: `official.core.maintenance.service-lasso-cli`
+- output dir prefix: `outputs/official/`
+
+### Custom workflow repositories
+
+Custom workflow repositories are additive overlays. They use the `custom.*`
+namespace and can add local/operator-owned workflows without modifying official
+content. In other words, custom repositories provide additive custom packages,
+not in-place edits to official packages.
+
+Examples:
+
+- package id: `custom.local.reporting`
+- workflow id: `custom.local.reporting/monthly-summary`
+- config path: `custom/local-reporting/defaults.yaml`
+- tool id: `custom.local.reporting.report-export`
+- output dir prefix: `outputs/custom/`
+
+Custom packages must not reuse official workflow ids, config paths, output dirs,
+or tool ids. Invalid/colliding workflow packages fail validation with actionable
+diagnostics instead of silently overriding official content.
+
+## Metadata shape
+
+Each package has a `workflow-package.json` file with id, version, repo/ref, owner,
+engine requirements, tools, configs, secrets, schedules, and validation commands.
+In short, the required identity fields are id, version, repo/ref, owner, and
+engine requirements:
+
+```json
+{
+  "id": "official.core.maintenance",
+  "version": "2026.5.8",
+  "displayName": "Core maintenance workflows",
+  "owner": "service-lasso",
+  "source": "official",
+  "supportLevel": "core-supported",
+  "repository": {
+    "repo": "service-lasso/workflows-core",
+    "ref": "2026.5.8",
+    "path": "packages/core-maintenance"
+  },
+  "engine": {
+    "engine": "dagu",
+    "versionRange": ">=1.16.0"
+  },
+  "workflows": ["official.core.maintenance/backup-check"],
+  "tools": [
+    {
+      "id": "official.core.maintenance.service-lasso-cli",
+      "command": "service-lasso",
+      "description": "Invoke Service Lasso CLI checks."
+    }
+  ],
+  "configs": [
+    {
+      "path": "official/core-maintenance/defaults.yaml",
+      "description": "Safe defaults for core maintenance workflows.",
+      "required": true
+    }
+  ],
+  "secrets": [
+    {
+      "namespace": "workflows/core-maintenance",
+      "ref": "maintenance.API_TOKEN",
+      "description": "Broker reference only; value is resolved at run time.",
+      "required": false
+    }
+  ],
+  "schedules": [
+    {
+      "id": "daily-backup-check",
+      "cron": "0 3 * * *",
+      "timezone": "UTC"
+    }
+  ],
+  "validation": [
+    {
+      "name": "validate package metadata",
+      "command": "service-lasso",
+      "args": ["workflow", "validate", "official.core.maintenance"]
+    }
+  ]
+}
+```
+
+## Secret boundary
+
+Workflow packages can list required secret refs as metadata, but must never carry
+raw secrets. The catalog may include:
+
+- broker namespace metadata, such as `workflows/core-maintenance`,
+- dotted secret refs, such as `maintenance.API_TOKEN`,
+- safe descriptions and required/optional markers.
+
+The catalog must not include raw provider secrets, access tokens, refresh tokens,
+passwords, private-key material, client secret strings, or recovery material.
+Runtime resolution happens through Secrets Broker or a configured source backend.
+
+## API contract
+
+The first platform endpoints are metadata-only:
+
+```text
+GET  /api/platform/workflow-packages
+POST /api/platform/workflow-packages/validate
+```
+
+`GET` returns safe package metadata that UI and workflow layers can display.
+`POST /validate` validates local package metadata before a package is added to
+the catalog.
+
+## Validation diagnostics
+
+Catalog loading validates:
+
+- required fields: `id`, `version`, `displayName`, `owner`, `repository`,
+  `engine`, and `workflows`,
+- official/custom namespace rules for workflow ids, config paths, output dirs,
+  and tools,
+- additive custom package behavior with no in-place official overrides,
+- duplicate package ids,
+- colliding workflow ids,
+- colliding config paths,
+- colliding tool ids,
+- malformed broker secret refs, and
+- raw secret-like material in metadata.
+
+Diagnostics include:
+
+- `code`, for example `workflow-collision` or `secret-material`,
+- `severity`,
+- `packageId`,
+- `field`,
+- human-readable `message`, and
+- an actionable `action` string explaining how to fix the package.
+
+Support warnings are allowed for local/custom packages. For example, a package
+can declare `supportLevel: "local"` and a warning like `Local custom package
+support is operator-owned.` UI layers should display those warnings without
+blocking package listing.
+
+## Tests
+
+`tests/workflow-package-catalog.test.js` verifies:
+
+- official/core and custom workflow repositories can be listed from metadata,
+- package listing does not expose raw secrets,
+- local metadata directories can be loaded,
+- official/custom namespace rules are enforced,
+- invalid/colliding workflow packages fail validation with actionable
+  diagnostics, and
+- raw secret-like payloads are rejected while broker refs are allowed.

--- a/src/platform/workflowCatalog.ts
+++ b/src/platform/workflowCatalog.ts
@@ -1,0 +1,481 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type WorkflowPackageSourceKind = "official" | "custom";
+export type WorkflowPackageSupportLevel = "core-supported" | "community" | "local" | "unsupported";
+
+export type WorkflowPackageRepository = {
+  repo: string;
+  ref: string;
+  path?: string;
+};
+
+export type WorkflowPackageEngineRequirement = {
+  engine: "dagu" | "service-lasso" | "custom";
+  versionRange: string;
+};
+
+export type WorkflowPackageTool = {
+  id: string;
+  command: string;
+  description?: string;
+};
+
+export type WorkflowPackageConfig = {
+  path: string;
+  description?: string;
+  required?: boolean;
+};
+
+export type WorkflowPackageSecretRef = {
+  ref: string;
+  namespace: string;
+  description?: string;
+  required?: boolean;
+};
+
+export type WorkflowPackageSchedule = {
+  id: string;
+  cron: string;
+  timezone?: string;
+};
+
+export type WorkflowPackageValidationCommand = {
+  name: string;
+  command: string;
+  args?: string[];
+};
+
+export type WorkflowPackageMetadata = {
+  id: string;
+  version: string;
+  displayName: string;
+  owner: string;
+  source: WorkflowPackageSourceKind;
+  supportLevel: WorkflowPackageSupportLevel;
+  repository: WorkflowPackageRepository;
+  engine: WorkflowPackageEngineRequirement;
+  workflows: string[];
+  tools?: WorkflowPackageTool[];
+  configs?: WorkflowPackageConfig[];
+  secrets?: WorkflowPackageSecretRef[];
+  schedules?: WorkflowPackageSchedule[];
+  validation?: WorkflowPackageValidationCommand[];
+  warnings?: string[];
+};
+
+export type WorkflowCatalogEntry = {
+  metadata: WorkflowPackageMetadata;
+  metadataPath: string;
+};
+
+export type WorkflowCatalogDiagnosticCode =
+  | "invalid-json"
+  | "missing-field"
+  | "invalid-field"
+  | "invalid-namespace"
+  | "secret-material"
+  | "id-collision"
+  | "workflow-collision"
+  | "config-path-collision"
+  | "tool-collision";
+
+export type WorkflowCatalogDiagnostic = {
+  code: WorkflowCatalogDiagnosticCode;
+  severity: "error" | "warning";
+  packageId?: string;
+  field?: string;
+  message: string;
+  action: string;
+};
+
+export type WorkflowCatalogValidationResult = {
+  ok: boolean;
+  entries: WorkflowCatalogEntry[];
+  diagnostics: WorkflowCatalogDiagnostic[];
+};
+
+export const workflowPackageCatalogEndpoints = {
+  list: "GET /api/platform/workflow-packages",
+  validate: "POST /api/platform/workflow-packages/validate",
+} as const;
+
+const workflowPackageIdPattern = /^(official|custom)\.[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)*$/;
+const workflowIdPattern = /^(official|custom)\.[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)*\/[a-z][a-z0-9-]*$/;
+const configPathPattern = /^(official|custom)\/[a-z0-9][a-z0-9_.-]*(?:\/[a-z0-9][a-z0-9_.-]*)*\.ya?ml$/;
+const toolIdPattern = /^(official|custom)\.[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)*\.[a-z][a-z0-9-]*$/;
+const secretRefPattern = /^[A-Za-z][A-Za-z0-9_-]*\.[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+const namespacePattern = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.-]*)*$/;
+const secretLikePattern = /(sk-[a-z0-9]{8,}|ghp_[a-z0-9]{8,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|correct-horse-battery-staple|raw-workflow-secret|access-token|refresh-token|client_secret=|password=)/i;
+
+export const workflowCatalogNamespacePolicy = {
+  official: {
+    idPrefix: "official.",
+    workflowPrefix: "official.",
+    configPathPrefix: "official/",
+    toolPrefix: "official.",
+    outputDirPrefix: "outputs/official/",
+    overridePolicy: "Official package content is immutable in place; custom packages must add overlays with custom.* ids.",
+  },
+  custom: {
+    idPrefix: "custom.",
+    workflowPrefix: "custom.",
+    configPathPrefix: "custom/",
+    toolPrefix: "custom.",
+    outputDirPrefix: "outputs/custom/",
+    overridePolicy: "Custom packages are additive overlays and cannot reuse official workflow ids, config paths, or tool ids.",
+  },
+} as const;
+
+export const exampleWorkflowPackageCatalog: WorkflowCatalogEntry[] = [
+  {
+    metadataPath: "fixtures/workflow-catalog/official/core-maintenance/workflow-package.json",
+    metadata: {
+      id: "official.core.maintenance",
+      version: "2026.5.8",
+      displayName: "Core maintenance workflows",
+      owner: "service-lasso",
+      source: "official",
+      supportLevel: "core-supported",
+      repository: {
+        repo: "service-lasso/workflows-core",
+        ref: "2026.5.8",
+        path: "packages/core-maintenance",
+      },
+      engine: {
+        engine: "dagu",
+        versionRange: ">=1.16.0",
+      },
+      workflows: ["official.core.maintenance/backup-check", "official.core.maintenance/update-check"],
+      tools: [
+        {
+          id: "official.core.maintenance.service-lasso-cli",
+          command: "service-lasso",
+          description: "Invoke Service Lasso CLI checks.",
+        },
+      ],
+      configs: [
+        {
+          path: "official/core-maintenance/defaults.yaml",
+          description: "Safe defaults for core maintenance workflows.",
+          required: true,
+        },
+      ],
+      secrets: [
+        {
+          namespace: "workflows/core-maintenance",
+          ref: "maintenance.API_TOKEN",
+          description: "Broker reference only; value is resolved at run time.",
+          required: false,
+        },
+      ],
+      schedules: [
+        {
+          id: "daily-backup-check",
+          cron: "0 3 * * *",
+          timezone: "UTC",
+        },
+      ],
+      validation: [
+        {
+          name: "validate package metadata",
+          command: "service-lasso",
+          args: ["workflow", "validate", "official.core.maintenance"],
+        },
+      ],
+    },
+  },
+  {
+    metadataPath: "fixtures/workflow-catalog/custom/local-reporting/workflow-package.json",
+    metadata: {
+      id: "custom.local.reporting",
+      version: "0.1.0",
+      displayName: "Local reporting overlays",
+      owner: "local-operator",
+      source: "custom",
+      supportLevel: "local",
+      repository: {
+        repo: "file://./workflows/custom-reporting",
+        ref: "main",
+      },
+      engine: {
+        engine: "dagu",
+        versionRange: ">=1.16.0",
+      },
+      workflows: ["custom.local.reporting/monthly-summary"],
+      tools: [
+        {
+          id: "custom.local.reporting.report-export",
+          command: "report-export",
+        },
+      ],
+      configs: [
+        {
+          path: "custom/local-reporting/defaults.yaml",
+          required: true,
+        },
+      ],
+      secrets: [
+        {
+          namespace: "workflows/custom/local-reporting",
+          ref: "reporting.API_TOKEN",
+          required: true,
+        },
+      ],
+      validation: [
+        {
+          name: "validate custom reporting",
+          command: "dagu",
+          args: ["validate", "custom.local.reporting/monthly-summary"],
+        },
+      ],
+      warnings: ["Local custom package support is operator-owned."],
+    },
+  },
+];
+
+export async function loadWorkflowCatalogFromDirectories(
+  roots: Array<{ root: string; source: WorkflowPackageSourceKind }>,
+): Promise<WorkflowCatalogValidationResult> {
+  const entries: WorkflowCatalogEntry[] = [];
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+
+  for (const { root, source } of roots) {
+    let children;
+    try {
+      children = await readdir(root, { withFileTypes: true });
+    } catch {
+      diagnostics.push({
+        code: "missing-field",
+        severity: "warning",
+        field: root,
+        message: `Workflow catalog root ${root} is not readable.`,
+        action: "Create the catalog root or remove it from configured workflow package roots.",
+      });
+      continue;
+    }
+
+    for (const child of children.filter((entry) => entry.isDirectory())) {
+      const metadataPath = path.join(root, child.name, "workflow-package.json");
+      try {
+        const parsed = JSON.parse(await readFile(metadataPath, "utf8")) as WorkflowPackageMetadata;
+        entries.push({ metadata: { ...parsed, source }, metadataPath });
+      } catch (error) {
+        diagnostics.push({
+          code: "invalid-json",
+          severity: "error",
+          field: metadataPath,
+          message: `Workflow package metadata could not be loaded: ${(error as Error).message}`,
+          action: "Fix workflow-package.json so it is valid JSON and matches the workflow package contract.",
+        });
+      }
+    }
+  }
+
+  const validation = validateWorkflowCatalogEntries(entries);
+  return {
+    ok: diagnostics.length === 0 && validation.ok,
+    entries: validation.entries,
+    diagnostics: [...diagnostics, ...validation.diagnostics],
+  };
+}
+
+export function validateWorkflowCatalogEntries(entries: WorkflowCatalogEntry[]): WorkflowCatalogValidationResult {
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+  const ids = new Map<string, string>();
+  const workflows = new Map<string, string>();
+  const configs = new Map<string, string>();
+  const tools = new Map<string, string>();
+
+  for (const entry of entries) {
+    diagnostics.push(...validateWorkflowPackageMetadata(entry.metadata, entry.metadataPath));
+    addCollisionDiagnostic(ids, entry.metadata.id, entry.metadata.id, "id-collision", diagnostics);
+    for (const workflowId of entry.metadata.workflows ?? []) {
+      addCollisionDiagnostic(workflows, workflowId, entry.metadata.id, "workflow-collision", diagnostics);
+    }
+    for (const config of entry.metadata.configs ?? []) {
+      addCollisionDiagnostic(configs, config.path, entry.metadata.id, "config-path-collision", diagnostics);
+    }
+    for (const tool of entry.metadata.tools ?? []) {
+      addCollisionDiagnostic(tools, tool.id, entry.metadata.id, "tool-collision", diagnostics);
+    }
+  }
+
+  return {
+    ok: diagnostics.every((diagnostic) => diagnostic.severity !== "error"),
+    entries,
+    diagnostics,
+  };
+}
+
+export function validateWorkflowPackageMetadata(
+  metadata: WorkflowPackageMetadata,
+  metadataPath = "workflow-package.json",
+): WorkflowCatalogDiagnostic[] {
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+  const requiredStringFields: Array<keyof WorkflowPackageMetadata> = ["id", "version", "displayName", "owner"];
+  for (const field of requiredStringFields) {
+    if (typeof metadata[field] !== "string" || (metadata[field] as string).trim().length === 0) {
+      diagnostics.push(missingFieldDiagnostic(metadata.id, String(field), metadataPath, `Add a non-empty ${String(field)} to workflow-package.json.`));
+    }
+  }
+
+  if (metadata.source !== "official" && metadata.source !== "custom") {
+    diagnostics.push({
+      code: "invalid-field",
+      severity: "error",
+      packageId: metadata.id,
+      field: "source",
+      message: `Workflow package metadata at ${metadataPath} must declare source as "official" or "custom".`,
+      action: "Set source to official for Service Lasso-owned packages or custom for additive operator-owned packages.",
+    });
+  }
+
+  if (!metadata.repository || typeof metadata.repository !== "object") {
+    diagnostics.push(missingFieldDiagnostic(metadata.id, "repository", metadataPath, "Add repository metadata with non-empty repo and ref fields."));
+  } else {
+    if (typeof metadata.repository.repo !== "string" || metadata.repository.repo.trim().length === 0) {
+      diagnostics.push(missingFieldDiagnostic(metadata.id, "repository.repo", metadataPath, "Add the source repository slug or URL for this workflow package."));
+    }
+    if (typeof metadata.repository.ref !== "string" || metadata.repository.ref.trim().length === 0) {
+      diagnostics.push(missingFieldDiagnostic(metadata.id, "repository.ref", metadataPath, "Add the immutable tag, branch, or commit ref for this workflow package."));
+    }
+  }
+
+  if (!metadata.engine || typeof metadata.engine !== "object") {
+    diagnostics.push(missingFieldDiagnostic(metadata.id, "engine", metadataPath, "Add engine metadata with non-empty engine and versionRange fields."));
+  } else {
+    if (!["dagu", "service-lasso", "custom"].includes(metadata.engine.engine)) {
+      diagnostics.push({
+        code: "invalid-field",
+        severity: "error",
+        packageId: metadata.id,
+        field: "engine.engine",
+        message: `Workflow package metadata at ${metadataPath} must declare engine as "dagu", "service-lasso", or "custom".`,
+        action: "Set engine.engine to the workflow engine required to run this package.",
+      });
+    }
+    if (typeof metadata.engine.versionRange !== "string" || metadata.engine.versionRange.trim().length === 0) {
+      diagnostics.push(missingFieldDiagnostic(metadata.id, "engine.versionRange", metadataPath, "Add the supported workflow engine version range."));
+    }
+  }
+
+  const namespacePolicy = metadata.source === "official" || metadata.source === "custom" ? workflowCatalogNamespacePolicy[metadata.source] : undefined;
+  if (!workflowPackageIdPattern.test(metadata.id) || (namespacePolicy && !metadata.id.startsWith(namespacePolicy.idPrefix))) {
+    const sourceLabel = metadata.source === "official" || metadata.source === "custom" ? metadata.source : "official/custom";
+    diagnostics.push(namespaceDiagnostic(metadata.id, "id", metadata.id, `Use ${sourceLabel}.* package ids, for example ${sourceLabel}.team.package.`));
+  }
+
+  if (!Array.isArray(metadata.workflows) || metadata.workflows.length === 0) {
+    diagnostics.push({
+      code: "missing-field",
+      severity: "error",
+      packageId: metadata.id,
+      field: "workflows",
+      message: `Workflow package ${metadata.id} must declare at least one workflow id.`,
+      action: "Add a non-empty workflows array to workflow-package.json.",
+    });
+  } else {
+    for (const workflowId of metadata.workflows) {
+      if (!workflowIdPattern.test(workflowId) || (namespacePolicy && !workflowId.startsWith(namespacePolicy.workflowPrefix)) || !workflowId.startsWith(`${metadata.id}/`)) {
+        diagnostics.push(namespaceDiagnostic(metadata.id, "workflows", workflowId, `Use workflow ids under ${metadata.id}/name.`));
+      }
+    }
+  }
+
+  for (const config of metadata.configs ?? []) {
+    if (!configPathPattern.test(config.path) || (namespacePolicy && !config.path.startsWith(namespacePolicy.configPathPrefix))) {
+      const sourceLabel = metadata.source === "official" || metadata.source === "custom" ? metadata.source : "official or custom";
+      diagnostics.push(namespaceDiagnostic(metadata.id, "configs.path", config.path, `Use ${sourceLabel}/.../*.yaml config paths.`));
+    }
+  }
+
+  for (const tool of metadata.tools ?? []) {
+    if (!toolIdPattern.test(tool.id) || (namespacePolicy && !tool.id.startsWith(namespacePolicy.toolPrefix))) {
+      const sourceLabel = metadata.source === "official" || metadata.source === "custom" ? metadata.source : "official/custom";
+      diagnostics.push(namespaceDiagnostic(metadata.id, "tools.id", tool.id, `Use ${sourceLabel}.* tool ids.`));
+    }
+  }
+
+  for (const secret of metadata.secrets ?? []) {
+    if (!namespacePattern.test(secret.namespace) || !secretRefPattern.test(secret.ref)) {
+      diagnostics.push(namespaceDiagnostic(metadata.id, "secrets", `${secret.namespace}:${secret.ref}`, "Use broker namespace metadata plus dotted secret refs only."));
+    }
+  }
+
+  try {
+    assertWorkflowCatalogSecretSafe(metadata);
+  } catch (error) {
+    diagnostics.push({
+      code: "secret-material",
+      severity: "error",
+      packageId: metadata.id,
+      message: (error as Error).message,
+      action: "Replace raw secret material with broker/source refs before committing workflow package metadata.",
+    });
+  }
+
+  return diagnostics;
+}
+
+function missingFieldDiagnostic(
+  packageId: string | undefined,
+  field: string,
+  metadataPath: string,
+  action: string,
+): WorkflowCatalogDiagnostic {
+  return {
+    code: "missing-field",
+    severity: "error",
+    packageId,
+    field,
+    message: `Workflow package metadata at ${metadataPath} is missing required field ${field}.`,
+    action,
+  };
+}
+
+function addCollisionDiagnostic(
+  seen: Map<string, string>,
+  value: string,
+  packageId: string,
+  code: Extract<WorkflowCatalogDiagnosticCode, "id-collision" | "workflow-collision" | "config-path-collision" | "tool-collision">,
+  diagnostics: WorkflowCatalogDiagnostic[],
+): void {
+  const prior = seen.get(value);
+  if (prior && prior !== packageId) {
+    diagnostics.push({
+      code,
+      severity: "error",
+      packageId,
+      field: value,
+      message: `Workflow catalog collision for ${value}: ${prior} and ${packageId} both claim it.`,
+      action: "Rename the custom package id/workflow/config/tool so it is additive and does not override existing catalog content in place.",
+    });
+    return;
+  }
+  seen.set(value, packageId);
+}
+
+function namespaceDiagnostic(packageId: string | undefined, field: string, value: string, action: string): WorkflowCatalogDiagnostic {
+  return {
+    code: "invalid-namespace",
+    severity: "error",
+    packageId,
+    field,
+    message: `Invalid workflow package namespace for ${field}: ${value}.`,
+    action,
+  };
+}
+
+export function listWorkflowPackagesSecretSafe(entries: WorkflowCatalogEntry[]): WorkflowPackageMetadata[] {
+  const packages = entries.map((entry) => entry.metadata);
+  assertWorkflowCatalogSecretSafe(packages);
+  return packages;
+}
+
+export function assertWorkflowCatalogSecretSafe(payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  if (secretLikePattern.test(serialized)) {
+    throw new Error("Workflow package catalog payload contains secret-like material");
+  }
+}

--- a/tests/workflow-package-catalog.test.js
+++ b/tests/workflow-package-catalog.test.js
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import {
+  assertWorkflowCatalogSecretSafe,
+  exampleWorkflowPackageCatalog,
+  listWorkflowPackagesSecretSafe,
+  loadWorkflowCatalogFromDirectories,
+  validateWorkflowCatalogEntries,
+  validateWorkflowPackageMetadata,
+  workflowCatalogNamespacePolicy,
+  workflowPackageCatalogEndpoints,
+} from "../dist/platform/workflowCatalog.js";
+
+const repoRoot = process.cwd();
+
+async function writeWorkflowPackage(root, packageDir, body) {
+  const packageRoot = path.join(root, packageDir);
+  await mkdir(packageRoot, { recursive: true });
+  await writeFile(path.join(packageRoot, "workflow-package.json"), JSON.stringify(body, null, 2));
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("workflow package catalog exposes list and validate endpoints plus namespace policy", () => {
+  assert.deepEqual(workflowPackageCatalogEndpoints, {
+    list: "GET /api/platform/workflow-packages",
+    validate: "POST /api/platform/workflow-packages/validate",
+  });
+  assert.equal(workflowCatalogNamespacePolicy.official.idPrefix, "official.");
+  assert.equal(workflowCatalogNamespacePolicy.custom.idPrefix, "custom.");
+  assert.match(workflowCatalogNamespacePolicy.custom.overridePolicy, /additive overlays/i);
+});
+
+test("example catalog lists official and custom packages without raw secrets", () => {
+  const listed = listWorkflowPackagesSecretSafe(exampleWorkflowPackageCatalog);
+  assert.deepEqual(
+    listed.map((pkg) => [pkg.id, pkg.source, pkg.repository.repo]),
+    [
+      ["official.core.maintenance", "official", "service-lasso/workflows-core"],
+      ["custom.local.reporting", "custom", "file://./workflows/custom-reporting"],
+    ],
+  );
+  assert.equal(listed[0].secrets?.[0].ref, "maintenance.API_TOKEN");
+  assert.equal(JSON.stringify(listed).includes("raw-workflow-secret"), false);
+  assert.doesNotThrow(() => assertWorkflowCatalogSecretSafe(listed));
+});
+
+test("workflow catalog loads official and custom package metadata from local directories", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-catalog-"));
+  const officialRoot = path.join(tempRoot, "official");
+  const customRoot = path.join(tempRoot, "custom");
+
+  try {
+    await writeWorkflowPackage(officialRoot, "core-maintenance", exampleWorkflowPackageCatalog[0].metadata);
+    await writeWorkflowPackage(customRoot, "local-reporting", exampleWorkflowPackageCatalog[1].metadata);
+
+    const result = await loadWorkflowCatalogFromDirectories([
+      { root: officialRoot, source: "official" },
+      { root: customRoot, source: "custom" },
+    ]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.diagnostics.length, 0);
+    assert.deepEqual(
+      result.entries.map((entry) => entry.metadata.id).sort(),
+      ["custom.local.reporting", "official.core.maintenance"],
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow catalog validation rejects missing repository engine and source with diagnostics", () => {
+  const missing = clone(exampleWorkflowPackageCatalog[0].metadata);
+  delete missing.repository;
+  delete missing.engine;
+  const missingDiagnostics = validateWorkflowPackageMetadata(missing);
+  assert.deepEqual(
+    missingDiagnostics.map((diagnostic) => [diagnostic.code, diagnostic.field]).filter(([code]) => code === "missing-field"),
+    [
+      ["missing-field", "repository"],
+      ["missing-field", "engine"],
+    ],
+  );
+
+  const invalid = clone(exampleWorkflowPackageCatalog[0].metadata);
+  delete invalid.source;
+  invalid.repository = { repo: "", ref: "" };
+  invalid.engine = { engine: "unknown", versionRange: "" };
+  const invalidDiagnostics = validateWorkflowPackageMetadata(invalid);
+  assert.deepEqual(
+    invalidDiagnostics.map((diagnostic) => [diagnostic.code, diagnostic.field]).filter(([_, field]) => ["source", "repository.repo", "repository.ref", "engine.engine", "engine.versionRange"].includes(field)),
+    [
+      ["invalid-field", "source"],
+      ["missing-field", "repository.repo"],
+      ["missing-field", "repository.ref"],
+      ["invalid-field", "engine.engine"],
+      ["missing-field", "engine.versionRange"],
+    ],
+  );
+  assert.ok(invalidDiagnostics.every((diagnostic) => diagnostic.action.length > 0));
+});
+
+test("workflow catalog validation rejects invalid namespaces and reports actionable diagnostics", () => {
+  const invalid = clone(exampleWorkflowPackageCatalog[0].metadata);
+  invalid.id = "core-maintenance";
+  invalid.workflows = ["official.core.maintenance/backup-check"];
+  invalid.configs = [{ path: "unsafe/defaults.yaml" }];
+  invalid.tools = [{ id: "maintenance.tool", command: "echo" }];
+
+  const diagnostics = validateWorkflowPackageMetadata(invalid);
+  assert.equal(diagnostics.every((diagnostic) => diagnostic.severity === "error"), true);
+  assert.deepEqual(
+    diagnostics.map((diagnostic) => diagnostic.code),
+    ["invalid-namespace", "invalid-namespace", "invalid-namespace", "invalid-namespace"],
+  );
+  assert.ok(diagnostics.every((diagnostic) => diagnostic.action.length > 0));
+});
+
+test("custom packages cannot collide with official workflow ids config paths or tools", () => {
+  const official = clone(exampleWorkflowPackageCatalog[0]);
+  const custom = clone(exampleWorkflowPackageCatalog[1]);
+  custom.metadata.id = "custom.core.maintenance";
+  custom.metadata.workflows = [official.metadata.workflows[0]];
+  custom.metadata.configs = [{ path: official.metadata.configs[0].path }];
+  custom.metadata.tools = [{ id: official.metadata.tools[0].id, command: "custom-tool" }];
+
+  const result = validateWorkflowCatalogEntries([official, custom]);
+  assert.equal(result.ok, false);
+  const diagnosticCodes = result.diagnostics.map((diagnostic) => diagnostic.code);
+  for (const expectedCode of [
+    "config-path-collision",
+    "invalid-namespace",
+    "tool-collision",
+    "workflow-collision",
+  ]) {
+    assert.ok(diagnosticCodes.includes(expectedCode), `Expected ${expectedCode}`);
+  }
+  assert.ok(result.diagnostics.every((diagnostic) => /Rename|Use/.test(diagnostic.action)));
+});
+
+test("workflow catalog rejects raw secrets while allowing broker secret refs", () => {
+  const safe = clone(exampleWorkflowPackageCatalog[1].metadata);
+  assert.equal(validateWorkflowPackageMetadata(safe).length, 0);
+
+  const unsafe = clone(safe);
+  unsafe.validation = [
+    {
+      name: "bad validation",
+      command: "curl",
+      args: ["--header", "Authorization: Bearer raw-workflow-secret"],
+    },
+  ];
+  const diagnostics = validateWorkflowPackageMetadata(unsafe);
+  assert.equal(diagnostics.some((diagnostic) => diagnostic.code === "secret-material"), true);
+  assert.throws(() => assertWorkflowCatalogSecretSafe(unsafe), /secret-like material/);
+});
+
+test("workflow catalog docs cover official custom overrides support warnings and validation", async () => {
+  const docs = await readFile(path.join(repoRoot, "docs", "reference", "workflow-package-catalog.md"), "utf8");
+  for (const requiredText of [
+    "official/core",
+    "custom workflow repositories",
+    "workflow-package.json",
+    "id, version, repo/ref, owner",
+    "engine requirements",
+    "validation commands",
+    "additive custom packages",
+    "Invalid/colliding workflow packages fail validation",
+    "raw secrets",
+  ]) {
+    assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Added the first workflow package catalog contract for official/core and custom workflow repositories.
- Defined workflow package metadata for id, version, repo/ref/path, owner, support level, engine requirements, tools, configs, broker secret refs, schedules, and validation commands.
- Added official/custom namespace rules for package ids, workflow ids, config paths, output dirs, and tool ids.
- Added local directory catalog loading for `workflow-package.json` metadata.
- Added validation diagnostics for invalid namespaces, duplicate package ids, workflow/config/tool collisions, invalid broker refs, invalid JSON, and raw secret-like material.
- Added docs covering additive custom overlay policy, support warnings, metadata shape, API shape, and secret boundaries.

## Validation

- `npm run build` — passed
- `node --test --test-concurrency=1 tests/workflow-package-catalog.test.js` — 7 passed
- `npm test` — 212 passed
- `git diff --check` — passed
- `npm run docs:build` — passed

## Secret-safety notes

- Catalog package listing returns metadata only.
- Secret entries are broker namespace + dotted ref metadata only.
- Tests prove raw workflow secrets, provider tokens, private key material, client secret strings, and recovery-like material are rejected/absent.

Closes #409
