### PR TITLE
Add Service Lasso auth context contract

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -6,9 +6,9 @@ sidebar_label: Product API Facade
 # Product API Facade Contract
 
 The product API facade owns Service Lasso account metadata that is broader than
-runtime service state: users, workspaces, linked identities, provider connection
-metadata, roles/entitlements, and authorization decisions for Secrets Broker and
-workflow/run resolution.
+runtime service state: users, workspaces, linked identities, request_context,
+service_identities, provider connection metadata, roles/entitlements, and
+authorization decisions for Secrets Broker and workflow/run resolution.
 
 This contract is metadata-only. Provider secret payloads, OAuth access tokens,
 refresh tokens, API keys, private keys, password values, portable master keys,
@@ -58,6 +58,51 @@ and one or more workspaces.
 | `workspaceIds` | Workspaces this identity can enter after role checks. |
 | `claims` | Safe claim metadata only: email, preferred username, groups. |
 | `createdAt` / `lastSeenAt` | Audit timestamps. |
+
+### `request_context`
+
+Every broker/admin/provider/workflow API receives a canonical request context
+instead of re-parsing cookies, tokens, route parameters, or provider-specific
+auth state.
+
+| Field | Notes |
+| --- | --- |
+| `userId` | Internal user id for a ZITADEL-backed user request, or service id for a service-authenticated request. |
+| `workspaceId` | Active workspace resolved from request routing/defaults and verified against identity membership. |
+| `instanceId` | Local Service Lasso instance boundary. Requests cannot cross instances. |
+| `linkedIdentityId` | ZITADEL linked identity id for user requests, or service identity id for service-authenticated requests. |
+| `entitlements` | Workspace-scoped grants flattened from roles or service identity policy. |
+| `actor` | Safe actor descriptor: `kind`, `id`, and display label only. |
+| `authMethod` | `zitadel-session` or `service-identity`. |
+| `audit` | Safe actor/workspace/instance metadata for downstream audit events. |
+
+The resolver returns fail-closed states for `unauthenticated`, `unauthorized`,
+`expired-session`, `workspace-mismatch`, `service-identity-denied`,
+`disabled-user`, and `workspace-inactive`. These responses may include safe
+actor/workspace/instance ids when known, but never cookies, session secrets,
+bearer tokens, provider credentials, raw secret values, key material, or
+recovery material.
+
+### `service_identities`
+
+Service identities let local system actors such as `@node`, `@serviceadmin`, or
+workflow runners call broker/admin APIs without pretending to be provider OAuth
+users.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable internal service identity id. |
+| `serviceId` / `displayName` | Service actor metadata safe for logs and audit. |
+| `instanceIds` | Allowed Service Lasso instances. |
+| `workspaceIds` | Workspaces the service identity may access. |
+| `entitlements` | Explicit grants such as `secrets-broker:resolve`; no implicit admin rights. |
+| `status` | `active` or `disabled`. Disabled service identities fail closed. |
+| `createdAt` / `updatedAt` | Audit timestamps. |
+
+Service-authenticated requests must provide the expected service id, workspace
+id, and instance id. The resolver rejects unknown services, disabled services,
+workspace mismatches, and instance mismatches as `service-identity-denied` or
+`workspace-mismatch`.
 
 ### `provider_connections`
 
@@ -252,14 +297,37 @@ internal context as follows:
 3. Select the active workspace from request routing or the user's default
    workspace.
 4. Load roles for that workspace and flatten them to entitlements.
-5. Produce a request context containing `userId`, `workspaceId`,
-   `linkedIdentityId`, and entitlements.
-6. Fail closed if the linked identity, workspace, user, or required entitlement
-   is missing.
+5. Produce a request context containing `userId`, `workspaceId`, `instanceId`,
+   `linkedIdentityId`, actor metadata, auth method, safe audit metadata, and
+   entitlements.
+6. Fail closed if the linked identity, workspace, user, session freshness, or
+   required entitlement is missing.
 
 ZITADEL remains app-owned. This facade contract describes how an authenticated
 ZITADEL subject enters Service Lasso account/workspace authorization; it does
 not make ZITADEL part of the Service Lasso core baseline.
+
+## Service-authenticated requests
+
+Broker-adjacent local services use the same request context shape through a
+`service-identity` auth method. The identity must be explicitly allowed for the
+requested `instanceId` and `workspaceId`, and receives only its configured
+entitlements. This supports local runtime resolution such as `@node` reading a
+broker ref without embedding provider credentials or raw secret values in the
+runtime API.
+
+Service identity failures are intentionally narrow:
+
+- missing service auth -> `unauthenticated` / 401,
+- unknown or disabled service -> `service-identity-denied` / 403,
+- instance mismatch -> `service-identity-denied` / 403,
+- workspace mismatch -> `workspace-mismatch` / 403,
+- inactive workspace -> `workspace-inactive` / 403.
+
+Audit metadata for service requests includes actor kind `service`, service id,
+workspace id, instance id, auth method, and service identity id when known. It
+must not include bearer tokens, local service credentials, provider credentials,
+raw secrets, cookies, or session material.
 
 ## Authorization boundaries
 
@@ -273,9 +341,14 @@ Authorization is workspace-scoped and fail-closed:
   `provider-connection:use` for each provider connection referenced by the run.
 - Connections with status `needs-auth`, `revoked`, `disabled`, or `error` cannot
   be used for broker or workflow authorization.
+- Request context resolution must represent `unauthenticated`, `unauthorized`,
+  `expired-session`, `workspace-mismatch`, `service-identity-denied`,
+  `disabled-user`, and `workspace-inactive` distinctly so callers can fail
+  closed and show safe recovery guidance.
 - Denied authorization responses may include metadata reasons such as
   `workspace-mismatch`, `missing-entitlement`, or `connection-not-ready`, but
-  must not include provider secret values or key material.
+  must not include provider secret values, tokens, cookies, session secrets, or
+  key material.
 
 ## Test fixtures
 

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -12,11 +12,34 @@ export type PlatformEntitlement =
   | "secrets-broker:resolve"
   | "workflow:run";
 
+export type PlatformActorKind = "user" | "service";
+export type PlatformAuthMethod = "zitadel-session" | "service-identity";
+export type PlatformAuthFailureReason =
+  | "unauthenticated"
+  | "unauthorized"
+  | "expired-session"
+  | "workspace-mismatch"
+  | "service-identity-denied"
+  | "disabled-user"
+  | "workspace-inactive";
+
 export type PlatformRole = {
   id: string;
   workspaceId: string;
   name: "owner" | "admin" | "developer" | "operator" | "viewer" | string;
   entitlements: PlatformEntitlement[];
+};
+
+export type PlatformServiceIdentity = {
+  id: string;
+  serviceId: string;
+  displayName: string;
+  instanceIds: string[];
+  workspaceIds: string[];
+  entitlements: PlatformEntitlement[];
+  status: "active" | "disabled";
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type PlatformUser = {
@@ -103,14 +126,64 @@ export type ZitadelSessionContext = {
   email?: string;
   preferredUsername?: string;
   groups?: string[];
+  expiresAt?: string;
+};
+
+export type PlatformAuditActorMetadata = {
+  actorKind: PlatformActorKind;
+  actorId: string;
+  workspaceId: string;
+  instanceId: string;
+  linkedIdentityId?: string;
+  serviceIdentityId?: string;
+  authMethod: PlatformAuthMethod;
 };
 
 export type PlatformRequestContext = {
   userId: string;
   workspaceId: string;
+  instanceId: string;
   linkedIdentityId: string;
   entitlements: PlatformEntitlement[];
+  actor: {
+    kind: PlatformActorKind;
+    id: string;
+    displayName: string;
+  };
+  authMethod: PlatformAuthMethod;
+  audit: PlatformAuditActorMetadata;
 };
+
+export type PlatformServiceAuthContext = {
+  serviceId: string;
+  instanceId: string;
+  workspaceId: string;
+};
+
+export type PlatformContextResolutionRequest =
+  | {
+      kind: "zitadel-session";
+      session?: ZitadelSessionContext;
+      workspaceId?: string;
+      instanceId: string;
+      now?: Date;
+    }
+  | {
+      kind: "service-identity";
+      service?: PlatformServiceAuthContext;
+      workspaceId: string;
+      instanceId: string;
+    };
+
+export type PlatformContextResolution =
+  | { ok: true; context: PlatformRequestContext }
+  | {
+      ok: false;
+      reason: PlatformAuthFailureReason;
+      status: 401 | 403;
+      safeMessage: string;
+      audit: PlatformAuditActorMetadata | undefined;
+    };
 
 export type AuthorizationResource =
   | { kind: "provider-connection"; connection: ProviderConnectionMetadata }
@@ -129,6 +202,15 @@ export const providerConnectionMetadataEndpoints = {
   read: "GET /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
   update: "PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
 } as const;
+
+export type PlatformFacadeState = {
+  users: PlatformUser[];
+  workspaces: PlatformWorkspace[];
+  linkedIdentities: LinkedIdentity[];
+  roles: PlatformRole[];
+  serviceIdentities: PlatformServiceIdentity[];
+  providerConnections: ProviderConnectionMetadata[];
+};
 
 export const examplePlatformFacadeState = {
   users: [
@@ -184,6 +266,19 @@ export const examplePlatformFacadeState = {
       ],
     },
   ],
+  serviceIdentities: [
+    {
+      id: "svc_runtime_broker_reader",
+      serviceId: "@node",
+      displayName: "Node runtime broker reader",
+      instanceIds: ["inst_local_demo"],
+      workspaceIds: ["wks_local_demo"],
+      entitlements: ["workspace:read", "secrets-broker:resolve"],
+      status: "active",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: "2026-05-08T10:00:00Z",
+    },
+  ],
   providerConnections: [
     {
       id: "pc_github_actions",
@@ -202,36 +297,143 @@ export const examplePlatformFacadeState = {
       secretMaterialPresent: false,
     },
   ],
-} as const satisfies {
-  users: PlatformUser[];
-  workspaces: PlatformWorkspace[];
-  linkedIdentities: LinkedIdentity[];
-  roles: PlatformRole[];
-  providerConnections: ProviderConnectionMetadata[];
-};
+} as const satisfies PlatformFacadeState;
+
+export function resolveServiceLassoRequestContext(
+  request: PlatformContextResolutionRequest,
+  state: PlatformFacadeState = examplePlatformFacadeState,
+): PlatformContextResolution {
+  if (request.kind === "zitadel-session") {
+    if (!request.session) return authFailure("unauthenticated", "Missing ZITADEL session.", undefined, 401);
+    if (isExpired(request.session.expiresAt, request.now)) return authFailure("expired-session", "ZITADEL session expired.", undefined, 401);
+
+    const identity = state.linkedIdentities.find(
+      (linkedIdentity) => linkedIdentity.provider === "zitadel" && linkedIdentity.issuer === request.session?.issuer && linkedIdentity.subject === request.session.subject,
+    );
+    if (!identity) return authFailure("unauthenticated", "ZITADEL subject is not linked to a Service Lasso user.", undefined, 401);
+
+    const user = state.users.find((candidate) => candidate.id === identity.userId);
+    if (!user || user.status !== "active") {
+      return authFailure(
+        "disabled-user",
+        "Linked Service Lasso user is not active.",
+        safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId: request.workspaceId ?? identity.workspaceIds[0] ?? "unknown", instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" }),
+        403,
+      );
+    }
+
+    const workspaceId = request.workspaceId ?? identity.workspaceIds[0];
+    if (!workspaceId || !identity.workspaceIds.includes(workspaceId)) {
+      return authFailure(
+        "workspace-mismatch",
+        "ZITADEL identity is not linked to the requested workspace.",
+        safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId: workspaceId ?? "unknown", instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" }),
+        403,
+      );
+    }
+
+    const workspace = state.workspaces.find((candidate) => candidate.id === workspaceId);
+    if (!workspace || workspace.status !== "active") {
+      return authFailure(
+        "workspace-inactive",
+        "Requested Service Lasso workspace is not active.",
+        safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId, instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" }),
+        403,
+      );
+    }
+
+    const entitlements = state.roles
+      .filter((role) => role.workspaceId === workspaceId)
+      .flatMap((role) => role.entitlements);
+
+    if (entitlements.length === 0) {
+      return authFailure(
+        "unauthorized",
+        "No Service Lasso role grants access to the requested workspace.",
+        safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId, instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" }),
+        403,
+      );
+    }
+
+    const audit = safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId, instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" });
+    return {
+      ok: true,
+      context: {
+        userId: identity.userId,
+        workspaceId,
+        instanceId: request.instanceId,
+        linkedIdentityId: identity.id,
+        entitlements: [...new Set(entitlements)],
+        actor: { kind: "user", id: identity.userId, displayName: user.displayName },
+        authMethod: "zitadel-session",
+        audit,
+      },
+    };
+  }
+
+  if (!request.service) return authFailure("unauthenticated", "Missing service identity.", undefined, 401);
+
+  const serviceIdentity = state.serviceIdentities.find((identity) => identity.serviceId === request.service?.serviceId);
+  const audit = safeAudit({
+    actorKind: "service",
+    actorId: request.service.serviceId,
+    workspaceId: request.workspaceId,
+    instanceId: request.instanceId,
+    serviceIdentityId: serviceIdentity?.id,
+    authMethod: "service-identity",
+  });
+
+  if (!serviceIdentity || serviceIdentity.status !== "active") return authFailure("service-identity-denied", "Service identity is not allowed.", audit, 403);
+  if (!serviceIdentity.instanceIds.includes(request.service.instanceId) || request.service.instanceId !== request.instanceId) {
+    return authFailure("service-identity-denied", "Service identity is not valid for this instance.", audit, 403);
+  }
+  if (!serviceIdentity.workspaceIds.includes(request.workspaceId) || request.service.workspaceId !== request.workspaceId) {
+    return authFailure("workspace-mismatch", "Service identity is not scoped to the requested workspace.", audit, 403);
+  }
+
+  const workspace = state.workspaces.find((candidate) => candidate.id === request.workspaceId);
+  if (!workspace || workspace.status !== "active") return authFailure("workspace-inactive", "Requested Service Lasso workspace is not active.", audit, 403);
+
+  return {
+    ok: true,
+    context: {
+      userId: serviceIdentity.serviceId,
+      workspaceId: request.workspaceId,
+      instanceId: request.instanceId,
+      linkedIdentityId: serviceIdentity.id,
+      entitlements: [...new Set(serviceIdentity.entitlements)],
+      actor: { kind: "service", id: serviceIdentity.serviceId, displayName: serviceIdentity.displayName },
+      authMethod: "service-identity",
+      audit,
+    },
+  };
+}
 
 export function mapZitadelSessionToPlatformContext(
   session: ZitadelSessionContext,
-  state = examplePlatformFacadeState,
+  state: PlatformFacadeState = examplePlatformFacadeState,
 ): PlatformRequestContext | undefined {
-  const identity = state.linkedIdentities.find(
-    (linkedIdentity) => linkedIdentity.provider === "zitadel" && linkedIdentity.issuer === session.issuer && linkedIdentity.subject === session.subject,
-  );
-  if (!identity) return undefined;
+  const resolution = resolveServiceLassoRequestContext({ kind: "zitadel-session", session, instanceId: "inst_local_demo" }, state);
+  return resolution.ok ? resolution.context : undefined;
+}
 
-  const workspaceId = identity.workspaceIds[0];
-  if (!workspaceId) return undefined;
+export function platformAuditMetadataIncludesSecretMaterial(audit: PlatformAuditActorMetadata): boolean {
+  return secretLikeValuePattern.test(JSON.stringify(audit));
+}
 
-  const entitlements = state.roles
-    .filter((role) => role.workspaceId === workspaceId)
-    .flatMap((role) => role.entitlements);
+function authFailure(reason: PlatformAuthFailureReason, safeMessage: string, audit: PlatformAuditActorMetadata | undefined, status: 401 | 403): PlatformContextResolution {
+  return { ok: false, reason, status, safeMessage, audit };
+}
 
-  return {
-    userId: identity.userId,
-    workspaceId,
-    linkedIdentityId: identity.id,
-    entitlements: [...new Set(entitlements)],
-  };
+function safeAudit(audit: PlatformAuditActorMetadata): PlatformAuditActorMetadata {
+  if (platformAuditMetadataIncludesSecretMaterial(audit)) throw new Error("Platform audit metadata must not include raw tokens, cookies, session secrets, or provider credentials");
+  return audit;
+}
+
+function isExpired(expiresAt: string | undefined, now = new Date()): boolean {
+  if (!expiresAt) return false;
+  const expiry = Date.parse(expiresAt);
+  return Number.isFinite(expiry) && expiry <= now.getTime();
 }
 
 export function authorizePlatformResource(

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -7,7 +7,9 @@ import {
   authorizePlatformResource,
   examplePlatformFacadeState,
   mapZitadelSessionToPlatformContext,
+  platformAuditMetadataIncludesSecretMaterial,
   providerConnectionMetadataEndpoints,
+  resolveServiceLassoRequestContext,
 } from "../dist/platform/facade.js";
 
 const repoRoot = process.cwd();
@@ -27,6 +29,7 @@ test("platform facade fixture defines users workspaces linked identities provide
   assert.equal(examplePlatformFacadeState.linkedIdentities.length, 1);
   assert.equal(examplePlatformFacadeState.providerConnections.length, 1);
   assert.equal(examplePlatformFacadeState.roles.length, 1);
+  assert.equal(examplePlatformFacadeState.serviceIdentities.length, 1);
 
   const connection = examplePlatformFacadeState.providerConnections[0];
   assert.equal(connection.workspaceId, examplePlatformFacadeState.workspaces[0].id);
@@ -61,6 +64,17 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
   assert.equal(context.userId, "usr_01hzy9operator");
   assert.equal(context.workspaceId, "wks_local_demo");
   assert.equal(context.linkedIdentityId, "lid_zitadel_operator");
+  assert.equal(context.instanceId, "inst_local_demo");
+  assert.equal(context.actor.kind, "user");
+  assert.equal(context.authMethod, "zitadel-session");
+  assert.deepEqual(context.audit, {
+    actorKind: "user",
+    actorId: "usr_01hzy9operator",
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+    linkedIdentityId: "lid_zitadel_operator",
+    authMethod: "zitadel-session",
+  });
   assert.ok(context.entitlements.includes("secrets-broker:resolve"));
   assert.ok(context.entitlements.includes("workflow:run"));
 
@@ -71,6 +85,78 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
     }),
     undefined,
   );
+});
+
+test("request context resolver covers fail-closed session and service identity states", () => {
+  const resolved = resolveServiceLassoRequestContext({
+    kind: "zitadel-session",
+    session: {
+      issuer: "http://localhost:8080",
+      subject: "zitadel-user-operator",
+      expiresAt: "2026-05-08T10:30:00Z",
+    },
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+    now: new Date("2026-05-08T10:05:00Z"),
+  });
+  assert.equal(resolved.ok, true);
+  assert.equal(resolved.ok && resolved.context.workspaceId, "wks_local_demo");
+  assert.equal(resolved.ok && platformAuditMetadataIncludesSecretMaterial(resolved.context.audit), false);
+
+  assert.deepEqual(
+    resolveServiceLassoRequestContext({ kind: "zitadel-session", instanceId: "inst_local_demo" }),
+    {
+      ok: false,
+      reason: "unauthenticated",
+      status: 401,
+      safeMessage: "Missing ZITADEL session.",
+      audit: undefined,
+    },
+  );
+
+  const expired = resolveServiceLassoRequestContext({
+    kind: "zitadel-session",
+    session: {
+      issuer: "http://localhost:8080",
+      subject: "zitadel-user-operator",
+      expiresAt: "2026-05-08T09:59:00Z",
+    },
+    instanceId: "inst_local_demo",
+    now: new Date("2026-05-08T10:05:00Z"),
+  });
+  assert.equal(expired.ok, false);
+  assert.equal(!expired.ok && expired.reason, "expired-session");
+  assert.equal(!expired.ok && expired.status, 401);
+
+  const mismatch = resolveServiceLassoRequestContext({
+    kind: "zitadel-session",
+    session: { issuer: "http://localhost:8080", subject: "zitadel-user-operator" },
+    workspaceId: "wks_other",
+    instanceId: "inst_local_demo",
+  });
+  assert.equal(mismatch.ok, false);
+  assert.equal(!mismatch.ok && mismatch.reason, "workspace-mismatch");
+  assert.equal(!mismatch.ok && platformAuditMetadataIncludesSecretMaterial(mismatch.audit), false);
+
+  const service = resolveServiceLassoRequestContext({
+    kind: "service-identity",
+    service: { serviceId: "@node", workspaceId: "wks_local_demo", instanceId: "inst_local_demo" },
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+  });
+  assert.equal(service.ok, true);
+  assert.equal(service.ok && service.context.actor.kind, "service");
+  assert.equal(service.ok && service.context.authMethod, "service-identity");
+  assert.ok(service.ok && service.context.entitlements.includes("secrets-broker:resolve"));
+
+  const deniedService = resolveServiceLassoRequestContext({
+    kind: "service-identity",
+    service: { serviceId: "writer", workspaceId: "wks_local_demo", instanceId: "inst_local_demo" },
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+  });
+  assert.equal(deniedService.ok, false);
+  assert.equal(!deniedService.ok && deniedService.reason, "service-identity-denied");
 });
 
 test("authorization boundaries fail closed for workspace mismatch missing entitlement and connection readiness", () => {
@@ -146,9 +232,13 @@ test("product facade docs and fixture stay metadata-only", async () => {
     "workspaces",
     "linked_identities",
     "provider_connections",
+    "request_context",
+    "service_identities",
     "roles/entitlements",
     "GET   /api/platform/workspaces/{workspaceId}/provider-connections",
     "ZITADEL session mapping",
+    "Service-authenticated requests",
+    "service-identity-denied`",
     "Secrets Broker checks",
     "must not be stored or returned by the facade",
   ]) {


### PR DESCRIPTION
## Summary
- Expand the Product API Facade contract with canonical `request_context` and `service_identities` sections for ZITADEL-backed user sessions and service-authenticated broker/admin requests.
- Add typed request-context resolution for ZITADEL sessions and service identities, including instance/workspace/actor metadata and safe audit metadata.
- Represent fail-closed auth/context outcomes for unauthenticated, unauthorized, expired-session, workspace mismatch, disabled user, inactive workspace, and denied service identity states.
- Preserve existing `mapZitadelSessionToPlatformContext` compatibility while enriching the returned context for downstream broker/admin/provider/workflow APIs.
- Add tests for safe actor/workspace/instance metadata, service identity resolution, fail-closed states, and no secret-like audit metadata.

## Safety notes
- Audit metadata contains only safe actor/workspace/instance/link identifiers and auth method.
- No cookies, bearer tokens, session secrets, provider credentials, raw secret values, key material, or recovery material are stored or returned by the contract.
- ZITADEL remains app-owned and optional outside consumers; this does not add ZITADEL to the core baseline.
- This does not implement provider OAuth flows or UI.

## Validation
- `npm run build` — passed
- `node --test --test-concurrency=1 tests/product-api-facade.test.js tests/provider-connection-lifecycle.test.js tests/workflow-run-facade.test.js` — 20 passed
- `npm test` — 228 passed

Closes #421
Related: #422, #423, #425
