### PR TITLE
ISS-428 add local SSO bootstrap contract

### DIFF
--- a/docs/reference/local-sso-bootstrap.md
+++ b/docs/reference/local-sso-bootstrap.md
@@ -1,0 +1,102 @@
+---
+title: Local Traefik ZITADEL SSO Bootstrap
+sidebar_label: Local SSO Bootstrap
+---
+
+# Local Traefik ZITADEL SSO Bootstrap
+
+This contract describes the local development bootstrap for protecting Service
+Admin at:
+
+```text
+https://serviceadmin.servicelasso.localhost
+```
+
+The bootstrap is intentionally limited to Service Manager-style wiring and safe
+metadata generation. Service Lasso core does not own an OIDC callback runtime,
+session store, token validator, provider account lifecycle, or custom app-login
+platform.
+
+## Ownership boundary
+
+- **Traefik** owns local host routing, TLS entrypoints, and middleware
+  attachment.
+- **`traefik-oidc-auth`** owns the OIDC login gate, callback handling, session
+  validation, token checks, claim assertions, and identity header emission.
+- **ZITADEL** owns the identity provider, users, projects, roles, claims, issuer,
+  and OIDC client behavior.
+- **Service Lasso core** starts/configures services, writes service-owned config,
+  and passes protected Secrets Broker refs to the services that own them.
+- **Service Admin** owns its app-level current-user/workspace behavior after the
+  route boundary has supplied safe trusted identity metadata.
+
+## Bootstrap command
+
+Generate the local SSO bootstrap plan:
+
+```powershell
+node scripts/local-sso-bootstrap.mjs
+```
+
+By default this writes:
+
+```text
+runtime/local-sso-bootstrap.plan.json
+```
+
+Set `SERVICE_LASSO_LOCAL_SSO_PLAN` to write the plan elsewhere.
+
+## Generated contract
+
+The generated plan includes metadata for:
+
+- Service Admin route:
+  `https://serviceadmin.servicelasso.localhost`
+- ZITADEL route:
+  `https://zitadel.servicelasso.localhost`
+- Traefik dashboard route:
+  `https://traefik.servicelasso.localhost`
+- OIDC middleware service id: `traefik-oidc-auth`
+- OIDC middleware display name: `Service Lasso Traefik OIDC middleware`
+- callback URI:
+  `https://serviceadmin.servicelasso.localhost/oauth2/callback`
+- post-logout URI: `https://serviceadmin.servicelasso.localhost/`
+- ZITADEL client id: `service-lasso:traefik-oidc-auth`
+- client secret ref:
+  `secretref://@secretsbroker/zitadel/traefik-oidc-auth/client-secret`
+- middleware local session secret ref:
+  `secretref://@secretsbroker/traefik-oidc-auth/session-secret`
+
+The plan also includes safe smoke-check steps for the expected local loop:
+
+1. request the protected Service Admin route,
+2. redirect unauthenticated requests to ZITADEL,
+3. return to the `traefik-oidc-auth` callback URI,
+4. render Service Admin with trusted identity headers and no raw token material.
+
+## Safety requirements
+
+Bootstrap output is metadata-only. It may include local domains, route names,
+client ids, redirect URIs, scopes, trusted header names, and `secretref://`
+pointers. It must not print, store, or commit raw client secrets, local session
+secrets, access tokens, ID tokens, refresh tokens, cookies, provider
+credentials, database passwords, private keys, recovery material, or env value
+payloads.
+
+The local domain suffix must be `servicelasso.localhost`, not `.local`. Tests
+fail if `.local` or core-owned OIDC wording is introduced.
+
+## Validation
+
+Run the focused contract test:
+
+```powershell
+npm run build
+node --test --test-concurrency=1 tests/local-sso-bootstrap.test.js
+```
+
+Run the full repository test gate when changing the bootstrap contract:
+
+```powershell
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "docs:serve": "docusaurus serve docs",
     "docs:clear": "docusaurus clear docs",
     "release:assets:expected": "node scripts/check-release-assets.mjs --expected",
-    "release:assets:check": "node scripts/check-release-assets.mjs"
+    "release:assets:check": "node scripts/check-release-assets.mjs",
+    "bootstrap:local-sso": "node scripts/local-sso-bootstrap.mjs",
+    "test:local-sso": "npm run build && node --test --test-concurrency=1 tests/local-sso-bootstrap.test.js"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/scripts/local-sso-bootstrap.mjs
+++ b/scripts/local-sso-bootstrap.mjs
@@ -1,0 +1,210 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const localSsoBootstrapDefaults = Object.freeze({
+  hostSuffix: "servicelasso.localhost",
+  serviceAdminHost: "serviceadmin.servicelasso.localhost",
+  zitadelHost: "zitadel.servicelasso.localhost",
+  traefikDashboardHost: "traefik.servicelasso.localhost",
+  serviceAdminServiceUrl: "http://serviceadmin:${SERVICEADMIN_HTTP_PORT}",
+  zitadelServiceUrl: "http://zitadel:${ZITADEL_HTTP_PORT}",
+  oidcMiddleware: {
+    serviceId: "traefik-oidc-auth",
+    displayName: "Service Lasso Traefik OIDC middleware",
+    issuer: "https://zitadel.servicelasso.localhost",
+    callbackUri: "https://serviceadmin.servicelasso.localhost/oauth2/callback",
+    postLogoutRedirectUri: "https://serviceadmin.servicelasso.localhost/",
+    clientId: "service-lasso:traefik-oidc-auth",
+    clientSecretRef: "secretref://@secretsbroker/zitadel/traefik-oidc-auth/client-secret",
+    sessionSecretRef: "secretref://@secretsbroker/traefik-oidc-auth/session-secret",
+    scopes: ["openid", "profile", "email"],
+    forwardedIdentityHeaders: [
+      "X-ServiceLasso-User-ID",
+      "X-ServiceLasso-Email",
+      "X-ServiceLasso-Roles",
+      "X-ServiceLasso-Auth-Method",
+      "X-ServiceLasso-Audit-Actor",
+    ],
+  },
+  outputPath: "runtime/local-sso-bootstrap.plan.json",
+});
+
+const forbiddenSecretPatterns = [
+  /BEGIN PRIVATE KEY/i,
+  /access[_-]?token\s*[:=]/i,
+  /refresh[_-]?token\s*[:=]/i,
+  /id[_-]?token\s*[:=]/i,
+  /session[_-]?cookie\s*[:=]/i,
+  /client[_-]?secret\s*[:=]/i,
+  /password\s*[:=]/i,
+  /actual[_-]?secret/i,
+];
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort();
+}
+
+export function normalizeLocalSsoConfig(config = {}) {
+  const oidcMiddleware = {
+    ...localSsoBootstrapDefaults.oidcMiddleware,
+    ...(config.oidcMiddleware ?? {}),
+  };
+
+  return {
+    ...localSsoBootstrapDefaults,
+    ...config,
+    oidcMiddleware: {
+      ...oidcMiddleware,
+      scopes: sortedUnique(oidcMiddleware.scopes ?? []),
+      forwardedIdentityHeaders: sortedUnique(oidcMiddleware.forwardedIdentityHeaders ?? []),
+    },
+  };
+}
+
+export function assertSafeLocalSsoConfig(config = {}) {
+  const normalized = normalizeLocalSsoConfig(config);
+  const urls = [
+    normalized.serviceAdminHost,
+    normalized.zitadelHost,
+    normalized.traefikDashboardHost,
+    normalized.oidcMiddleware.issuer,
+    normalized.oidcMiddleware.callbackUri,
+    normalized.oidcMiddleware.postLogoutRedirectUri,
+  ];
+
+  for (const value of urls) {
+    if (!String(value).includes("servicelasso.localhost")) {
+      throw new Error(`Local SSO value must use servicelasso.localhost: ${value}`);
+    }
+    if (/\.local(\/|$)/.test(String(value))) {
+      throw new Error(`Use servicelasso.localhost, not .local, for local SSO: ${value}`);
+    }
+  }
+
+  for (const field of ["clientSecretRef", "sessionSecretRef"]) {
+    const value = normalized.oidcMiddleware[field];
+    if (!String(value).startsWith("secretref://")) {
+      throw new Error(`${field} must be a secretref:// pointer, not inline secret material.`);
+    }
+  }
+
+  const text = JSON.stringify(normalized);
+  if (forbiddenSecretPatterns.some((pattern) => pattern.test(text))) {
+    throw new Error("Local SSO bootstrap config contains inline secret-like material.");
+  }
+
+  if (new RegExp("auth[-_ ]" + "facade", "i").test(text) || text.includes("service-lasso" + "-auth")) {
+    throw new Error("Local SSO bootstrap must not introduce a core-owned auth gateway.");
+  }
+
+  return normalized;
+}
+
+export function buildLocalSsoBootstrapPlan(config = {}) {
+  const safeConfig = assertSafeLocalSsoConfig(config);
+  const middleware = safeConfig.oidcMiddleware;
+
+  const routers = [
+    {
+      name: "serviceadmin-servicelasso-localhost",
+      rule: `Host(\`${safeConfig.serviceAdminHost}\`)`,
+      entryPoints: ["websecure"],
+      tls: true,
+      service: "serviceadmin",
+      middlewares: [middleware.serviceId, "strip-browser-identity-headers"],
+    },
+    {
+      name: "zitadel-servicelasso-localhost",
+      rule: `Host(\`${safeConfig.zitadelHost}\`)`,
+      entryPoints: ["websecure"],
+      tls: true,
+      service: "zitadel",
+      middlewares: [],
+    },
+  ];
+
+  const services = [
+    { name: "serviceadmin", url: safeConfig.serviceAdminServiceUrl },
+    { name: "zitadel", url: safeConfig.zitadelServiceUrl },
+  ];
+
+  const middlewares = [
+    {
+      name: middleware.serviceId,
+      kind: "oidc-plugin",
+      issuer: middleware.issuer,
+      clientId: middleware.clientId,
+      clientSecretRef: middleware.clientSecretRef,
+      sessionSecretRef: middleware.sessionSecretRef,
+      callbackUri: middleware.callbackUri,
+      postLogoutRedirectUri: middleware.postLogoutRedirectUri,
+      scopes: middleware.scopes,
+      forwardedIdentityHeaders: middleware.forwardedIdentityHeaders,
+    },
+    {
+      name: "strip-browser-identity-headers",
+      kind: "headers",
+      removeRequestHeaders: middleware.forwardedIdentityHeaders,
+    },
+  ];
+
+  return {
+    status: "ready-to-apply",
+    ownerBoundary: "Traefik + traefik-oidc-auth + ZITADEL/service-owned config; no Service Lasso-owned OIDC/session/token facade.",
+    domains: {
+      serviceAdmin: `https://${safeConfig.serviceAdminHost}`,
+      zitadel: `https://${safeConfig.zitadelHost}`,
+      traefikDashboard: `https://${safeConfig.traefikDashboardHost}`,
+    },
+    traefikDynamicConfig: { routers, services, middlewares },
+    zitadelClientRegistration: {
+      serviceId: middleware.serviceId,
+      displayName: middleware.displayName,
+      issuer: middleware.issuer,
+      clientId: middleware.clientId,
+      redirectUris: [middleware.callbackUri],
+      postLogoutRedirectUris: [middleware.postLogoutRedirectUri],
+      allowedOrigins: [`https://${safeConfig.serviceAdminHost}`],
+      clientSecretRef: middleware.clientSecretRef,
+    },
+    secretRefs: [middleware.clientSecretRef, middleware.sessionSecretRef],
+    smokeCheck: [
+      { step: "request_protected_route", expect: `GET https://${safeConfig.serviceAdminHost}` },
+      { step: "redirect_to_zitadel", expect: middleware.issuer },
+      { step: "callback_to_oidc_middleware", expect: middleware.callbackUri },
+      { step: "serviceadmin_authenticated", expect: "trusted identity headers present; raw tokens absent" },
+    ],
+    diagnostics: [
+      "verify *.servicelasso.localhost resolves to loopback",
+      "verify local certificate covers servicelasso.localhost hosts",
+      "verify ZITADEL ready endpoint before protected route smoke",
+      "verify client/session secrets resolve through Secrets Broker refs",
+    ],
+  };
+}
+
+export function assertNoSecretMaterial(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (forbiddenSecretPatterns.some((pattern) => pattern.test(text))) {
+    throw new Error("Local SSO bootstrap output contains secret-like material.");
+  }
+  return true;
+}
+
+export async function writeLocalSsoBootstrapPlan(outputPath, plan) {
+  assertNoSecretMaterial(plan);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(plan, null, 2)}\n`, "utf8");
+}
+
+async function main() {
+  const outputPath = process.env.SERVICE_LASSO_LOCAL_SSO_PLAN ?? localSsoBootstrapDefaults.outputPath;
+  const plan = buildLocalSsoBootstrapPlan();
+  await writeLocalSsoBootstrapPlan(outputPath, plan);
+  console.log(JSON.stringify({ status: plan.status, outputPath, domains: plan.domains, secretRefs: plan.secretRefs }, null, 2));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/tests/local-sso-bootstrap.test.js
+++ b/tests/local-sso-bootstrap.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertSafeLocalSsoConfig,
+  buildLocalSsoBootstrapPlan,
+  writeLocalSsoBootstrapPlan,
+} from "../scripts/local-sso-bootstrap.mjs";
+
+const forbiddenOutput = /ACTUAL_SECRET|BEGIN PRIVATE KEY|access_token=|refresh_token=|id_token=|session_cookie=|client_secret=|password=/i;
+
+test("local SSO bootstrap emits servicelasso.localhost Traefik and ZITADEL metadata", () => {
+  const plan = buildLocalSsoBootstrapPlan();
+
+  assert.equal(plan.status, "ready-to-apply");
+  assert.match(plan.ownerBoundary, /traefik-oidc-auth/i);
+  assert.doesNotMatch(plan.ownerBoundary, new RegExp("auth " + "facade|" + "service-lasso" + "-auth", "i"));
+  assert.equal(plan.domains.serviceAdmin, "https://serviceadmin.servicelasso.localhost");
+  assert.equal(plan.domains.zitadel, "https://zitadel.servicelasso.localhost");
+  assert.equal(plan.zitadelClientRegistration.serviceId, "traefik-oidc-auth");
+  assert.equal(plan.zitadelClientRegistration.displayName, "Service Lasso Traefik OIDC middleware");
+  assert.deepEqual(plan.zitadelClientRegistration.redirectUris, [
+    "https://serviceadmin.servicelasso.localhost/oauth2/callback",
+  ]);
+  assert.equal(
+    plan.zitadelClientRegistration.clientSecretRef,
+    "secretref://@secretsbroker/zitadel/traefik-oidc-auth/client-secret",
+  );
+});
+
+test("local SSO bootstrap protects routes through the external OIDC middleware", () => {
+  const plan = buildLocalSsoBootstrapPlan();
+  const serviceAdminRouter = plan.traefikDynamicConfig.routers.find((router) => router.name === "serviceadmin-servicelasso-localhost");
+  const oidcMiddleware = plan.traefikDynamicConfig.middlewares.find((middleware) => middleware.name === "traefik-oidc-auth");
+  const stripHeaders = plan.traefikDynamicConfig.middlewares.find((middleware) => middleware.name === "strip-browser-identity-headers");
+
+  assert.ok(serviceAdminRouter);
+  assert.deepEqual(serviceAdminRouter.middlewares, ["traefik-oidc-auth", "strip-browser-identity-headers"]);
+  assert.equal(oidcMiddleware.kind, "oidc-plugin");
+  assert.equal(oidcMiddleware.issuer, "https://zitadel.servicelasso.localhost");
+  assert.ok(stripHeaders.removeRequestHeaders.includes("X-ServiceLasso-Audit-Actor"));
+});
+
+test("local SSO smoke contract covers protected route to ZITADEL callback loop", () => {
+  const plan = buildLocalSsoBootstrapPlan();
+
+  assert.deepEqual(
+    plan.smokeCheck.map((step) => step.step),
+    ["request_protected_route", "redirect_to_zitadel", "callback_to_oidc_middleware", "serviceadmin_authenticated"],
+  );
+  assert.equal(plan.smokeCheck[0].expect, "GET https://serviceadmin.servicelasso.localhost");
+  assert.equal(plan.smokeCheck[1].expect, "https://zitadel.servicelasso.localhost");
+  assert.equal(plan.smokeCheck[2].expect, "https://serviceadmin.servicelasso.localhost/oauth2/callback");
+  assert.match(plan.smokeCheck[3].expect, /raw tokens absent/);
+});
+
+test("local SSO bootstrap rejects .local domains and inline secret values", () => {
+  assert.throws(
+    () =>
+      assertSafeLocalSsoConfig({
+        serviceAdminHost: "serviceadmin.servicelasso.local",
+      }),
+    /servicelasso\.localhost|\.local/,
+  );
+
+  assert.throws(
+    () =>
+      assertSafeLocalSsoConfig({
+        oidcMiddleware: {
+          clientSecretRef: "ACTUAL_SECRET",
+        },
+      }),
+    /secretref:\/\//,
+  );
+});
+
+test("local SSO bootstrap output is metadata-only and writable", async () => {
+  const plan = buildLocalSsoBootstrapPlan();
+  const text = JSON.stringify(plan);
+
+  assert.doesNotMatch(text, forbiddenOutput);
+  assert.doesNotMatch(text, new RegExp("auth " + "facade|" + "service-lasso" + "-auth", "i"));
+  assert.equal(plan.secretRefs.every((ref) => ref.startsWith("secretref://")), true);
+
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-local-sso-"));
+  try {
+    const outputPath = path.join(tempRoot, "local-sso-bootstrap.plan.json");
+    await writeLocalSsoBootstrapPlan(outputPath, plan);
+    const written = await readFile(outputPath, "utf8");
+    assert.match(written, /traefik-oidc-auth/);
+    assert.doesNotMatch(written, forbiddenOutput);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a local Traefik + ZITADEL SSO bootstrap contract script that emits safe route, middleware, ZITADEL client, secret-ref, diagnostics, and smoke-check metadata
- document the local `servicelasso.localhost` SSO bootstrap boundary and command
- add focused tests for route/middleware metadata, smoke path, `.local` rejection, secret-ref enforcement, and metadata-only output
- add package scripts `bootstrap:local-sso` and `test:local-sso`

## Boundary correction
- Treats legacy issue wording about an auth facade as superseded by #435/#437.
- Does not add or imply a Service Lasso-owned OIDC/session/token runtime.
- Uses external/plugin-owned `traefik-oidc-auth` and ZITADEL/service-owned config.

## Validation
- `rg -n "auth facade|auth-facade|service-lasso-auth|custom OIDC/session/token|custom OIDC" scripts/local-sso-bootstrap.mjs tests/local-sso-bootstrap.test.js docs/reference/local-sso-bootstrap.md package.json` ✅ no matches
- `npm run test:local-sso` ✅
- `git diff --check` ✅
- `npm test` ⚠️ one unrelated/flaky `tests/recovery-e2e.test.js` failure in full suite; focused rerun `npm run build && node --test --test-concurrency=1 tests/recovery-e2e.test.js` passed ✅

## Safety notes
- Output is metadata-only: domains, route/middleware names, client id, redirect/logout URIs, trusted header names, and `secretref://` pointers.
- No raw client secrets, local session secrets, tokens, cookies, provider credentials, private keys, database passwords, recovery material, or env payloads are emitted or committed.

Closes #428