### PR TITLE
ISS-425 add secret leak regression harness

### DIFF
--- a/docs/reference/secret-leak-regression-harness.md
+++ b/docs/reference/secret-leak-regression-harness.md
@@ -1,0 +1,50 @@
+# Secret leak regression harness
+
+Service Lasso test suites should use deterministic fake sentinels plus common credential-shape detection whenever a feature can render, log, export, persist, screenshot, or report secret-adjacent data.
+
+The reusable harness lives in `src/testing/secretLeakHarness.ts` and is exported from the package wrapper for downstream tests.
+
+## What to scan
+
+Add covered surfaces as plain strings or nested objects:
+
+- route paths and query strings
+- page titles, breadcrumbs, and rendered text
+- console/server logs and diagnostics
+- support bundles, reports, exports, and snapshots
+- local/session storage dumps
+- workflow YAML, run logs, and artifacts
+- screenshot/failure-artifact text extraction when available
+
+## Sentinel policy
+
+Use only deterministic fake material. The default sentinels are clearly fake Service Lasso values and must not resemble live credentials. The harness also detects common credential shapes such as bearer tokens, basic-auth URLs, GitHub tokens, AWS access keys, and private-key blocks.
+
+Raw sentinel values may appear only inside deliberately contained test inputs. Any generated output containing them must be scrub-verified by `assertNoSecretMaterial` or equivalent before it becomes a durable artifact.
+
+## Example
+
+```ts
+import { assertNoSecretMaterial } from "@service-lasso/service-lasso";
+
+await assertNoSecretMaterial({
+  route: "/secrets-broker",
+  title: document.title,
+  text: document.body.textContent ?? "",
+  localStorage: { ...localStorage },
+});
+```
+
+Metadata-only broker surfaces are allowed:
+
+```json
+{
+  "ref": "api.DB_PASSWORD",
+  "status": "policy-denied",
+  "required": true,
+  "valuePresent": true,
+  "fingerprint": "0123456789abcdef"
+}
+```
+
+Do not allow raw values, raw tokens, cookies, private keys, provider credentials, or unredacted secret material in comments, logs, PR bodies, docs, support bundles, or test artifacts.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -78,6 +78,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/secret-leak-regression-harness",
+          label: "Secret Leak Regression Harness",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,5 +1,13 @@
 export type { RuntimeApp } from "../../dist/runtime/app.js";
-export type { ApiServerOptions, RunningApiServer } from "../../dist/server/index.js";
+export type {
+  ApiServerOptions,
+  RunningApiServer,
+} from "../../dist/server/index.js";
+export type {
+  SecretLeakFinding,
+  SecretLeakScanOptions,
+  SecretLeakSentinel,
+} from "../../dist/testing/secretLeakHarness.js";
 
 export declare function startRuntimeApp(
   options?: import("../../dist/server/index.js").ApiServerOptions,
@@ -10,3 +18,19 @@ export declare const createRuntime: typeof startRuntimeApp;
 export declare function startApiServer(
   options?: import("../../dist/server/index.js").ApiServerOptions,
 ): Promise<import("../../dist/server/index.js").RunningApiServer>;
+
+export declare function scanForSecretMaterial(
+  input: unknown,
+  options?: import("../../dist/testing/secretLeakHarness.js").SecretLeakScanOptions,
+): Promise<
+  import("../../dist/testing/secretLeakHarness.js").SecretLeakFinding[]
+>;
+
+export declare function assertNoSecretMaterial(
+  input: unknown,
+  options?: import("../../dist/testing/secretLeakHarness.js").SecretLeakScanOptions,
+): Promise<void>;
+
+export declare function serviceLassoSecretLeakSentinels(): Promise<
+  import("../../dist/testing/secretLeakHarness.js").SecretLeakSentinel[]
+>;

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -6,6 +6,10 @@ async function loadApiServer() {
   return import("../../dist/server/index.js");
 }
 
+async function loadSecretLeakHarness() {
+  return import("../../dist/testing/secretLeakHarness.js");
+}
+
 export async function startRuntimeApp(options = {}) {
   const runtimeModule = await loadRuntimeApp();
   return runtimeModule.startRuntimeApp(options);
@@ -16,4 +20,19 @@ export const createRuntime = startRuntimeApp;
 export async function startApiServer(options = {}) {
   const serverModule = await loadApiServer();
   return serverModule.startApiServer(options);
+}
+
+export async function scanForSecretMaterial(input, options = {}) {
+  const harness = await loadSecretLeakHarness();
+  return harness.scanForSecretMaterial(input, options);
+}
+
+export async function assertNoSecretMaterial(input, options = {}) {
+  const harness = await loadSecretLeakHarness();
+  return harness.assertNoSecretMaterial(input, options);
+}
+
+export async function serviceLassoSecretLeakSentinels() {
+  const harness = await loadSecretLeakHarness();
+  return harness.serviceLassoSecretLeakSentinels;
 }

--- a/src/testing/secretLeakHarness.ts
+++ b/src/testing/secretLeakHarness.ts
@@ -1,0 +1,142 @@
+export interface SecretLeakSentinel {
+  label: string;
+  value: string;
+  description: string;
+}
+
+export interface SecretLeakFinding {
+  path: string;
+  kind: "sentinel" | "credential-shape";
+  label: string;
+  excerpt: string;
+}
+
+export interface SecretLeakScanOptions {
+  sentinels?: SecretLeakSentinel[];
+  includeDefaultCredentialShapes?: boolean;
+}
+
+export const serviceLassoSecretLeakSentinels: SecretLeakSentinel[] = [
+  {
+    label: "service-lasso-fake-token",
+    value: "SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE",
+    description:
+      "Clearly fake project sentinel for token-like leak regression tests.",
+  },
+  {
+    label: "service-lasso-fake-password",
+    value: "SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE",
+    description:
+      "Clearly fake project sentinel for password-like leak regression tests.",
+  },
+  {
+    label: "service-lasso-fake-private-key",
+    value: "-----BEGIN SERVICE LASSO FAKE PRIVATE KEY-----",
+    description:
+      "Clearly fake project sentinel for private-key-like leak regression tests.",
+  },
+];
+
+const credentialShapePatterns: Array<{ label: string; pattern: RegExp }> = [
+  { label: "bearer-token", pattern: /Bearer\s+[A-Za-z0-9._~+/-]{24,}/g },
+  { label: "basic-auth-url", pattern: /https?:\/\/[^\s/:]+:[^\s/@]{6,}@/g },
+  { label: "aws-access-key", pattern: /AKIA[0-9A-Z]{16}/g },
+  { label: "github-token", pattern: /gh[pousr]_[A-Za-z0-9_]{30,}/g },
+  {
+    label: "private-key-block",
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g,
+  },
+];
+
+function excerpt(value: string, index: number, length: number): string {
+  const start = Math.max(0, index - 16);
+  const end = Math.min(value.length, index + length + 16);
+  return value.slice(start, end);
+}
+
+function collectStrings(
+  input: unknown,
+  path: string,
+  output: Array<{ path: string; value: string }>,
+): void {
+  if (typeof input === "string") {
+    output.push({ path, value: input });
+    return;
+  }
+  if (input === null || input === undefined) {
+    return;
+  }
+  if (
+    typeof input === "number" ||
+    typeof input === "boolean" ||
+    typeof input === "bigint"
+  ) {
+    return;
+  }
+  if (Array.isArray(input)) {
+    input.forEach((entry, index) =>
+      collectStrings(entry, `${path}[${index}]`, output),
+    );
+    return;
+  }
+  if (typeof input === "object") {
+    for (const [key, value] of Object.entries(
+      input as Record<string, unknown>,
+    )) {
+      collectStrings(value, path ? `${path}.${key}` : key, output);
+    }
+  }
+}
+
+export function scanForSecretMaterial(
+  input: unknown,
+  options: SecretLeakScanOptions = {},
+): SecretLeakFinding[] {
+  const strings: Array<{ path: string; value: string }> = [];
+  collectStrings(input, "$", strings);
+  const findings: SecretLeakFinding[] = [];
+  const sentinels = options.sentinels ?? serviceLassoSecretLeakSentinels;
+
+  for (const item of strings) {
+    for (const sentinel of sentinels) {
+      const index = item.value.indexOf(sentinel.value);
+      if (index >= 0) {
+        findings.push({
+          path: item.path,
+          kind: "sentinel",
+          label: sentinel.label,
+          excerpt: excerpt(item.value, index, sentinel.value.length),
+        });
+      }
+    }
+
+    if (options.includeDefaultCredentialShapes !== false) {
+      for (const { label, pattern } of credentialShapePatterns) {
+        pattern.lastIndex = 0;
+        for (const match of item.value.matchAll(pattern)) {
+          findings.push({
+            path: item.path,
+            kind: "credential-shape",
+            label,
+            excerpt: excerpt(item.value, match.index ?? 0, match[0].length),
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function assertNoSecretMaterial(
+  input: unknown,
+  options: SecretLeakScanOptions = {},
+): void {
+  const findings = scanForSecretMaterial(input, options);
+  if (findings.length > 0) {
+    const summary = findings
+      .map((finding) => `${finding.kind}:${finding.label}@${finding.path}`)
+      .join(", ");
+    throw new Error(`Secret material leak detected: ${summary}`);
+  }
+}

--- a/tests/secret-leak-harness.test.js
+++ b/tests/secret-leak-harness.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  assertNoSecretMaterial,
+  scanForSecretMaterial,
+  serviceLassoSecretLeakSentinels,
+} from "../dist/testing/secretLeakHarness.js";
+
+test("secret leak harness detects project sentinel values across nested surfaces", () => {
+  const payload = {
+    route: "/safe",
+    page: {
+      title: "Secrets Broker",
+      text: `value=${serviceLassoSecretLeakSentinels[0].value}`,
+    },
+    storage: ["metadata only"],
+  };
+
+  const findings = scanForSecretMaterial(payload);
+
+  assert.deepEqual(
+    findings.map((finding) => [finding.kind, finding.label, finding.path]),
+    [["sentinel", "service-lasso-fake-token", "$.page.text"]],
+  );
+  assert.throws(
+    () => assertNoSecretMaterial(payload),
+    /Secret material leak detected/,
+  );
+});
+
+test("secret leak harness detects common credential shapes", () => {
+  const findings = scanForSecretMaterial({
+    log: "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+  });
+
+  assert.deepEqual(
+    findings.map((finding) => [finding.kind, finding.label]),
+    [["credential-shape", "bearer-token"]],
+  );
+});
+
+test("secret leak harness allows metadata-only broker surfaces", () => {
+  assertNoSecretMaterial({
+    ref: "api.DB_PASSWORD",
+    status: "policy-denied",
+    required: true,
+    valuePresent: true,
+    fingerprint: "0123456789abcdef",
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable secret-material leak regression harness with deterministic fake Service Lasso sentinels and credential-shape detection.
- Export harness helpers from the package wrapper for downstream tests.
- Document required cross-surface usage for routes, rendered text, logs, diagnostics, exports, snapshots, storage, workflow artifacts, and screenshots/text extraction.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/secret-leak-harness.test.js`
- `npm test` (247 pass)
- `npm run docs:build`
- `git diff --check`

Fixes #425
