### PR TITLE
Implement service startup broker resolution pipeline

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -20,10 +20,12 @@ It is meant to make the runtime and service templates usable without forcing ser
 ## Important current rule
 
 The current template direction is:
+
 - **default health model = `process`**
 - other health models are used only when explicitly declared by service config
 
 Supported explicit healthcheck types include:
+
 - `http`
 - `tcp`
 - `file`
@@ -34,6 +36,7 @@ Supported explicit healthcheck types include:
 `service.json` is the canonical service manifest used by Service Lasso to understand how a service should be discovered, prepared, executed, and monitored.
 
 At a high level it carries:
+
 - identity
 - operator metadata
 - lifecycle/action hints
@@ -101,61 +104,76 @@ The current sample in this repo is:
 ## Top-level fields
 
 ### `id`
+
 Unique service identifier.
 
 Example:
+
 ```json
 "id": "echo-service"
 ```
 
 Current direction:
+
 - required
 - should be stable
 - should align with the service repo’s identity
 
 ### `name`
+
 Human-facing display name.
 
 Example:
+
 ```json
 "name": "Echo Service"
 ```
 
 ### `description`
+
 Short operator-facing description.
 
 ### `enabled`
+
 Whether the service is enabled by default.
 
 ### `role`
+
 Declares whether the manifest describes a normal managed service or a local runtime provider.
 
 Supported values:
+
 - `service` or omitted: a normal service that can be installed, configured, started, stopped, and health-checked as a managed process when execution metadata is present
 - `provider`: a runtime provider such as `@node`, `@python`, or `@java`; providers can be local/no-download or release-backed through `artifact` metadata
 
 Provider-role services are installed/configured so their variables and dependency contract are available, but baseline start does not launch them as long-running daemon processes unless a later provider contract explicitly requires that.
 
 Example:
+
 ```json
 "role": "provider"
 ```
 
 ### `version`
+
 Current package/version identity for the service.
 
 ### `logoutput`
+
 Whether stdout/stderr style runtime logging should be captured/displayed.
 
 ### `icon`
+
 UI/operator-facing symbolic icon list.
 
 Current direction:
+
 - `icon` should be an array of entries
 - each entry should identify an icon `provider` and `name`
 - consumers can choose the first icon provider they support
 
 Example:
+
 ```json
 "icon": [
   {
@@ -166,14 +184,17 @@ Example:
 ```
 
 ### `logo`
+
 UI/operator-facing image/logo list.
 
 Current direction:
+
 - `logo` should be an array of entries
 - the simple form is just `path`
 - later entries can grow to include more metadata such as format/theme/size
 
 Example:
+
 ```json
 "logo": [
   {
@@ -183,9 +204,11 @@ Example:
 ```
 
 ### `servicetype`
+
 Numeric service type classification value.
 
 ### `servicelocation`
+
 Numeric service location classification value.
 
 ## `actions`
@@ -193,11 +216,13 @@ Numeric service location classification value.
 `actions` is where the service defines or overrides named lifecycle actions.
 
 Current intended rule:
+
 - actions correspond to known Service Lasso lifecycle/action names
 - service config can override how a named action behaves for that service
 - if a service does not override a supported action, Lasso default behavior applies
 
 Current sample actions:
+
 - `install`
 - `config`
 - `start`
@@ -223,6 +248,7 @@ Current sample actions:
 ```
 
 ### Current action semantics direction
+
 - `install`
   - prepare/install payload and required local setup
 - `config`
@@ -241,39 +267,48 @@ Additional action names may exist later, but this first-pass template should sta
 This is where the service tells Lasso how to run and supervise it.
 
 ### `serviceorder`
+
 Startup ordering hint.
 
 Example:
+
 ```json
 "serviceorder": 100
 ```
 
 ### `serviceport`
+
 Primary service port.
 
 In the sample, `0` is being used as a simple first-pass placeholder/default meaning “no fixed service port required by this sample”.
 
 ### `execcwd`
+
 Execution working directory.
 
 Example:
+
 ```json
 "execcwd": "runtime"
 ```
 
 ### `executable`
+
 Executable or executable key/name used for the service runtime.
 
 Example:
+
 ```json
 "executable": "echo-service"
 ```
 
 Current direction:
+
 - when a service runs directly, `executable` can be the local binary/script name or path
 - when a service runs through a runtime provider, `executable` should be treated as the executable key exposed by that provider
 
 Provider-backed example:
+
 ```json
 "execservice": "@node",
 "executable": "NODE",
@@ -281,15 +316,18 @@ Provider-backed example:
 ```
 
 Meaning:
+
 - `execservice` chooses the runtime/provider service to use
 - `executable` chooses which executable from that provider should be invoked
 - the resulting runtime command is conceptually `NODE runtime/server.js`
 
 This means `execservice` and `executable` are related, but not the same thing:
+
 - `execservice` = who runs it
 - `executable` = what binary from that runner gets used
 
 Practical rule:
+
 - use both when you want provider-backed execution to stay explicit
 - do not assume `execservice` alone is enough unless Service Lasso later defines provider defaults clearly enough to make `executable` optional
 
@@ -309,6 +347,7 @@ Practical rule:
 ```
 
 Current core behavior:
+
 - Service Lasso selects `commandline[process.platform]`, falling back to `commandline.default`.
 - `${...}` selectors are resolved with the same service variables used for env/config materialization.
 - Selector planning classifies `${VAR}` as local/current-service/derived/legacy-compatible lookup and `${namespace.KEY}` as an explicit broker lookup.
@@ -319,24 +358,30 @@ Current core behavior:
 - Keep `args` as the fallback when no platform/default commandline is declared.
 
 ### `execservice`
+
 Runtime-provider service used to run this service through another packaged/runtime service.
 
 Example:
+
 ```json
 "execservice": "@node"
 ```
 
 Use this when:
+
 - the service should run through a packaged Node/Python/Java runtime provider
 - the service does not own the runtime binary directly inside its own payload
 
 Do not use this when:
+
 - the service already ships and runs its own executable directly
 
 ### `env`
+
 Service-local environment variables.
 
 Example:
+
 ```json
 "env": {
   "ECHO_MESSAGE": "hello from service-template"
@@ -344,6 +389,7 @@ Example:
 ```
 
 Current direction:
+
 - service env should be explicit
 - avoid depending on uncontrolled host-machine env leakage
 - use `${VAR}` for local/current-service/derived values and legacy `globalenv` compatibility
@@ -356,6 +402,7 @@ Current direction:
 Services without a `broker` block keep the existing behavior. There is no implicit migration from `env` or `globalenv` into broker state.
 
 Shape:
+
 ```json
 "broker": {
   "enabled": true,
@@ -406,6 +453,7 @@ Shape:
 ```
 
 Fields:
+
 - `enabled`: optional boolean. `false` can be used to leave a declared broker contract dormant.
 - `namespace`: optional default service namespace. It must be a non-empty broker namespace string such as `services/consumer`.
 - `buckets`: optional array declaring the namespace buckets this manifest participates in. Bucket namespaces must be unique.
@@ -434,6 +482,7 @@ Fields:
 - `writeback.generatedSecrets[].required`: optional boolean; required captures should fail closed when the source cannot be resolved.
 
 Launch-time writeback identity:
+
 - Services with `broker.writeback` declared receive a short-lived per-launch broker credential from the runtime.
 - The credential is scoped to the service id plus `writeback.allowedNamespaces`, `writeback.allowedRefs`, and `writeback.allowedOperations`.
 - Runtime injects the credential through reserved process env keys: `SERVICE_LASSO_BROKER_IDENTITY_ID`, `SERVICE_LASSO_BROKER_CREDENTIAL`, and `SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT`.
@@ -442,6 +491,7 @@ Launch-time writeback identity:
 - Broker writeback audit records should use the launched service identity and the optional `writeback.auditReason`.
 
 Selector semantics:
+
 - `${VAR}` means local/current-service variables only, including derived variables and legacy-compatible values already visible to the service.
 - `${namespace.KEY}` means an explicit broker lookup.
 - Bare names never fall through into broker namespaces.
@@ -450,6 +500,7 @@ Selector semantics:
 - `imports[].as` may intentionally line up with an `env` key only when that env value is exactly the same dotted broker selector, for example `"DB_PASSWORD": "${database.PASSWORD}"`. It must not collide with `globalenv` output names.
 
 Producer example:
+
 ```json
 {
   "id": "token-producer",
@@ -461,9 +512,7 @@ Producer example:
   "broker": {
     "enabled": true,
     "namespace": "services/token-producer",
-    "buckets": [
-      { "namespace": "services/token-producer", "kind": "service" }
-    ],
+    "buckets": [{ "namespace": "services/token-producer", "kind": "service" }],
     "exports": [
       {
         "namespace": "services/token-producer",
@@ -492,6 +541,7 @@ Producer example:
 ```
 
 Consumer example:
+
 ```json
 {
   "id": "token-consumer",
@@ -520,6 +570,7 @@ Consumer example:
 ```
 
 Migration from `globalenv`:
+
 ```json
 {
   "globalenv": {
@@ -531,13 +582,16 @@ Migration from `globalenv`:
 Legacy `globalenv` remains a compatibility path for bounded provider/tool values that are already safe to share. New cross-service secret flow should move to explicit broker imports/exports so values are bucketed as current-service, app-level, explicitly shared, or truly global instead of ambiently merged into every launched process.
 
 Ordinary services should consume broker values through service-local `env` names or through an explicit CLI/adapter resolution step. Keep the manifest reviewable:
+
 - map each secret to a concrete env key, for example `"DB_PASSWORD": "${database.PASSWORD}"`
 - declare the same dotted ref in `broker.imports[]`; undeclared dotted refs are denied instead of falling back to ambient/global lookup
 - do not print resolved values in normal logs, diagnostics, issue comments, or support bundles
 - prefer env mapping for long-running processes; use CLI-style resolution only for controlled setup/adapter paths that do not echo arguments or outputs containing raw secrets
-- missing, denied, or source-auth-required refs should fail with actionable diagnostics that name the ref and reason without including the secret value
+- missing, locked, auth-required, policy-denied, source-unavailable, or degraded refs should fail with actionable diagnostics that name the ref and reason without including the secret value
+- startup resolution batches unique declared broker selectors once per launch and materializes raw values only into the launched service environment/config boundary; see [Startup Broker Resolution](./startup-broker-resolution.md)
 
 Becomes an explicit broker contract:
+
 ```json
 {
   "env": {
@@ -563,24 +617,30 @@ Becomes an explicit broker contract:
 ```
 
 ### `depend_on`
+
 Explicit dependencies.
 
 Example:
+
 ```json
 "depend_on": []
 ```
 
 Current direction:
+
 - use this for services that require another service/runtime/provider first
 - keep empty for the minimal sample
 
 ## Healthcheck
 
 ### Default rule
+
 Current rule:
+
 - if a service does not explicitly require another model, the default is **`process`**
 
 Example:
+
 ```json
 "healthcheck": {
   "type": "process"
@@ -590,7 +650,9 @@ Example:
 This is the right default for a simple sample service.
 
 ### Explicit healthcheck types
+
 Service Lasso supports these explicit healthcheck types:
+
 - `http`
 - `tcp`
 - `file`
@@ -599,11 +661,14 @@ Service Lasso supports these explicit healthcheck types:
 `process` is the current template default direction; use one of the explicit types above when a service needs a stronger readiness signal.
 
 ### `process` healthcheck
+
 Use when:
+
 - service health is adequately represented by the process being up/running
 - you do not need a deeper readiness endpoint yet
 
 Sample:
+
 ```json
 "healthcheck": {
   "type": "process"
@@ -611,10 +676,13 @@ Sample:
 ```
 
 ### `http` healthcheck
+
 Use when:
+
 - the service exposes an HTTP readiness or health endpoint
 
 Sample:
+
 ```json
 "healthcheck": {
   "type": "http",
@@ -624,10 +692,13 @@ Sample:
 ```
 
 ### `tcp` healthcheck
+
 Use when:
+
 - readiness is best represented by a socket accepting connections
 
 Sample:
+
 ```json
 "healthcheck": {
   "type": "tcp"
@@ -637,10 +708,13 @@ Sample:
 This relies on the configured service host/port.
 
 ### `file` healthcheck
+
 Use when:
+
 - the service creates a file that represents successful readiness/setup
 
 Sample:
+
 ```json
 "healthcheck": {
   "type": "file",
@@ -649,10 +723,13 @@ Sample:
 ```
 
 ### `variable` healthcheck
+
 Use when:
+
 - a specific resolved/exported variable is the readiness signal
 
 Sample:
+
 ```json
 "healthcheck": {
   "type": "variable",
@@ -716,9 +793,11 @@ service-lasso setup run typedb init-schema
 ```
 
 ### Release artifacts and update policy
+
 Current core manifests use first-class `artifact` metadata when a service archive should be acquired from a GitHub release.
 
 Pinned example:
+
 ```json
 "artifact": {
   "kind": "archive",
@@ -739,6 +818,7 @@ Pinned example:
 If `artifact.source.tag` is present and no active `updates` policy is declared, Service Lasso treats the service as pinned.
 
 Moving update checks require an explicit `updates` block:
+
 ```json
 "updates": {
   "enabled": true,
@@ -749,12 +829,14 @@ Moving update checks require an explicit `updates` block:
 ```
 
 Supported `updates.mode` values:
+
 - `disabled`
 - `notify`
 - `download`
 - `install`
 
 Current core status:
+
 - `notify` can be used by the read-only update discovery function to classify `pinned`, `latest`, `update_available`, `unavailable`, or `check_failed`
 - `download` downloads candidates without installing them
 - `install` can install candidates through CLI/API or the opt-in scheduler when policy and safety gates allow
@@ -763,14 +845,18 @@ Current core status:
 - `runningService` controls whether a running service is deferred or stopped/restarted during install
 
 ### Environment generation
+
 Current broader Service Lasso direction includes:
+
 - explicit service-local env via `env`
 - possible cross-service/global env behavior via `globalenv`
 
 The sample template keeps this minimal for now.
 
 ### Ports and URLs
+
 More complex services can use additional fields such as:
+
 - `serviceportsecondary`
 - `serviceportconsole`
 - `serviceportdebug`
@@ -780,7 +866,9 @@ More complex services can use additional fields such as:
 These are not all used in the minimal sample, but they remain relevant for more complex services.
 
 ### Runtime-provider relationships
+
 Runtime-provider services use:
+
 - `execservice`
 
 This is relevant when a service is run via another runtime-provider service such as Node, Python, or Java.
@@ -790,6 +878,7 @@ The minimal sample does not use this yet.
 ## Canonical vs illustrative right now
 
 ### Treat as current first-pass canonical direction
+
 - one service per repo
 - `service.json` as the main service contract file
 - lifecycle-focused `actions`
@@ -800,6 +889,7 @@ The minimal sample does not use this yet.
 - explicit override to other health models when needed
 
 ### Still illustrative / not fully locked yet
+
 - exact numeric meaning of `servicetype`
 - exact numeric meaning of `servicelocation`
 - final exact schema shape for all optional `execconfig` fields
@@ -809,6 +899,7 @@ The minimal sample does not use this yet.
 ## Recommended authoring guidance
 
 For the first template-based service:
+
 1. keep the manifest small
 2. use `process` health unless another model is clearly needed
 3. explicitly declare env and dependencies
@@ -818,5 +909,6 @@ For the first template-based service:
 ## Related docs
 
 Start here for the broader Service Lasso contract:
+
 - `docs/service-authoring/overview.md`
 - `docs/development/new-lasso-service-guide.md`

--- a/docs/reference/startup-broker-resolution.md
+++ b/docs/reference/startup-broker-resolution.md
@@ -1,0 +1,96 @@
+# Startup broker resolution
+
+Service launch can consume Secrets Broker refs declared in `service.json` without exposing resolved values outside the launch materialization boundary.
+
+## Manifest shape
+
+Declare broker imports under `broker.imports`, then reference them from `env` with `${namespace.KEY}` selectors:
+
+```json
+{
+  "id": "api",
+  "name": "API",
+  "description": "Service using broker-backed config",
+  "env": {
+    "DATABASE_URL": "postgres://app:${database.PASSWORD}@db/service",
+    "API_TOKEN": "${service.API_TOKEN}"
+  },
+  "broker": {
+    "imports": [
+      {
+        "namespace": "shared/database",
+        "ref": "database.PASSWORD",
+        "as": "DB_PASSWORD",
+        "required": true
+      },
+      {
+        "namespace": "services/api",
+        "ref": "service.API_TOKEN",
+        "as": "API_TOKEN",
+        "required": false
+      }
+    ]
+  }
+}
+```
+
+Precedence at launch is:
+
+1. provider env from the selected runtime provider
+2. Service Lasso manifest/derived/global variables, with broker selectors substituted only for declared imports
+3. broker imports with `as` names that do not override existing manifest env keys
+4. scoped broker writeback identity env, when the service declares broker writeback permissions
+
+Raw broker values may be present only in the process environment/config handed to the launched service. They must not be written to logs, status payloads, diagnostics, issue comments, PR bodies, or test artifacts.
+
+## Startup pipeline
+
+The runtime startup path is formalized as:
+
+1. Compile a selector plan from service `env` plus `broker.imports`.
+2. Deduplicate broker refs so each unique selector is looked up at most once per launch.
+3. Batch lookup the unique refs through the Secrets Broker boundary.
+4. Classify every unresolved ref as one of:
+   - `missing`
+   - `locked`
+   - `auth-required`
+   - `policy-denied`
+   - `source-unavailable`
+   - `degraded`
+5. Fail closed before process spawn when any `required: true` import is unresolved.
+6. Materialize resolved values only into the launched service environment/config.
+7. Emit safe metadata only: ref name, classification, `required`, and `as` target.
+
+Policy-denied refs are intentionally separate from missing refs. Operators should see that access was denied, not that config disappeared.
+
+## Cache invalidation
+
+Selector plans are cached by service manifest path/id and the effective `env` + `broker.imports` content. The cache invalidates when:
+
+- an env template changes
+- a broker import is added, removed, renamed, or changes `required` / `as`
+- materialization templates change for config/install planning
+
+The cache stores selector metadata only, never resolved broker values.
+
+## Safe diagnostics
+
+Safe failure metadata example:
+
+```json
+{
+  "ref": "database.PASSWORD",
+  "status": "locked",
+  "required": true,
+  "as": "DB_PASSWORD"
+}
+```
+
+Unsafe output that must not be logged or returned:
+
+```text
+DB_PASSWORD=...
+access_token=...
+client_secret=...
+raw resolved secret values
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,6 +68,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/startup-broker-resolution",
+          label: "Startup Broker Resolution",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/src/runtime/broker/launch-resolution.ts
+++ b/src/runtime/broker/launch-resolution.ts
@@ -1,0 +1,252 @@
+import type {
+  DiscoveredService,
+  ServiceBrokerImport,
+} from "../../contracts/service.js";
+import {
+  compileCachedServiceSelectorPlan,
+  type ServiceSelectorPlan,
+  type ServiceVariableResolutionOptions,
+} from "../operator/variables.js";
+
+export type BrokerLaunchLookupStatus =
+  | "resolved"
+  | "missing"
+  | "locked"
+  | "auth-required"
+  | "policy-denied"
+  | "source-unavailable"
+  | "degraded";
+
+export interface BrokerLaunchLookupDecision {
+  ref: string;
+  status: BrokerLaunchLookupStatus;
+  value?: string;
+}
+
+export interface BrokerLaunchLookupRequest {
+  service: DiscoveredService;
+  refs: string[];
+}
+
+export type BrokerLaunchLookup = (
+  request: BrokerLaunchLookupRequest,
+) => Promise<BrokerLaunchLookupDecision[]> | BrokerLaunchLookupDecision[];
+
+export interface ServiceStartupBrokerPlan {
+  serviceId: string;
+  selectorPlan: ServiceSelectorPlan;
+  brokerRefs: string[];
+  imports: Array<{
+    namespace: string;
+    ref: string;
+    as: string | null;
+    required: boolean;
+  }>;
+}
+
+export interface ServiceStartupBrokerFailure {
+  ref: string;
+  status: Exclude<BrokerLaunchLookupStatus, "resolved">;
+  required: boolean;
+  as: string | null;
+}
+
+export interface ServiceStartupBrokerResolution {
+  serviceId: string;
+  plan: ServiceStartupBrokerPlan;
+  variableResolution: ServiceVariableResolutionOptions;
+  decisions: Array<Omit<BrokerLaunchLookupDecision, "value">>;
+  failures: ServiceStartupBrokerFailure[];
+}
+
+function normalizeImport(entry: ServiceBrokerImport) {
+  return {
+    namespace: entry.namespace,
+    ref: entry.ref,
+    as: entry.as ?? null,
+    required: entry.required === true,
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function setToArray(values: Set<string>): string[] | undefined {
+  return values.size > 0 ? [...values] : undefined;
+}
+
+function mergeRecords(
+  left: Record<string, string> | undefined,
+  right: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+  return { ...(left ?? {}), ...(right ?? {}) };
+}
+
+function mergeLists(
+  left: Set<string> | string[] | undefined,
+  right: string[] | undefined,
+): string[] | undefined {
+  const merged = new Set<string>();
+  if (Array.isArray(left)) {
+    for (const value of left) merged.add(value);
+  } else if (left) {
+    for (const value of left) merged.add(value);
+  }
+  for (const value of right ?? []) merged.add(value);
+  return merged.size > 0 ? [...merged] : undefined;
+}
+
+export function mergeServiceVariableResolutionOptions(
+  base: ServiceVariableResolutionOptions = {},
+  launch: ServiceVariableResolutionOptions = {},
+): ServiceVariableResolutionOptions {
+  return {
+    ...base,
+    ...launch,
+    brokerValues: mergeRecords(base.brokerValues, launch.brokerValues),
+    deniedBrokerRefs: mergeLists(
+      base.deniedBrokerRefs,
+      launch.deniedBrokerRefs as string[] | undefined,
+    ),
+    lockedBrokerRefs: mergeLists(
+      base.lockedBrokerRefs,
+      launch.lockedBrokerRefs as string[] | undefined,
+    ),
+    sourceAuthRequiredBrokerRefs: mergeLists(
+      base.sourceAuthRequiredBrokerRefs,
+      launch.sourceAuthRequiredBrokerRefs as string[] | undefined,
+    ),
+    sourceUnavailableBrokerRefs: mergeLists(
+      base.sourceUnavailableBrokerRefs,
+      launch.sourceUnavailableBrokerRefs as string[] | undefined,
+    ),
+    degradedBrokerRefs: mergeLists(
+      base.degradedBrokerRefs,
+      launch.degradedBrokerRefs as string[] | undefined,
+    ),
+    diagnostics: base.diagnostics ?? launch.diagnostics,
+  };
+}
+
+export function compileServiceStartupBrokerPlan(
+  service: DiscoveredService,
+): ServiceStartupBrokerPlan {
+  const imports = (service.manifest.broker?.imports ?? []).map(normalizeImport);
+  const importTemplates = imports.map((entry) => `\${${entry.ref}}`);
+  const selectorPlan = compileCachedServiceSelectorPlan(
+    `service:${service.manifestPath}:${service.manifest.id}:startup-broker`,
+    {
+      env: JSON.stringify(service.manifest.env ?? {}),
+      imports: JSON.stringify(imports),
+      importTemplates: importTemplates.join("\n"),
+    },
+  );
+
+  return {
+    serviceId: service.manifest.id,
+    selectorPlan,
+    brokerRefs: unique([
+      ...selectorPlan.brokerRefs,
+      ...imports.map((entry) => entry.ref),
+    ]),
+    imports,
+  };
+}
+
+function importByRef(
+  imports: ServiceStartupBrokerPlan["imports"],
+): Map<string, ServiceStartupBrokerPlan["imports"][number]> {
+  const result = new Map<string, ServiceStartupBrokerPlan["imports"][number]>();
+  for (const entry of imports) {
+    result.set(entry.ref, entry);
+  }
+  return result;
+}
+
+export async function resolveServiceStartupBrokerResolution(
+  service: DiscoveredService,
+  lookup: BrokerLaunchLookup,
+  baseResolution: ServiceVariableResolutionOptions = {},
+): Promise<ServiceStartupBrokerResolution> {
+  const plan = compileServiceStartupBrokerPlan(service);
+  const decisions = await lookup({ service, refs: plan.brokerRefs });
+  const expectedRefs = new Set(plan.brokerRefs);
+  const importMap = importByRef(plan.imports);
+  const brokerValues: Record<string, string> = {};
+  const denied = new Set<string>();
+  const locked = new Set<string>();
+  const authRequired = new Set<string>();
+  const sourceUnavailable = new Set<string>();
+  const degraded = new Set<string>();
+  const seen = new Set<string>();
+  const failures: ServiceStartupBrokerFailure[] = [];
+
+  const addFailure = (
+    ref: string,
+    status: ServiceStartupBrokerFailure["status"],
+  ) => {
+    const imported = importMap.get(ref);
+    failures.push({
+      ref,
+      status,
+      required: imported?.required === true,
+      as: imported?.as ?? null,
+    });
+  };
+
+  for (const decision of decisions) {
+    if (!expectedRefs.has(decision.ref) || seen.has(decision.ref)) {
+      continue;
+    }
+    seen.add(decision.ref);
+
+    if (decision.status === "resolved" && decision.value !== undefined) {
+      brokerValues[decision.ref] = decision.value;
+      continue;
+    }
+
+    if (decision.status === "policy-denied") denied.add(decision.ref);
+    if (decision.status === "locked") locked.add(decision.ref);
+    if (decision.status === "auth-required") authRequired.add(decision.ref);
+    if (decision.status === "source-unavailable")
+      sourceUnavailable.add(decision.ref);
+    if (decision.status === "degraded") degraded.add(decision.ref);
+    addFailure(
+      decision.ref,
+      decision.status === "resolved" ? "missing" : decision.status,
+    );
+  }
+
+  for (const ref of plan.brokerRefs) {
+    if (!seen.has(ref)) {
+      addFailure(ref, "missing");
+    }
+  }
+
+  return {
+    serviceId: service.manifest.id,
+    plan,
+    variableResolution: mergeServiceVariableResolutionOptions(baseResolution, {
+      brokerValues,
+      deniedBrokerRefs: setToArray(denied),
+      lockedBrokerRefs: setToArray(locked),
+      sourceAuthRequiredBrokerRefs: setToArray(authRequired),
+      sourceUnavailableBrokerRefs: setToArray(sourceUnavailable),
+      degradedBrokerRefs: setToArray(degraded),
+    }),
+    decisions: decisions
+      .filter((decision) => expectedRefs.has(decision.ref))
+      .map((decision) => ({ ref: decision.ref, status: decision.status })),
+    failures,
+  };
+}
+
+export function summarizeRequiredStartupBrokerFailures(
+  resolution: ServiceStartupBrokerResolution,
+): ServiceStartupBrokerFailure[] {
+  return resolution.failures.filter((failure) => failure.required);
+}

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,24 +1,49 @@
 import type { DiscoveredService } from "../../contracts/service.js";
 import { LifecycleStateError } from "../../server/errors.js";
-import { startManagedProcess, stopManagedProcess } from "../execution/supervisor.js";
-import { mintScopedBrokerIdentity, revokeServiceScopedBrokerIdentities } from "../broker/identity.js";
+import {
+  startManagedProcess,
+  stopManagedProcess,
+} from "../execution/supervisor.js";
+import {
+  mintScopedBrokerIdentity,
+  revokeServiceScopedBrokerIdentities,
+} from "../broker/identity.js";
+import {
+  mergeServiceVariableResolutionOptions,
+  resolveServiceStartupBrokerResolution,
+  summarizeRequiredStartupBrokerFailures,
+  type BrokerLaunchLookup,
+} from "../broker/launch-resolution.js";
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
-import { collectRuntimeGlobalEnv, type ServiceVariableResolutionOptions } from "../operator/variables.js";
+import {
+  collectRuntimeGlobalEnv,
+  type ServiceVariableResolutionOptions,
+} from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
 import { createDirectExecutionPlan } from "../providers/direct.js";
 import { resolveProviderExecution } from "../providers/resolveProvider.js";
 import { assertDoctorPreflightAllowsRestart } from "../recovery/doctor.js";
 import { appendServiceRecoveryHistoryEvents } from "../recovery/history.js";
 import { acquireInstallArtifact } from "../setup/acquire.js";
-import { materializeConfigArtifacts, materializeInstallArtifacts } from "../setup/materialize.js";
+import {
+  materializeConfigArtifacts,
+  materializeInstallArtifacts,
+} from "../setup/materialize.js";
 import { writeServiceState } from "../state/writeState.js";
 import { isProviderRole } from "../roles.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
-import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
+import type {
+  LifecycleAction,
+  LifecycleActionResult,
+  ServiceLifecycleState,
+} from "./types.js";
 
-function calculateRunDurationMs(startedAt: string | null, finishedAt: string): number | null {
+function calculateRunDurationMs(
+  startedAt: string | null,
+  finishedAt: string,
+): number | null {
   if (!startedAt) {
     return null;
   }
@@ -38,14 +63,21 @@ function applyRunCompletionMetrics(
   finishedAt: string,
   termination: "stopped" | "exited" | "crashed",
 ): ServiceLifecycleState["runtime"]["metrics"] {
-  const runDurationMs = calculateRunDurationMs(current.runtime.startedAt, finishedAt);
+  const runDurationMs = calculateRunDurationMs(
+    current.runtime.startedAt,
+    finishedAt,
+  );
 
   return {
     ...current.runtime.metrics,
-    stopCount: current.runtime.metrics.stopCount + (termination === "stopped" ? 1 : 0),
-    exitCount: current.runtime.metrics.exitCount + (termination === "exited" ? 1 : 0),
-    crashCount: current.runtime.metrics.crashCount + (termination === "crashed" ? 1 : 0),
-    totalRunDurationMs: current.runtime.metrics.totalRunDurationMs + (runDurationMs ?? 0),
+    stopCount:
+      current.runtime.metrics.stopCount + (termination === "stopped" ? 1 : 0),
+    exitCount:
+      current.runtime.metrics.exitCount + (termination === "exited" ? 1 : 0),
+    crashCount:
+      current.runtime.metrics.crashCount + (termination === "crashed" ? 1 : 0),
+    totalRunDurationMs:
+      current.runtime.metrics.totalRunDurationMs + (runDurationMs ?? 0),
     lastRunDurationMs: runDurationMs,
   };
 }
@@ -59,7 +91,10 @@ function applyProcessLaunchMetrics(
   let lastRunDurationMs = current.runtime.metrics.lastRunDurationMs;
 
   if (action === "restart" && current.running) {
-    const previousRunDurationMs = calculateRunDurationMs(current.runtime.startedAt, startedAt);
+    const previousRunDurationMs = calculateRunDurationMs(
+      current.runtime.startedAt,
+      startedAt,
+    );
     totalRunDurationMs += previousRunDurationMs ?? 0;
     lastRunDurationMs = previousRunDurationMs;
   }
@@ -67,7 +102,8 @@ function applyProcessLaunchMetrics(
   return {
     ...current.runtime.metrics,
     launchCount: current.runtime.metrics.launchCount + 1,
-    restartCount: current.runtime.metrics.restartCount + (action === "restart" ? 1 : 0),
+    restartCount:
+      current.runtime.metrics.restartCount + (action === "restart" ? 1 : 0),
     totalRunDurationMs,
     lastRunDurationMs,
   };
@@ -75,12 +111,16 @@ function applyProcessLaunchMetrics(
 
 export interface ServiceLifecycleActionOptions {
   variableResolution?: ServiceVariableResolutionOptions;
+  brokerLookup?: BrokerLaunchLookup;
 }
 
 function applyState(
   serviceId: string,
   action: LifecycleAction,
-  recipe: (current: ServiceLifecycleState) => { nextState: ServiceLifecycleState; message: string },
+  recipe: (current: ServiceLifecycleState) => {
+    nextState: ServiceLifecycleState;
+    message: string;
+  },
   ok = true,
 ): LifecycleActionResult {
   const current = getLifecycleState(serviceId);
@@ -108,14 +148,60 @@ function updateRuntimeState(
   return setLifecycleState(serviceId, recipe(current));
 }
 
+function formatStartupBrokerFailureMessage(
+  serviceId: string,
+  failures: ReturnType<typeof summarizeRequiredStartupBrokerFailures>,
+): string {
+  const refs = failures
+    .map((failure) => `${failure.ref}:${failure.status}`)
+    .join(", ");
+  return `Cannot start service "${serviceId}" because required broker refs are unresolved (${refs}).`;
+}
+
+async function resolveLaunchVariableResolution(
+  service: DiscoveredService,
+  options: ServiceLifecycleActionOptions,
+): Promise<ServiceVariableResolutionOptions | undefined> {
+  if (!options.brokerLookup) {
+    return options.variableResolution;
+  }
+
+  const resolution = await resolveServiceStartupBrokerResolution(
+    service,
+    options.brokerLookup,
+    options.variableResolution,
+  );
+  const requiredFailures = summarizeRequiredStartupBrokerFailures(resolution);
+  if (requiredFailures.length > 0) {
+    throw new LifecycleStateError(
+      formatStartupBrokerFailureMessage(service.manifest.id, requiredFailures),
+    );
+  }
+
+  return mergeServiceVariableResolutionOptions(
+    options.variableResolution,
+    resolution.variableResolution,
+  );
+}
+
 async function persistProcessExit(
   service: DiscoveredService,
   exitCode: number | null,
 ): Promise<void> {
   const finishedAt = new Date().toISOString();
-  const revokedIdentities = revokeServiceScopedBrokerIdentities(service.manifest.id, { now: new Date(finishedAt) });
-  const revokedIdentity = revokedIdentities.at(-1) ?? getLifecycleState(service.manifest.id).runtime.brokerIdentity;
-  const termination = (exitCode ?? getLifecycleState(service.manifest.id).runtime.exitCode ?? 0) === 0 ? "exited" : "crashed";
+  const revokedIdentities = revokeServiceScopedBrokerIdentities(
+    service.manifest.id,
+    { now: new Date(finishedAt) },
+  );
+  const revokedIdentity =
+    revokedIdentities.at(-1) ??
+    getLifecycleState(service.manifest.id).runtime.brokerIdentity;
+  const termination =
+    (exitCode ??
+      getLifecycleState(service.manifest.id).runtime.exitCode ??
+      0) === 0
+      ? "exited"
+      : "crashed";
   const state = updateRuntimeState(service.manifest.id, (current) => ({
     ...current,
     running: false,
@@ -148,7 +234,10 @@ function resolveExecutionPlanForLifecycle(
     return resolveProviderExecution(service, registry);
   }
 
-  return createDirectExecutionPlan(service.manifest, current.installArtifacts.artifact);
+  return createDirectExecutionPlan(
+    service.manifest,
+    current.installArtifacts.artifact,
+  );
 }
 
 export async function installService(
@@ -156,7 +245,9 @@ export async function installService(
   registry?: ServiceRegistry,
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
-  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const sharedGlobalEnv = registry
+    ? collectRuntimeGlobalEnv(registry.list())
+    : {};
   const acquiredArtifact = await acquireInstallArtifact(service);
   const artifacts = await materializeInstallArtifacts(service, sharedGlobalEnv);
 
@@ -187,12 +278,22 @@ export async function configService(
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new LifecycleStateError(`Cannot config service "${serviceId}" before install.`);
+    throw new LifecycleStateError(
+      `Cannot config service "${serviceId}" before install.`,
+    );
   }
 
-  const resolvedPorts = registry ? await negotiateServicePorts(service, registry.list()) : current.runtime.ports;
-  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
-  const artifacts = await materializeConfigArtifacts(service, sharedGlobalEnv, resolvedPorts);
+  const resolvedPorts = registry
+    ? await negotiateServicePorts(service, registry.list())
+    : current.runtime.ports;
+  const sharedGlobalEnv = registry
+    ? collectRuntimeGlobalEnv(registry.list())
+    : {};
+  const artifacts = await materializeConfigArtifacts(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+  );
 
   return applyState(serviceId, "config", (state) => ({
     nextState: {
@@ -216,21 +317,33 @@ export async function startService(
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new LifecycleStateError(`Cannot start service "${serviceId}" before install.`);
+    throw new LifecycleStateError(
+      `Cannot start service "${serviceId}" before install.`,
+    );
   }
   if (!current.configured) {
-    throw new LifecycleStateError(`Cannot start service "${serviceId}" before config.`);
+    throw new LifecycleStateError(
+      `Cannot start service "${serviceId}" before config.`,
+    );
   }
   if (current.running) {
-    throw new LifecycleStateError(`Cannot start service "${serviceId}" because it is already running.`);
+    throw new LifecycleStateError(
+      `Cannot start service "${serviceId}" because it is already running.`,
+    );
   }
-  const executionPlan = resolveExecutionPlanForLifecycle(service, current, registry);
+  const executionPlan = resolveExecutionPlanForLifecycle(
+    service,
+    current,
+    registry,
+  );
   if (
     executionPlan.provider === "direct" &&
     !service.manifest.executable &&
     !current.installArtifacts.artifact?.command
   ) {
-    throw new LifecycleStateError(`Cannot start service "${serviceId}" because no executable is configured.`);
+    throw new LifecycleStateError(
+      `Cannot start service "${serviceId}" because no executable is configured.`,
+    );
   }
 
   if (registry) {
@@ -240,7 +353,9 @@ export async function startService(
     for (const dependencyId of dependencyOrder) {
       const dependency = registry.getById(dependencyId);
       if (!dependency) {
-        throw new LifecycleStateError(`Cannot start service "${serviceId}" because dependency "${dependencyId}" was not found.`);
+        throw new LifecycleStateError(
+          `Cannot start service "${serviceId}" because dependency "${dependencyId}" was not found.`,
+        );
       }
 
       const dependencyState = getLifecycleState(dependencyId);
@@ -260,27 +375,38 @@ export async function startService(
       }
 
       if (!dependencyState.running) {
-        const dependencyResult = await startService(dependency, registry, options);
+        const dependencyResult = await startService(
+          dependency,
+          registry,
+          options,
+        );
         await writeServiceState(dependency, dependencyResult.state);
       }
     }
   }
 
-  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const sharedGlobalEnv = registry
+    ? collectRuntimeGlobalEnv(registry.list())
+    : {};
   revokeServiceScopedBrokerIdentities(serviceId);
   const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
-  const resolvedPorts = Object.keys(current.runtime.ports).length > 0
-    ? current.runtime.ports
-    : registry
-      ? await negotiateServicePorts(service, registry.list())
-      : {};
+  const resolvedPorts =
+    Object.keys(current.runtime.ports).length > 0
+      ? current.runtime.ports
+      : registry
+        ? await negotiateServicePorts(service, registry.list())
+        : {};
+  const variableResolution = await resolveLaunchVariableResolution(
+    service,
+    options,
+  );
   const handle = await startManagedProcess({
     service,
     executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
     secureEnv: scopedBrokerIdentity?.env,
-    variableResolution: options.variableResolution,
+    variableResolution,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -317,7 +443,8 @@ export async function startService(
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
     const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId);
-    const revokedIdentity = revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
+    const revokedIdentity =
+      revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
     return applyState(
       serviceId,
       "start",
@@ -331,7 +458,11 @@ export async function startService(
             finishedAt: new Date().toISOString(),
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
-            metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
+            metrics: applyRunCompletionMetrics(
+              state,
+              new Date().toISOString(),
+              "stopped",
+            ),
             brokerIdentity: revokedIdentity,
           },
         },
@@ -362,17 +493,24 @@ export async function startService(
   }));
 }
 
-export async function stopService(service: DiscoveredService): Promise<LifecycleActionResult> {
+export async function stopService(
+  service: DiscoveredService,
+): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.running) {
-    throw new LifecycleStateError(`Cannot stop service "${serviceId}" because it is not running.`);
+    throw new LifecycleStateError(
+      `Cannot stop service "${serviceId}" because it is not running.`,
+    );
   }
 
   const stopped = await stopManagedProcess(serviceId);
   const finishedAt = new Date().toISOString();
-  const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId, { now: new Date(finishedAt) });
-  const revokedIdentity = revokedIdentities.at(-1) ?? current.runtime.brokerIdentity;
+  const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId, {
+    now: new Date(finishedAt),
+  });
+  const revokedIdentity =
+    revokedIdentities.at(-1) ?? current.runtime.brokerIdentity;
 
   return applyState(serviceId, "stop", (state) => ({
     nextState: {
@@ -400,18 +538,28 @@ export async function restartService(
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
-    throw new LifecycleStateError(`Cannot restart service "${serviceId}" before install.`);
+    throw new LifecycleStateError(
+      `Cannot restart service "${serviceId}" before install.`,
+    );
   }
   if (!current.configured) {
-    throw new LifecycleStateError(`Cannot restart service "${serviceId}" before config.`);
+    throw new LifecycleStateError(
+      `Cannot restart service "${serviceId}" before config.`,
+    );
   }
-  const executionPlan = resolveExecutionPlanForLifecycle(service, current, registry);
+  const executionPlan = resolveExecutionPlanForLifecycle(
+    service,
+    current,
+    registry,
+  );
   if (
     executionPlan.provider === "direct" &&
     !service.manifest.executable &&
     !current.installArtifacts.artifact?.command
   ) {
-    throw new LifecycleStateError(`Cannot restart service "${serviceId}" because no executable is configured.`);
+    throw new LifecycleStateError(
+      `Cannot restart service "${serviceId}" because no executable is configured.`,
+    );
   }
   await assertDoctorPreflightAllowsRestart(service);
 
@@ -420,20 +568,27 @@ export async function restartService(
   }
   revokeServiceScopedBrokerIdentities(serviceId);
 
-  const sharedGlobalEnv = registry ? collectRuntimeGlobalEnv(registry.list()) : {};
+  const sharedGlobalEnv = registry
+    ? collectRuntimeGlobalEnv(registry.list())
+    : {};
   const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
-  const resolvedPorts = Object.keys(current.runtime.ports).length > 0
-    ? current.runtime.ports
-    : registry
-      ? await negotiateServicePorts(service, registry.list())
-      : {};
+  const resolvedPorts =
+    Object.keys(current.runtime.ports).length > 0
+      ? current.runtime.ports
+      : registry
+        ? await negotiateServicePorts(service, registry.list())
+        : {};
+  const variableResolution = await resolveLaunchVariableResolution(
+    service,
+    options,
+  );
   const handle = await startManagedProcess({
     service,
     executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
     secureEnv: scopedBrokerIdentity?.env,
-    variableResolution: options.variableResolution,
+    variableResolution,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;
@@ -470,7 +625,8 @@ export async function restartService(
   if (!readiness.ready) {
     const stopped = await stopManagedProcess(serviceId);
     const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId);
-    const revokedIdentity = revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
+    const revokedIdentity =
+      revokedIdentities.at(-1) ?? scopedBrokerIdentity?.metadata ?? null;
     const failedResult = applyState(
       serviceId,
       "restart",
@@ -484,7 +640,11 @@ export async function restartService(
             finishedAt: new Date().toISOString(),
             exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
             lastTermination: "stopped",
-            metrics: applyRunCompletionMetrics(state, new Date().toISOString(), "stopped"),
+            metrics: applyRunCompletionMetrics(
+              state,
+              new Date().toISOString(),
+              "stopped",
+            ),
             brokerIdentity: revokedIdentity,
           },
         },
@@ -492,13 +652,15 @@ export async function restartService(
       }),
       false,
     );
-    await appendServiceRecoveryHistoryEvents(service, [{
-      kind: "restart",
-      serviceId,
-      ok: false,
-      message: failedResult.message,
-      at: new Date().toISOString(),
-    }]);
+    await appendServiceRecoveryHistoryEvents(service, [
+      {
+        kind: "restart",
+        serviceId,
+        ok: false,
+        message: failedResult.message,
+        at: new Date().toISOString(),
+      },
+    ]);
     return failedResult;
   }
 
@@ -521,12 +683,14 @@ export async function restartService(
     },
     message: readiness.message.replace(/^Start/, "Restart"),
   }));
-  await appendServiceRecoveryHistoryEvents(service, [{
-    kind: "restart",
-    serviceId,
-    ok: result.ok,
-    message: result.message,
-    at: new Date().toISOString(),
-  }]);
+  await appendServiceRecoveryHistoryEvents(service, [
+    {
+      kind: "restart",
+      serviceId,
+      ok: result.ok,
+      message: result.message,
+      at: new Date().toISOString(),
+    },
+  ]);
   return result;
 }

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -44,7 +44,14 @@ interface CachedSelectorPlan {
   plan: ServiceSelectorPlan;
 }
 
-export type ServiceSelectorDiagnosticReason = "unresolved-local" | "missing-broker" | "denied-broker" | "source-auth-required";
+export type ServiceSelectorDiagnosticReason =
+  | "unresolved-local"
+  | "missing-broker"
+  | "locked-broker"
+  | "denied-broker"
+  | "source-auth-required"
+  | "source-unavailable"
+  | "degraded-broker";
 
 export interface ServiceSelectorDiagnostic {
   selector: string;
@@ -57,7 +64,10 @@ export interface ServiceTextResolutionOptions {
   diagnostics?: ServiceSelectorDiagnostic[];
   allowedBrokerRefs?: Set<string> | string[];
   deniedBrokerRefs?: Set<string> | string[];
+  lockedBrokerRefs?: Set<string> | string[];
   sourceAuthRequiredBrokerRefs?: Set<string> | string[];
+  sourceUnavailableBrokerRefs?: Set<string> | string[];
+  degradedBrokerRefs?: Set<string> | string[];
 }
 
 export interface ServiceVariableResolutionOptions extends ServiceTextResolutionOptions {}
@@ -69,7 +79,10 @@ export interface ServiceVariablesPayload {
   diagnostics: ServiceSelectorDiagnostic[];
 }
 
-const compiledTemplateCache = new Map<string, CompiledServiceSelectorTemplate>();
+const compiledTemplateCache = new Map<
+  string,
+  CompiledServiceSelectorTemplate
+>();
 const selectorPlanCache = new Map<string, CachedSelectorPlan>();
 const selectorPlanCacheStats = {
   planHits: 0,
@@ -97,11 +110,16 @@ export function getServiceSelectorPlanCacheStats(): ServiceSelectorPlanCacheStat
   };
 }
 
-function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVariableEntry[] {
+function buildPortVariables(
+  resolvedPorts: Record<string, number>,
+): ServiceVariableEntry[] {
   const entries: ServiceVariableEntry[] = [];
 
   for (const [name, value] of Object.entries(resolvedPorts)) {
-    const normalizedName = name.trim().replace(/[^A-Za-z0-9]+/g, "_").toUpperCase();
+    const normalizedName = name
+      .trim()
+      .replace(/[^A-Za-z0-9]+/g, "_")
+      .toUpperCase();
     entries.push({
       key: `${normalizedName}_PORT`,
       value: String(value),
@@ -149,7 +167,9 @@ function createSelectorRef(selector: string): ServiceSelectorRef {
   };
 }
 
-function compileServiceSelectorTemplate(value: string): CompiledServiceSelectorTemplate {
+function compileServiceSelectorTemplate(
+  value: string,
+): CompiledServiceSelectorTemplate {
   const cached = compiledTemplateCache.get(value);
   if (cached) {
     selectorPlanCacheStats.templateHits += 1;
@@ -184,7 +204,9 @@ function compileServiceSelectorTemplate(value: string): CompiledServiceSelectorT
   return compiled;
 }
 
-function fingerprintSelectorValues(values: string[] | Record<string, string>): string {
+function fingerprintSelectorValues(
+  values: string[] | Record<string, string>,
+): string {
   if (Array.isArray(values)) {
     return JSON.stringify({ kind: "array", values });
   }
@@ -219,7 +241,9 @@ export function compileCachedServiceSelectorPlan(
   return plan;
 }
 
-export function compileServiceSelectorPlan(values: string[] | Record<string, string>): ServiceSelectorPlan {
+export function compileServiceSelectorPlan(
+  values: string[] | Record<string, string>,
+): ServiceSelectorPlan {
   const texts = Array.isArray(values) ? values : Object.values(values);
   const selectors = new Map<string, ServiceSelectorRef>();
 
@@ -232,8 +256,12 @@ export function compileServiceSelectorPlan(values: string[] | Record<string, str
   const orderedSelectors = [...selectors.values()];
   return {
     selectors: orderedSelectors,
-    localRefs: orderedSelectors.filter((selector) => selector.kind === "local").map((selector) => selector.key),
-    brokerRefs: orderedSelectors.filter((selector) => selector.kind === "broker").map((selector) => selector.selector),
+    localRefs: orderedSelectors
+      .filter((selector) => selector.kind === "local")
+      .map((selector) => selector.key),
+    brokerRefs: orderedSelectors
+      .filter((selector) => selector.kind === "broker")
+      .map((selector) => selector.selector),
   };
 }
 
@@ -248,12 +276,19 @@ function mergeSelectorPlans(plans: ServiceSelectorPlan[]): ServiceSelectorPlan {
   const orderedSelectors = [...selectors.values()];
   return {
     selectors: orderedSelectors,
-    localRefs: orderedSelectors.filter((selector) => selector.kind === "local").map((selector) => selector.key),
-    brokerRefs: orderedSelectors.filter((selector) => selector.kind === "broker").map((selector) => selector.selector),
+    localRefs: orderedSelectors
+      .filter((selector) => selector.kind === "local")
+      .map((selector) => selector.key),
+    brokerRefs: orderedSelectors
+      .filter((selector) => selector.kind === "broker")
+      .map((selector) => selector.selector),
   };
 }
 
-function hasRef(refs: Set<string> | string[] | undefined, ref: string): boolean {
+function hasRef(
+  refs: Set<string> | string[] | undefined,
+  ref: string,
+): boolean {
   if (!refs) {
     return false;
   }
@@ -274,29 +309,76 @@ function replaceVariableSelectors(
 
       const { raw, ref } = token;
       if (ref.kind === "broker") {
-        if (options.allowedBrokerRefs && !hasRef(options.allowedBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+        if (
+          options.allowedBrokerRefs &&
+          !hasRef(options.allowedBrokerRefs, ref.selector)
+        ) {
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "denied-broker",
+          });
           return raw;
         }
         if (hasRef(options.deniedBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "denied-broker" });
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "denied-broker",
+          });
+          return raw;
+        }
+        if (hasRef(options.lockedBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "locked-broker",
+          });
           return raw;
         }
         if (hasRef(options.sourceAuthRequiredBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "source-auth-required" });
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "source-auth-required",
+          });
+          return raw;
+        }
+        if (hasRef(options.sourceUnavailableBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "source-unavailable",
+          });
+          return raw;
+        }
+        if (hasRef(options.degradedBrokerRefs, ref.selector)) {
+          options.diagnostics?.push({
+            selector: ref.selector,
+            kind: "broker",
+            reason: "degraded-broker",
+          });
           return raw;
         }
         const brokerValue = options.brokerValues?.[ref.selector];
         if (brokerValue !== undefined) {
           return brokerValue;
         }
-        options.diagnostics?.push({ selector: ref.selector, kind: "broker", reason: "missing-broker" });
+        options.diagnostics?.push({
+          selector: ref.selector,
+          kind: "broker",
+          reason: "missing-broker",
+        });
         return raw;
       }
 
       const entry = variables.find((candidate) => candidate.key === ref.key);
       if (!entry) {
-        options.diagnostics?.push({ selector: ref.selector, kind: "local", reason: "unresolved-local" });
+        options.diagnostics?.push({
+          selector: ref.selector,
+          kind: "local",
+          reason: "unresolved-local",
+        });
       }
       return entry ? entry.value : raw;
     })
@@ -310,19 +392,24 @@ export function buildServiceVariables(
   options: ServiceVariableResolutionOptions = {},
 ): ServiceVariablesPayload {
   const statePaths = getServiceStatePaths(service.serviceRoot);
-  const installArtifact = getLifecycleState(service.manifest.id).installArtifacts.artifact;
+  const installArtifact = getLifecycleState(service.manifest.id)
+    .installArtifacts.artifact;
   const executableHome = installArtifact?.extractedPath ?? service.serviceRoot;
-  const rawManifestVariables = Object.entries(service.manifest.env ?? {}).map(([key, value]) => ({
-    key,
-    value,
-    scope: "manifest" as const,
-  }));
+  const rawManifestVariables = Object.entries(service.manifest.env ?? {}).map(
+    ([key, value]) => ({
+      key,
+      value,
+      scope: "manifest" as const,
+    }),
+  );
 
-  const globalVariables = Object.entries(sharedGlobalEnv).map(([key, value]) => ({
-    key,
-    value,
-    scope: "global" as const,
-  }));
+  const globalVariables = Object.entries(sharedGlobalEnv).map(
+    ([key, value]) => ({
+      key,
+      value,
+      scope: "global" as const,
+    }),
+  );
 
   const derivedVariables: ServiceVariableEntry[] = [
     {
@@ -363,7 +450,10 @@ export function buildServiceVariables(
       ? [
           {
             key: "SERVICE_ARTIFACT_COMMAND",
-            value: path.resolve(installArtifact.extractedPath, installArtifact.command),
+            value: path.resolve(
+              installArtifact.extractedPath,
+              installArtifact.command,
+            ),
             scope: "derived" as const,
           },
         ]
@@ -372,8 +462,11 @@ export function buildServiceVariables(
   ];
 
   const manifestDiagnostics: ServiceSelectorDiagnostic[] = [];
-  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
-  const allowedBrokerRefs = declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined;
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map(
+    (entry) => entry.ref,
+  );
+  const allowedBrokerRefs =
+    declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined;
   const brokerResolutionOptions: ServiceTextResolutionOptions = {
     ...options,
     allowedBrokerRefs,
@@ -381,24 +474,66 @@ export function buildServiceVariables(
   };
   const manifestVariables = rawManifestVariables.map((entry) => ({
     ...entry,
-    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables], brokerResolutionOptions),
+    value: replaceVariableSelectors(
+      entry.value,
+      [...rawManifestVariables, ...globalVariables, ...derivedVariables],
+      brokerResolutionOptions,
+    ),
   }));
 
-  const manifestVariableKeys = new Set(manifestVariables.map((entry) => entry.key));
+  const manifestVariableKeys = new Set(
+    manifestVariables.map((entry) => entry.key),
+  );
   const brokerImportVariables = (service.manifest.broker?.imports ?? [])
     .filter((entry) => entry.as && !manifestVariableKeys.has(entry.as))
     .flatMap((entry): ServiceVariableEntry[] => {
       if (hasRef(options.deniedBrokerRefs, entry.ref)) {
-        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "denied-broker" });
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "denied-broker",
+        });
+        return [];
+      }
+      if (hasRef(options.lockedBrokerRefs, entry.ref)) {
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "locked-broker",
+        });
         return [];
       }
       if (hasRef(options.sourceAuthRequiredBrokerRefs, entry.ref)) {
-        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "source-auth-required" });
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "source-auth-required",
+        });
+        return [];
+      }
+      if (hasRef(options.sourceUnavailableBrokerRefs, entry.ref)) {
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "source-unavailable",
+        });
+        return [];
+      }
+      if (hasRef(options.degradedBrokerRefs, entry.ref)) {
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "degraded-broker",
+        });
         return [];
       }
       const brokerValue = options.brokerValues?.[entry.ref];
       if (brokerValue === undefined) {
-        manifestDiagnostics.push({ selector: entry.ref, kind: "broker", reason: "missing-broker" });
+        manifestDiagnostics.push({
+          selector: entry.ref,
+          kind: "broker",
+          reason: "missing-broker",
+        });
         return [];
       }
       return [{ key: entry.as as string, value: brokerValue, scope: "broker" }];
@@ -406,7 +541,12 @@ export function buildServiceVariables(
 
   return {
     serviceId: service.manifest.id,
-    variables: [...manifestVariables, ...brokerImportVariables, ...globalVariables, ...derivedVariables],
+    variables: [
+      ...manifestVariables,
+      ...brokerImportVariables,
+      ...globalVariables,
+      ...derivedVariables,
+    ],
     selectorPlan: compileCachedServiceSelectorPlan(
       `service:${service.manifestPath}:${service.manifest.id}:env`,
       service.manifest.env ?? {},
@@ -420,16 +560,25 @@ export function collectServiceGlobalEnv(
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
 ): Record<string, string> {
-  const variablesPayload = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts);
+  const variablesPayload = buildServiceVariables(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+  );
   const variables = variablesPayload.variables;
   const configuredGlobalEnv = service.manifest.globalenv ?? {};
 
   return Object.fromEntries(
-    Object.entries(configuredGlobalEnv).map(([key, value]) => [key, replaceVariableSelectors(value, variables)]),
+    Object.entries(configuredGlobalEnv).map(([key, value]) => [
+      key,
+      replaceVariableSelectors(value, variables),
+    ]),
   );
 }
 
-export function compileServiceMaterializationSelectorPlan(service: DiscoveredService): ServiceSelectorPlan {
+export function compileServiceMaterializationSelectorPlan(
+  service: DiscoveredService,
+): ServiceSelectorPlan {
   const installFiles = service.manifest.install?.files ?? [];
   const configFiles = service.manifest.config?.files ?? [];
   const cacheKey = `service:${service.manifestPath}:${service.manifest.id}:materialization`;
@@ -455,15 +604,26 @@ export function compileServiceMaterializationSelectorPlan(service: DiscoveredSer
 
   selectorPlanCacheStats.planMisses += 1;
   const plan = mergeSelectorPlans([
-    compileCachedServiceSelectorPlan(`${cacheKey}:env`, service.manifest.env ?? {}),
-    compileCachedServiceSelectorPlan(`${cacheKey}:globalenv`, service.manifest.globalenv ?? {}),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:env`,
+      service.manifest.env ?? {},
+    ),
+    compileCachedServiceSelectorPlan(
+      `${cacheKey}:globalenv`,
+      service.manifest.globalenv ?? {},
+    ),
     compileCachedServiceSelectorPlan(
       `${cacheKey}:broker-imports`,
-      (service.manifest.broker?.imports ?? []).map((entry) => `\${${entry.ref}}`),
+      (service.manifest.broker?.imports ?? []).map(
+        (entry) => `\${${entry.ref}}`,
+      ),
     ),
     compileCachedServiceSelectorPlan(
       `${cacheKey}:broker-exports`,
-      (service.manifest.broker?.exports ?? []).flatMap((entry) => [`\${${entry.ref}}`, entry.source]),
+      (service.manifest.broker?.exports ?? []).flatMap((entry) => [
+        `\${${entry.ref}}`,
+        entry.source,
+      ]),
     ),
     compileCachedServiceSelectorPlan(
       `${cacheKey}:install`,
@@ -486,21 +646,37 @@ export function resolveServiceText(
   resolvedPorts: Record<string, number> = {},
   options: ServiceTextResolutionOptions = {},
 ): string {
-  const variablesPayload = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts, options);
-  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
+  const variablesPayload = buildServiceVariables(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+    options,
+  );
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map(
+    (entry) => entry.ref,
+  );
   return replaceVariableSelectors(value, variablesPayload.variables, {
     ...options,
-    allowedBrokerRefs: declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined,
+    allowedBrokerRefs:
+      declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined,
   });
 }
 
-export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<string, string> {
+export function collectRuntimeGlobalEnv(
+  services: DiscoveredService[],
+): Record<string, string> {
   const sharedGlobalEnv: Record<string, string> = {};
 
   for (const service of services) {
     const state = getLifecycleState(service.manifest.id);
-    const resolvedPorts = Object.keys(state.runtime.ports).length > 0 ? state.runtime.ports : service.manifest.ports ?? {};
-    Object.assign(sharedGlobalEnv, collectServiceGlobalEnv(service, sharedGlobalEnv, resolvedPorts));
+    const resolvedPorts =
+      Object.keys(state.runtime.ports).length > 0
+        ? state.runtime.ports
+        : (service.manifest.ports ?? {});
+    Object.assign(
+      sharedGlobalEnv,
+      collectServiceGlobalEnv(service, sharedGlobalEnv, resolvedPorts),
+    );
   }
 
   return sharedGlobalEnv;
@@ -516,5 +692,9 @@ export function resolveServiceVariable(
   if (ref.kind === "broker") {
     return undefined;
   }
-  return buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.find((entry) => entry.key === ref.key);
+  return buildServiceVariables(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+  ).variables.find((entry) => entry.key === ref.key);
 }

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -3,9 +3,19 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { readFile, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import {
+  installService,
+  configService,
+  startService,
+} from "../dist/runtime/lifecycle/actions.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
-import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+import {
+  makeTempServicesRoot,
+  writeExecutableFixtureService,
+} from "./test-helpers.js";
 
 async function postJson(url) {
   const response = await fetch(url, { method: "POST" });
@@ -28,37 +38,49 @@ async function waitFor(predicate, timeoutMs = 1_000) {
 
 test("lifecycle actions execute in the expected bounded order", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
   await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    const install = await postJson(`${apiServer.url}/api/services/echo-service/install`);
+    const install = await postJson(
+      `${apiServer.url}/api/services/echo-service/install`,
+    );
     assert.equal(install.status, 200);
     assert.equal(install.body.action, "install");
     assert.equal(install.body.state.installed, true);
     assert.equal(install.body.state.configured, false);
     assert.equal(install.body.state.running, false);
 
-    const config = await postJson(`${apiServer.url}/api/services/echo-service/config`);
+    const config = await postJson(
+      `${apiServer.url}/api/services/echo-service/config`,
+    );
     assert.equal(config.status, 200);
     assert.equal(config.body.action, "config");
     assert.equal(config.body.state.configured, true);
 
-    const start = await postJson(`${apiServer.url}/api/services/echo-service/start`);
+    const start = await postJson(
+      `${apiServer.url}/api/services/echo-service/start`,
+    );
     assert.equal(start.status, 200);
     assert.equal(start.body.action, "start");
     assert.equal(start.body.state.running, true);
     assert.equal(start.body.state.runtime.pid > 0, true);
     assert.equal(typeof start.body.state.runtime.command, "string");
 
-    const restart = await postJson(`${apiServer.url}/api/services/echo-service/restart`);
+    const restart = await postJson(
+      `${apiServer.url}/api/services/echo-service/restart`,
+    );
     assert.equal(restart.status, 200);
     assert.equal(restart.body.action, "restart");
     assert.equal(restart.body.state.running, true);
     assert.equal(restart.body.state.runtime.pid > 0, true);
 
-    const stop = await postJson(`${apiServer.url}/api/services/echo-service/stop`);
+    const stop = await postJson(
+      `${apiServer.url}/api/services/echo-service/stop`,
+    );
     assert.equal(stop.status, 200);
     assert.equal(stop.body.action, "stop");
     assert.equal(stop.body.state.running, false);
@@ -66,12 +88,20 @@ test("lifecycle actions execute in the expected bounded order", async () => {
 
     let detailBody;
     await waitFor(async () => {
-      const detailResponse = await fetch(`${apiServer.url}/api/services/echo-service`);
+      const detailResponse = await fetch(
+        `${apiServer.url}/api/services/echo-service`,
+      );
       detailBody = await detailResponse.json();
       return detailBody.service.lifecycle.runtime.exitCode === 0;
     });
 
-    assert.deepEqual(detailBody.service.lifecycle.actionHistory, ["install", "config", "start", "restart", "stop"]);
+    assert.deepEqual(detailBody.service.lifecycle.actionHistory, [
+      "install",
+      "config",
+      "start",
+      "restart",
+      "stop",
+    ]);
     assert.equal(detailBody.service.lifecycle.lastAction, "stop");
     assert.equal(detailBody.service.lifecycle.runtime.exitCode, 0);
   } finally {
@@ -83,47 +113,71 @@ test("lifecycle actions execute in the expected bounded order", async () => {
 
 test("install and config materialize bounded on-disk artifacts and persist them in lifecycle state", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
-  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "materialized-service", {
-    ports: {
-      service: 41234,
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "materialized-service",
+    {
+      ports: {
+        service: 41234,
+      },
+      install: {
+        files: [
+          {
+            path: "./runtime/install.txt",
+            content: "installed ${SERVICE_ID}",
+          },
+        ],
+      },
+      config: {
+        files: [
+          {
+            path: "./runtime/config.env",
+            content:
+              "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ROOT=${SERVICE_ROOT}\n",
+          },
+        ],
+      },
     },
-    install: {
-      files: [
-        {
-          path: "./runtime/install.txt",
-          content: "installed ${SERVICE_ID}",
-        },
-      ],
-    },
-    config: {
-      files: [
-        {
-          path: "./runtime/config.env",
-          content: "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ROOT=${SERVICE_ROOT}\n",
-        },
-      ],
-    },
-  });
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    const install = await postJson(`${apiServer.url}/api/services/materialized-service/install`);
-    const config = await postJson(`${apiServer.url}/api/services/materialized-service/config`);
+    const install = await postJson(
+      `${apiServer.url}/api/services/materialized-service/install`,
+    );
+    const config = await postJson(
+      `${apiServer.url}/api/services/materialized-service/config`,
+    );
 
     const installPath = path.join(serviceRoot, "runtime", "install.txt");
     const configPath = path.join(serviceRoot, "runtime", "config.env");
     const stored = await readStoredState(serviceRoot);
 
     assert.equal(install.status, 200);
-    assert.deepEqual(install.body.state.installArtifacts.files, ["runtime/install.txt"]);
-    assert.equal(typeof install.body.state.installArtifacts.updatedAt, "string");
-    assert.equal(await readFile(installPath, "utf8"), "installed materialized-service");
+    assert.deepEqual(install.body.state.installArtifacts.files, [
+      "runtime/install.txt",
+    ]);
+    assert.equal(
+      typeof install.body.state.installArtifacts.updatedAt,
+      "string",
+    );
+    assert.equal(
+      await readFile(installPath, "utf8"),
+      "installed materialized-service",
+    );
 
     assert.equal(config.status, 200);
-    assert.deepEqual(config.body.state.configArtifacts.files, ["runtime/config.env"]);
+    assert.deepEqual(config.body.state.configArtifacts.files, [
+      "runtime/config.env",
+    ]);
     assert.equal(typeof config.body.state.configArtifacts.updatedAt, "string");
-    assert.equal(await readFile(configPath, "utf8"), `SERVICE_PORT=41234\nSERVICE_ROOT=${serviceRoot}\n`);
+    assert.equal(
+      await readFile(configPath, "utf8"),
+      `SERVICE_PORT=41234\nSERVICE_ROOT=${serviceRoot}\n`,
+    );
     assert.deepEqual(stored.install.files, ["runtime/install.txt"]);
     assert.deepEqual(stored.config.files, ["runtime/config.env"]);
   } finally {
@@ -135,41 +189,67 @@ test("install and config materialize bounded on-disk artifacts and persist them 
 
 test("config can rerun without reinstall and rewrites effective config artifacts", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
-  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "rerunnable-config-service", {
-    ports: {
-      service: 41235,
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "rerunnable-config-service",
+    {
+      ports: {
+        service: 41235,
+      },
+      config: {
+        files: [
+          {
+            path: "./runtime/config.env",
+            content: "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ID=${SERVICE_ID}\n",
+          },
+        ],
+      },
     },
-    config: {
-      files: [
-        {
-          path: "./runtime/config.env",
-          content: "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ID=${SERVICE_ID}\n",
-        },
-      ],
-    },
-  });
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    await postJson(`${apiServer.url}/api/services/rerunnable-config-service/install`);
+    await postJson(
+      `${apiServer.url}/api/services/rerunnable-config-service/install`,
+    );
 
-    const firstConfig = await postJson(`${apiServer.url}/api/services/rerunnable-config-service/config`);
+    const firstConfig = await postJson(
+      `${apiServer.url}/api/services/rerunnable-config-service/config`,
+    );
     await new Promise((resolve) => setTimeout(resolve, 20));
-    const secondConfig = await postJson(`${apiServer.url}/api/services/rerunnable-config-service/config`);
+    const secondConfig = await postJson(
+      `${apiServer.url}/api/services/rerunnable-config-service/config`,
+    );
 
     const configPath = path.join(serviceRoot, "runtime", "config.env");
-    const detailResponse = await fetch(`${apiServer.url}/api/services/rerunnable-config-service`);
+    const detailResponse = await fetch(
+      `${apiServer.url}/api/services/rerunnable-config-service`,
+    );
     const detailBody = await detailResponse.json();
 
     assert.equal(firstConfig.status, 200);
     assert.equal(secondConfig.status, 200);
     assert.equal(secondConfig.body.state.configured, true);
-    assert.deepEqual(secondConfig.body.state.actionHistory, ["install", "config", "config"]);
-    assert.equal(await readFile(configPath, "utf8"), "SERVICE_PORT=41235\nSERVICE_ID=rerunnable-config-service\n");
+    assert.deepEqual(secondConfig.body.state.actionHistory, [
+      "install",
+      "config",
+      "config",
+    ]);
+    assert.equal(
+      await readFile(configPath, "utf8"),
+      "SERVICE_PORT=41235\nSERVICE_ID=rerunnable-config-service\n",
+    );
     assert.equal(detailResponse.status, 200);
-    assert.deepEqual(detailBody.service.lifecycle.configArtifacts.files, ["runtime/config.env"]);
-    assert.equal(typeof detailBody.service.lifecycle.configArtifacts.updatedAt, "string");
+    assert.deepEqual(detailBody.service.lifecycle.configArtifacts.files, [
+      "runtime/config.env",
+    ]);
+    assert.equal(
+      typeof detailBody.service.lifecycle.configArtifacts.updatedAt,
+      "string",
+    );
   } finally {
     await apiServer.stop();
     resetLifecycleState();
@@ -179,8 +259,13 @@ test("config can rerun without reinstall and rewrites effective config artifacts
 
 test("intentional stop keeps persisted lifecycle metadata on stop", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
-  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "echo-service");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "echo-service",
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -188,17 +273,26 @@ test("intentional stop keeps persisted lifecycle metadata on stop", async () => 
     await postJson(`${apiServer.url}/api/services/echo-service/config`);
     await postJson(`${apiServer.url}/api/services/echo-service/start`);
 
-    const stop = await postJson(`${apiServer.url}/api/services/echo-service/stop`);
+    const stop = await postJson(
+      `${apiServer.url}/api/services/echo-service/stop`,
+    );
     assert.equal(stop.status, 200);
 
     await waitFor(async () => {
       const stored = await readStoredState(serviceRoot);
-      return stored.runtime.lastAction === "stop" && stored.runtime.running === false;
+      return (
+        stored.runtime.lastAction === "stop" && stored.runtime.running === false
+      );
     });
 
     const stored = await readStoredState(serviceRoot);
     assert.equal(stored.runtime.lastAction, "stop");
-    assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "start", "stop"]);
+    assert.deepEqual(stored.runtime.actionHistory, [
+      "install",
+      "config",
+      "start",
+      "stop",
+    ]);
     assert.equal(stored.runtime.running, false);
     assert.equal(stored.runtime.lastTermination, "stopped");
     assert.equal(typeof stored.runtime.finishedAt, "string");
@@ -211,15 +305,24 @@ test("intentional stop keeps persisted lifecycle metadata on stop", async () => 
 
 test("restart replaces the running process and clears stale termination evidence", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
-  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "restart-service");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "restart-service",
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
     await postJson(`${apiServer.url}/api/services/restart-service/install`);
     await postJson(`${apiServer.url}/api/services/restart-service/config`);
-    const start = await postJson(`${apiServer.url}/api/services/restart-service/start`);
-    const restart = await postJson(`${apiServer.url}/api/services/restart-service/restart`);
+    const start = await postJson(
+      `${apiServer.url}/api/services/restart-service/start`,
+    );
+    const restart = await postJson(
+      `${apiServer.url}/api/services/restart-service/restart`,
+    );
 
     const stored = await readStoredState(serviceRoot);
 
@@ -228,12 +331,20 @@ test("restart replaces the running process and clears stale termination evidence
     assert.equal(restart.body.state.running, true);
     assert.equal(restart.body.state.lastAction, "restart");
     assert.equal(restart.body.state.runtime.pid > 0, true);
-    assert.notEqual(restart.body.state.runtime.pid, start.body.state.runtime.pid);
+    assert.notEqual(
+      restart.body.state.runtime.pid,
+      start.body.state.runtime.pid,
+    );
     assert.equal(restart.body.state.runtime.finishedAt, null);
     assert.equal(restart.body.state.runtime.lastTermination, null);
     assert.equal(stored.runtime.running, true);
     assert.equal(stored.runtime.lastAction, "restart");
-    assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "start", "restart"]);
+    assert.deepEqual(stored.runtime.actionHistory, [
+      "install",
+      "config",
+      "start",
+      "restart",
+    ]);
     assert.equal(stored.runtime.finishedAt, null);
     assert.equal(stored.runtime.lastTermination, null);
   } finally {
@@ -243,17 +354,75 @@ test("restart replaces the running process and clears stale termination evidence
   }
 });
 
+test("start blocks required broker failures with safe ref and status metadata", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-startup-broker-fail-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "broker-gated", {
+    env: {
+      DB_PASSWORD: "${database.PASSWORD}",
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+          required: true,
+        },
+      ],
+    },
+  });
+
+  try {
+    const discovered = await discoverServices(servicesRoot);
+    const registry = createServiceRegistry(discovered);
+    const service = registry.getById("broker-gated");
+    assert.ok(service);
+
+    await installService(service, registry);
+    await configService(service, registry);
+    await assert.rejects(
+      () =>
+        startService(service, registry, {
+          brokerLookup: () => [
+            {
+              ref: "database.PASSWORD",
+              status: "policy-denied",
+              value: "raw-secret-must-not-leak",
+            },
+          ],
+        }),
+      (error) => {
+        assert.match(error.message, /database\.PASSWORD:policy-denied/);
+        assert.equal(error.message.includes("raw-secret-must-not-leak"), false);
+        return true;
+      },
+    );
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("start fails before config and keeps the error explicit", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
   await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    const install = await postJson(`${apiServer.url}/api/services/echo-service/install`);
+    const install = await postJson(
+      `${apiServer.url}/api/services/echo-service/install`,
+    );
     assert.equal(install.status, 200);
 
-    const start = await postJson(`${apiServer.url}/api/services/echo-service/start`);
+    const start = await postJson(
+      `${apiServer.url}/api/services/echo-service/start`,
+    );
     assert.equal(start.status, 409);
     assert.equal(start.body.error, "invalid_lifecycle_state");
     assert.equal(start.body.statusCode, 409);
@@ -267,12 +436,16 @@ test("start fails before config and keeps the error explicit", async () => {
 
 test("unknown lifecycle actions return a deterministic client error", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
   await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    const response = await postJson(`${apiServer.url}/api/services/echo-service/ship-it`);
+    const response = await postJson(
+      `${apiServer.url}/api/services/echo-service/ship-it`,
+    );
 
     assert.equal(response.status, 400);
     assert.equal(response.body.error, "invalid_action");
@@ -287,7 +460,9 @@ test("unknown lifecycle actions return a deterministic client error", async () =
 
 test("runtime summary reflects running services after lifecycle actions", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
   await writeExecutableFixtureService(servicesRoot, "echo-service");
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
@@ -310,7 +485,9 @@ test("runtime summary reflects running services after lifecycle actions", async 
 
 test("start waits for configured readiness and returns healthy once ready", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
   await writeExecutableFixtureService(servicesRoot, "ready-file-service", {
     readyFileAfterMs: 120,
     readyFileRelativePath: "./runtime/ready.txt",
@@ -329,7 +506,9 @@ test("start waits for configured readiness and returns healthy once ready", asyn
     await postJson(`${apiServer.url}/api/services/ready-file-service/config`);
 
     const startedAt = Date.now();
-    const start = await postJson(`${apiServer.url}/api/services/ready-file-service/start`);
+    const start = await postJson(
+      `${apiServer.url}/api/services/ready-file-service/start`,
+    );
     const elapsedMs = Date.now() - startedAt;
 
     assert.equal(start.status, 200);
@@ -348,23 +527,31 @@ test("start waits for configured readiness and returns healthy once ready", asyn
 
 test("start returns a deterministic non-ready result when readiness times out", async () => {
   resetLifecycleState();
-  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-lifecycle-");
-  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "not-ready-service", {
-    healthcheck: {
-      type: "file",
-      file: "./runtime/ready.txt",
-      retries: 3,
-      interval: 25,
-      start_period: 10,
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "not-ready-service",
+    {
+      healthcheck: {
+        type: "file",
+        file: "./runtime/ready.txt",
+        retries: 3,
+        interval: 25,
+        start_period: 10,
+      },
     },
-  });
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
     await postJson(`${apiServer.url}/api/services/not-ready-service/install`);
     await postJson(`${apiServer.url}/api/services/not-ready-service/config`);
 
-    const start = await postJson(`${apiServer.url}/api/services/not-ready-service/start`);
+    const start = await postJson(
+      `${apiServer.url}/api/services/not-ready-service/start`,
+    );
 
     assert.equal(start.status, 200);
     assert.equal(start.body.ok, false);
@@ -378,7 +565,11 @@ test("start returns a deterministic non-ready result when readiness times out", 
     const stored = await readStoredState(serviceRoot);
     assert.equal(stored.runtime.lastAction, "start");
     assert.equal(stored.runtime.running, false);
-    assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "start"]);
+    assert.deepEqual(stored.runtime.actionHistory, [
+      "install",
+      "config",
+      "start",
+    ]);
   } finally {
     await apiServer.stop();
     resetLifecycleState();

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -13,12 +13,22 @@ import {
   resolveServiceText,
   resolveServiceVariable,
 } from "../dist/runtime/operator/variables.js";
+import {
+  compileServiceStartupBrokerPlan,
+  resolveServiceStartupBrokerResolution,
+  summarizeRequiredStartupBrokerFailures,
+} from "../dist/runtime/broker/launch-resolution.js";
 import { materializeConfigArtifacts } from "../dist/runtime/setup/materialize.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 
 function fixtureService(overrides = {}) {
   return {
-    manifestPath: path.join(process.cwd(), "services", "consumer", "service.json"),
+    manifestPath: path.join(
+      process.cwd(),
+      "services",
+      "consumer",
+      "service.json",
+    ),
     serviceRoot: path.join(process.cwd(), "services", "consumer"),
     manifest: {
       id: "consumer",
@@ -33,13 +43,22 @@ function fixtureService(overrides = {}) {
 test("selector planning classifies local and broker selectors and deduplicates broker refs", () => {
   const plan = compileServiceSelectorPlan({
     local: "${SERVICE_ROOT}:${LOCAL_ONLY}",
-    secret: "${secretsbroker.API_KEY}:${secretsbroker.API_KEY}:${vault.database.password}",
+    secret:
+      "${secretsbroker.API_KEY}:${secretsbroker.API_KEY}:${vault.database.password}",
   });
 
   assert.deepEqual(plan.localRefs, ["SERVICE_ROOT", "LOCAL_ONLY"]);
-  assert.deepEqual(plan.brokerRefs, ["secretsbroker.API_KEY", "vault.database.password"]);
+  assert.deepEqual(plan.brokerRefs, [
+    "secretsbroker.API_KEY",
+    "vault.database.password",
+  ]);
   assert.deepEqual(
-    plan.selectors.map((selector) => [selector.selector, selector.kind, selector.namespace ?? null, selector.key]),
+    plan.selectors.map((selector) => [
+      selector.selector,
+      selector.kind,
+      selector.namespace ?? null,
+      selector.key,
+    ]),
     [
       ["SERVICE_ROOT", "local", null, "SERVICE_ROOT"],
       ["LOCAL_ONLY", "local", null, "LOCAL_ONLY"],
@@ -61,11 +80,21 @@ test("service variable resolution preserves local precedence and legacy globalen
     ports: { service: 4310 },
   });
 
-  const payload = buildServiceVariables(service, { SHARED_VALUE: "global", LEGACY_TOOL_HOME: "C:/tools/legacy" });
-  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry.value]));
+  const payload = buildServiceVariables(service, {
+    SHARED_VALUE: "global",
+    LEGACY_TOOL_HOME: "C:/tools/legacy",
+  });
+  const byKey = Object.fromEntries(
+    payload.variables.map((entry) => [entry.key, entry.value]),
+  );
 
   assert.equal(byKey.LOCAL_ONLY, "local");
-  assert.equal(resolveServiceVariable(service, "${SHARED_VALUE}", { SHARED_VALUE: "global" })?.value, "local-wins");
+  assert.equal(
+    resolveServiceVariable(service, "${SHARED_VALUE}", {
+      SHARED_VALUE: "global",
+    })?.value,
+    "local-wins",
+  );
   assert.equal(byKey.FROM_DERIVED, "consumer:4310");
   assert.equal(byKey.FROM_GLOBAL, "C:/tools/legacy");
 });
@@ -84,19 +113,35 @@ test("broker imports materialize to service-specific env names", () => {
         { namespace: "shared/database", kind: "shared" },
       ],
       imports: [
-        { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
-        { namespace: "services/consumer", ref: "consumer.API_TOKEN", as: "API_TOKEN" },
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+          required: true,
+        },
+        {
+          namespace: "services/consumer",
+          ref: "consumer.API_TOKEN",
+          as: "API_TOKEN",
+        },
       ],
     },
   });
 
-  const payload = buildServiceVariables(service, {}, {}, {
-    brokerValues: {
-      "database.PASSWORD": "resolved-password",
-      "consumer.API_TOKEN": "resolved-token",
+  const payload = buildServiceVariables(
+    service,
+    {},
+    {},
+    {
+      brokerValues: {
+        "database.PASSWORD": "resolved-password",
+        "consumer.API_TOKEN": "resolved-token",
+      },
     },
-  });
-  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry]));
+  );
+  const byKey = Object.fromEntries(
+    payload.variables.map((entry) => [entry.key, entry]),
+  );
 
   assert.deepEqual(payload.diagnostics, []);
   assert.equal(byKey.FROM_SELECTOR.value, "resolved-password");
@@ -117,24 +162,43 @@ test("broker selectors require explicit imports and report denied/source auth di
     },
     broker: {
       imports: [
-        { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" },
-        { namespace: "shared/database", ref: "database.DENIED", as: "DENIED_PASSWORD" },
-        { namespace: "shared/database", ref: "database.SOURCE_AUTH", as: "AUTH_PASSWORD" },
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+        },
+        {
+          namespace: "shared/database",
+          ref: "database.DENIED",
+          as: "DENIED_PASSWORD",
+        },
+        {
+          namespace: "shared/database",
+          ref: "database.SOURCE_AUTH",
+          as: "AUTH_PASSWORD",
+        },
       ],
     },
   });
 
-  const payload = buildServiceVariables(service, {}, {}, {
-    brokerValues: {
-      "database.PASSWORD": "resolved-password",
-      "vault.API_TOKEN": "should-not-leak",
-      "database.DENIED": "denied-secret",
-      "database.SOURCE_AUTH": "auth-secret",
+  const payload = buildServiceVariables(
+    service,
+    {},
+    {},
+    {
+      brokerValues: {
+        "database.PASSWORD": "resolved-password",
+        "vault.API_TOKEN": "should-not-leak",
+        "database.DENIED": "denied-secret",
+        "database.SOURCE_AUTH": "auth-secret",
+      },
+      deniedBrokerRefs: ["database.DENIED"],
+      sourceAuthRequiredBrokerRefs: ["database.SOURCE_AUTH"],
     },
-    deniedBrokerRefs: ["database.DENIED"],
-    sourceAuthRequiredBrokerRefs: ["database.SOURCE_AUTH"],
-  });
-  const byKey = Object.fromEntries(payload.variables.map((entry) => [entry.key, entry.value]));
+  );
+  const byKey = Object.fromEntries(
+    payload.variables.map((entry) => [entry.key, entry.value]),
+  );
 
   assert.equal(byKey.DECLARED, "resolved-password");
   assert.equal(byKey.UNDECLARED, "${vault.API_TOKEN}");
@@ -147,9 +211,17 @@ test("broker selectors require explicit imports and report denied/source auth di
   assert.deepEqual(payload.diagnostics, [
     { selector: "vault.API_TOKEN", kind: "broker", reason: "denied-broker" },
     { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
-    { selector: "database.SOURCE_AUTH", kind: "broker", reason: "source-auth-required" },
+    {
+      selector: "database.SOURCE_AUTH",
+      kind: "broker",
+      reason: "source-auth-required",
+    },
     { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
-    { selector: "database.SOURCE_AUTH", kind: "broker", reason: "source-auth-required" },
+    {
+      selector: "database.SOURCE_AUTH",
+      kind: "broker",
+      reason: "source-auth-required",
+    },
   ]);
 });
 
@@ -157,13 +229,21 @@ test("bare selectors do not fall back into broker namespaces", () => {
   resetLifecycleState();
   const service = fixtureService({ env: { LOCAL_SECRET: "${API_KEY}" } });
   const diagnostics = [];
-  const resolved = resolveServiceText("token=${API_KEY}", service, {}, {}, {
-    brokerValues: { "secretsbroker.API_KEY": "resolved-secret" },
-    diagnostics,
-  });
+  const resolved = resolveServiceText(
+    "token=${API_KEY}",
+    service,
+    {},
+    {},
+    {
+      brokerValues: { "secretsbroker.API_KEY": "resolved-secret" },
+      diagnostics,
+    },
+  );
 
   assert.equal(resolved, "token=${API_KEY}");
-  assert.deepEqual(diagnostics, [{ selector: "API_KEY", kind: "local", reason: "unresolved-local" }]);
+  assert.deepEqual(diagnostics, [
+    { selector: "API_KEY", kind: "local", reason: "unresolved-local" },
+  ]);
 });
 
 test("explicit broker selectors resolve only from broker values and report missing refs", () => {
@@ -181,13 +261,24 @@ test("explicit broker selectors resolve only from broker values and report missi
     },
   );
 
-  assert.equal(resolved, "token=resolved-secret; missing=${secretsbroker.MISSING}; local=local");
-  assert.deepEqual(diagnostics, [{ selector: "secretsbroker.MISSING", kind: "broker", reason: "missing-broker" }]);
+  assert.equal(
+    resolved,
+    "token=resolved-secret; missing=${secretsbroker.MISSING}; local=local",
+  );
+  assert.deepEqual(diagnostics, [
+    {
+      selector: "secretsbroker.MISSING",
+      kind: "broker",
+      reason: "missing-broker",
+    },
+  ]);
 });
 
 test("config materialization resolves declared broker imports without leaking denied values", async () => {
   resetLifecycleState();
-  const serviceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-broker-config-"));
+  const serviceRoot = await mkdtemp(
+    path.join(os.tmpdir(), "service-lasso-broker-config-"),
+  );
   const service = {
     manifestPath: path.join(serviceRoot, "service.json"),
     serviceRoot,
@@ -201,15 +292,25 @@ test("config materialization resolves declared broker imports without leaking de
       },
       broker: {
         imports: [
-          { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
-          { namespace: "shared/database", ref: "database.DENIED", as: "DENIED_PASSWORD" },
+          {
+            namespace: "shared/database",
+            ref: "database.PASSWORD",
+            as: "DB_PASSWORD",
+            required: true,
+          },
+          {
+            namespace: "shared/database",
+            ref: "database.DENIED",
+            as: "DENIED_PASSWORD",
+          },
         ],
       },
       config: {
         files: [
           {
             path: "runtime/config.json",
-            content: "{\n  \"password\": \"${database.PASSWORD}\",\n  \"denied\": \"${database.DENIED}\"\n}\n",
+            content:
+              '{\n  "password": "${database.PASSWORD}",\n  "denied": "${database.DENIED}"\n}\n',
           },
         ],
       },
@@ -217,15 +318,23 @@ test("config materialization resolves declared broker imports without leaking de
   };
 
   try {
-    await materializeConfigArtifacts(service, {}, {}, {
-      brokerValues: {
-        "database.PASSWORD": "resolved-password",
-        "database.DENIED": "denied-secret",
+    await materializeConfigArtifacts(
+      service,
+      {},
+      {},
+      {
+        brokerValues: {
+          "database.PASSWORD": "resolved-password",
+          "database.DENIED": "denied-secret",
+        },
+        deniedBrokerRefs: ["database.DENIED"],
       },
-      deniedBrokerRefs: ["database.DENIED"],
-    });
+    );
 
-    const content = await readFile(path.join(serviceRoot, "runtime", "config.json"), "utf8");
+    const content = await readFile(
+      path.join(serviceRoot, "runtime", "config.json"),
+      "utf8",
+    );
     assert.match(content, /resolved-password/);
     assert.match(content, /\$\{database\.DENIED\}/);
     assert.equal(content.includes("denied-secret"), false);
@@ -234,16 +343,264 @@ test("config materialization resolves declared broker imports without leaking de
   }
 });
 
+test("startup broker resolution batches unique selectors and materializes only launch env values", async () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      DATABASE_URL: "postgres://app:${database.PASSWORD}@db/service",
+      OPTIONAL_TOKEN: "${optional.API_TOKEN}",
+      DUPLICATE: "${database.PASSWORD}:${database.PASSWORD}",
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+          required: true,
+        },
+        {
+          namespace: "optional",
+          ref: "optional.API_TOKEN",
+          as: "OPTIONAL_TOKEN",
+          required: false,
+        },
+      ],
+    },
+  });
+
+  const requestedBatches = [];
+  const resolution = await resolveServiceStartupBrokerResolution(
+    service,
+    ({ refs }) => {
+      requestedBatches.push(refs);
+      return [
+        {
+          ref: "database.PASSWORD",
+          status: "resolved",
+          value: "resolved-password",
+        },
+        { ref: "optional.API_TOKEN", status: "missing" },
+      ];
+    },
+  );
+  const payload = buildServiceVariables(
+    service,
+    {},
+    {},
+    resolution.variableResolution,
+  );
+  const byKey = Object.fromEntries(
+    payload.variables.map((entry) => [entry.key, entry.value]),
+  );
+
+  assert.deepEqual(requestedBatches, [
+    ["database.PASSWORD", "optional.API_TOKEN"],
+  ]);
+  assert.equal(
+    byKey.DATABASE_URL,
+    "postgres://app:resolved-password@db/service",
+  );
+  assert.equal(byKey.DB_PASSWORD, "resolved-password");
+  assert.equal(byKey.OPTIONAL_TOKEN, "${optional.API_TOKEN}");
+  assert.deepEqual(summarizeRequiredStartupBrokerFailures(resolution), []);
+  assert.equal(
+    JSON.stringify({
+      decisions: resolution.decisions,
+      failures: resolution.failures,
+    }).includes("resolved-password"),
+    false,
+  );
+});
+
+test("startup broker resolution classifies required failures without leaking lookup values", async () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      LOCKED: "${vault.LOCKED}",
+      DENIED: "${vault.DENIED}",
+      AUTH: "${vault.AUTH}",
+      OFFLINE: "${vault.OFFLINE}",
+      DEGRADED: "${vault.DEGRADED}",
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "vault",
+          ref: "vault.LOCKED",
+          as: "LOCKED",
+          required: true,
+        },
+        {
+          namespace: "vault",
+          ref: "vault.DENIED",
+          as: "DENIED",
+          required: true,
+        },
+        { namespace: "vault", ref: "vault.AUTH", as: "AUTH", required: true },
+        {
+          namespace: "vault",
+          ref: "vault.OFFLINE",
+          as: "OFFLINE",
+          required: true,
+        },
+        {
+          namespace: "vault",
+          ref: "vault.DEGRADED",
+          as: "DEGRADED",
+          required: true,
+        },
+        {
+          namespace: "vault",
+          ref: "vault.MISSING",
+          as: "MISSING",
+          required: true,
+        },
+      ],
+    },
+  });
+
+  const resolution = await resolveServiceStartupBrokerResolution(
+    service,
+    () => [
+      {
+        ref: "vault.LOCKED",
+        status: "locked",
+        value: "locked-value-must-not-leak",
+      },
+      {
+        ref: "vault.DENIED",
+        status: "policy-denied",
+        value: "denied-value-must-not-leak",
+      },
+      {
+        ref: "vault.AUTH",
+        status: "auth-required",
+        value: "auth-value-must-not-leak",
+      },
+      {
+        ref: "vault.OFFLINE",
+        status: "source-unavailable",
+        value: "offline-value-must-not-leak",
+      },
+      {
+        ref: "vault.DEGRADED",
+        status: "degraded",
+        value: "degraded-value-must-not-leak",
+      },
+    ],
+  );
+  const requiredFailures = summarizeRequiredStartupBrokerFailures(resolution);
+  const payload = buildServiceVariables(
+    service,
+    {},
+    {},
+    resolution.variableResolution,
+  );
+
+  assert.deepEqual(
+    requiredFailures.map((failure) => [
+      failure.ref,
+      failure.status,
+      failure.required,
+    ]),
+    [
+      ["vault.LOCKED", "locked", true],
+      ["vault.DENIED", "policy-denied", true],
+      ["vault.AUTH", "auth-required", true],
+      ["vault.OFFLINE", "source-unavailable", true],
+      ["vault.DEGRADED", "degraded", true],
+      ["vault.MISSING", "missing", true],
+    ],
+  );
+  assert.deepEqual(payload.diagnostics, [
+    { selector: "vault.LOCKED", kind: "broker", reason: "locked-broker" },
+    { selector: "vault.DENIED", kind: "broker", reason: "denied-broker" },
+    { selector: "vault.AUTH", kind: "broker", reason: "source-auth-required" },
+    { selector: "vault.OFFLINE", kind: "broker", reason: "source-unavailable" },
+    { selector: "vault.DEGRADED", kind: "broker", reason: "degraded-broker" },
+    { selector: "vault.MISSING", kind: "broker", reason: "missing-broker" },
+  ]);
+  const serialized = JSON.stringify({ resolution, payload });
+  assert.equal(serialized.includes("must-not-leak"), false);
+});
+
+test("startup broker plan cache invalidates on env and broker import changes", () => {
+  resetServiceSelectorPlanCache();
+  const service = fixtureService({
+    env: { PASSWORD: "${database.PASSWORD}" },
+    broker: {
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+          required: true,
+        },
+      ],
+    },
+  });
+
+  const first = compileServiceStartupBrokerPlan(service);
+  const second = compileServiceStartupBrokerPlan(service);
+  service.manifest.env.API_TOKEN = "${service.API_TOKEN}";
+  const envChanged = compileServiceStartupBrokerPlan(service);
+  service.manifest.broker.imports.push({
+    namespace: "service",
+    ref: "service.API_TOKEN",
+    as: "API_TOKEN",
+  });
+  const importChanged = compileServiceStartupBrokerPlan(service);
+
+  assert.equal(second.selectorPlan, first.selectorPlan);
+  assert.notEqual(envChanged.selectorPlan, first.selectorPlan);
+  assert.deepEqual(envChanged.brokerRefs, [
+    "database.PASSWORD",
+    "service.API_TOKEN",
+  ]);
+  assert.deepEqual(importChanged.brokerRefs, [
+    "database.PASSWORD",
+    "service.API_TOKEN",
+  ]);
+  assert.equal(getServiceSelectorPlanCacheStats().planInvalidations >= 2, true);
+});
+
 test("materialization selector plan covers env, globalenv, install, and config templates", () => {
   const service = fixtureService({
     env: { LOCAL_SECRET_REF: "${secretsbroker.API_KEY}" },
     globalenv: { TOOL_HOME: "${SERVICE_ROOT}/tool" },
     broker: {
-      imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
-      exports: [{ namespace: "consumer/runtime", ref: "consumer.PUBLIC_URL", source: "${PUBLIC_URL}" }],
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+        },
+      ],
+      exports: [
+        {
+          namespace: "consumer/runtime",
+          ref: "consumer.PUBLIC_URL",
+          source: "${PUBLIC_URL}",
+        },
+      ],
     },
-    install: { files: [{ path: "generated/${SERVICE_ID}.txt", content: "${vault.shared.token}" }] },
-    config: { files: [{ path: "config/${secretsbroker.CONFIG_NAME}.json", content: "${LOCAL_SECRET_REF}" }] },
+    install: {
+      files: [
+        {
+          path: "generated/${SERVICE_ID}.txt",
+          content: "${vault.shared.token}",
+        },
+      ],
+    },
+    config: {
+      files: [
+        {
+          path: "config/${secretsbroker.CONFIG_NAME}.json",
+          content: "${LOCAL_SECRET_REF}",
+        },
+      ],
+    },
   });
 
   const plan = compileServiceMaterializationSelectorPlan(service);
@@ -297,27 +654,47 @@ test("materialization selector plan cache invalidates on broker policy and confi
   const service = fixtureService({
     env: { LOCAL_SECRET_REF: "${secretsbroker.API_KEY}" },
     broker: {
-      imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
+      imports: [
+        {
+          namespace: "shared/database",
+          ref: "database.PASSWORD",
+          as: "DB_PASSWORD",
+        },
+      ],
     },
-    config: { files: [{ path: "config/${SERVICE_ID}.json", content: "${database.PASSWORD}" }] },
+    config: {
+      files: [
+        { path: "config/${SERVICE_ID}.json", content: "${database.PASSWORD}" },
+      ],
+    },
   });
 
   const first = compileServiceMaterializationSelectorPlan(service);
   const second = compileServiceMaterializationSelectorPlan(service);
 
   service.manifest.broker.imports = [
-    { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" },
+    {
+      namespace: "shared/database",
+      ref: "database.PASSWORD",
+      as: "DB_PASSWORD",
+    },
     { namespace: "shared/database", ref: "database.USER", as: "DB_USER" },
   ];
-  const withBrokerPolicyChange = compileServiceMaterializationSelectorPlan(service);
+  const withBrokerPolicyChange =
+    compileServiceMaterializationSelectorPlan(service);
 
-  service.manifest.config.files[0].content = "${database.PASSWORD}:${database.USER}:${vault.extra.token}";
+  service.manifest.config.files[0].content =
+    "${database.PASSWORD}:${database.USER}:${vault.extra.token}";
   const withConfigChange = compileServiceMaterializationSelectorPlan(service);
 
   assert.equal(second, first);
   assert.notEqual(withBrokerPolicyChange, first);
   assert.notEqual(withConfigChange, withBrokerPolicyChange);
-  assert.deepEqual(withBrokerPolicyChange.brokerRefs, ["secretsbroker.API_KEY", "database.PASSWORD", "database.USER"]);
+  assert.deepEqual(withBrokerPolicyChange.brokerRefs, [
+    "secretsbroker.API_KEY",
+    "database.PASSWORD",
+    "database.USER",
+  ]);
   assert.deepEqual(withConfigChange.brokerRefs, [
     "secretsbroker.API_KEY",
     "database.PASSWORD",


### PR DESCRIPTION
## Summary
- add a launch-time startup broker resolution helper that compiles/deduplicates broker selectors, batches lookup refs, classifies unresolved broker states, and merges safe launch variable-resolution metadata
- wire lifecycle start/restart through the optional broker lookup boundary so required broker failures fail closed before process spawn with ref/status metadata only
- extend selector diagnostics and tests for substitution, cache invalidation, missing/locked/auth-required/policy-denied/source-unavailable/degraded states, and no raw-value leaks
- document service.json env / broker.import usage, precedence, cache invalidation, and safe diagnostics

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/lifecycle-actions.test.js tests/variable-selector-planning.test.js`
- `npm test` (238 pass)
- `npm run docs:build`
- `git diff --check`

Closes #423
