### PR TITLE
ISS-435 narrow core provider boundary

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -1,26 +1,34 @@
 ---
-title: Product API Facade Contract
-sidebar_label: Product API Facade
+title: Core Boundary Facade Contract
+sidebar_label: Core Boundary Facade
 ---
 
-# Product API Facade Contract
+# Core Boundary Facade Contract
 
-The product API facade owns Service Lasso account metadata that is broader than
-runtime service state: users, workspaces, linked identities, request_context,
-service_identities, provider connection metadata, roles/entitlements, and
-authorization decisions for Secrets Broker and workflow/run resolution.
+Service Lasso core is limited to Service Manager and Secrets Broker. This
+facade is therefore not a product account platform, provider-account API, app
+auth system, or custom OIDC/session/callback/token implementation. It defines
+only the safe metadata shapes core needs to wire service lifecycle decisions,
+Secrets Broker refs, policy/audit checks, and workflow/run handoff decisions.
 
-This contract is metadata-only. Provider secret payloads, OAuth access tokens,
-refresh tokens, API keys, private keys, password values, portable master keys,
-and recovery material must not be stored or returned by the facade. Store secret
-material behind a Secrets Broker or source-backend reference and return only the
-safe reference metadata needed to authorize and diagnose access.
+User, workspace, linked identity, and role records in this document are minimal
+safe context fixtures consumed by core after an app-owned identity service has
+authenticated the request. ZITADEL, Traefik, Service Admin, and other consuming
+services own their auth mechanics and provider-specific behavior.
+
+Provider connection records are Secrets Broker source/ref metadata records, not
+general third-party account lifecycle records. Provider secret payloads, OAuth
+access tokens, refresh tokens, API keys, private keys, password values,
+portable master keys, session cookies, callback payloads, and recovery material
+must not be stored or returned by the facade. Store secret material behind a
+Secrets Broker or source-backend reference and return only the safe reference
+metadata needed to authorize and diagnose access.
 
 ## Data model
 
 ### `users`
 
-A user is the internal product principal.
+A user is a safe internal actor reference consumed by core after app-owned authentication succeeds.
 
 | Field | Notes |
 | --- | --- |
@@ -32,8 +40,8 @@ A user is the internal product principal.
 
 ### `workspaces`
 
-A workspace scopes users, provider connections, broker authorization, and
-workflow/run ownership.
+A workspace scopes safe actor references, Secrets Broker source metadata,
+broker authorization, and workflow/run handoff metadata.
 
 | Field | Notes |
 | --- | --- |
@@ -45,8 +53,9 @@ workflow/run ownership.
 
 ### `linked_identities`
 
-A linked identity maps an external identity provider subject to an internal user
-and one or more workspaces.
+A linked identity records safe identity metadata supplied by an app-owned
+identity service; core does not authenticate, callback, or refresh the
+identity provider session.
 
 | Field | Notes |
 | --- | --- |
@@ -61,9 +70,9 @@ and one or more workspaces.
 
 ### `request_context`
 
-Every broker/admin/provider/workflow API receives a canonical request context
+Every broker/admin/workflow handoff receives a canonical request context
 instead of re-parsing cookies, tokens, route parameters, or provider-specific
-auth state.
+auth state in core.
 
 | Field | Notes |
 | --- | --- |
@@ -106,8 +115,9 @@ workspace mismatches, and instance mismatches as `service-identity-denied` or
 
 ### `provider_connections`
 
-A provider connection is safe metadata for a third-party or service provider
-integration. It must be clearly split from secret payloads.
+A provider connection record is safe Secrets Broker source/ref metadata for a
+third-party or service provider integration. It is not a provider account
+lifecycle object and must be clearly split from secret payloads.
 
 | Field | Notes |
 | --- | --- |
@@ -137,20 +147,20 @@ entitlements are:
 
 - `workspace:read`
 - `workspace:admin`
-- `provider-connection:read`
-- `provider-connection:write`
-- `provider-connection:use`
+- `secrets-broker-source:read`
+- `secrets-broker-source:write`
+- `secrets-broker-source:use`
 - `secrets-broker:resolve`
 - `workflow:run`
 
 Secrets Broker resolution requires `secrets-broker:resolve` in the same
 workspace as the requested broker namespace. Workflow/run resolution requires
 `workflow:run`; if a workflow uses provider connection metadata, it also
-requires `provider-connection:use` for each referenced connection.
+requires `secrets-broker-source:use` for each referenced Secrets Broker source metadata record.
 
-## Provider connection metadata API
+## Secrets Broker source metadata API
 
-The facade exposes CRUD for metadata only:
+The facade exposes CRUD for Secrets Broker source/ref metadata only. These routes intentionally do not create provider accounts, perform OAuth, refresh provider tokens, manage callbacks, or store provider credentials:
 
 ```text
 GET   /api/platform/workspaces/{workspaceId}/provider-connections
@@ -209,23 +219,26 @@ Delete removes the metadata record from the facade response set and emits a safe
 facade must never return raw provider secrets, access tokens, refresh tokens,
 API keys, password values, private keys, key material, or recovery material.
 
-## Provider connection lifecycle API
+## Secrets Broker source metadata lifecycle API
 
-Provider lifecycle actions are stable core API contracts that UI and workflow
-layers can call without embedding provider-specific behavior. The refresh/test
-operations let consumers verify provider reachability and scope posture without
-mutating provider secret payloads. Provider-specific OAuth or token flows may
-still be unavailable in early slices; unavailable flows
-must return actionable `setup-needed` or `provider-unavailable` responses rather
-than dead actions.
+Core lifecycle actions are metadata/status contracts for Secrets Broker
+source/ref records. They do not run provider-specific OAuth, reconnect,
+callback, token refresh, provider account setup, or session logic. Services and
+packages own those provider flows and may report safe status back to core.
+
+The metadata refresh/test operations let consumers verify stored safe metadata,
+source availability, and scope posture without mutating provider secret
+payloads. When provider-owned action is required, core returns actionable
+`setup-needed`, `source-auth-required`, or `provider-unavailable` metadata so UI
+and services can hand off without embedding provider behavior in core.
 
 ```text
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable
-POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-source-auth-required
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-reconnect-required
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh-metadata
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test-metadata
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable-metadata
+POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect-metadata
 ```
 
 Normalized lifecycle statuses are:
@@ -247,7 +260,7 @@ Lifecycle responses include safe metadata only:
 {
   "connectionId": "pc_github_ready",
   "provider": "github",
-  "action": "test",
+  "action": "test-metadata",
   "status": "connected",
   "ok": true,
   "auditEvent": {
@@ -255,7 +268,7 @@ Lifecycle responses include safe metadata only:
     "workspaceId": "wks_local_demo",
     "connectionId": "pc_github_ready",
     "provider": "github",
-    "action": "test",
+    "action": "test-metadata",
     "fromStatus": "connected",
     "toStatus": "connected",
     "outcome": "success",
@@ -273,13 +286,13 @@ secret values:
 {
   "connectionId": "pc_slack_missing",
   "provider": "slack",
-  "action": "connect",
+  "action": "record-source-auth-required",
   "status": "source_auth_required",
   "ok": false,
   "error": {
     "code": "setup-needed",
     "message": "Provider connection needs operator setup before it can be used.",
-    "action": "Open the provider setup flow and complete authorization.",
+    "action": "Hand off to the owning service/package setup flow; core records metadata only.",
     "provider": "slack",
     "retryable": true,
     "documentationRef": "docs/reference/product-api-facade.md#provider-connection-lifecycle-api"
@@ -294,7 +307,7 @@ permissions, or unavailable provider support, but must never include access
 tokens, refresh tokens, API keys, provider secrets, key material, or recovery
 material.
 
-Reference lifecycle fixtures cover healthy, expiring, missing/setup-required, refresh-failed, denied, revoked, reconnect-required, disconnected, and deleted states in `src/platform/providerConnectionLifecycle.ts`.
+Reference lifecycle fixtures cover healthy, expiring, missing/setup-required, refresh-failed, denied, revoked, reconnect-required, metadata-disconnected, and deleted states in `src/platform/providerConnectionLifecycle.ts`.
 Tests in `tests/provider-connection-lifecycle.test.js` verify status
 normalization, secret-safe error payloads, unavailable action stubs, and safe
 audit transition metadata.
@@ -316,9 +329,7 @@ internal context as follows:
 6. Fail closed if the linked identity, workspace, user, session freshness, or
    required entitlement is missing.
 
-ZITADEL remains app-owned. This facade contract describes how an authenticated
-ZITADEL subject enters Service Lasso account/workspace authorization; it does
-not make ZITADEL part of the Service Lasso core baseline.
+ZITADEL remains app/service-owned. This facade contract describes the safe identity metadata core may consume after authentication; it does not make ZITADEL, OIDC sessions, callbacks, or token handling part of the Service Lasso core baseline.
 
 ## Service-authenticated requests
 
@@ -346,12 +357,12 @@ raw secrets, cookies, or session material.
 
 Authorization is workspace-scoped and fail-closed:
 
-- Provider connection read/write/use checks must compare the request workspace to
+- Secrets Broker source metadata read/write/use checks must compare the request workspace to
   the connection `workspaceId`.
 - Secrets Broker checks must compare the request workspace to the broker
   namespace owner and require `secrets-broker:resolve`.
 - Workflow/run checks must require `workflow:run`, then require
-  `provider-connection:use` for each provider connection referenced by the run.
+  `secrets-broker-source:use` for each Secrets Broker source metadata record referenced by the run.
 - Connections with status `needs-auth`, `revoked`, `disabled`, or `error` cannot
   be used for broker or workflow authorization.
 - Request context resolution must represent `unauthenticated`, `unauthorized`,

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -6,9 +6,9 @@ export type ProviderConnectionStatus = "ready" | "needs-auth" | "expiring" | "re
 export type PlatformEntitlement =
   | "workspace:read"
   | "workspace:admin"
-  | "provider-connection:read"
-  | "provider-connection:write"
-  | "provider-connection:use"
+  | "secrets-broker-source:read"
+  | "secrets-broker-source:write"
+  | "secrets-broker-source:use"
   | "secrets-broker:resolve"
   | "workflow:run";
 
@@ -85,6 +85,7 @@ export type ProviderConnectionAffectedSummary = {
 };
 
 export type ProviderConnectionMetadata = {
+  // Core boundary: this is Secrets Broker source/ref metadata only, not a provider account/auth lifecycle record.
   id: string;
   workspaceId: string;
   ownerUserId: string;
@@ -213,6 +214,12 @@ export type AuthorizationDecision = {
   requiredEntitlements: PlatformEntitlement[];
 };
 
+export const coreFacadeBoundary = {
+  owns: ["service-manager", "secrets-broker"],
+  excludes: ["provider-account-lifecycle", "provider-oauth", "oidc-callbacks", "session-token-handling", "raw-secret-material"],
+  providerConnectionScope: "secrets-broker-source-metadata-only",
+} as const;
+
 export const providerConnectionMetadataEndpoints = {
   list: "GET /api/platform/workspaces/{workspaceId}/provider-connections",
   create: "POST /api/platform/workspaces/{workspaceId}/provider-connections",
@@ -277,8 +284,8 @@ export const examplePlatformFacadeState = {
       name: "operator",
       entitlements: [
         "workspace:read",
-        "provider-connection:read",
-        "provider-connection:use",
+        "secrets-broker-source:read",
+        "secrets-broker-source:use",
         "secrets-broker:resolve",
         "workflow:run",
       ],
@@ -349,7 +356,7 @@ export function listProviderConnectionMetadata(
   workspaceId: string,
   now = "2026-05-08T11:05:00Z",
 ): ProviderConnectionMetadataOperationResult {
-  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:read");
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "secrets-broker-source:read");
   if (denied) return deniedResult(state, context, workspaceId, undefined, undefined, "list", denied, now);
   const connections = state.providerConnections.filter((connection) => connection.workspaceId === workspaceId && connection.status !== "deleted");
   connections.forEach(assertProviderConnectionMetadataOnly);
@@ -368,7 +375,7 @@ export function readProviderConnectionMetadata(
   connectionId: string,
   now = "2026-05-08T11:05:00Z",
 ): ProviderConnectionMetadataOperationResult {
-  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:read");
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "secrets-broker-source:read");
   if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "read", denied, now);
   const connection = state.providerConnections.find((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
   if (!connection) return notFoundResult(state, context, workspaceId, connectionId, "read", now);
@@ -382,7 +389,7 @@ export function createProviderConnectionMetadata(
   request: CreateProviderConnectionMetadataRequest,
   now = "2026-05-08T11:05:00Z",
 ): ProviderConnectionMetadataOperationResult {
-  const denied = authorizeProviderConnectionMetadataAction(context, request.workspaceId, "provider-connection:write");
+  const denied = authorizeProviderConnectionMetadataAction(context, request.workspaceId, "secrets-broker-source:write");
   if (denied) return deniedResult(state, context, request.workspaceId, undefined, request.provider, "create", denied, now);
   const connection: ProviderConnectionMetadata = {
     id: `pc_${request.provider.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}_${Date.parse(now)}`,
@@ -418,7 +425,7 @@ export function updateProviderConnectionMetadata(
   patch: UpdateProviderConnectionMetadataRequest,
   now = "2026-05-08T11:05:00Z",
 ): ProviderConnectionMetadataOperationResult {
-  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:write");
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "secrets-broker-source:write");
   if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "update", denied, now);
   const index = state.providerConnections.findIndex((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
   if (index === -1) return notFoundResult(state, context, workspaceId, connectionId, "update", now);
@@ -440,7 +447,7 @@ export function deleteProviderConnectionMetadata(
   connectionId: string,
   now = "2026-05-08T11:05:00Z",
 ): ProviderConnectionMetadataOperationResult {
-  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "provider-connection:write");
+  const denied = authorizeProviderConnectionMetadataAction(context, workspaceId, "secrets-broker-source:write");
   if (denied) return deniedResult(state, context, workspaceId, connectionId, undefined, "delete", denied, now);
   const connection = state.providerConnections.find((candidate) => candidate.workspaceId === workspaceId && candidate.id === connectionId && candidate.status !== "deleted");
   if (!connection) return notFoundResult(state, context, workspaceId, connectionId, "delete", now);
@@ -628,9 +635,9 @@ export function authorizePlatformResource(
 }
 
 function requiredEntitlementsForResource(resource: AuthorizationResource): PlatformEntitlement[] {
-  if (resource.kind === "provider-connection") return ["provider-connection:use"];
+  if (resource.kind === "provider-connection") return ["secrets-broker-source:use"];
   if (resource.kind === "secrets-broker-ref") return ["secrets-broker:resolve"];
-  return ["workflow:run", "provider-connection:use"];
+  return ["workflow:run", "secrets-broker-source:use"];
 }
 
 const secretLikeFieldPattern = /(secret|token|apiKey|api_key|privateKey|private_key|password|credential|recoveryMaterial|recovery_material|keyMaterial|key_material)$/i;

--- a/src/platform/providerConnectionLifecycle.ts
+++ b/src/platform/providerConnectionLifecycle.ts
@@ -13,7 +13,13 @@ export type ProviderConnectionLifecycleStatus =
   | "degraded"
   | "deleted";
 
-export type ProviderConnectionLifecycleAction = "connect" | "reconnect" | "refresh" | "test" | "disable" | "disconnect";
+export type ProviderConnectionLifecycleAction =
+  | "record-source-auth-required"
+  | "record-reconnect-required"
+  | "refresh-metadata"
+  | "test-metadata"
+  | "disable-metadata"
+  | "disconnect-metadata";
 
 export type ProviderLifecycleErrorCode =
   | "setup-needed"
@@ -72,13 +78,18 @@ export type ProviderLifecycleActionResponse = {
   error?: ProviderConnectionLifecycleError;
 };
 
+export const providerConnectionLifecycleBoundary = {
+  scope: "secrets-broker-source-metadata-only",
+  excludes: ["provider-oauth", "provider-token-refresh", "oidc-callbacks", "session-handling", "provider-account-lifecycle"],
+} as const;
+
 export const providerConnectionLifecycleEndpoints = {
-  connect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect",
-  reconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect",
-  refresh: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh",
-  test: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test",
-  disable: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable",
-  disconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect",
+  recordSourceAuthRequired: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-source-auth-required",
+  recordReconnectRequired: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-reconnect-required",
+  refreshMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh-metadata",
+  testMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test-metadata",
+  disableMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable-metadata",
+  disconnectMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect-metadata",
 } as const;
 
 const now = "2026-05-08T11:05:00Z";
@@ -109,14 +120,14 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "connected",
-    expectedAction: "test",
+    expectedAction: "test-metadata",
     nextActionLabel: "Test connection",
     lastAuditEvent: {
       id: "audit_provider_ready_001",
       workspaceId: "wks_local_demo",
       connectionId: "pc_github_ready",
       provider: "github",
-      action: "test",
+      action: "test-metadata",
       fromStatus: "connected",
       toStatus: "connected",
       outcome: "success",
@@ -146,14 +157,14 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "expiring",
-    expectedAction: "refresh",
+    expectedAction: "refresh-metadata",
     nextActionLabel: "Refresh connection",
     lastAuditEvent: {
       id: "audit_provider_expiring_001",
       workspaceId: "wks_local_demo",
       connectionId: "pc_github_expiring",
       provider: "github",
-      action: "refresh",
+      action: "refresh-metadata",
       fromStatus: "connected",
       toStatus: "expiring",
       outcome: "success",
@@ -180,12 +191,12 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "source_auth_required",
-    expectedAction: "connect",
+    expectedAction: "record-source-auth-required",
     nextActionLabel: "Connect provider",
     safeError: {
       code: "setup-needed",
       message: "Provider connection needs operator setup before it can be used.",
-      action: "Open the provider setup flow and complete authorization.",
+      action: "Hand off to the owning service/package setup flow; core records metadata only.",
       provider: "slack",
       retryable: true,
       documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
@@ -195,7 +206,7 @@ export const providerConnectionLifecycleFixtures: Record<
       workspaceId: "wks_local_demo",
       connectionId: "pc_slack_missing",
       provider: "slack",
-      action: "connect",
+      action: "record-source-auth-required",
       toStatus: "source_auth_required",
       outcome: "setup-needed",
       at: now,
@@ -224,12 +235,12 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "refresh_failed",
-    expectedAction: "reconnect",
+    expectedAction: "record-reconnect-required",
     nextActionLabel: "Reconnect provider",
     safeError: {
       code: "source-auth-required",
       message: "Provider refresh failed and needs a reconnect before dependent workflows run.",
-      action: "Reconnect the provider and retry affected workflows after authorization succeeds.",
+      action: "Hand off to the owning service/package reconnect flow and retry affected workflows after safe metadata reports success.",
       provider: "github",
       retryable: true,
       documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
@@ -239,7 +250,7 @@ export const providerConnectionLifecycleFixtures: Record<
       workspaceId: "wks_local_demo",
       connectionId: "pc_github_refresh_failed",
       provider: "github",
-      action: "refresh",
+      action: "refresh-metadata",
       fromStatus: "connected",
       toStatus: "refresh_failed",
       outcome: "unavailable",
@@ -267,12 +278,12 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "permission_changed",
-    expectedAction: "reconnect",
+    expectedAction: "record-reconnect-required",
     nextActionLabel: "Reconnect with required scopes",
     safeError: {
       code: "permission-denied",
       message: "Provider rejected the requested scope set.",
-      action: "Reconnect the provider with the required scopes or update workflow requirements.",
+      action: "Hand off to the owning service/package scope flow or update workflow requirements.",
       provider: "stripe",
       retryable: true,
       documentationRef: "docs/reference/product-api-facade.md#authorization-boundaries",
@@ -282,7 +293,7 @@ export const providerConnectionLifecycleFixtures: Record<
       workspaceId: "wks_local_demo",
       connectionId: "pc_stripe_denied",
       provider: "stripe",
-      action: "test",
+      action: "test-metadata",
       fromStatus: "connected",
       toStatus: "permission_changed",
       outcome: "denied",
@@ -311,12 +322,12 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "revoked",
-    expectedAction: "reconnect",
+    expectedAction: "record-reconnect-required",
     nextActionLabel: "Reconnect provider",
     safeError: {
       code: "source-auth-required",
       message: "Provider authorization was revoked.",
-      action: "Reconnect the provider or disconnect the metadata record.",
+      action: "Hand off to the owning service/package reconnect flow or disconnect the metadata record.",
       provider: "slack",
       retryable: true,
       documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
@@ -326,7 +337,7 @@ export const providerConnectionLifecycleFixtures: Record<
       workspaceId: "wks_local_demo",
       connectionId: "pc_slack_revoked",
       provider: "slack",
-      action: "disconnect",
+      action: "disconnect-metadata",
       fromStatus: "connected",
       toStatus: "revoked",
       outcome: "unavailable",
@@ -355,12 +366,12 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "reconnect_required",
-    expectedAction: "reconnect",
+    expectedAction: "record-reconnect-required",
     nextActionLabel: "Reconnect provider",
     safeError: {
       code: "source-auth-required",
       message: "Provider authorization must be refreshed before workflows can use this connection.",
-      action: "Start the reconnect flow and retry the workflow after authorization succeeds.",
+      action: "Record reconnect-required metadata and retry the workflow after the owning service reports authorization success.",
       provider: "google-calendar",
       retryable: true,
       documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
@@ -370,7 +381,7 @@ export const providerConnectionLifecycleFixtures: Record<
       workspaceId: "wks_local_demo",
       connectionId: "pc_calendar_reconnect",
       provider: "google-calendar",
-      action: "refresh",
+      action: "refresh-metadata",
       fromStatus: "expiring",
       toStatus: "reconnect_required",
       outcome: "unavailable",
@@ -398,14 +409,14 @@ export const providerConnectionLifecycleFixtures: Record<
       secretMaterialPresent: false,
     },
     lifecycleStatus: "deleted",
-    expectedAction: "disconnect",
+    expectedAction: "disconnect-metadata",
     nextActionLabel: "Connection metadata deleted",
     lastAuditEvent: {
       id: "audit_provider_deleted_001",
       workspaceId: "wks_local_demo",
       connectionId: "pc_slack_deleted",
       provider: "slack",
-      action: "disconnect",
+      action: "disconnect-metadata",
       fromStatus: "revoked",
       toStatus: "deleted",
       outcome: "success",
@@ -444,8 +455,8 @@ export function createProviderLifecycleUnavailableResponse(
   const decision = authorizePlatformResource(context, { kind: "provider-connection", connection: fixture.connection });
   const safeError = fixture.safeError ?? {
     code: "action-not-implemented" as const,
-    message: "Provider-specific lifecycle flow is not implemented yet.",
-    action: "Use the provider setup documentation or retry after this provider flow is enabled.",
+    message: "Provider-specific lifecycle flow is outside core.",
+    action: "Use the owning service/package setup documentation; core records metadata status only.",
     provider: request.provider,
     retryable: false,
     documentationRef: "docs/reference/product-api-facade.md#provider-connection-lifecycle-api",
@@ -469,7 +480,7 @@ export function createProviderLifecycleUnavailableResponse(
       error: {
         code: "permission-denied",
         message: "Requester is not authorized to use this provider connection.",
-        action: "Request provider-connection:use in the target workspace or switch workspace context.",
+        action: "Request secrets-broker-source:use in the target workspace or switch workspace context.",
         provider: request.provider,
         retryable: false,
         documentationRef: "docs/reference/product-api-facade.md#authorization-boundaries",

--- a/src/platform/workflowRunFacade.ts
+++ b/src/platform/workflowRunFacade.ts
@@ -243,14 +243,14 @@ export function startWorkflowFacadeRun(
     requiredProviderConnectionIds: workflow.requiredProviderConnectionIds,
   });
   if (!runAuth.allowed) {
-    return denied(authorizationReasonToFacadeError(runAuth.reason), `Workflow run start denied: ${runAuth.reason}.`, "Satisfy workspace, workflow:run, and provider-connection:use requirements before start.");
+    return denied(authorizationReasonToFacadeError(runAuth.reason), `Workflow run start denied: ${runAuth.reason}.`, "Satisfy workspace, workflow:run, and secrets-broker-source:use requirements before start.");
   }
 
   for (const connectionId of workflow.requiredProviderConnectionIds) {
     const connection = state.providerConnections.find((candidate) => candidate.id === connectionId);
-    if (!connection) return denied("connection-not-ready", `Required provider connection ${connectionId} is missing.`, "Create and verify the provider connection before start.");
+    if (!connection) return denied("connection-not-ready", `Required Secrets Broker source metadata record ${connectionId} is missing.`, "Create and verify the Secrets Broker source metadata before start.");
     const decision = authorizePlatformResource(context, { kind: "provider-connection", connection });
-    if (!decision.allowed) return denied(authorizationReasonToFacadeError(decision.reason), `Provider connection ${connectionId} denied: ${decision.reason}.`, "Verify provider connection readiness and entitlements before start.");
+    if (!decision.allowed) return denied(authorizationReasonToFacadeError(decision.reason), `Secrets Broker source metadata ${connectionId} denied: ${decision.reason}.`, "Verify source metadata readiness and entitlements before start.");
   }
 
   for (const secret of workflow.secretDependencies) {

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   assertProviderConnectionMetadataOnly,
+  coreFacadeBoundary,
   createProviderConnectionMetadata,
   deleteProviderConnectionMetadata,
   authorizePlatformResource,
@@ -29,6 +30,11 @@ const forbiddenSecrets = [
 ];
 
 test("platform facade fixture defines users workspaces linked identities provider connections and roles", () => {
+  assert.deepEqual(coreFacadeBoundary.owns, ["service-manager", "secrets-broker"]);
+  assert.equal(coreFacadeBoundary.providerConnectionScope, "secrets-broker-source-metadata-only");
+  assert.ok(coreFacadeBoundary.excludes.includes("provider-account-lifecycle"));
+  assert.ok(coreFacadeBoundary.excludes.includes("session-token-handling"));
+
   assert.equal(examplePlatformFacadeState.users.length, 1);
   assert.equal(examplePlatformFacadeState.workspaces.length, 1);
   assert.equal(examplePlatformFacadeState.linkedIdentities.length, 1);
@@ -65,7 +71,7 @@ test("provider connection metadata CRUD operations are authorization-gated and s
     subject: "zitadel-user-operator",
   });
   assert.ok(context);
-  const adminContext = { ...context, entitlements: [...context.entitlements, "provider-connection:write"] };
+  const adminContext = { ...context, entitlements: [...context.entitlements, "secrets-broker-source:write"] };
 
   const listed = listProviderConnectionMetadata(examplePlatformFacadeState, context, "wks_local_demo");
   assert.equal(listed.ok, true);
@@ -247,7 +253,7 @@ test("authorization boundaries fail closed for workspace mismatch missing entitl
   assert.deepEqual(authorizePlatformResource(context, { kind: "provider-connection", connection }), {
     allowed: true,
     reason: "allowed",
-    requiredEntitlements: ["provider-connection:use"],
+    requiredEntitlements: ["secrets-broker-source:use"],
   });
 
   assert.equal(
@@ -300,7 +306,7 @@ test("provider connection metadata rejects raw secret and recovery material fiel
   );
 });
 
-test("product facade docs and fixture stay metadata-only", async () => {
+test("core boundary facade docs and fixture stay metadata-only", async () => {
   const docs = await readFile(path.join(repoRoot, "docs", "reference", "product-api-facade.md"), "utf8");
   const fixture = JSON.stringify(examplePlatformFacadeState);
 
@@ -311,14 +317,14 @@ test("product facade docs and fixture stay metadata-only", async () => {
     "provider_connections",
     "request_context",
     "service_identities",
-    "roles/entitlements",
+    "`roles` and entitlements",
     "GET   /api/platform/workspaces/{workspaceId}/provider-connections",
     "DELETE /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}",
     "ZITADEL session mapping",
     "Service-authenticated requests",
     "service-identity-denied`",
     "Secrets Broker checks",
-    "must not be stored or returned by the facade",
+    "not a product account platform",
   ]) {
     assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
   }

--- a/tests/provider-connection-lifecycle.test.js
+++ b/tests/provider-connection-lifecycle.test.js
@@ -7,6 +7,7 @@ import {
   assertProviderLifecyclePayloadSecretSafe,
   createProviderLifecycleUnavailableResponse,
   normalizeProviderConnectionLifecycleStatus,
+  providerConnectionLifecycleBoundary,
   providerConnectionLifecycleEndpoints,
   providerConnectionLifecycleFixtures,
 } from "../dist/platform/providerConnectionLifecycle.js";
@@ -32,14 +33,19 @@ function operatorContext() {
   return context;
 }
 
-test("provider lifecycle API exposes stable action endpoints", () => {
+test("provider lifecycle API exposes metadata-only action endpoints", () => {
+  assert.equal(providerConnectionLifecycleBoundary.scope, "secrets-broker-source-metadata-only");
+  assert.ok(providerConnectionLifecycleBoundary.excludes.includes("provider-oauth"));
+  assert.ok(providerConnectionLifecycleBoundary.excludes.includes("provider-token-refresh"));
+  assert.ok(providerConnectionLifecycleBoundary.excludes.includes("oidc-callbacks"));
+
   assert.deepEqual(providerConnectionLifecycleEndpoints, {
-    connect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/connect",
-    reconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/reconnect",
-    refresh: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh",
-    test: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test",
-    disable: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable",
-    disconnect: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect",
+    recordSourceAuthRequired: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-source-auth-required",
+    recordReconnectRequired: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/record-reconnect-required",
+    refreshMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/refresh-metadata",
+    testMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/test-metadata",
+    disableMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disable-metadata",
+    disconnectMetadata: "POST /api/platform/workspaces/{workspaceId}/provider-connections/{connectionId}/disconnect-metadata",
   });
   assertProviderLifecyclePayloadSecretSafe(providerConnectionLifecycleEndpoints);
 });
@@ -81,7 +87,7 @@ test("provider lifecycle status normalization covers connected expiring failure 
 test("unimplemented provider-specific lifecycle flows return actionable setup-needed or unavailable errors", () => {
   const context = operatorContext();
   const missing = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.missing, {
-    action: "connect",
+    action: "record-source-auth-required",
     connectionId: "pc_slack_missing",
     provider: "slack",
     requestedAt: "2026-05-08T11:05:00Z",
@@ -89,11 +95,11 @@ test("unimplemented provider-specific lifecycle flows return actionable setup-ne
   assert.equal(missing.ok, false);
   assert.equal(missing.status, "source_auth_required");
   assert.equal(missing.error?.code, "setup-needed");
-  assert.match(missing.error?.action ?? "", /setup flow/i);
+  assert.match(missing.error?.action ?? "", /owning service/i);
   assert.equal(missing.auditEvent.outcome, "setup-needed");
 
   const reconnect = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.reconnectRequired, {
-    action: "refresh",
+    action: "refresh-metadata",
     connectionId: "pc_calendar_reconnect",
     provider: "google-calendar",
     requestedAt: "2026-05-08T11:05:00Z",
@@ -101,14 +107,14 @@ test("unimplemented provider-specific lifecycle flows return actionable setup-ne
   assert.equal(reconnect.ok, false);
   assert.equal(reconnect.status, "reconnect_required");
   assert.equal(reconnect.error?.code, "source-auth-required");
-  assert.match(reconnect.error?.action ?? "", /reconnect flow/i);
+  assert.match(reconnect.error?.action ?? "", /reconnect-required metadata/i);
   assertProviderLifecyclePayloadSecretSafe([missing, reconnect]);
 });
 
 test("provider lifecycle authorization denial is fail-closed and secret-safe", () => {
   const context = { ...operatorContext(), entitlements: ["workspace:read"] };
   const denied = createProviderLifecycleUnavailableResponse(context, providerConnectionLifecycleFixtures.healthy, {
-    action: "test",
+    action: "test-metadata",
     connectionId: "pc_github_ready",
     provider: "github",
     requestedAt: "2026-05-08T11:05:00Z",
@@ -124,11 +130,12 @@ test("provider lifecycle authorization denial is fail-closed and secret-safe", (
 test("provider lifecycle docs and fixtures stay free of raw secrets key material and recovery material", async () => {
   const docs = await readFile(path.join(repoRoot, "docs", "reference", "product-api-facade.md"), "utf8");
   for (const requiredText of [
-    "Provider connection lifecycle API",
-    "connect",
-    "reconnect",
-    "refresh/test",
-    "disconnect",
+    "Secrets Broker source metadata lifecycle API",
+    "record-source-auth-required",
+    "record-reconnect-required",
+    "refresh-metadata",
+    "test-metadata",
+    "disconnect-metadata",
     "connected",
     "refresh_failed",
     "source_auth_required",

--- a/tests/workflow-run-facade.test.js
+++ b/tests/workflow-run-facade.test.js
@@ -20,7 +20,7 @@ const context = {
   userId: "usr_01hzy9operator",
   workspaceId: "wks_local_demo",
   linkedIdentityId: "lid_zitadel_operator",
-  entitlements: ["workspace:read", "provider-connection:use", "secrets-broker:resolve", "workflow:run"],
+  entitlements: ["workspace:read", "secrets-broker-source:use", "secrets-broker:resolve", "workflow:run"],
 };
 
 function clone(value) {
@@ -74,7 +74,7 @@ test("workflow run facade normalizes Dagu and generic statuses", () => {
 });
 
 test("workflow start fails closed for workspace entitlement provider and secret policy", () => {
-  const missingWorkflowRun = startWorkflowFacadeRun({ ...context, entitlements: ["workspace:read", "provider-connection:use", "secrets-broker:resolve"] }, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" });
+  const missingWorkflowRun = startWorkflowFacadeRun({ ...context, entitlements: ["workspace:read", "secrets-broker-source:use", "secrets-broker:resolve"] }, { workspaceId: "wks_local_demo", workflowId: "official.core.maintenance/backup-check" });
   assert.equal(missingWorkflowRun.ok, false);
   assert.equal(missingWorkflowRun.error.code, "missing-entitlement");
 


### PR DESCRIPTION
## Summary
- Narrows the Product API Facade contract into a Core Boundary Facade owned by Service Manager + Secrets Broker only.
- Reframes provider connection lifecycle as Secrets Broker source/ref metadata status actions only.
- Updates entitlements/tests so workflows depend on `secrets-broker-source:use`, not a broader provider account lifecycle permission.

## Boundary guardrails
- No provider OAuth, provider token refresh, OIDC callback/session handling, provider account lifecycle, or raw credential payload ownership added to core.
- Provider connection records remain safe metadata/handles/status/audit only.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/product-api-facade.test.js tests/provider-connection-lifecycle.test.js`
- `npm test`
- `git diff --check`