### PR TITLE
Add workflow repo sync activation rollback controller

### DIFF
--- a/docs/reference/workflow-repo-sync-activation.md
+++ b/docs/reference/workflow-repo-sync-activation.md
@@ -1,0 +1,73 @@
+# Workflow repo sync and activation controller
+
+Service Lasso workflow content updates through pinned Git/release refs, not by blindly pulling a mutable branch into active production state. The workflow repo sync controller is the first contract for fetching official/core and custom workflow repositories into an instance-local workspace, validating them, and activating them safely.
+
+## API contract
+
+The platform surface is intentionally small and state-oriented:
+
+- `GET /api/platform/workflow-repos/state` returns the active revision, previous-good revision, failed activation evidence, and activation history.
+- `POST /api/platform/workflow-repos/sync` fetches configured workflow repo sources into a staging workspace.
+- `POST /api/platform/workflow-repos/activate` validates staged workflow package metadata and promotes a complete activation.
+- `POST /api/platform/workflow-repos/rollback` restores the previous-good revision pointer when an activated revision must be backed out.
+
+The initial implementation exposes this as a platform controller contract in `src/platform/workflowSyncController.ts`; runtime route binding can wrap the same state shape later.
+
+## Source configuration
+
+Each workflow source must declare:
+
+- `id` — stable source id, usually matching the package id.
+- `source` — `official` for Service Lasso-owned workflow content or `custom` for additive operator content.
+- `repo` — repository slug or local/file source.
+- `ref` — pinned release tag or immutable commit/ref.
+- `channel` — optional release channel metadata such as `stable` or `preview`.
+- `path` — optional package-root path inside the synced repository.
+
+Mutable production refs such as `main`, `master`, `develop`, `latest`, or `HEAD` are rejected by validation. This keeps sync from turning into an uncontrolled `git pull main` against the active workflow directory.
+
+## Activation model
+
+Activation is staged before promotion:
+
+1. Fetch each configured source into `workspaceRoot/staging/<activation-id>/<source-id>`.
+2. Load `workflow-package.json` metadata from each synced package root.
+3. Validate package metadata, source/ref alignment, Dagu workflow definition files, namespace rules, raw secret boundaries, and catalog collisions.
+4. Promote the complete staging directory to `workspaceRoot/active/<activation-id>` only after validation passes.
+5. Write state atomically to `state.json` with the new active revision and prior active revision as `previousGood`.
+
+The active revision is a composed source/revision string, for example:
+
+```text
+official.core.maintenance@2026.5.8+custom.local.reporting@v0.1.0
+```
+
+The active state includes mounted package roots, source revisions, activated package ids, and activation history. API consumers should display both active and previous-good revisions so operators can see what changed and what rollback target is available.
+
+## Validation and rollback
+
+Activation fails before promotion when:
+
+- a source is missing `id`, `repo`, `ref`, or has an invalid `source` kind;
+- a source uses a mutable production ref such as `main`;
+- package metadata fails the workflow catalog contract;
+- package metadata repo/ref does not match the configured synced source;
+- a Dagu package declares a workflow id but does not include a matching `workflows/<name>.yaml` or `workflows/<name>.yml` definition;
+- custom content collides with official package ids, workflow ids, config paths, or tool ids;
+- raw secret/token/key/recovery material appears in workflow metadata.
+
+On validation or fetch/activation failure, the controller records failed activation evidence and leaves the previous active revision mounted. `failed.rolledBackTo` names the active revision that remained in effect.
+
+Manual rollback swaps `active` and `previousGood` state pointers and appends a rollback history record. Rollback does not invent a new workflow package revision; it restores the previously activated known-good revision.
+
+## Custom package policy
+
+Custom workflow packages remain additive overlays. They may add `custom.*` package ids, workflow ids, tools, and config paths, but must not edit or override official/core content in place. Collisions are activation blockers, not warnings.
+
+## Secret boundary
+
+The sync controller reuses the workflow catalog secret boundary:
+
+- broker secret refs are allowed as metadata (`namespace` + dotted `ref`);
+- raw provider tokens, API keys, private keys, passwords, client secrets, and recovery material are rejected before activation;
+- state/API payloads contain metadata and refs only, not secret values.

--- a/src/platform/workflowSyncController.ts
+++ b/src/platform/workflowSyncController.ts
@@ -1,0 +1,378 @@
+import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  type WorkflowCatalogDiagnostic,
+  type WorkflowCatalogEntry,
+  type WorkflowPackageSourceKind,
+  loadWorkflowCatalogFromDirectories,
+} from "./workflowCatalog.js";
+
+export type WorkflowRepoSource = {
+  id: string;
+  source: WorkflowPackageSourceKind;
+  repo: string;
+  ref: string;
+  channel?: string;
+  path?: string;
+};
+
+export type WorkflowRepoSyncedRevision = {
+  sourceId: string;
+  source: WorkflowPackageSourceKind;
+  repo: string;
+  ref: string;
+  channel?: string;
+  revision: string;
+  workspacePath: string;
+  packageRoot: string;
+  syncedAt: string;
+};
+
+export type WorkflowRepoActiveRevision = {
+  activationId: string;
+  revision: string;
+  activatedAt: string;
+  activeRoot: string;
+  packageRoots: string[];
+  sources: WorkflowRepoSyncedRevision[];
+  packages: string[];
+};
+
+export type WorkflowRepoSyncState = {
+  active?: WorkflowRepoActiveRevision;
+  previousGood?: WorkflowRepoActiveRevision;
+  failed?: {
+    activationId: string;
+    failedAt: string;
+    reason: string;
+    diagnostics: WorkflowCatalogDiagnostic[];
+    attemptedSources: WorkflowRepoSyncedRevision[];
+    rolledBackTo?: string;
+  };
+  history: Array<{
+    activationId: string;
+    result: "activated" | "rolled-back";
+    revision: string;
+    at: string;
+    diagnostics: WorkflowCatalogDiagnostic[];
+  }>;
+};
+
+export type WorkflowRepoFetchRequest = {
+  source: WorkflowRepoSource;
+  destination: string;
+};
+
+export type WorkflowRepoFetchResult = {
+  revision: string;
+  packageRoot?: string;
+};
+
+export type WorkflowRepoFetcher = (request: WorkflowRepoFetchRequest) => Promise<WorkflowRepoFetchResult>;
+
+export type WorkflowRepoSyncControllerOptions = {
+  workspaceRoot: string;
+  statePath?: string;
+  now?: () => Date;
+  fetcher: WorkflowRepoFetcher;
+};
+
+export type WorkflowRepoActivationResult = {
+  ok: boolean;
+  state: WorkflowRepoSyncState;
+  active?: WorkflowRepoActiveRevision;
+  diagnostics: WorkflowCatalogDiagnostic[];
+  synced: WorkflowRepoSyncedRevision[];
+};
+
+export const workflowRepoSyncEndpoints = {
+  state: "GET /api/platform/workflow-repos/state",
+  sync: "POST /api/platform/workflow-repos/sync",
+  activate: "POST /api/platform/workflow-repos/activate",
+  rollback: "POST /api/platform/workflow-repos/rollback",
+} as const;
+
+export async function activateWorkflowRepoSources(
+  sources: WorkflowRepoSource[],
+  options: WorkflowRepoSyncControllerOptions,
+): Promise<WorkflowRepoActivationResult> {
+  const now = options.now ?? (() => new Date());
+  const statePath = options.statePath ?? path.join(options.workspaceRoot, "state.json");
+  const previousState = await readWorkflowRepoSyncState(statePath);
+  const activationId = `activation-${now().toISOString().replace(/[:.]/g, "-")}`;
+  const stagingRoot = path.join(options.workspaceRoot, "staging", activationId);
+  const activeRoot = path.join(options.workspaceRoot, "active", activationId);
+  await mkdir(stagingRoot, { recursive: true });
+
+  const synced: WorkflowRepoSyncedRevision[] = [];
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+
+  if (!Array.isArray(sources) || sources.length === 0) {
+    diagnostics.push({
+      code: "missing-field",
+      severity: "error",
+      field: "sources",
+      message: "Workflow repo activation requires at least one configured workflow repo source.",
+      action: "Configure at least one official or custom workflow repo source with an explicit pinned ref before activation.",
+    });
+    return await recordWorkflowActivationFailure({
+      activationId,
+      statePath,
+      previousState,
+      reason: "workflow activation has no configured sources",
+      diagnostics,
+      synced,
+      at: now().toISOString(),
+    });
+  }
+
+  try {
+    for (const source of sources) {
+      validateWorkflowRepoSource(source, diagnostics);
+      if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+        continue;
+      }
+      const destination = path.join(stagingRoot, safeSegment(source.id));
+      await mkdir(destination, { recursive: true });
+      const fetched = await options.fetcher({ source, destination });
+      const packageRoot = path.resolve(destination, fetched.packageRoot ?? source.path ?? ".");
+      synced.push({
+        sourceId: source.id,
+        source: source.source,
+        repo: source.repo,
+        ref: source.ref,
+        channel: source.channel,
+        revision: fetched.revision,
+        workspacePath: destination,
+        packageRoot,
+        syncedAt: now().toISOString(),
+      });
+    }
+
+    const catalog = await loadWorkflowCatalogFromDirectories(synced.map((entry) => ({ root: entry.packageRoot, source: entry.source })));
+    diagnostics.push(...catalog.diagnostics);
+    diagnostics.push(...validateActivationRepositoryPins(catalog.entries, synced));
+    diagnostics.push(...await validateDaguWorkflowDefinitions(catalog.entries));
+
+    if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+      return await recordWorkflowActivationFailure({
+        activationId,
+        statePath,
+        previousState,
+        reason: "workflow validation failed before activation",
+        diagnostics,
+        synced,
+        at: now().toISOString(),
+      });
+    }
+
+    await mkdir(path.dirname(activeRoot), { recursive: true });
+    await rm(activeRoot, { recursive: true, force: true });
+    await rename(stagingRoot, activeRoot);
+
+    const active: WorkflowRepoActiveRevision = {
+      activationId,
+      revision: composeActivationRevision(synced),
+      activatedAt: now().toISOString(),
+      activeRoot,
+      packageRoots: synced.map((entry) => path.join(activeRoot, safeSegment(entry.sourceId), path.relative(entry.workspacePath, entry.packageRoot))),
+      sources: synced.map((entry) => ({ ...entry, workspacePath: path.join(activeRoot, safeSegment(entry.sourceId)), packageRoot: path.join(activeRoot, safeSegment(entry.sourceId), path.relative(entry.workspacePath, entry.packageRoot)) })),
+      packages: catalog.entries.map((entry) => entry.metadata.id).sort(),
+    };
+
+    const nextState: WorkflowRepoSyncState = {
+      active,
+      previousGood: previousState.active ?? previousState.previousGood,
+      history: [
+        ...previousState.history,
+        { activationId, result: "activated", revision: active.revision, at: active.activatedAt, diagnostics: [] },
+      ],
+    };
+    await writeWorkflowRepoSyncState(statePath, nextState);
+    return { ok: true, state: nextState, active, diagnostics: [], synced: active.sources };
+  } catch (error) {
+    diagnostics.push({
+      code: "invalid-field",
+      severity: "error",
+      message: `Workflow activation failed before promotion: ${(error as Error).message}`,
+      action: "Fix the fetch/sync source or workflow package metadata; previous active revision remains mounted.",
+    });
+    return await recordWorkflowActivationFailure({
+      activationId,
+      statePath,
+      previousState,
+      reason: "workflow activation failed before promotion",
+      diagnostics,
+      synced,
+      at: now().toISOString(),
+    });
+  }
+}
+
+export async function rollbackWorkflowRepoActivation(options: Omit<WorkflowRepoSyncControllerOptions, "fetcher">): Promise<WorkflowRepoSyncState> {
+  const statePath = options.statePath ?? path.join(options.workspaceRoot, "state.json");
+  const state = await readWorkflowRepoSyncState(statePath);
+  if (!state.previousGood) {
+    return state;
+  }
+  const now = options.now ?? (() => new Date());
+  const rolledBack: WorkflowRepoSyncState = {
+    active: state.previousGood,
+    previousGood: state.active,
+    history: [
+      ...state.history,
+      { activationId: `rollback-${now().toISOString().replace(/[:.]/g, "-")}`, result: "rolled-back", revision: state.previousGood.revision, at: now().toISOString(), diagnostics: [] },
+    ],
+  };
+  await writeWorkflowRepoSyncState(statePath, rolledBack);
+  return rolledBack;
+}
+
+export async function readWorkflowRepoSyncState(statePath: string): Promise<WorkflowRepoSyncState> {
+  try {
+    return JSON.parse(await readFile(statePath, "utf8")) as WorkflowRepoSyncState;
+  } catch {
+    return { history: [] };
+  }
+}
+
+function validateWorkflowRepoSource(source: WorkflowRepoSource, diagnostics: WorkflowCatalogDiagnostic[]): void {
+  for (const field of ["id", "repo", "ref"] as const) {
+    if (typeof source[field] !== "string" || source[field].trim().length === 0) {
+      diagnostics.push({
+        code: "missing-field",
+        severity: "error",
+        packageId: source.id,
+        field,
+        message: `Workflow repo source is missing required field ${field}.`,
+        action: "Configure workflow repo sources with explicit id, repo, source kind, and pinned ref/channel metadata.",
+      });
+    }
+  }
+  if (source.source !== "official" && source.source !== "custom") {
+    diagnostics.push({
+      code: "invalid-field",
+      severity: "error",
+      packageId: source.id,
+      field: "source",
+      message: "Workflow repo source must be official or custom.",
+      action: "Use official for Service Lasso-owned workflow sources and custom for additive operator sources.",
+    });
+  }
+  if (["main", "master", "develop", "latest", "HEAD"].includes(source.ref)) {
+    diagnostics.push({
+      code: "invalid-field",
+      severity: "error",
+      packageId: source.id,
+      field: "ref",
+      message: `Workflow repo source ${source.id} uses mutable ref ${source.ref}.`,
+      action: "Pin workflow sync to a release tag or immutable commit; do not blindly pull main into active production state.",
+    });
+  }
+}
+
+async function validateDaguWorkflowDefinitions(entries: WorkflowCatalogEntry[]): Promise<WorkflowCatalogDiagnostic[]> {
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+  for (const entry of entries) {
+    if (entry.metadata.engine.engine !== "dagu") {
+      continue;
+    }
+    const packageRoot = path.dirname(entry.metadataPath);
+    for (const workflowId of entry.metadata.workflows ?? []) {
+      const workflowName = workflowId.split("/").at(-1) ?? workflowId;
+      const candidates = [
+        path.join(packageRoot, "workflows", `${workflowName}.yaml`),
+        path.join(packageRoot, "workflows", `${workflowName}.yml`),
+        path.join(packageRoot, `${workflowName}.yaml`),
+        path.join(packageRoot, `${workflowName}.yml`),
+      ];
+      const exists = await Promise.any(candidates.map(async (candidate) => {
+        await access(candidate);
+        return true;
+      })).catch(() => false);
+      if (!exists) {
+        diagnostics.push({
+          code: "missing-field",
+          severity: "error",
+          packageId: entry.metadata.id,
+          field: "workflows",
+          message: `Dagu workflow definition for ${workflowId} is missing from ${packageRoot}.`,
+          action: `Add workflows/${workflowName}.yaml or workflows/${workflowName}.yml before activation.`,
+        });
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function validateActivationRepositoryPins(entries: WorkflowCatalogEntry[], synced: WorkflowRepoSyncedRevision[]): WorkflowCatalogDiagnostic[] {
+  const diagnostics: WorkflowCatalogDiagnostic[] = [];
+  for (const entry of entries) {
+    const source = synced.find((candidate) => candidate.source === entry.metadata.source && candidate.repo === entry.metadata.repository.repo);
+    if (!source) {
+      diagnostics.push({
+        code: "invalid-field",
+        severity: "error",
+        packageId: entry.metadata.id,
+        field: "repository.repo",
+        message: `Workflow package ${entry.metadata.id} came from an unconfigured repository ${entry.metadata.repository.repo}.`,
+        action: "Configure the repo source explicitly before activation.",
+      });
+      continue;
+    }
+    if (entry.metadata.repository.ref !== source.ref && entry.metadata.repository.ref !== source.revision) {
+      diagnostics.push({
+        code: "invalid-field",
+        severity: "error",
+        packageId: entry.metadata.id,
+        field: "repository.ref",
+        message: `Workflow package ${entry.metadata.id} metadata ref ${entry.metadata.repository.ref} does not match synced ref ${source.ref}/${source.revision}.`,
+        action: "Align workflow-package.json repository.ref with the pinned source ref or resolved immutable revision.",
+      });
+    }
+  }
+  return diagnostics;
+}
+
+async function recordWorkflowActivationFailure(args: {
+  activationId: string;
+  statePath: string;
+  previousState: WorkflowRepoSyncState;
+  reason: string;
+  diagnostics: WorkflowCatalogDiagnostic[];
+  synced: WorkflowRepoSyncedRevision[];
+  at: string;
+}): Promise<WorkflowRepoActivationResult> {
+  const failed: WorkflowRepoSyncState = {
+    ...args.previousState,
+    failed: {
+      activationId: args.activationId,
+      failedAt: args.at,
+      reason: args.reason,
+      diagnostics: args.diagnostics,
+      attemptedSources: args.synced,
+      rolledBackTo: args.previousState.active?.revision,
+    },
+    history: [
+      ...args.previousState.history,
+      { activationId: args.activationId, result: "rolled-back", revision: args.previousState.active?.revision ?? "none", at: args.at, diagnostics: args.diagnostics },
+    ],
+  };
+  await writeWorkflowRepoSyncState(args.statePath, failed);
+  return { ok: false, state: failed, active: args.previousState.active, diagnostics: args.diagnostics, synced: args.synced };
+}
+
+async function writeWorkflowRepoSyncState(statePath: string, state: WorkflowRepoSyncState): Promise<void> {
+  await mkdir(path.dirname(statePath), { recursive: true });
+  const tempPath = `${statePath}.${process.pid}.tmp`;
+  await writeFile(tempPath, JSON.stringify(state, null, 2));
+  await rename(tempPath, statePath);
+}
+
+function composeActivationRevision(synced: WorkflowRepoSyncedRevision[]): string {
+  return synced.map((entry) => `${entry.sourceId}@${entry.revision}`).sort().join("+");
+}
+
+function safeSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, "-");
+}

--- a/tests/workflow-sync-controller.test.js
+++ b/tests/workflow-sync-controller.test.js
@@ -1,0 +1,249 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  activateWorkflowRepoSources,
+  readWorkflowRepoSyncState,
+  rollbackWorkflowRepoActivation,
+  workflowRepoSyncEndpoints,
+} from "../dist/platform/workflowSyncController.js";
+import { exampleWorkflowPackageCatalog } from "../dist/platform/workflowCatalog.js";
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function writePackage(root, packageDir, metadata, options = {}) {
+  const packageRoot = path.join(root, packageDir);
+  await mkdir(packageRoot, { recursive: true });
+  await writeFile(path.join(packageRoot, "workflow-package.json"), JSON.stringify(metadata, null, 2));
+  if (options.withDaguDefinitions !== false) {
+    await mkdir(path.join(packageRoot, "workflows"), { recursive: true });
+    for (const workflowId of metadata.workflows ?? []) {
+      const workflowName = workflowId.split("/").at(-1);
+      await writeFile(path.join(packageRoot, "workflows", `${workflowName}.yaml`), `name: ${workflowName}\nsteps: []\n`);
+    }
+  }
+}
+
+function fixedClock() {
+  let tick = 0;
+  return () => new Date(Date.UTC(2026, 4, 8, 11, 45, tick++));
+}
+
+function sourceFor(metadata, id = metadata.id) {
+  return {
+    id,
+    source: metadata.source,
+    repo: metadata.repository.repo,
+    ref: metadata.repository.ref,
+    channel: "stable",
+  };
+}
+
+test("workflow repo sync exposes state sync activate and rollback endpoint contract", () => {
+  assert.deepEqual(workflowRepoSyncEndpoints, {
+    state: "GET /api/platform/workflow-repos/state",
+    sync: "POST /api/platform/workflow-repos/sync",
+    activate: "POST /api/platform/workflow-repos/activate",
+    rollback: "POST /api/platform/workflow-repos/rollback",
+  });
+});
+
+test("workflow repo activation syncs pinned sources validates packages and records active previous revisions", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  const custom = clone(exampleWorkflowPackageCatalog[1].metadata);
+  custom.repository.ref = "v0.1.0";
+
+  try {
+    const result = await activateWorkflowRepoSources([sourceFor(official), sourceFor(custom)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        const metadata = source.source === "official" ? official : custom;
+        await writePackage(destination, metadata.id, metadata);
+        return { revision: source.ref };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.diagnostics.length, 0);
+    assert.deepEqual(result.active?.packages, ["custom.local.reporting", "official.core.maintenance"]);
+    assert.match(result.active?.activeRoot ?? "", /active/);
+    assert.deepEqual(result.active?.sources.map((entry) => [entry.sourceId, entry.ref]), [
+      ["official.core.maintenance", "2026.5.8"],
+      ["custom.local.reporting", "v0.1.0"],
+    ]);
+
+    const secondOfficial = clone(official);
+    secondOfficial.version = "2026.5.9";
+    secondOfficial.repository.ref = "2026.5.9";
+    const second = await activateWorkflowRepoSources([sourceFor(secondOfficial)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, secondOfficial.id, secondOfficial);
+        return { revision: source.ref };
+      },
+    });
+
+    assert.equal(second.ok, true);
+    assert.equal(second.state.previousGood?.revision, result.active?.revision);
+    assert.equal(second.state.active?.revision, "official.core.maintenance@2026.5.9");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow repo activation rejects empty source sets without promoting empty active state", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  try {
+    const initial = await activateWorkflowRepoSources([sourceFor(official)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, official.id, official);
+        return { revision: source.ref };
+      },
+    });
+    assert.equal(initial.ok, true);
+
+    const empty = await activateWorkflowRepoSources([], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async () => {
+        throw new Error("fetcher should not run for empty sources");
+      },
+    });
+
+    assert.equal(empty.ok, false);
+    assert.equal(empty.active?.revision, initial.active?.revision);
+    assert.equal(empty.state.failed?.rolledBackTo, initial.active?.revision);
+    assert.ok(empty.diagnostics.some((diagnostic) => diagnostic.code === "missing-field" && diagnostic.field === "sources"));
+    assert.ok(empty.diagnostics.every((diagnostic) => /Configure at least one/.test(diagnostic.action)));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow repo activation rejects mutable refs before production activation", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  try {
+    const result = await activateWorkflowRepoSources([{ ...sourceFor(official), ref: "main" }], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ destination }) => {
+        await writePackage(destination, official.id, official);
+        return { revision: "main" };
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.state.active, undefined);
+    assert.equal(result.state.failed?.rolledBackTo, undefined);
+    assert.ok(result.diagnostics.some((diagnostic) => diagnostic.field === "ref" && /do not blindly pull main/i.test(diagnostic.action)));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow repo activation rejects missing Dagu definitions before activation", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  try {
+    const result = await activateWorkflowRepoSources([sourceFor(official)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, official.id, official, { withDaguDefinitions: false });
+        return { revision: source.ref };
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.ok(result.diagnostics.some((diagnostic) => /Dagu workflow definition/.test(diagnostic.message)));
+    assert.equal(result.state.active, undefined);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow repo activation rejects catalog collisions and keeps previous-good active", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  const custom = clone(exampleWorkflowPackageCatalog[1].metadata);
+  custom.repository.ref = "v0.1.0";
+  custom.workflows = [official.workflows[0]];
+
+  try {
+    const initial = await activateWorkflowRepoSources([sourceFor(official)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, official.id, official);
+        return { revision: source.ref };
+      },
+    });
+    assert.equal(initial.ok, true);
+
+    const failed = await activateWorkflowRepoSources([sourceFor(official), sourceFor(custom)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        const metadata = source.source === "official" ? official : custom;
+        await writePackage(destination, metadata.id, metadata);
+        return { revision: source.ref };
+      },
+    });
+
+    assert.equal(failed.ok, false);
+    assert.equal(failed.active?.revision, initial.active?.revision);
+    assert.equal(failed.state.failed?.rolledBackTo, initial.active?.revision);
+    assert.ok(failed.diagnostics.some((diagnostic) => diagnostic.code === "workflow-collision"));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow repo rollback restores previous-good revision state", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-sync-"));
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  const next = clone(official);
+  next.version = "2026.5.9";
+  next.repository.ref = "2026.5.9";
+
+  try {
+    const first = await activateWorkflowRepoSources([sourceFor(official)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, official.id, official);
+        return { revision: source.ref };
+      },
+    });
+    const second = await activateWorkflowRepoSources([sourceFor(next)], {
+      workspaceRoot: tempRoot,
+      now: fixedClock(),
+      fetcher: async ({ source, destination }) => {
+        await writePackage(destination, next.id, next);
+        return { revision: source.ref };
+      },
+    });
+    assert.notEqual(first.active?.revision, second.active?.revision);
+
+    const rolledBack = await rollbackWorkflowRepoActivation({ workspaceRoot: tempRoot, now: fixedClock() });
+    assert.equal(rolledBack.active?.revision, first.active?.revision);
+    assert.equal(rolledBack.previousGood?.revision, second.active?.revision);
+
+    const persisted = await readWorkflowRepoSyncState(path.join(tempRoot, "state.json"));
+    assert.equal(persisted.active?.revision, first.active?.revision);
+    assert.equal(persisted.history.at(-1)?.result, "rolled-back");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Added the first workflow repo sync/activation/rollback controller contract.
- Defined configured official/custom workflow repo sources with pinned refs/channels and mutable-ref rejection.
- Added staged instance-local sync and atomic promotion to active activation roots.
- Added active/previous-good/failed activation state with rollback history and source revision evidence.
- Reused workflow catalog validation and added activation checks for source repo/ref alignment and Dagu workflow definition files before promotion.
- Added docs covering API shape, source configuration, activation model, validation/rollback behavior, custom package policy, and secret boundaries.

## Validation

- `npm run build` — passed
- `node --test --test-concurrency=1 tests/workflow-sync-controller.test.js` — 6 passed
- `npm test` — 219 passed
- `git diff --check` — passed
- `npm run docs:build` — passed

## Notes

- Activation rejects mutable production refs such as `main`, `master`, `develop`, `latest`, and `HEAD`.
- Failed validation leaves the previous active revision mounted and records rollback evidence.
- State/API payloads include metadata and broker refs only; workflow repo sync does not expose raw secret values.

Closes #410
