### PR TITLE
Add workflow run facade endpoints and status normalization

### DIFF
--- a/docs/reference/workflow-run-facade.md
+++ b/docs/reference/workflow-run-facade.md
@@ -1,0 +1,94 @@
+# Workflow run facade
+
+Service Lasso exposes product-facing workflow and run contracts so apps and Service Admin do not couple directly to Dagu internals. The first facade is metadata-only and can map to Dagu or another workflow runner later.
+
+## Endpoint contract
+
+The facade surface is workspace-scoped:
+
+- `GET /api/platform/workspaces/{workspaceId}/workflows` — list workflows.
+- `GET /api/platform/workspaces/{workspaceId}/workflows/{workflowId}` — get workflow.
+- `POST /api/platform/workspaces/{workspaceId}/workflows/{workflowId}/runs` — start run.
+- `GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}` — get run by facade run id or mapped engine run id.
+- `POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/cancel` — cancel run.
+- `POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/retry` — retry run.
+- `GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/logs` — run logs summary and cursor metadata.
+- `GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/artifacts` — artifacts summary metadata.
+
+The initial implementation lives in `src/platform/workflowRunFacade.ts` as a product contract and test fixture. Runtime HTTP binding can wrap the same shapes later.
+
+## Workflow shape
+
+A workflow definition includes:
+
+- facade workflow id;
+- workspace id;
+- package id from the workflow package catalog;
+- display name;
+- engine kind and engine workflow id;
+- required provider connection ids;
+- secret dependency status by ref metadata only.
+
+Dagu-specific fields are either hidden behind normalized fields or clearly namespaced under `engine.dagu`. Product clients should use the facade ids and normalized status values first.
+
+## Run shape
+
+A run includes:
+
+- `facadeRunId` — stable Service Lasso run id for product clients;
+- `engine.runId` — mapped engine run id for operator correlation;
+- normalized `status`;
+- engine status and optional namespaced Dagu run id;
+- provider connection ids;
+- secret dependency refs and status metadata;
+- audit events linking facade run ids to engine run ids;
+- run logs summary metadata;
+- artifacts summary metadata.
+
+## Status normalization
+
+Engine-specific statuses use status normalization before product clients see them. Statuses are normalized to:
+
+- `queued`
+- `running`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `cancelling`
+- `retrying`
+- `unknown`
+
+For Dagu, `not_started` and scheduled states map to `queued`, `success` maps to `succeeded`, `error` maps to `failed`, and cancel/cancelled variants map to `cancelled`.
+
+## Start policy
+
+Before a start run request is accepted, the facade performs fail-closed workspace/provider/broker policy checks:
+
+1. The request context workspace must match the target workspace.
+2. The context must include `workflow:run` and provider-use entitlements.
+3. Required provider connections must exist in the same workspace and be ready.
+4. Required broker secret refs must be available and resolvable by metadata policy.
+5. Missing or denied secret dependencies block the start request.
+
+Errors are normalized and actionable: workspace mismatch, missing entitlement, connection not ready, missing secret, denied secret, workflow not found, run not found, and invalid transition.
+
+## Secret dependency status by ref metadata only
+
+The facade may return:
+
+```json
+{
+  "namespace": "workflows/core-maintenance",
+  "ref": "maintenance.API_TOKEN",
+  "status": "available",
+  "required": true
+}
+```
+
+It must not return raw secret values, provider tokens, API keys, refresh tokens, private keys, passwords, recovery material, or broker payloads. Secret resolution happens behind the broker at run time.
+
+## Cancellation, retry, logs, and artifacts
+
+Cancel and retry produce audit events that link the facade run id, engine run id, workflow id, workspace id, actor, action, outcome, and timestamp. Cancellation enters `cancelling`; retry enters `retrying` and is only valid from failed/cancelled states.
+
+Run logs and artifacts are summaries only. Product clients get availability, cursors, ids, names, content types, and sizes. Raw log streaming and artifact download policies can be layered behind the same facade later.

--- a/src/platform/workflowRunFacade.ts
+++ b/src/platform/workflowRunFacade.ts
@@ -1,0 +1,415 @@
+import {
+  type PlatformRequestContext,
+  type ProviderConnectionMetadata,
+  authorizePlatformResource,
+} from "./facade.js";
+
+export type WorkflowEngineKind = "dagu" | "service-lasso" | "custom";
+export type WorkflowFacadeRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled" | "cancelling" | "retrying" | "unknown";
+export type WorkflowFacadeErrorCode =
+  | "workspace-mismatch"
+  | "missing-entitlement"
+  | "connection-not-ready"
+  | "missing-secret"
+  | "secret-denied"
+  | "workflow-not-found"
+  | "run-not-found"
+  | "invalid-transition";
+
+export type WorkflowSecretDependencyStatus = "available" | "missing" | "denied";
+
+export type WorkflowSecretDependency = {
+  namespace: string;
+  ref: string;
+  status: WorkflowSecretDependencyStatus;
+  required: boolean;
+  description?: string;
+};
+
+export type WorkflowFacadeDefinition = {
+  id: string;
+  workspaceId: string;
+  packageId: string;
+  displayName: string;
+  engine: {
+    kind: WorkflowEngineKind;
+    workflowId: string;
+    dagu?: {
+      workflowName: string;
+    };
+  };
+  requiredProviderConnectionIds: string[];
+  secretDependencies: WorkflowSecretDependency[];
+};
+
+export type WorkflowFacadeAuditEvent = {
+  id: string;
+  at: string;
+  actorUserId: string;
+  action: "workflow.run.start" | "workflow.run.cancel" | "workflow.run.retry";
+  facadeRunId: string;
+  engineRunId?: string;
+  workflowId: string;
+  workspaceId: string;
+  outcome: "accepted" | "denied";
+  reason?: WorkflowFacadeErrorCode;
+};
+
+export type WorkflowFacadeRun = {
+  facadeRunId: string;
+  workspaceId: string;
+  workflowId: string;
+  status: WorkflowFacadeRunStatus;
+  engine: {
+    kind: WorkflowEngineKind;
+    runId: string;
+    status: string;
+    dagu?: {
+      runId: string;
+    };
+  };
+  providerConnectionIds: string[];
+  secretDependencies: WorkflowSecretDependency[];
+  auditEvents: WorkflowFacadeAuditEvent[];
+  logsSummary?: {
+    available: boolean;
+    lineCount?: number;
+    nextCursor?: string;
+  };
+  artifactsSummary?: Array<{
+    id: string;
+    name: string;
+    contentType?: string;
+    sizeBytes?: number;
+  }>;
+  startedAt: string;
+  updatedAt: string;
+};
+
+export type WorkflowRunFacadeState = {
+  workflows: WorkflowFacadeDefinition[];
+  runs: WorkflowFacadeRun[];
+  providerConnections: ProviderConnectionMetadata[];
+};
+
+export type WorkflowFacadeResult<T> =
+  | { ok: true; value: T; auditEvent?: WorkflowFacadeAuditEvent }
+  | { ok: false; error: { code: WorkflowFacadeErrorCode; message: string; action: string; details?: unknown }; auditEvent?: WorkflowFacadeAuditEvent };
+
+export type StartWorkflowRunRequest = {
+  workspaceId: string;
+  workflowId: string;
+  input?: Record<string, unknown>;
+};
+
+export const workflowRunFacadeEndpoints = {
+  listWorkflows: "GET /api/platform/workspaces/{workspaceId}/workflows",
+  getWorkflow: "GET /api/platform/workspaces/{workspaceId}/workflows/{workflowId}",
+  startRun: "POST /api/platform/workspaces/{workspaceId}/workflows/{workflowId}/runs",
+  getRun: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}",
+  cancelRun: "POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/cancel",
+  retryRun: "POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/retry",
+  runLogs: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/logs",
+  runArtifacts: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/artifacts",
+} as const;
+
+export const exampleWorkflowRunFacadeState: WorkflowRunFacadeState = {
+  workflows: [
+    {
+      id: "official.core.maintenance/backup-check",
+      workspaceId: "wks_local_demo",
+      packageId: "official.core.maintenance",
+      displayName: "Backup check",
+      engine: {
+        kind: "dagu",
+        workflowId: "official.core.maintenance/backup-check",
+        dagu: {
+          workflowName: "backup-check",
+        },
+      },
+      requiredProviderConnectionIds: ["pc_github_actions"],
+      secretDependencies: [
+        {
+          namespace: "workflows/core-maintenance",
+          ref: "maintenance.API_TOKEN",
+          status: "available",
+          required: true,
+          description: "Broker reference only; raw value resolves at run time.",
+        },
+      ],
+    },
+  ],
+  runs: [
+    {
+      facadeRunId: "wfr_20260508_backup_check_01",
+      workspaceId: "wks_local_demo",
+      workflowId: "official.core.maintenance/backup-check",
+      status: "running",
+      engine: {
+        kind: "dagu",
+        runId: "dagu-run-20260508-01",
+        status: "running",
+        dagu: {
+          runId: "dagu-run-20260508-01",
+        },
+      },
+      providerConnectionIds: ["pc_github_actions"],
+      secretDependencies: [
+        {
+          namespace: "workflows/core-maintenance",
+          ref: "maintenance.API_TOKEN",
+          status: "available",
+          required: true,
+        },
+      ],
+      auditEvents: [
+        {
+          id: "aud_workflow_run_start_01",
+          at: "2026-05-08T12:05:00Z",
+          actorUserId: "usr_01hzy9operator",
+          action: "workflow.run.start",
+          facadeRunId: "wfr_20260508_backup_check_01",
+          engineRunId: "dagu-run-20260508-01",
+          workflowId: "official.core.maintenance/backup-check",
+          workspaceId: "wks_local_demo",
+          outcome: "accepted",
+        },
+      ],
+      logsSummary: {
+        available: true,
+        lineCount: 42,
+        nextCursor: "log-cursor-42",
+      },
+      artifactsSummary: [
+        {
+          id: "artifact-summary-json",
+          name: "summary.json",
+          contentType: "application/json",
+          sizeBytes: 128,
+        },
+      ],
+      startedAt: "2026-05-08T12:05:00Z",
+      updatedAt: "2026-05-08T12:05:10Z",
+    },
+  ],
+  providerConnections: [
+    {
+      id: "pc_github_actions",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "github",
+      kind: "oauth",
+      displayName: "GitHub Actions metadata connection",
+      status: "ready",
+      scopes: ["repo:read", "workflow:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/github",
+      secretRef: "provider.github.oauth.client",
+      lastVerifiedAt: "2026-05-08T10:05:00Z",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:05:00Z",
+      secretMaterialPresent: false,
+    },
+  ],
+};
+
+export function listWorkflowFacadeDefinitions(context: PlatformRequestContext, workspaceId: string, state = exampleWorkflowRunFacadeState): WorkflowFacadeResult<WorkflowFacadeDefinition[]> {
+  if (context.workspaceId !== workspaceId) return denied("workspace-mismatch", "Workspace mismatch for workflow list.", "Use a session scoped to the requested workspace.");
+  if (!context.entitlements.includes("workspace:read")) return denied("missing-entitlement", "Missing workspace read entitlement.", "Grant workspace:read before listing workflows.");
+  return { ok: true, value: state.workflows.filter((workflow) => workflow.workspaceId === workspaceId).map(secretSafeWorkflow) };
+}
+
+export function getWorkflowFacadeDefinition(context: PlatformRequestContext, workspaceId: string, workflowId: string, state = exampleWorkflowRunFacadeState): WorkflowFacadeResult<WorkflowFacadeDefinition> {
+  const listed = listWorkflowFacadeDefinitions(context, workspaceId, state);
+  if (!listed.ok) return listed;
+  const workflow = listed.value.find((candidate) => candidate.id === workflowId);
+  if (!workflow) return denied("workflow-not-found", `Workflow ${workflowId} is not available in workspace ${workspaceId}.`, "Refresh the workflow catalog or choose an active workflow id.");
+  return { ok: true, value: workflow };
+}
+
+export function startWorkflowFacadeRun(
+  context: PlatformRequestContext,
+  request: StartWorkflowRunRequest,
+  state = exampleWorkflowRunFacadeState,
+  now = () => new Date(),
+): WorkflowFacadeResult<WorkflowFacadeRun> {
+  const workflowResult = getWorkflowFacadeDefinition(context, request.workspaceId, request.workflowId, state);
+  if (!workflowResult.ok) return workflowResult;
+  const workflow = workflowResult.value;
+
+  const runAuth = authorizePlatformResource(context, {
+    kind: "workflow-run",
+    workspaceId: request.workspaceId,
+    workflowId: request.workflowId,
+    requiredProviderConnectionIds: workflow.requiredProviderConnectionIds,
+  });
+  if (!runAuth.allowed) {
+    return denied(authorizationReasonToFacadeError(runAuth.reason), `Workflow run start denied: ${runAuth.reason}.`, "Satisfy workspace, workflow:run, and provider-connection:use requirements before start.");
+  }
+
+  for (const connectionId of workflow.requiredProviderConnectionIds) {
+    const connection = state.providerConnections.find((candidate) => candidate.id === connectionId);
+    if (!connection) return denied("connection-not-ready", `Required provider connection ${connectionId} is missing.`, "Create and verify the provider connection before start.");
+    const decision = authorizePlatformResource(context, { kind: "provider-connection", connection });
+    if (!decision.allowed) return denied(authorizationReasonToFacadeError(decision.reason), `Provider connection ${connectionId} denied: ${decision.reason}.`, "Verify provider connection readiness and entitlements before start.");
+  }
+
+  for (const secret of workflow.secretDependencies) {
+    if (secret.status === "missing") return denied("missing-secret", `Required secret ref ${secret.ref} is missing.`, "Populate the broker ref before starting the workflow.");
+    if (secret.status === "denied") return denied("secret-denied", `Required secret ref ${secret.ref} is denied.`, "Grant broker policy access to the workflow service identity before start.");
+    const decision = authorizePlatformResource(context, { kind: "secrets-broker-ref", workspaceId: request.workspaceId, brokerNamespace: secret.namespace, ref: secret.ref });
+    if (!decision.allowed) return denied(authorizationReasonToFacadeError(decision.reason), `Secret ref ${secret.ref} cannot be resolved: ${decision.reason}.`, "Grant secrets-broker:resolve before start.");
+  }
+
+  const startedAt = now().toISOString();
+  const facadeRunId = `wfr_${request.workspaceId}_${request.workflowId.replace(/[^A-Za-z0-9]+/g, "_")}_${startedAt.replace(/[^0-9]/g, "")}`;
+  const engineRunId = `${workflow.engine.kind}-run-${startedAt.replace(/[^0-9]/g, "")}`;
+  const auditEvent: WorkflowFacadeAuditEvent = {
+    id: `aud_${facadeRunId}_start`,
+    at: startedAt,
+    actorUserId: context.userId,
+    action: "workflow.run.start",
+    facadeRunId,
+    engineRunId,
+    workflowId: workflow.id,
+    workspaceId: request.workspaceId,
+    outcome: "accepted",
+  };
+  const run: WorkflowFacadeRun = {
+    facadeRunId,
+    workspaceId: request.workspaceId,
+    workflowId: workflow.id,
+    status: "queued",
+    engine: {
+      kind: workflow.engine.kind,
+      runId: engineRunId,
+      status: "queued",
+      ...(workflow.engine.kind === "dagu" ? { dagu: { runId: engineRunId } } : {}),
+    },
+    providerConnectionIds: [...workflow.requiredProviderConnectionIds],
+    secretDependencies: workflow.secretDependencies.map(secretSafeSecretDependency),
+    auditEvents: [auditEvent],
+    logsSummary: { available: false },
+    artifactsSummary: [],
+    startedAt,
+    updatedAt: startedAt,
+  };
+  assertWorkflowRunFacadeSecretSafe(run);
+  return { ok: true, value: run, auditEvent };
+}
+
+export function getWorkflowFacadeRun(context: PlatformRequestContext, workspaceId: string, runId: string, state = exampleWorkflowRunFacadeState): WorkflowFacadeResult<WorkflowFacadeRun> {
+  const run = state.runs.find((candidate) => candidate.facadeRunId === runId || candidate.engine.runId === runId);
+  if (!run) return denied("run-not-found", `Workflow run ${runId} was not found.`, "Use a known facade run id from the workflow run list.");
+  if (run.workspaceId !== workspaceId || context.workspaceId !== workspaceId) return denied("workspace-mismatch", "Workspace mismatch for workflow run.", "Use a session scoped to the requested workspace.");
+  return { ok: true, value: secretSafeRun(run) };
+}
+
+export function cancelWorkflowFacadeRun(context: PlatformRequestContext, workspaceId: string, runId: string, state = exampleWorkflowRunFacadeState, now = () => new Date()): WorkflowFacadeResult<WorkflowFacadeRun> {
+  const current = getWorkflowFacadeRun(context, workspaceId, runId, state);
+  if (!current.ok) return current;
+  if (!["queued", "running", "retrying"].includes(current.value.status)) return denied("invalid-transition", `Cannot cancel workflow run in ${current.value.status} status.`, "Cancel only queued, running, or retrying runs.");
+  const at = now().toISOString();
+  const auditEvent: WorkflowFacadeAuditEvent = {
+    id: `aud_${current.value.facadeRunId}_cancel`,
+    at,
+    actorUserId: context.userId,
+    action: "workflow.run.cancel",
+    facadeRunId: current.value.facadeRunId,
+    engineRunId: current.value.engine.runId,
+    workflowId: current.value.workflowId,
+    workspaceId,
+    outcome: "accepted",
+  };
+  const cancelled = { ...current.value, status: "cancelling" as const, updatedAt: at, auditEvents: [...current.value.auditEvents, auditEvent] };
+  return { ok: true, value: cancelled, auditEvent };
+}
+
+export function retryWorkflowFacadeRun(context: PlatformRequestContext, workspaceId: string, runId: string, state = exampleWorkflowRunFacadeState, now = () => new Date()): WorkflowFacadeResult<WorkflowFacadeRun> {
+  const current = getWorkflowFacadeRun(context, workspaceId, runId, state);
+  if (!current.ok) return current;
+  if (!["failed", "cancelled"].includes(current.value.status)) return denied("invalid-transition", `Cannot retry workflow run in ${current.value.status} status.`, "Retry only failed or cancelled runs.");
+  const at = now().toISOString();
+  const auditEvent: WorkflowFacadeAuditEvent = {
+    id: `aud_${current.value.facadeRunId}_retry`,
+    at,
+    actorUserId: context.userId,
+    action: "workflow.run.retry",
+    facadeRunId: current.value.facadeRunId,
+    engineRunId: current.value.engine.runId,
+    workflowId: current.value.workflowId,
+    workspaceId,
+    outcome: "accepted",
+  };
+  return { ok: true, value: { ...current.value, status: "retrying", updatedAt: at, auditEvents: [...current.value.auditEvents, auditEvent] }, auditEvent };
+}
+
+export function mapEngineRunStatus(engine: WorkflowEngineKind, status: string): WorkflowFacadeRunStatus {
+  const normalized = status.toLowerCase();
+  if (engine === "dagu") {
+    if (["queued", "not_started", "scheduled"].includes(normalized)) return "queued";
+    if (["running", "started"].includes(normalized)) return "running";
+    if (["success", "succeeded", "finished"].includes(normalized)) return "succeeded";
+    if (["error", "failed"].includes(normalized)) return "failed";
+    if (["cancel", "cancelled", "canceled"].includes(normalized)) return "cancelled";
+  }
+  if (["queued", "running", "succeeded", "failed", "cancelled", "cancelling", "retrying"].includes(normalized)) return normalized as WorkflowFacadeRunStatus;
+  return "unknown";
+}
+
+export function assertWorkflowRunFacadeSecretSafe(payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  if (secretLikeValuePattern.test(serialized)) {
+    throw new Error("Workflow run facade payload contains secret-like material");
+  }
+  for (const [key] of Object.entries(flattenObject(payload))) {
+    if (secretLikeFieldPattern.test(key) && !allowedSecretMetadataFields.has(key.split(".").at(-1) ?? key)) {
+      throw new Error(`Workflow run facade payload contains secret-like field ${key}`);
+    }
+  }
+}
+
+function secretSafeWorkflow(workflow: WorkflowFacadeDefinition): WorkflowFacadeDefinition {
+  const safe = { ...workflow, secretDependencies: workflow.secretDependencies.map(secretSafeSecretDependency) };
+  assertWorkflowRunFacadeSecretSafe(safe);
+  return safe;
+}
+
+function secretSafeRun(run: WorkflowFacadeRun): WorkflowFacadeRun {
+  const safe = { ...run, secretDependencies: run.secretDependencies.map(secretSafeSecretDependency) };
+  assertWorkflowRunFacadeSecretSafe(safe);
+  return safe;
+}
+
+function secretSafeSecretDependency(secret: WorkflowSecretDependency): WorkflowSecretDependency {
+  return {
+    namespace: secret.namespace,
+    ref: secret.ref,
+    status: secret.status,
+    required: secret.required,
+    description: secret.description,
+  };
+}
+
+function denied(code: WorkflowFacadeErrorCode, message: string, action: string): WorkflowFacadeResult<never> {
+  return { ok: false, error: { code, message, action } };
+}
+
+function authorizationReasonToFacadeError(reason: "allowed" | "missing-entitlement" | "workspace-mismatch" | "connection-not-ready"): WorkflowFacadeErrorCode {
+  if (reason === "allowed") return "missing-entitlement";
+  return reason;
+}
+
+function flattenObject(value: unknown, prefix = ""): Record<string, unknown> {
+  if (!value || typeof value !== "object") return {};
+  const entries: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const dotted = prefix ? `${prefix}.${key}` : key;
+    entries[dotted] = child;
+    if (child && typeof child === "object") Object.assign(entries, flattenObject(child, dotted));
+  }
+  return entries;
+}
+
+const allowedSecretMetadataFields = new Set(["secretDependencies", "secretRef", "secretMaterialPresent"]);
+const secretLikeFieldPattern = /(secretValue|secret_value|tokenValue|token_value|apiKey|api_key|privateKey|private_key|password|credential|recoveryMaterial|recovery_material|keyMaterial|key_material)$/i;
+const secretLikeValuePattern = /(sk-[a-z0-9]{8,}|ghp_[a-z0-9]{8,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|correct-horse-battery-staple|raw-workflow-secret|access-token-value|refresh-token-value|private-key-material|recovery phrase|client_secret=|password=)/i;

--- a/tests/workflow-run-facade.test.js
+++ b/tests/workflow-run-facade.test.js
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  assertWorkflowRunFacadeSecretSafe,
+  cancelWorkflowFacadeRun,
+  exampleWorkflowRunFacadeState,
+  getWorkflowFacadeDefinition,
+  getWorkflowFacadeRun,
+  listWorkflowFacadeDefinitions,
+  mapEngineRunStatus,
+  retryWorkflowFacadeRun,
+  startWorkflowFacadeRun,
+  workflowRunFacadeEndpoints,
+} from "../dist/platform/workflowRunFacade.js";
+
+const repoRoot = process.cwd();
+const context = {
+  userId: "usr_01hzy9operator",
+  workspaceId: "wks_local_demo",
+  linkedIdentityId: "lid_zitadel_operator",
+  entitlements: ["workspace:read", "provider-connection:use", "secrets-broker:resolve", "workflow:run"],
+};
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("workflow run facade exposes product-facing endpoint contract", () => {
+  assert.deepEqual(workflowRunFacadeEndpoints, {
+    listWorkflows: "GET /api/platform/workspaces/{workspaceId}/workflows",
+    getWorkflow: "GET /api/platform/workspaces/{workspaceId}/workflows/{workflowId}",
+    startRun: "POST /api/platform/workspaces/{workspaceId}/workflows/{workflowId}/runs",
+    getRun: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}",
+    cancelRun: "POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/cancel",
+    retryRun: "POST /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/retry",
+    runLogs: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/logs",
+    runArtifacts: "GET /api/platform/workspaces/{workspaceId}/workflow-runs/{runId}/artifacts",
+  });
+});
+
+test("workflow facade lists gets and starts runs with facade and engine run linkage", () => {
+  const list = listWorkflowFacadeDefinitions(context, "wks_local_demo");
+  assert.equal(list.ok, true);
+  assert.equal(list.value[0].id, "official.core.maintenance/backup-check");
+  assert.deepEqual(list.value[0].secretDependencies.map((secret) => [secret.namespace, secret.ref, secret.status]), [
+    ["workflows/core-maintenance", "maintenance.API_TOKEN", "available"],
+  ]);
+
+  const workflow = getWorkflowFacadeDefinition(context, "wks_local_demo", "official.core.maintenance/backup-check");
+  assert.equal(workflow.ok, true);
+  assert.equal(workflow.value.engine.kind, "dagu");
+  assert.equal(workflow.value.engine.dagu.workflowName, "backup-check");
+
+  const started = startWorkflowFacadeRun(context, { workspaceId: "wks_local_demo", workflowId: workflow.value.id }, exampleWorkflowRunFacadeState, () => new Date("2026-05-08T12:10:00Z"));
+  assert.equal(started.ok, true);
+  assert.equal(started.value.status, "queued");
+  assert.match(started.value.facadeRunId, /^wfr_/);
+  assert.match(started.value.engine.runId, /^dagu-run-/);
+  assert.equal(started.value.engine.dagu.runId, started.value.engine.runId);
+  assert.equal(started.value.auditEvents[0].engineRunId, started.value.engine.runId);
+  assert.doesNotThrow(() => assertWorkflowRunFacadeSecretSafe(started.value));
+});
+
+test("workflow run facade normalizes Dagu and generic statuses", () => {
+  assert.equal(mapEngineRunStatus("dagu", "not_started"), "queued");
+  assert.equal(mapEngineRunStatus("dagu", "running"), "running");
+  assert.equal(mapEngineRunStatus("dagu", "success"), "succeeded");
+  assert.equal(mapEngineRunStatus("dagu", "error"), "failed");
+  assert.equal(mapEngineRunStatus("dagu", "cancel"), "cancelled");
+  assert.equal(mapEngineRunStatus("custom", "retrying"), "retrying");
+  assert.equal(mapEngineRunStatus("dagu", "engine-specific-surprise"), "unknown");
+});
+
+test("workflow start fails closed for workspace entitlement provider and secret policy", () => {
+  const missingWorkflowRun = startWorkflowFacadeRun({ ...context, entitlements: ["workspace:read", "provider-connection:use", "secrets-broker:resolve"] }, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" });
+  assert.equal(missingWorkflowRun.ok, false);
+  assert.equal(missingWorkflowRun.error.code, "missing-entitlement");
+
+  const connectionState = clone(exampleWorkflowRunFacadeState);
+  connectionState.providerConnections[0].status = "needs-auth";
+  const connectionDenied = startWorkflowFacadeRun(context, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" }, connectionState);
+  assert.equal(connectionDenied.ok, false);
+  assert.equal(connectionDenied.error.code, "connection-not-ready");
+
+  const missingSecretState = clone(exampleWorkflowRunFacadeState);
+  missingSecretState.workflows[0].secretDependencies[0].status = "missing";
+  const missingSecret = startWorkflowFacadeRun(context, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" }, missingSecretState);
+  assert.equal(missingSecret.ok, false);
+  assert.equal(missingSecret.error.code, "missing-secret");
+  assert.match(missingSecret.error.action, /Populate the broker ref/);
+
+  const deniedSecretState = clone(exampleWorkflowRunFacadeState);
+  deniedSecretState.workflows[0].secretDependencies[0].status = "denied";
+  const deniedSecret = startWorkflowFacadeRun(context, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" }, deniedSecretState);
+  assert.equal(deniedSecret.ok, false);
+  assert.equal(deniedSecret.error.code, "secret-denied");
+});
+
+test("workflow run facade cancels and retries with normalized audit events", () => {
+  const cancelled = cancelWorkflowFacadeRun(context, "wks_local_demo", "wfr_20260508_backup_check_01", exampleWorkflowRunFacadeState, () => new Date("2026-05-08T12:11:00Z"));
+  assert.equal(cancelled.ok, true);
+  assert.equal(cancelled.value.status, "cancelling");
+  assert.equal(cancelled.value.auditEvents.at(-1).action, "workflow.run.cancel");
+  assert.equal(cancelled.value.auditEvents.at(-1).engineRunId, "dagu-run-20260508-01");
+
+  const retryState = clone(exampleWorkflowRunFacadeState);
+  retryState.runs[0].status = "failed";
+  retryState.runs[0].engine.status = "error";
+  const retried = retryWorkflowFacadeRun(context, "wks_local_demo", "wfr_20260508_backup_check_01", retryState, () => new Date("2026-05-08T12:12:00Z"));
+  assert.equal(retried.ok, true);
+  assert.equal(retried.value.status, "retrying");
+  assert.equal(retried.value.auditEvents.at(-1).action, "workflow.run.retry");
+});
+
+test("workflow run facade renders run logs artifacts and secrets without raw secret material", () => {
+  const run = getWorkflowFacadeRun(context, "wks_local_demo", "wfr_20260508_backup_check_01");
+  assert.equal(run.ok, true);
+  assert.equal(run.value.logsSummary.available, true);
+  assert.equal(run.value.artifactsSummary[0].name, "summary.json");
+  assert.deepEqual(Object.keys(run.value.secretDependencies[0]).sort(), ["description", "namespace", "ref", "required", "status"].sort());
+  assert.equal(JSON.stringify(run.value).includes("raw-workflow-secret"), false);
+  assert.equal(JSON.stringify(run.value).includes("access-token-value"), false);
+  assert.doesNotThrow(() => assertWorkflowRunFacadeSecretSafe(run.value));
+  assert.throws(() => assertWorkflowRunFacadeSecretSafe({ ...run.value, accessToken: "access-token-value" }), /secret-like/);
+});
+
+test("workflow run facade docs cover endpoints status policy and no-secret rendering", async () => {
+  const docs = await readFile(path.join(repoRoot, "docs", "reference", "workflow-run-facade.md"), "utf8");
+  for (const requiredText of [
+    "list workflows",
+    "start run",
+    "cancel run",
+    "retry run",
+    "run logs",
+    "artifacts summary",
+    "status normalization",
+    "workspace/provider/broker policy checks",
+    "secret dependency status by ref metadata only",
+    "Dagu-specific fields",
+    "raw secret values",
+  ]) {
+    assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Added the first product-facing workflow/run facade contract.
- Defined stable workspace-scoped endpoints for list/get workflows, start/get/cancel/retry runs, run logs, and artifacts summary.
- Added normalized facade run statuses and Dagu status mapping.
- Added workflow/run metadata shapes that link facade run ids to engine run ids and namespaced Dagu details.
- Added fail-closed start checks for workspace, `workflow:run`, provider connection readiness, and broker secret dependency status.
- Added secret-safe dependency rendering by broker namespace/ref/status metadata only.
- Added audit event shapes for start/cancel/retry.
- Added docs covering API shape, status normalization, policy checks, cancellation/retry, logs/artifacts summaries, Dagu namespacing, and secret boundaries.

## Validation

- `npm run build` — passed
- `node --test --test-concurrency=1 tests/workflow-run-facade.test.js` — 7 passed
- `npm test` — 227 passed
- `git diff --check` — passed
- `npm run docs:build` — passed

## Secret-safety notes

- Secret dependencies are returned only as namespace/ref/status/required metadata.
- Raw secret values, provider tokens, API keys, private keys, recovery material, and credential-like fields are rejected by the facade guard.
- Dagu-specific fields are namespaced under `engine.dagu`; product clients should use facade ids/status first.

Closes #411
