### PR TITLE
ISS-422 add provider connections lifecycle API

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -116,10 +116,13 @@ integration. It must be clearly split from secret payloads.
 | `provider` | Provider key, for example `github`, `stripe`, or `vault`. |
 | `kind` | `oauth`, `api-token`, `webhook`, `secrets-broker-source`, or `custom`. |
 | `displayName` | Operator-facing label. |
-| `status` | `ready`, `needs-auth`, `revoked`, `disabled`, or `error`. |
+| `status` | `ready`, `needs-auth`, `expiring`, `refresh-failed`, `revoked`, `disabled`, `error`, or `deleted`. Deleted records are not listed by default. |
+| `accountId` | Provider-side account, org, tenant, or installation id, when safe to expose. |
 | `scopes` | Granted/expected provider scopes as labels. |
 | `brokerNamespace` / `secretRef` | Pointer to secret material, never the value itself. |
-| `lastVerifiedAt` | Last successful metadata/auth check. |
+| `expiresAt` / `lastRefreshAt` / `lastVerifiedAt` | Safe lifecycle timing metadata. |
+| `lastError` | Safe diagnostic summary only; no provider response bodies or credentials. |
+| `affectedSummary` | Safe summary of affected `serviceIds`, broker refs, and workflow ids. |
 | `secretMaterialPresent` | Must be `false` in facade responses. A true value is a contract violation. |
 | `createdAt` / `updatedAt` | Audit timestamps. |
 
@@ -154,6 +157,7 @@ GET   /api/platform/workspaces/{workspaceId}/provider-connections
 POST  /api/platform/workspaces/{workspaceId}/provider-connections
 GET   /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
 PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
+DELETE /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
 ```
 
 ### Create request
@@ -165,6 +169,7 @@ PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
   "provider": "github",
   "kind": "oauth",
   "displayName": "GitHub Actions metadata connection",
+  "accountId": "github-org-service-lasso",
   "scopes": ["repo:read", "workflow:read"],
   "brokerNamespace": "workspaces/local-demo/provider-connections/github",
   "secretRef": "provider.github.oauth.client"
@@ -182,17 +187,25 @@ PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}
   "kind": "oauth",
   "displayName": "GitHub Actions metadata connection",
   "status": "ready",
+  "accountId": "github-org-service-lasso",
   "scopes": ["repo:read", "workflow:read"],
   "brokerNamespace": "workspaces/local-demo/provider-connections/github",
   "secretRef": "provider.github.oauth.client",
+  "expiresAt": "2026-05-30T00:00:00Z",
+  "lastRefreshAt": "2026-05-08T10:04:00Z",
   "lastVerifiedAt": "2026-05-08T10:05:00Z",
+  "affectedSummary": {
+    "serviceIds": ["@serviceadmin"],
+    "brokerRefs": ["provider.github.oauth.client"],
+    "workflowIds": ["wf_release_checks"]
+  },
   "secretMaterialPresent": false,
   "createdAt": "2026-05-08T10:00:00Z",
   "updatedAt": "2026-05-08T10:05:00Z"
 }
 ```
 
-The response is safe to log because it contains reference metadata only. The
+Delete removes the metadata record from the facade response set and emits a safe audit event; deletion of broker secret payloads remains a separate Secrets Broker operation. The response is safe to log because it contains reference metadata only. The
 facade must never return raw provider secrets, access tokens, refresh tokens,
 API keys, password values, private keys, key material, or recovery material.
 
@@ -226,6 +239,7 @@ Normalized lifecycle statuses are:
 - `disabled`
 - `source_auth_required`
 - `degraded`
+- `deleted`
 
 Lifecycle responses include safe metadata only:
 
@@ -280,8 +294,7 @@ permissions, or unavailable provider support, but must never include access
 tokens, refresh tokens, API keys, provider secrets, key material, or recovery
 material.
 
-Reference lifecycle fixtures cover healthy, missing/setup-required, denied, and
-reconnect-required states in `src/platform/providerConnectionLifecycle.ts`.
+Reference lifecycle fixtures cover healthy, expiring, missing/setup-required, refresh-failed, denied, revoked, reconnect-required, disconnected, and deleted states in `src/platform/providerConnectionLifecycle.ts`.
 Tests in `tests/provider-connection-lifecycle.test.js` verify status
 normalization, secret-safe error payloads, unavailable action stubs, and safe
 audit transition metadata.

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -2,7 +2,7 @@ export type PlatformUserStatus = "active" | "disabled" | "pending";
 export type PlatformWorkspaceStatus = "active" | "suspended" | "archived";
 export type LinkedIdentityProvider = "zitadel" | "github" | "google" | "telegram" | "custom-oidc";
 export type ProviderConnectionKind = "oauth" | "api-token" | "webhook" | "secrets-broker-source" | "custom";
-export type ProviderConnectionStatus = "ready" | "needs-auth" | "revoked" | "disabled" | "error";
+export type ProviderConnectionStatus = "ready" | "needs-auth" | "expiring" | "refresh-failed" | "revoked" | "disabled" | "error" | "deleted";
 export type PlatformEntitlement =
   | "workspace:read"
   | "workspace:admin"
@@ -78,6 +78,12 @@ export type LinkedIdentity = {
   lastSeenAt?: string;
 };
 
+export type ProviderConnectionAffectedSummary = {
+  serviceIds: string[];
+  brokerRefs: string[];
+  workflowIds: string[];
+};
+
 export type ProviderConnectionMetadata = {
   id: string;
   workspaceId: string;
@@ -86,10 +92,15 @@ export type ProviderConnectionMetadata = {
   kind: ProviderConnectionKind;
   displayName: string;
   status: ProviderConnectionStatus;
+  accountId?: string;
   scopes: string[];
   brokerNamespace?: string;
   secretRef?: string;
+  expiresAt?: string;
+  lastRefreshAt?: string;
   lastVerifiedAt?: string;
+  lastError?: string;
+  affectedSummary?: ProviderConnectionAffectedSummary;
   createdAt: string;
   updatedAt: string;
   // Metadata only. Secret payloads, access tokens, refresh tokens, API keys,
@@ -103,6 +114,7 @@ export type CreateProviderConnectionMetadataRequest = {
   provider: string;
   kind: ProviderConnectionKind;
   displayName: string;
+  accountId?: string;
   scopes?: string[];
   brokerNamespace?: string;
   secretRef?: string;
@@ -113,10 +125,15 @@ export type UpdateProviderConnectionMetadataRequest = Partial<
     ProviderConnectionMetadata,
     | "displayName"
     | "status"
+    | "accountId"
     | "scopes"
     | "brokerNamespace"
     | "secretRef"
+    | "expiresAt"
+    | "lastRefreshAt"
     | "lastVerifiedAt"
+    | "lastError"
+    | "affectedSummary"
   >
 >;
 
@@ -201,6 +218,7 @@ export const providerConnectionMetadataEndpoints = {
   create: "POST /api/platform/workspaces/{workspaceId}/provider-connections",
   read: "GET /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
   update: "PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+  delete: "DELETE /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
 } as const;
 
 export type PlatformFacadeState = {
@@ -288,16 +306,167 @@ export const examplePlatformFacadeState = {
       kind: "oauth",
       displayName: "GitHub Actions metadata connection",
       status: "ready",
+      accountId: "github-org-service-lasso",
       scopes: ["repo:read", "workflow:read"],
       brokerNamespace: "workspaces/local-demo/provider-connections/github",
       secretRef: "provider.github.oauth.client",
+      expiresAt: "2026-05-30T00:00:00Z",
+      lastRefreshAt: "2026-05-08T10:04:00Z",
       lastVerifiedAt: "2026-05-08T10:05:00Z",
+      affectedSummary: {
+        serviceIds: ["@serviceadmin"],
+        brokerRefs: ["provider.github.oauth.client"],
+        workflowIds: ["wf_release_checks"],
+      },
       createdAt: "2026-05-08T10:00:00Z",
       updatedAt: "2026-05-08T10:05:00Z",
       secretMaterialPresent: false,
     },
   ],
 } as const satisfies PlatformFacadeState;
+
+export type ProviderConnectionMetadataAuditAction = "create" | "read" | "update" | "delete" | "list";
+
+export type ProviderConnectionMetadataAuditEvent = {
+  id: string;
+  workspaceId: string;
+  connectionId?: string;
+  provider?: string;
+  action: ProviderConnectionMetadataAuditAction;
+  outcome: "success" | "denied" | "not-found";
+  at: string;
+  actorUserId: string;
+  safeDetail: string;
+};
+
+export type ProviderConnectionMetadataOperationResult =
+  | { ok: true; state: PlatformFacadeState; connection?: ProviderConnectionMetadata; connections?: ProviderConnectionMetadata[]; auditEvent: ProviderConnectionMetadataAuditEvent }
+  | { ok: false; state: PlatformFacadeState; error: { code: "permission-denied" | "connection-not-found" | "invalid-secret-material"; message: string }; auditEvent: ProviderConnectionMetadataAuditEvent };
+
+export function listProviderConnectionMetadata(
+  state: PlatformFacadeState,
+  context: PlatformRequestContext,
+  workspaceId: string,
+  now = "2026-05-08T11:05:00Z",
+): ProviderConnectionMetadataOperationResult {
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:read");
+  if (denied) return deniedResult(state, context, workspaceId, undefined, undefined, "list", denied, now);
+  const connections = state.providerConnections.filter((connection) => connection.workspaceId === workspaceId && connection.status !== "deleted");
+  connections.forEach(assertProviderConnectionMetadataOnly);
+  return {
+    ok: true,
+    state,
+    connections,
+    auditEvent: metadataAudit(context, workspaceId, undefined, undefined, "list", "success", now, "Listed provider connection metadata records."),
+  };
+}
+
+export function readProviderConnectionMetadata(
+  state: PlatformFacadeState,
+  context: PlatformRequestContext,
+  workspaceId: string,
+  connectionId: string,
+  now = "2026-05-08T11:05:00Z",
+): ProviderConnectionMetadataOperationResult {
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:read");
+  if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "read", denied, now);
+  const connection = state.providerConnections.find((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
+  if (!connection) return notFoundResult(state, context, workspaceId, connectionId, "read", now);
+  assertProviderConnectionMetadataOnly(connection);
+  return { ok: true, state, connection, auditEvent: metadataAudit(context, workspaceId, connectionId, connection.provider, "read", "success", now, "Read provider connection metadata record.") };
+}
+
+export function createProviderConnectionMetadata(
+  state: PlatformFacadeState,
+  context: PlatformRequestContext,
+  request: CreateProviderConnectionMetadataRequest,
+  now = "2026-05-08T11:05:00Z",
+): ProviderConnectionMetadataOperationResult {
+  const denied = authorizeProviderConnectionMetadataAction(context, request.workspaceId, "provider-connection:write");
+  if (denied) return deniedResult(state, context, request.workspaceId, undefined, request.provider, "create", denied, now);
+  const connection: ProviderConnectionMetadata = {
+    id: `pc_${request.provider.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}_${Date.parse(now)}`,
+    workspaceId: request.workspaceId,
+    ownerUserId: request.ownerUserId,
+    provider: request.provider,
+    kind: request.kind,
+    displayName: request.displayName,
+    status: "needs-auth",
+    accountId: request.accountId,
+    scopes: request.scopes ?? [],
+    brokerNamespace: request.brokerNamespace,
+    secretRef: request.secretRef,
+    affectedSummary: { serviceIds: [], brokerRefs: request.secretRef ? [request.secretRef] : [], workflowIds: [] },
+    secretMaterialPresent: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+  try {
+    assertProviderConnectionPayloadSecretSafe(request);
+    assertProviderConnectionMetadataOnly(connection);
+  } catch {
+    return { ok: false, state, error: { code: "invalid-secret-material", message: "Provider connection metadata request contains secret-like material." }, auditEvent: metadataAudit(context, request.workspaceId, undefined, request.provider, "create", "denied", now, "Rejected provider connection metadata containing secret-like material.") };
+  }
+  return { ok: true, state: { ...state, providerConnections: [...state.providerConnections, connection] }, connection, auditEvent: metadataAudit(context, request.workspaceId, connection.id, request.provider, "create", "success", now, "Created provider connection metadata record; secret material remains behind broker refs.") };
+}
+
+export function updateProviderConnectionMetadata(
+  state: PlatformFacadeState,
+  context: PlatformRequestContext,
+  workspaceId: string,
+  connectionId: string,
+  patch: UpdateProviderConnectionMetadataRequest,
+  now = "2026-05-08T11:05:00Z",
+): ProviderConnectionMetadataOperationResult {
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:write");
+  if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "update", denied, now);
+  const index = state.providerConnections.findIndex((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
+  if (index === -1) return notFoundResult(state, context, workspaceId, connectionId, "update", now);
+  const connection = { ...state.providerConnections[index], ...patch, updatedAt: now };
+  try {
+    assertProviderConnectionPayloadSecretSafe(patch);
+    assertProviderConnectionMetadataOnly(connection);
+  } catch {
+    return { ok: false, state, error: { code: "invalid-secret-material", message: "Provider connection metadata patch contains secret-like material." }, auditEvent: metadataAudit(context, workspaceId, connectionId, state.providerConnections[index].provider, "update", "denied", now, "Rejected provider connection metadata patch containing secret-like material.") };
+  }
+  const providerConnections = state.providerConnections.map((candidate, candidateIndex) => candidateIndex === index ? connection : candidate);
+  return { ok: true, state: { ...state, providerConnections }, connection, auditEvent: metadataAudit(context, workspaceId, connectionId, connection.provider, "update", "success", now, "Updated provider connection metadata record without exposing secret material.") };
+}
+
+export function deleteProviderConnectionMetadata(
+  state: PlatformFacadeState,
+  context: PlatformRequestContext,
+  workspaceId: string,
+  connectionId: string,
+  now = "2026-05-08T11:05:00Z",
+): ProviderConnectionMetadataOperationResult {
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:write");
+  if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "delete", denied, now);
+  const connection = state.providerConnections.find((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
+  if (!connection) return notFoundResult(state, context, workspaceId, connectionId, "delete", now);
+  const providerConnections = state.providerConnections.filter((candidate) => candidate !== connection);
+  return { ok: true, state: { ...state, providerConnections }, connection: { ...connection, status: "deleted", updatedAt: now }, auditEvent: metadataAudit(context, workspaceId, connectionId, connection.provider, "delete", "success", now, "Deleted provider connection metadata record; broker secret payload deletion remains a Secrets Broker operation.") };
+}
+
+function authorizeProviderConnectionMetadataAction(context: PlatformRequestContext, workspaceId: string, entitlement: PlatformEntitlement): string | undefined {
+  if (context.workspaceId !== workspaceId) return "workspace-mismatch";
+  if (!context.entitlements.includes(entitlement)) return "missing-entitlement";
+  return undefined;
+}
+
+function deniedResult(state: PlatformFacadeState, context: PlatformRequestContext, workspaceId: string, connectionId: string | undefined, provider: string | undefined, action: ProviderConnectionMetadataAuditAction, reason: string, now: string): ProviderConnectionMetadataOperationResult {
+  return { ok: false, state, error: { code: "permission-denied", message: `Provider connection metadata ${action} denied: ${reason}.` }, auditEvent: metadataAudit(context, workspaceId, connectionId, provider, action, "denied", now, `Provider connection metadata ${action} denied: ${reason}.`) };
+}
+
+function notFoundResult(state: PlatformFacadeState, context: PlatformRequestContext, workspaceId: string, connectionId: string, action: ProviderConnectionMetadataAuditAction, now: string): ProviderConnectionMetadataOperationResult {
+  return { ok: false, state, error: { code: "connection-not-found", message: "Provider connection metadata record was not found." }, auditEvent: metadataAudit(context, workspaceId, connectionId, undefined, action, "not-found", now, "Provider connection metadata record was not found.") };
+}
+
+function metadataAudit(context: PlatformRequestContext, workspaceId: string, connectionId: string | undefined, provider: string | undefined, action: ProviderConnectionMetadataAuditAction, outcome: ProviderConnectionMetadataAuditEvent["outcome"], at: string, safeDetail: string): ProviderConnectionMetadataAuditEvent {
+  const audit = { id: `audit_provider_metadata_${action}_${Date.parse(at)}`, workspaceId, connectionId, provider, action, outcome, at, actorUserId: context.userId, safeDetail };
+  if (secretLikeValuePattern.test(JSON.stringify(audit))) throw new Error("Provider connection metadata audit must not include secret material");
+  return audit;
+}
 
 export function resolveServiceLassoRequestContext(
   request: PlatformContextResolutionRequest,
@@ -466,6 +635,13 @@ function requiredEntitlementsForResource(resource: AuthorizationResource): Platf
 
 const secretLikeFieldPattern = /(secret|token|apiKey|api_key|privateKey|private_key|password|credential|recoveryMaterial|recovery_material|keyMaterial|key_material)$/i;
 const secretLikeValuePattern = /(sk-[a-z0-9]{8,}|ghp_[a-z0-9]{8,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|correct-horse-battery-staple|raw-provider-secret|refresh-token|access-token|recovery phrase)/i;
+
+export function assertProviderConnectionPayloadSecretSafe(payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  if (secretLikeFieldPattern.test(serialized) || secretLikeValuePattern.test(serialized)) {
+    throw new Error("Provider connection payload contains secret-like material");
+  }
+}
 
 export function assertProviderConnectionMetadataOnly(connection: ProviderConnectionMetadata): void {
   const entries = Object.entries(connection) as Array<[string, unknown]>;

--- a/src/platform/providerConnectionLifecycle.ts
+++ b/src/platform/providerConnectionLifecycle.ts
@@ -10,7 +10,8 @@ export type ProviderConnectionLifecycleStatus =
   | "permission_changed"
   | "disabled"
   | "source_auth_required"
-  | "degraded";
+  | "degraded"
+  | "deleted";
 
 export type ProviderConnectionLifecycleAction = "connect" | "reconnect" | "refresh" | "test" | "disable" | "disconnect";
 
@@ -83,7 +84,7 @@ export const providerConnectionLifecycleEndpoints = {
 const now = "2026-05-08T11:05:00Z";
 
 export const providerConnectionLifecycleFixtures: Record<
-  "healthy" | "missing" | "denied" | "reconnectRequired",
+  "healthy" | "expiring" | "missing" | "refreshFailed" | "denied" | "revoked" | "reconnectRequired" | "deleted",
   ProviderConnectionLifecycleFixture
 > = {
   healthy: {
@@ -95,10 +96,14 @@ export const providerConnectionLifecycleFixtures: Record<
       kind: "oauth",
       displayName: "GitHub ready connection",
       status: "ready",
+      accountId: "github-org-service-lasso",
       scopes: ["repo:read", "workflow:read"],
       brokerNamespace: "workspaces/local-demo/provider-connections/github",
       secretRef: "provider.github.oauth.client",
+      expiresAt: "2026-05-30T00:00:00Z",
+      lastRefreshAt: "2026-05-08T11:00:00Z",
       lastVerifiedAt: now,
+      affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.github.oauth.client"], workflowIds: ["wf_release_checks"] },
       createdAt: "2026-05-08T10:00:00Z",
       updatedAt: now,
       secretMaterialPresent: false,
@@ -120,6 +125,43 @@ export const providerConnectionLifecycleFixtures: Record<
       safeDetail: "Provider metadata check succeeded; no provider credential values returned.",
     },
   },
+  expiring: {
+    connection: {
+      id: "pc_github_expiring",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "github",
+      kind: "oauth",
+      displayName: "GitHub expiring connection",
+      status: "expiring",
+      accountId: "github-org-service-lasso",
+      scopes: ["repo:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/github",
+      secretRef: "provider.github.oauth.client",
+      expiresAt: "2026-05-08T23:00:00Z",
+      lastRefreshAt: "2026-05-08T09:00:00Z",
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.github.oauth.client"], workflowIds: ["wf_release_checks"] },
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "expiring",
+    expectedAction: "refresh",
+    nextActionLabel: "Refresh connection",
+    lastAuditEvent: {
+      id: "audit_provider_expiring_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_github_expiring",
+      provider: "github",
+      action: "refresh",
+      fromStatus: "connected",
+      toStatus: "expiring",
+      outcome: "success",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider credential expiry is approaching; metadata only returned.",
+    },
+  },
   missing: {
     connection: {
       id: "pc_slack_missing",
@@ -129,6 +171,7 @@ export const providerConnectionLifecycleFixtures: Record<
       kind: "oauth",
       displayName: "Slack setup required",
       status: "needs-auth",
+      accountId: "slack-workspace-service-lasso",
       scopes: ["channels:read"],
       brokerNamespace: "workspaces/local-demo/provider-connections/slack",
       secretRef: "provider.slack.oauth.client",
@@ -160,6 +203,52 @@ export const providerConnectionLifecycleFixtures: Record<
       safeDetail: "Provider authorization is not configured; no provider credential values returned.",
     },
   },
+  refreshFailed: {
+    connection: {
+      id: "pc_github_refresh_failed",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "github",
+      kind: "oauth",
+      displayName: "GitHub refresh failed connection",
+      status: "refresh-failed",
+      accountId: "github-org-service-lasso",
+      scopes: ["repo:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/github",
+      secretRef: "provider.github.oauth.client",
+      lastRefreshAt: "2026-05-08T10:59:00Z",
+      lastError: "Provider refresh failed with a retryable authorization error.",
+      affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.github.oauth.client"], workflowIds: ["wf_release_checks"] },
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "refresh_failed",
+    expectedAction: "reconnect",
+    nextActionLabel: "Reconnect provider",
+    safeError: {
+      code: "source-auth-required",
+      message: "Provider refresh failed and needs a reconnect before dependent workflows run.",
+      action: "Reconnect the provider and retry affected workflows after authorization succeeds.",
+      provider: "github",
+      retryable: true,
+      documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
+    },
+    lastAuditEvent: {
+      id: "audit_provider_refresh_failed_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_github_refresh_failed",
+      provider: "github",
+      action: "refresh",
+      fromStatus: "connected",
+      toStatus: "refresh_failed",
+      outcome: "unavailable",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider refresh failed; no refresh payload or token value returned.",
+    },
+  },
+
   denied: {
     connection: {
       id: "pc_stripe_denied",
@@ -169,6 +258,7 @@ export const providerConnectionLifecycleFixtures: Record<
       kind: "api-token",
       displayName: "Stripe denied connection",
       status: "error",
+      accountId: "stripe-account-service-lasso",
       scopes: ["charges:read"],
       brokerNamespace: "workspaces/local-demo/provider-connections/stripe",
       secretRef: "provider.stripe.api.client",
@@ -201,6 +291,51 @@ export const providerConnectionLifecycleFixtures: Record<
       safeDetail: "Provider metadata check reported insufficient scope; credential values were not returned.",
     },
   },
+  revoked: {
+    connection: {
+      id: "pc_slack_revoked",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "slack",
+      kind: "oauth",
+      displayName: "Slack revoked connection",
+      status: "revoked",
+      accountId: "slack-workspace-service-lasso",
+      scopes: ["channels:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/slack",
+      secretRef: "provider.slack.oauth.client",
+      lastError: "Provider authorization was revoked by the source account.",
+      affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.slack.oauth.client"], workflowIds: ["wf_slack_digest"] },
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "revoked",
+    expectedAction: "reconnect",
+    nextActionLabel: "Reconnect provider",
+    safeError: {
+      code: "source-auth-required",
+      message: "Provider authorization was revoked.",
+      action: "Reconnect the provider or disconnect the metadata record.",
+      provider: "slack",
+      retryable: true,
+      documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
+    },
+    lastAuditEvent: {
+      id: "audit_provider_revoked_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_slack_revoked",
+      provider: "slack",
+      action: "disconnect",
+      fromStatus: "connected",
+      toStatus: "revoked",
+      outcome: "unavailable",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider authorization was revoked; metadata-only disconnect guidance returned.",
+    },
+  },
+
   reconnectRequired: {
     connection: {
       id: "pc_calendar_reconnect",
@@ -210,6 +345,7 @@ export const providerConnectionLifecycleFixtures: Record<
       kind: "oauth",
       displayName: "Calendar reconnect required",
       status: "needs-auth",
+      accountId: "google-workspace-service-lasso",
       scopes: ["calendar:read"],
       brokerNamespace: "workspaces/local-demo/provider-connections/google-calendar",
       secretRef: "provider.google-calendar.oauth.client",
@@ -243,6 +379,41 @@ export const providerConnectionLifecycleFixtures: Record<
       safeDetail: "Provider refresh failed with source authorization required; no refresh payload returned.",
     },
   },
+  deleted: {
+    connection: {
+      id: "pc_slack_deleted",
+      workspaceId: "wks_local_demo",
+      ownerUserId: "usr_01hzy9operator",
+      provider: "slack",
+      kind: "oauth",
+      displayName: "Slack deleted connection",
+      status: "deleted",
+      accountId: "slack-workspace-service-lasso",
+      scopes: ["channels:read"],
+      brokerNamespace: "workspaces/local-demo/provider-connections/slack",
+      secretRef: "provider.slack.oauth.client",
+      affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.slack.oauth.client"], workflowIds: ["wf_slack_digest"] },
+      createdAt: "2026-05-08T10:00:00Z",
+      updatedAt: now,
+      secretMaterialPresent: false,
+    },
+    lifecycleStatus: "deleted",
+    expectedAction: "disconnect",
+    nextActionLabel: "Connection metadata deleted",
+    lastAuditEvent: {
+      id: "audit_provider_deleted_001",
+      workspaceId: "wks_local_demo",
+      connectionId: "pc_slack_deleted",
+      provider: "slack",
+      action: "disconnect",
+      fromStatus: "revoked",
+      toStatus: "deleted",
+      outcome: "success",
+      at: now,
+      actorUserId: "usr_01hzy9operator",
+      safeDetail: "Provider connection metadata was deleted; broker secret payload removal is handled separately.",
+    },
+  },
 };
 
 export function normalizeProviderConnectionLifecycleStatus(input: {
@@ -252,11 +423,13 @@ export function normalizeProviderConnectionLifecycleStatus(input: {
   scopesChanged?: boolean;
   lastRefreshFailed?: boolean;
 }): ProviderConnectionLifecycleStatus {
+  if (input.metadataStatus === "deleted") return "deleted";
   if (input.metadataStatus === "disabled") return "disabled";
   if (input.metadataStatus === "revoked") return "revoked";
   if (input.sourceState === "auth-required" || input.metadataStatus === "needs-auth") return "source_auth_required";
   if (input.scopesChanged) return "permission_changed";
-  if (input.lastRefreshFailed) return "refresh_failed";
+  if (input.lastRefreshFailed || input.metadataStatus === "refresh-failed") return "refresh_failed";
+  if (input.metadataStatus === "expiring") return "expiring";
   if (input.sourceState === "degraded" || input.metadataStatus === "error") return "degraded";
   if (input.expiresAt && Date.parse(input.expiresAt) <= Date.parse("2026-05-09T00:00:00Z")) return "expiring";
   return "connected";

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -4,12 +4,17 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   assertProviderConnectionMetadataOnly,
+  createProviderConnectionMetadata,
+  deleteProviderConnectionMetadata,
   authorizePlatformResource,
   examplePlatformFacadeState,
+  listProviderConnectionMetadata,
   mapZitadelSessionToPlatformContext,
   platformAuditMetadataIncludesSecretMaterial,
   providerConnectionMetadataEndpoints,
+  readProviderConnectionMetadata,
   resolveServiceLassoRequestContext,
+  updateProviderConnectionMetadata,
 } from "../dist/platform/facade.js";
 
 const repoRoot = process.cwd();
@@ -46,11 +51,83 @@ test("provider connection metadata API exposes CRUD endpoints without secret pay
     create: "POST /api/platform/workspaces/{workspaceId}/provider-connections",
     read: "GET /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
     update: "PATCH /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
+    delete: "DELETE /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
   });
 
   const serializedEndpoints = JSON.stringify(providerConnectionMetadataEndpoints);
   assert.equal(serializedEndpoints.includes("secret-value"), false);
   assert.equal(serializedEndpoints.includes("token-value"), false);
+});
+
+test("provider connection metadata CRUD operations are authorization-gated and secret-safe", () => {
+  const context = mapZitadelSessionToPlatformContext({
+    issuer: "http://localhost:8080",
+    subject: "zitadel-user-operator",
+  });
+  assert.ok(context);
+  const adminContext = { ...context, entitlements: [...context.entitlements, "provider-connection:write"] };
+
+  const listed = listProviderConnectionMetadata(examplePlatformFacadeState, context, "wks_local_demo");
+  assert.equal(listed.ok, true);
+  assert.equal(listed.ok && listed.connections.length, 1);
+  assert.equal(listed.auditEvent.outcome, "success");
+
+  const created = createProviderConnectionMetadata(examplePlatformFacadeState, adminContext, {
+    workspaceId: "wks_local_demo",
+    ownerUserId: "usr_01hzy9operator",
+    provider: "slack",
+    kind: "oauth",
+    displayName: "Slack metadata connection",
+    accountId: "workspace-service-lasso",
+    scopes: ["channels:read"],
+    brokerNamespace: "workspaces/local-demo/provider-connections/slack",
+    secretRef: "provider.slack.oauth.client",
+  });
+  assert.equal(created.ok, true);
+  assert.equal(created.ok && created.connection.status, "needs-auth");
+  assert.equal(created.ok && created.connection.secretMaterialPresent, false);
+  assert.equal(created.ok && created.connection.affectedSummary.brokerRefs[0], "provider.slack.oauth.client");
+
+  const createdState = created.state;
+  const createdConnectionId = created.ok && created.connection.id;
+  assert.ok(createdConnectionId);
+
+  const read = readProviderConnectionMetadata(createdState, context, "wks_local_demo", createdConnectionId);
+  assert.equal(read.ok, true);
+  assert.equal(read.ok && read.connection.provider, "slack");
+
+  const updated = updateProviderConnectionMetadata(createdState, adminContext, "wks_local_demo", createdConnectionId, {
+    status: "expiring",
+    expiresAt: "2026-05-09T00:00:00Z",
+    lastRefreshAt: "2026-05-08T11:00:00Z",
+    lastError: "OAuth refresh window is near expiry; reconnect may be required.",
+    affectedSummary: { serviceIds: ["@serviceadmin"], brokerRefs: ["provider.slack.oauth.client"], workflowIds: ["wf_slack_digest"] },
+  });
+  assert.equal(updated.ok, true);
+  assert.equal(updated.ok && updated.connection.status, "expiring");
+  assert.equal(updated.ok && updated.connection.affectedSummary.workflowIds[0], "wf_slack_digest");
+
+  const deleted = deleteProviderConnectionMetadata(updated.state, adminContext, "wks_local_demo", createdConnectionId);
+  assert.equal(deleted.ok, true);
+  assert.equal(deleted.ok && deleted.connection.status, "deleted");
+  assert.equal(deleted.auditEvent.safeDetail.includes("Broker"), true);
+
+  const denied = updateProviderConnectionMetadata(createdState, context, "wks_local_demo", createdConnectionId, { displayName: "No write grant" });
+  assert.equal(denied.ok, false);
+  assert.equal(!denied.ok && denied.error.code, "permission-denied");
+
+  const secretRejected = createProviderConnectionMetadata(examplePlatformFacadeState, adminContext, {
+    workspaceId: "wks_local_demo",
+    ownerUserId: "usr_01hzy9operator",
+    provider: "bad",
+    kind: "api-token",
+    displayName: "access-token-value",
+    scopes: [],
+  });
+  assert.equal(secretRejected.ok, false);
+  assert.equal(!secretRejected.ok && secretRejected.error.code, "invalid-secret-material");
+
+  assert.equal(JSON.stringify([listed, created, updated, deleted]).includes("access-token-value"), false);
 });
 
 test("ZITADEL session context maps to internal user workspace and entitlements", () => {
@@ -236,6 +313,7 @@ test("product facade docs and fixture stay metadata-only", async () => {
     "service_identities",
     "roles/entitlements",
     "GET   /api/platform/workspaces/{workspaceId}/provider-connections",
+    "DELETE /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
     "ZITADEL session mapping",
     "Service-authenticated requests",
     "service-identity-denied`",

--- a/tests/provider-connection-lifecycle.test.js
+++ b/tests/provider-connection-lifecycle.test.js
@@ -44,11 +44,15 @@ test("provider lifecycle API exposes stable action endpoints", () => {
   assertProviderLifecyclePayloadSecretSafe(providerConnectionLifecycleEndpoints);
 });
 
-test("provider lifecycle fixtures cover healthy missing denied and reconnect-required states", () => {
+test("provider lifecycle fixtures cover healthy expiring auth-required refresh-failed revoked disconnected and deleted states", () => {
   assert.equal(providerConnectionLifecycleFixtures.healthy.lifecycleStatus, "connected");
+  assert.equal(providerConnectionLifecycleFixtures.expiring.lifecycleStatus, "expiring");
   assert.equal(providerConnectionLifecycleFixtures.missing.lifecycleStatus, "source_auth_required");
+  assert.equal(providerConnectionLifecycleFixtures.refreshFailed.lifecycleStatus, "refresh_failed");
   assert.equal(providerConnectionLifecycleFixtures.denied.lifecycleStatus, "permission_changed");
+  assert.equal(providerConnectionLifecycleFixtures.revoked.lifecycleStatus, "revoked");
   assert.equal(providerConnectionLifecycleFixtures.reconnectRequired.lifecycleStatus, "reconnect_required");
+  assert.equal(providerConnectionLifecycleFixtures.deleted.lifecycleStatus, "deleted");
 
   for (const fixture of Object.values(providerConnectionLifecycleFixtures)) {
     assert.equal(fixture.connection.secretMaterialPresent, false);
@@ -66,8 +70,11 @@ test("provider lifecycle status normalization covers connected expiring failure 
   assert.equal(normalizeProviderConnectionLifecycleStatus({ lastRefreshFailed: true }), "refresh_failed");
   assert.equal(normalizeProviderConnectionLifecycleStatus({ scopesChanged: true }), "permission_changed");
   assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "needs-auth" }), "source_auth_required");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "refresh-failed" }), "refresh_failed");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "expiring" }), "expiring");
   assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "revoked" }), "revoked");
   assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "disabled" }), "disabled");
+  assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "deleted" }), "deleted");
   assert.equal(normalizeProviderConnectionLifecycleStatus({ metadataStatus: "error" }), "degraded");
 });
 
@@ -125,6 +132,7 @@ test("provider lifecycle docs and fixtures stay free of raw secrets key material
     "connected",
     "refresh_failed",
     "source_auth_required",
+    "deleted",
     "setup-needed",
     "safe audit event",
   ]) {


### PR DESCRIPTION
## Summary
- extend provider connection metadata contract with delete, account/status timing/error metadata, affected service/ref/workflow summaries, and safe CRUD operation helpers
- expand lifecycle fixtures/status normalization for expiring, refresh-failed, revoked, and deleted states
- document metadata-only lifecycle/delete behavior and add regression coverage for authorization and credential leak guards

## Validation
- `npm test` — 229 passing
- `npm run typecheck`

Closes #422