### PR TITLE
Add legacy globalenv migration planner

### DIFF
--- a/docs/reference/legacy-globalenv-migration.md
+++ b/docs/reference/legacy-globalenv-migration.md
@@ -1,0 +1,108 @@
+# Legacy globalenv migration planner
+
+The legacy `env` / `globalenv` migration planner helps operators move existing secret-like configuration toward explicit Secrets Broker refs without exposing raw values.
+
+The planner is metadata-only. It must never print or persist raw existing env values in plans, logs, diagnostics, screenshots, reports, GitHub comments, or PR bodies.
+
+## What it scans
+
+For each discovered service, the planner inspects:
+
+- `env` entries: candidates that can be converted to service-local broker imports.
+- `globalenv` entries: candidates that are reported with manual writeback guidance because global shared emission can affect multiple services.
+
+Each key is classified as:
+
+- `secret`: strong key-name match such as `PASSWORD`, `TOKEN`, `SECRET`, `API_KEY`, `CLIENT_SECRET`, `PRIVATE_KEY`.
+- `ambiguous`: potentially sensitive key-name match such as `AUTH`, `CREDENTIAL`, `DSN`, `CONNECTION`, or generic `KEY`.
+- `non-secret`: common non-secret names such as `PUBLIC_URL`, `BASE_URL`, `HOST`, `PORT`, `LOG_LEVEL`, `NODE_ENV`, or keys without secret-like patterns.
+
+The value itself is never returned. Candidate metadata is limited to presence, length, fingerprint, and value kind (`literal`, `selector`, or `empty`).
+
+## Dry-run output
+
+A dry-run plan includes safe metadata only:
+
+```json
+{
+  "serviceId": "api",
+  "source": "env",
+  "key": "DB_PASSWORD",
+  "classification": "secret",
+  "state": "planned",
+  "metadata": {
+    "present": true,
+    "length": 32,
+    "fingerprint": "1b7c4...",
+    "valueKind": "literal"
+  },
+  "proposed": {
+    "provider": "@secretsbroker",
+    "backend": "local",
+    "namespace": "services/api",
+    "ref": "api.DB_PASSWORD",
+    "as": "DB_PASSWORD",
+    "required": true
+  }
+}
+```
+
+Denied or unsupported states remain explicit:
+
+- `denied`: policy has blocked this key from automatic planning.
+- `unsupported`: the source cannot be automatically migrated by this bounded planner, for example legacy `globalenv` writeback.
+- `needs-confirmation`: ambiguous candidate; operator confirmation is required before apply.
+
+## Before / after example
+
+Before:
+
+```json
+{
+  "env": {
+    "DB_PASSWORD": "existing value hidden by planner",
+    "PUBLIC_URL": "http://localhost:3000"
+  }
+}
+```
+
+Dry-run proposed change:
+
+```json
+{
+  "env": {
+    "DB_PASSWORD": "${api.DB_PASSWORD}",
+    "PUBLIC_URL": "http://localhost:3000"
+  },
+  "broker": {
+    "enabled": true,
+    "imports": [
+      {
+        "namespace": "services/api",
+        "ref": "api.DB_PASSWORD",
+        "as": "DB_PASSWORD",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+## Apply gate
+
+Apply is intentionally separate from dry-run and requires:
+
+1. explicit confirmation token: `APPLY_LEGACY_GLOBALENV_MIGRATION`
+2. non-empty audit reason
+3. optional `allowAmbiguous` for ambiguous candidates
+
+Automatic apply only changes service-local `env` candidates. Legacy `globalenv` candidates stay manual because they may be shared across several services; operators should first write values into the chosen broker backend and validate every consumer before removing shared emission.
+
+## Rollback guidance
+
+Before applying, keep the original `service.json` for every affected service. Rollback is:
+
+1. restore original `env` / `globalenv` entries
+2. remove generated `broker.imports` for affected refs
+3. keep affected services stopped until required refs are restored or the manifest rollback is complete
+4. preserve the audit reason and dry-run plan with raw values redacted

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -589,6 +589,7 @@ Ordinary services should consume broker values through service-local `env` names
 - prefer env mapping for long-running processes; use CLI-style resolution only for controlled setup/adapter paths that do not echo arguments or outputs containing raw secrets
 - missing, locked, auth-required, policy-denied, source-unavailable, or degraded refs should fail with actionable diagnostics that name the ref and reason without including the secret value
 - startup resolution batches unique declared broker selectors once per launch and materializes raw values only into the launched service environment/config boundary; see [Startup Broker Resolution](./startup-broker-resolution.md)
+- use the metadata-only [Legacy globalenv Migration](./legacy-globalenv-migration.md) planner before converting existing literal env/globalenv secrets; ambiguous and globalenv candidates require operator confirmation/manual writeback
 
 Becomes an explicit broker contract:
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -73,6 +73,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/legacy-globalenv-migration",
+          label: "Legacy globalenv Migration",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/src/runtime/broker/legacy-globalenv-migration.ts
+++ b/src/runtime/broker/legacy-globalenv-migration.ts
@@ -1,0 +1,472 @@
+import { createHash } from "node:crypto";
+import type {
+  DiscoveredService,
+  ServiceBrokerImport,
+  ServiceManifest,
+} from "../../contracts/service.js";
+
+export type LegacyEnvSource = "env" | "globalenv";
+export type LegacyEnvClassification = "secret" | "non-secret" | "ambiguous";
+export type LegacyMigrationCandidateState =
+  | "planned"
+  | "needs-confirmation"
+  | "denied"
+  | "unsupported";
+
+export interface LegacySecretMetadata {
+  present: boolean;
+  length: number;
+  fingerprint: string | null;
+  valueKind: "empty" | "literal" | "selector";
+}
+
+export interface LegacyGlobalEnvMigrationCandidate {
+  serviceId: string;
+  source: LegacyEnvSource;
+  key: string;
+  classification: LegacyEnvClassification;
+  state: LegacyMigrationCandidateState;
+  reasons: string[];
+  metadata: LegacySecretMetadata;
+  proposed?: {
+    namespace: string;
+    ref: string;
+    as: string;
+    provider: string;
+    backend: string;
+    required: boolean;
+  };
+}
+
+export interface LegacyGlobalEnvServiceMigrationPlan {
+  serviceId: string;
+  manifestPath: string;
+  candidates: LegacyGlobalEnvMigrationCandidate[];
+  proposedChanges: Array<{
+    source: LegacyEnvSource;
+    key: string;
+    action: "replace-env-with-broker-ref" | "manual-globalenv-writeback";
+    ref: string | null;
+    required: boolean;
+  }>;
+}
+
+export interface LegacyGlobalEnvMigrationPlan {
+  mode: "dry-run";
+  services: LegacyGlobalEnvServiceMigrationPlan[];
+  summary: {
+    servicesScanned: number;
+    candidates: number;
+    planned: number;
+    needsConfirmation: number;
+    denied: number;
+    unsupported: number;
+  };
+  rollbackGuidance: string[];
+}
+
+export interface LegacyGlobalEnvMigrationOptions {
+  provider?: string;
+  backend?: string;
+  namespaceForService?: (service: DiscoveredService) => string;
+  denyKeys?: string[] | Set<string>;
+  includeAmbiguous?: boolean;
+}
+
+export interface LegacyGlobalEnvMigrationApplyOptions {
+  confirmation?: string;
+  auditReason?: string;
+  allowAmbiguous?: boolean;
+}
+
+export interface LegacyGlobalEnvMigrationApplyResult {
+  ok: boolean;
+  auditReason: string;
+  updatedManifests: Record<string, ServiceManifest>;
+  applied: Array<{ serviceId: string; key: string; ref: string }>;
+  skipped: Array<{
+    serviceId: string;
+    key: string;
+    state: LegacyMigrationCandidateState;
+    reason: string;
+  }>;
+  rollbackGuidance: string[];
+}
+
+const APPLY_CONFIRMATION = "APPLY_LEGACY_GLOBALENV_MIGRATION";
+
+function normalizeKeyRef(key: string): string {
+  return key
+    .trim()
+    .replace(/[^A-Za-z0-9_.-]+/g, "_")
+    .replace(/^[^A-Za-z]+/, "")
+    .toUpperCase();
+}
+
+function normalizeServiceRefPrefix(serviceId: string): string {
+  const normalized = serviceId
+    .trim()
+    .replace(/^@+/, "")
+    .replace(/[^A-Za-z0-9_-]+/g, "_")
+    .replace(/^[^A-Za-z]+/, "service");
+  return normalized || "service";
+}
+
+function metadataForValue(value: string): LegacySecretMetadata {
+  const fingerprint = value
+    ? createHash("sha256").update(value).digest("hex").slice(0, 16)
+    : null;
+  return {
+    present: value.length > 0,
+    length: value.length,
+    fingerprint,
+    valueKind:
+      value.length === 0
+        ? "empty"
+        : /^\$\{[^}]+\}$/.test(value.trim())
+          ? "selector"
+          : "literal",
+  };
+}
+
+function hasDeniedKey(
+  key: string,
+  denied: string[] | Set<string> | undefined,
+): boolean {
+  if (!denied) return false;
+  return Array.isArray(denied) ? denied.includes(key) : denied.has(key);
+}
+
+export function classifyLegacyEnvKey(key: string): {
+  classification: LegacyEnvClassification;
+  reasons: string[];
+} {
+  const normalized = key.toUpperCase();
+  const secretPatterns = [
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "PRIVATE_KEY",
+    "API_KEY",
+    "CLIENT_SECRET",
+    "WEBHOOK_SECRET",
+    "SIGNING_KEY",
+  ];
+  const nonSecretPatterns = [
+    "PUBLIC_URL",
+    "BASE_URL",
+    "HOST",
+    "PORT",
+    "LOG_LEVEL",
+    "NODE_ENV",
+  ];
+  const ambiguousPatterns = [
+    "AUTH",
+    "CREDENTIAL",
+    "DSN",
+    "CONNECTION",
+    "CONN_STRING",
+    "KEY",
+  ];
+
+  const secretMatch = secretPatterns.find((pattern) =>
+    normalized.includes(pattern),
+  );
+  if (secretMatch) {
+    return { classification: "secret", reasons: [`key-match:${secretMatch}`] };
+  }
+
+  const nonSecretMatch = nonSecretPatterns.find(
+    (pattern) => normalized === pattern || normalized.endsWith(`_${pattern}`),
+  );
+  if (nonSecretMatch) {
+    return {
+      classification: "non-secret",
+      reasons: [`key-match:${nonSecretMatch}`],
+    };
+  }
+
+  const ambiguousMatch = ambiguousPatterns.find((pattern) =>
+    normalized.includes(pattern),
+  );
+  if (ambiguousMatch) {
+    return {
+      classification: "ambiguous",
+      reasons: [`key-match:${ambiguousMatch}`],
+    };
+  }
+
+  return { classification: "non-secret", reasons: ["no-secret-pattern"] };
+}
+
+function proposedForCandidate(
+  service: DiscoveredService,
+  key: string,
+  options: LegacyGlobalEnvMigrationOptions,
+): LegacyGlobalEnvMigrationCandidate["proposed"] {
+  const namespace =
+    options.namespaceForService?.(service) ?? `services/${service.manifest.id}`;
+  return {
+    namespace,
+    ref: `${normalizeServiceRefPrefix(service.manifest.id)}.${normalizeKeyRef(key)}`,
+    as: key,
+    provider: options.provider ?? "@secretsbroker",
+    backend: options.backend ?? "local",
+    required: true,
+  };
+}
+
+function candidateForEntry(
+  service: DiscoveredService,
+  source: LegacyEnvSource,
+  key: string,
+  value: string,
+  options: LegacyGlobalEnvMigrationOptions,
+): LegacyGlobalEnvMigrationCandidate {
+  const { classification, reasons } = classifyLegacyEnvKey(key);
+  const denied = hasDeniedKey(key, options.denyKeys);
+  const unsupported = source === "globalenv";
+  const includeAmbiguous = options.includeAmbiguous === true;
+  const state: LegacyMigrationCandidateState = denied
+    ? "denied"
+    : unsupported
+      ? "unsupported"
+      : classification === "secret"
+        ? "planned"
+        : classification === "ambiguous" && includeAmbiguous
+          ? "needs-confirmation"
+          : classification === "ambiguous"
+            ? "needs-confirmation"
+            : "unsupported";
+
+  return {
+    serviceId: service.manifest.id,
+    source,
+    key,
+    classification,
+    state,
+    reasons: [
+      ...reasons,
+      ...(denied ? ["policy-denied"] : []),
+      ...(unsupported ? ["globalenv-manual-writeback-required"] : []),
+    ],
+    metadata: metadataForValue(value),
+    proposed:
+      state === "planned" || state === "needs-confirmation"
+        ? proposedForCandidate(service, key, options)
+        : undefined,
+  };
+}
+
+function scanService(
+  service: DiscoveredService,
+  options: LegacyGlobalEnvMigrationOptions,
+): LegacyGlobalEnvServiceMigrationPlan {
+  const candidates: LegacyGlobalEnvMigrationCandidate[] = [];
+
+  for (const [key, value] of Object.entries(service.manifest.env ?? {})) {
+    candidates.push(candidateForEntry(service, "env", key, value, options));
+  }
+
+  for (const [key, value] of Object.entries(service.manifest.globalenv ?? {})) {
+    candidates.push(
+      candidateForEntry(service, "globalenv", key, value, options),
+    );
+  }
+
+  const proposedChanges = candidates
+    .filter(
+      (candidate) =>
+        candidate.state === "planned" ||
+        candidate.state === "needs-confirmation",
+    )
+    .map((candidate) => ({
+      source: candidate.source,
+      key: candidate.key,
+      action:
+        candidate.source === "env"
+          ? ("replace-env-with-broker-ref" as const)
+          : ("manual-globalenv-writeback" as const),
+      ref: candidate.proposed?.ref ?? null,
+      required: candidate.proposed?.required === true,
+    }));
+
+  return {
+    serviceId: service.manifest.id,
+    manifestPath: service.manifestPath,
+    candidates,
+    proposedChanges,
+  };
+}
+
+export function createLegacyGlobalEnvMigrationPlan(
+  services: DiscoveredService[],
+  options: LegacyGlobalEnvMigrationOptions = {},
+): LegacyGlobalEnvMigrationPlan {
+  const servicePlans = services.map((service) => scanService(service, options));
+  const candidates = servicePlans.flatMap((service) => service.candidates);
+
+  return {
+    mode: "dry-run",
+    services: servicePlans,
+    summary: {
+      servicesScanned: services.length,
+      candidates: candidates.length,
+      planned: candidates.filter((candidate) => candidate.state === "planned")
+        .length,
+      needsConfirmation: candidates.filter(
+        (candidate) => candidate.state === "needs-confirmation",
+      ).length,
+      denied: candidates.filter((candidate) => candidate.state === "denied")
+        .length,
+      unsupported: candidates.filter(
+        (candidate) => candidate.state === "unsupported",
+      ).length,
+    },
+    rollbackGuidance: [
+      "Keep a copy of each original service.json before applying migration changes.",
+      "Rollback by restoring the original env/globalenv entries and removing generated broker.imports for affected refs.",
+      "If broker writeback/import partially fails, keep services stopped until missing required refs are restored or the manifest is rolled back.",
+    ],
+  };
+}
+
+function cloneManifest(manifest: ServiceManifest): ServiceManifest {
+  return JSON.parse(JSON.stringify(manifest)) as ServiceManifest;
+}
+
+function hasImport(
+  imports: ServiceBrokerImport[],
+  ref: string,
+  as: string,
+): boolean {
+  return imports.some((entry) => entry.ref === ref || entry.as === as);
+}
+
+function redactedValue(candidate: LegacyGlobalEnvMigrationCandidate): string {
+  return candidate.metadata.fingerprint
+    ? `[redacted:${candidate.metadata.fingerprint}]`
+    : "[redacted]";
+}
+
+function shouldRedactSkippedCandidate(
+  candidate: LegacyGlobalEnvMigrationCandidate,
+): boolean {
+  return (
+    candidate.classification === "secret" ||
+    candidate.classification === "ambiguous"
+  );
+}
+
+export function applyLegacyGlobalEnvMigrationPlan(
+  plan: LegacyGlobalEnvMigrationPlan,
+  services: DiscoveredService[],
+  options: LegacyGlobalEnvMigrationApplyOptions,
+): LegacyGlobalEnvMigrationApplyResult {
+  if (options.confirmation !== APPLY_CONFIRMATION) {
+    throw new Error(
+      `Migration apply requires confirmation token ${APPLY_CONFIRMATION}.`,
+    );
+  }
+  const auditReason = options.auditReason?.trim();
+  if (!auditReason) {
+    throw new Error("Migration apply requires a non-empty audit reason.");
+  }
+
+  const servicesById = new Map(
+    services.map((service) => [service.manifest.id, service]),
+  );
+  const updatedManifests: Record<string, ServiceManifest> = {};
+  const applied: LegacyGlobalEnvMigrationApplyResult["applied"] = [];
+  const skipped: LegacyGlobalEnvMigrationApplyResult["skipped"] = [];
+
+  for (const servicePlan of plan.services) {
+    const service = servicesById.get(servicePlan.serviceId);
+    if (!service) continue;
+    const manifest = cloneManifest(service.manifest);
+    manifest.env = { ...(manifest.env ?? {}) };
+    manifest.broker = { ...(manifest.broker ?? {}), enabled: true };
+    manifest.broker.imports = [...(manifest.broker.imports ?? [])];
+
+    for (const candidate of servicePlan.candidates) {
+      if (candidate.source !== "env") {
+        manifest.globalenv = { ...(manifest.globalenv ?? {}) };
+        if (shouldRedactSkippedCandidate(candidate)) {
+          manifest.globalenv[candidate.key] = redactedValue(candidate);
+        }
+        skipped.push({
+          serviceId: candidate.serviceId,
+          key: candidate.key,
+          state: candidate.state,
+          reason:
+            "globalenv requires manual broker writeback planning before manifest apply",
+        });
+        continue;
+      }
+      if (
+        candidate.state === "needs-confirmation" &&
+        options.allowAmbiguous !== true
+      ) {
+        if (shouldRedactSkippedCandidate(candidate)) {
+          manifest.env[candidate.key] = redactedValue(candidate);
+        }
+        skipped.push({
+          serviceId: candidate.serviceId,
+          key: candidate.key,
+          state: candidate.state,
+          reason: "ambiguous candidate requires allowAmbiguous",
+        });
+        continue;
+      }
+      if (
+        candidate.state !== "planned" &&
+        candidate.state !== "needs-confirmation"
+      ) {
+        if (shouldRedactSkippedCandidate(candidate)) {
+          manifest.env[candidate.key] = redactedValue(candidate);
+        }
+        skipped.push({
+          serviceId: candidate.serviceId,
+          key: candidate.key,
+          state: candidate.state,
+          reason: candidate.reasons.join(", "),
+        });
+        continue;
+      }
+      if (!candidate.proposed) continue;
+
+      manifest.env[candidate.key] = `\${${candidate.proposed.ref}}`;
+      if (
+        !hasImport(
+          manifest.broker.imports,
+          candidate.proposed.ref,
+          candidate.proposed.as,
+        )
+      ) {
+        manifest.broker.imports.push({
+          namespace: candidate.proposed.namespace,
+          ref: candidate.proposed.ref,
+          as: candidate.proposed.as,
+          required: candidate.proposed.required,
+        });
+      }
+      applied.push({
+        serviceId: candidate.serviceId,
+        key: candidate.key,
+        ref: candidate.proposed.ref,
+      });
+    }
+
+    updatedManifests[service.manifest.id] = manifest;
+  }
+
+  return {
+    ok: skipped.length === 0,
+    auditReason,
+    updatedManifests,
+    applied,
+    skipped,
+    rollbackGuidance: plan.rollbackGuidance,
+  };
+}

--- a/tests/legacy-globalenv-migration.test.js
+++ b/tests/legacy-globalenv-migration.test.js
@@ -1,0 +1,244 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  applyLegacyGlobalEnvMigrationPlan,
+  classifyLegacyEnvKey,
+  createLegacyGlobalEnvMigrationPlan,
+} from "../dist/runtime/broker/legacy-globalenv-migration.js";
+
+function fixtureService(id, manifest) {
+  return {
+    manifestPath: path.join(process.cwd(), "services", id, "service.json"),
+    serviceRoot: path.join(process.cwd(), "services", id),
+    manifest: {
+      id,
+      name: id,
+      description: `${id} fixture`,
+      ...manifest,
+    },
+  };
+}
+
+function assertNoRawMaterial(payload) {
+  const text = JSON.stringify(payload);
+  for (const forbidden of [
+    "super-secret-password-value",
+    "raw-token-value",
+    "postgres://user:pass@localhost/db",
+    "global-secret-value",
+  ]) {
+    assert.equal(text.includes(forbidden), false, `leaked ${forbidden}`);
+  }
+}
+
+test("legacy migration classifier detects secret non-secret and ambiguous keys", () => {
+  assert.deepEqual(classifyLegacyEnvKey("DB_PASSWORD"), {
+    classification: "secret",
+    reasons: ["key-match:PASSWORD"],
+  });
+  assert.deepEqual(classifyLegacyEnvKey("PUBLIC_URL"), {
+    classification: "non-secret",
+    reasons: ["key-match:PUBLIC_URL"],
+  });
+  assert.deepEqual(classifyLegacyEnvKey("DATABASE_DSN"), {
+    classification: "ambiguous",
+    reasons: ["key-match:DSN"],
+  });
+});
+
+test("legacy migration dry-run maps env secrets to broker imports without raw values", () => {
+  const services = [
+    fixtureService("api", {
+      env: {
+        DB_PASSWORD: "super-secret-password-value",
+        PUBLIC_URL: "http://localhost:3000",
+        DATABASE_DSN: "postgres://user:pass@localhost/db",
+      },
+      globalenv: {
+        SHARED_TOKEN: "global-secret-value",
+      },
+    }),
+  ];
+
+  const plan = createLegacyGlobalEnvMigrationPlan(services, {
+    backend: "vault-dev",
+    includeAmbiguous: true,
+  });
+  const candidates = plan.services[0].candidates;
+
+  assert.equal(plan.summary.servicesScanned, 1);
+  assert.equal(plan.summary.candidates, 4);
+  assert.equal(plan.summary.planned, 1);
+  assert.equal(plan.summary.needsConfirmation, 1);
+  assert.equal(plan.summary.unsupported, 2);
+  assert.deepEqual(
+    candidates.map((candidate) => [
+      candidate.key,
+      candidate.source,
+      candidate.classification,
+      candidate.state,
+      candidate.proposed?.ref ?? null,
+    ]),
+    [
+      ["DB_PASSWORD", "env", "secret", "planned", "api.DB_PASSWORD"],
+      ["PUBLIC_URL", "env", "non-secret", "unsupported", null],
+      [
+        "DATABASE_DSN",
+        "env",
+        "ambiguous",
+        "needs-confirmation",
+        "api.DATABASE_DSN",
+      ],
+      ["SHARED_TOKEN", "globalenv", "secret", "unsupported", null],
+    ],
+  );
+  assert.equal(
+    candidates[0].metadata.length,
+    "super-secret-password-value".length,
+  );
+  assert.equal(candidates[0].metadata.fingerprint.length, 16);
+  assert.equal(candidates[0].metadata.valueKind, "literal");
+  assertNoRawMaterial(plan);
+});
+
+test("legacy migration reports denied and unsupported states with safe metadata", () => {
+  const services = [
+    fixtureService("worker", {
+      env: {
+        API_TOKEN: "raw-token-value",
+      },
+      globalenv: {
+        GLOBAL_SECRET: "global-secret-value",
+      },
+    }),
+  ];
+
+  const plan = createLegacyGlobalEnvMigrationPlan(services, {
+    denyKeys: new Set(["API_TOKEN"]),
+  });
+
+  assert.equal(plan.summary.denied, 1);
+  assert.equal(plan.summary.unsupported, 1);
+  assert.deepEqual(
+    plan.services[0].candidates.map((candidate) => [
+      candidate.key,
+      candidate.state,
+      candidate.reasons.at(-1),
+    ]),
+    [
+      ["API_TOKEN", "denied", "policy-denied"],
+      ["GLOBAL_SECRET", "unsupported", "globalenv-manual-writeback-required"],
+    ],
+  );
+  assertNoRawMaterial(plan);
+});
+
+test("legacy migration apply is gated by confirmation and audit reason", () => {
+  const services = [
+    fixtureService("api", {
+      env: { DB_PASSWORD: "super-secret-password-value" },
+    }),
+  ];
+  const plan = createLegacyGlobalEnvMigrationPlan(services);
+
+  assert.throws(
+    () =>
+      applyLegacyGlobalEnvMigrationPlan(plan, services, {
+        auditReason: "migrate api secret",
+      }),
+    /requires confirmation token/,
+  );
+  assert.throws(
+    () =>
+      applyLegacyGlobalEnvMigrationPlan(plan, services, {
+        confirmation: "APPLY_LEGACY_GLOBALENV_MIGRATION",
+        auditReason: " ",
+      }),
+    /requires a non-empty audit reason/,
+  );
+});
+
+test("legacy migration apply produces manifest changes, partial skips, and rollback guidance", () => {
+  const services = [
+    fixtureService("api", {
+      env: {
+        DB_PASSWORD: "super-secret-password-value",
+        DATABASE_DSN: "postgres://user:pass@localhost/db",
+        PUBLIC_URL: "http://localhost:3000",
+      },
+      globalenv: {
+        SHARED_TOKEN: "global-secret-value",
+      },
+      broker: {
+        imports: [
+          { namespace: "services/api", ref: "api.EXISTING", as: "EXISTING" },
+        ],
+      },
+    }),
+  ];
+  const plan = createLegacyGlobalEnvMigrationPlan(services, {
+    includeAmbiguous: true,
+  });
+
+  const result = applyLegacyGlobalEnvMigrationPlan(plan, services, {
+    confirmation: "APPLY_LEGACY_GLOBALENV_MIGRATION",
+    auditReason: "Move api legacy env secrets into broker refs",
+  });
+  const manifest = result.updatedManifests.api;
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.applied, [
+    { serviceId: "api", key: "DB_PASSWORD", ref: "api.DB_PASSWORD" },
+  ]);
+  assert.deepEqual(
+    result.skipped.map((entry) => [entry.key, entry.state]),
+    [
+      ["DATABASE_DSN", "needs-confirmation"],
+      ["PUBLIC_URL", "unsupported"],
+      ["SHARED_TOKEN", "unsupported"],
+    ],
+  );
+  assert.equal(manifest.env.DB_PASSWORD, "${api.DB_PASSWORD}");
+  assert.equal(manifest.env.PUBLIC_URL, "http://localhost:3000");
+  assert.deepEqual(manifest.broker.imports, [
+    { namespace: "services/api", ref: "api.EXISTING", as: "EXISTING" },
+    {
+      namespace: "services/api",
+      ref: "api.DB_PASSWORD",
+      as: "DB_PASSWORD",
+      required: true,
+    },
+  ]);
+  assert.match(
+    result.rollbackGuidance.join("\n"),
+    /restor(?:e|ing) the original env\/globalenv entries/,
+  );
+  assertNoRawMaterial(result);
+});
+
+test("legacy migration apply can include ambiguous env candidates only with explicit flag", () => {
+  const services = [
+    fixtureService("api", {
+      env: { DATABASE_DSN: "postgres://user:pass@localhost/db" },
+    }),
+  ];
+  const plan = createLegacyGlobalEnvMigrationPlan(services, {
+    includeAmbiguous: true,
+  });
+  const result = applyLegacyGlobalEnvMigrationPlan(plan, services, {
+    confirmation: "APPLY_LEGACY_GLOBALENV_MIGRATION",
+    auditReason: "Migrate confirmed ambiguous DSN",
+    allowAmbiguous: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.applied, [
+    { serviceId: "api", key: "DATABASE_DSN", ref: "api.DATABASE_DSN" },
+  ]);
+  assert.equal(
+    result.updatedManifests.api.env.DATABASE_DSN,
+    "${api.DATABASE_DSN}",
+  );
+  assertNoRawMaterial(result);
+});


### PR DESCRIPTION
## Summary
- add a metadata-only legacy env/globalenv migration planner for Secrets Broker refs
- classify secret, non-secret, ambiguous, denied, and unsupported candidates without returning raw values
- add gated apply planning with explicit confirmation/audit reason, ambiguous opt-in, partial skip reporting, and rollback guidance
- document before/after service.json mapping and link it from the service.json reference

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/legacy-globalenv-migration.test.js`
- `npm test` (244 pass)
- `npm run docs:build`
- `git diff --check`

Closes #424
