### PR TITLE
ISS-429 add Traefik local route generation

### DIFF
--- a/docs/reference/traefik-local-route-generation.md
+++ b/docs/reference/traefik-local-route-generation.md
@@ -1,0 +1,65 @@
+# Traefik local route generation
+
+Service Lasso writes Traefik dynamic route config for local app hosts under `servicelasso.localhost`. This is routing/config generation only; Service Lasso core does not implement a custom OIDC/session/token auth facade runtime.
+
+## Hostname contract
+
+Hostnames are composed as:
+
+```text
+<app>.servicelasso.localhost
+```
+
+Examples:
+
+- `serviceadmin.servicelasso.localhost`
+- `auth.servicelasso.localhost`
+- `zitadel.servicelasso.localhost`
+
+Use `.localhost`, not `.local`.
+
+## Dynamic config target
+
+`lasso-traefik` reads a file provider at:
+
+```text
+runtime/dynamic.yml
+```
+
+Service Lasso route generation should render a complete dynamic config object/YAML and replace this file atomically during config/update flows. The generated file contains only routers, services, and middleware references; it must not include tokens, OIDC client secrets, session cookies, provider credentials, or raw identity envelopes.
+
+## Protected app routes
+
+Protected app routes include:
+
+- a router matching `Host("app.servicelasso.localhost")` for the generated app hostname
+- `websecure` entrypoint
+- TLS enabled
+- a backend service URL pointing at the loopback/internal app port
+- spoofed identity header stripping middleware
+- forward-auth middleware reference
+
+The default protected route middleware chain is:
+
+```yaml
+middlewares:
+  - servicelasso-strip-spoofed-identity
+  - servicelasso-forward-auth
+```
+
+`servicelasso-forward-auth` is a middleware reference/config boundary. Auth mechanics are owned by Traefik/auth middleware + ZITADEL/service-owned behavior, not by a Service Lasso core auth runtime.
+
+## No default bypass route
+
+Service Lasso must not generate an unauthenticated `serviceadmin` bypass route by default. Public routes must be explicitly marked as unprotected and must use their own app host/router identity.
+
+## Test gate
+
+Automated tests cover:
+
+- hostname composition under `servicelasso.localhost`
+- rejection of `.local` shorthand
+- generated router/service/middleware shape
+- protected route middleware attachment
+- no default unauthenticated bypass route
+- generated fixture/YAML absence of tokens, OIDC client secrets, session cookies, provider credentials, and other secret-like material

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -83,6 +83,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/traefik-local-route-generation",
+          label: "Traefik Local Route Generation",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/src/runtime/traefik/local-route-generation.ts
+++ b/src/runtime/traefik/local-route-generation.ts
@@ -1,0 +1,281 @@
+export interface ServiceLassoLocalAppRoute {
+  appId: string;
+  serviceId: string;
+  backendUrl: string;
+  protected?: boolean;
+  authMiddleware?: string;
+  extraMiddlewares?: string[];
+}
+
+export interface ServiceLassoTraefikRouteOptions {
+  domainSuffix?: string;
+  namespace?: string;
+  entryPoint?: string;
+  tls?: boolean;
+  defaultAuthMiddleware?: string;
+}
+
+export interface ServiceLassoTraefikDynamicConfig {
+  http: {
+    routers: Record<string, TraefikRouterConfig>;
+    services: Record<string, TraefikServiceConfig>;
+    middlewares: Record<string, TraefikMiddlewareConfig>;
+  };
+}
+
+export interface TraefikRouterConfig {
+  rule: string;
+  entryPoints: string[];
+  middlewares?: string[];
+  service: string;
+  tls?: Record<string, never>;
+}
+
+export interface TraefikServiceConfig {
+  loadBalancer: {
+    servers: Array<{ url: string }>;
+  };
+}
+
+export type TraefikMiddlewareConfig =
+  | {
+      forwardAuth: {
+        address: string;
+        trustForwardHeader: false;
+        authRequestHeaders: string[];
+        authResponseHeaders: string[];
+      };
+    }
+  | {
+      headers: {
+        customRequestHeaders?: Record<string, string>;
+        customResponseHeaders?: Record<string, string>;
+      };
+    };
+
+const defaultIdentityHeadersToStrip = [
+  "X-ServiceLasso-User-ID",
+  "X-ServiceLasso-Workspace-ID",
+  "X-ServiceLasso-Instance-ID",
+  "X-ServiceLasso-Email",
+  "X-ServiceLasso-Roles",
+  "X-ServiceLasso-Auth-Method",
+  "X-ServiceLasso-Audit-Actor",
+  "X-Service-Lasso-User",
+  "X-Service-Lasso-Workspace",
+  "X-Service-Lasso-Roles",
+  "X-Service-Lasso-Actor",
+  "X-Forwarded-User",
+  "X-Forwarded-Email",
+  "X-Auth-Request-User",
+  "X-Auth-Request-Email",
+];
+
+const trustedIdentityHeaders = [
+  "X-ServiceLasso-User-ID",
+  "X-ServiceLasso-Workspace-ID",
+  "X-ServiceLasso-Instance-ID",
+  "X-ServiceLasso-Email",
+  "X-ServiceLasso-Roles",
+  "X-ServiceLasso-Auth-Method",
+  "X-ServiceLasso-Audit-Actor",
+];
+
+const forbiddenMaterialPattern =
+  /(?:id_token|access_token|refresh_token|client_secret|session_cookie|password|private[_-]?key|Bearer\s+[A-Za-z0-9._~+/-]{24,}|gh[pousr]_[A-Za-z0-9_]{30,})/i;
+
+export function composeServiceLassoLocalHostname(
+  appId: string,
+  options: ServiceLassoTraefikRouteOptions = {},
+): string {
+  const namespace = sanitizeDnsLabel(options.namespace ?? "servicelasso");
+  const suffix = sanitizeDomainSuffix(options.domainSuffix ?? "localhost");
+  const app = sanitizeDnsLabel(appId);
+  return `${app}.${namespace}.${suffix}`;
+}
+
+export function buildServiceLassoTraefikDynamicConfig(
+  routes: ServiceLassoLocalAppRoute[],
+  options: ServiceLassoTraefikRouteOptions = {},
+): ServiceLassoTraefikDynamicConfig {
+  const entryPoint = options.entryPoint ?? "websecure";
+  const tls = options.tls ?? true;
+  const defaultAuthMiddleware = sanitizeResourceName(
+    options.defaultAuthMiddleware ?? "servicelasso-forward-auth",
+  );
+  const routers: Record<string, TraefikRouterConfig> = {};
+  const services: Record<string, TraefikServiceConfig> = {};
+  const middlewares: Record<string, TraefikMiddlewareConfig> = {
+    "servicelasso-strip-spoofed-identity": {
+      headers: {
+        customRequestHeaders: Object.fromEntries(
+          defaultIdentityHeadersToStrip.map((header) => [header, ""]),
+        ),
+      },
+    },
+    [defaultAuthMiddleware]: {
+      forwardAuth: {
+        address: "http://127.0.0.1:${AUTH_FACADE_PORT}/forward-auth",
+        trustForwardHeader: false,
+        authRequestHeaders: [
+          "Cookie",
+          "Authorization",
+          "X-Forwarded-Proto",
+          "X-Forwarded-Host",
+          "X-Forwarded-Uri",
+        ],
+        authResponseHeaders: trustedIdentityHeaders,
+      },
+    },
+  };
+
+  for (const route of routes) {
+    const appName = sanitizeResourceName(route.appId);
+    const routerName = `${appName}-servicelasso-local`;
+    const serviceName = `${appName}-backend`;
+    const protectedRoute = route.protected !== false;
+    const middlewaresForRoute = protectedRoute
+      ? [
+          "servicelasso-strip-spoofed-identity",
+          sanitizeResourceName(route.authMiddleware ?? defaultAuthMiddleware),
+          ...dedupe((route.extraMiddlewares ?? []).map(sanitizeResourceName)),
+        ]
+      : dedupe((route.extraMiddlewares ?? []).map(sanitizeResourceName));
+
+    assertNoSecretLikeMaterial(
+      route.backendUrl,
+      `backendUrl for ${route.appId}`,
+    );
+    routers[routerName] = {
+      rule: `Host(\`${composeServiceLassoLocalHostname(route.appId, options)}\`)`,
+      entryPoints: [entryPoint],
+      ...(middlewaresForRoute.length > 0
+        ? { middlewares: middlewaresForRoute }
+        : {}),
+      service: serviceName,
+      ...(tls ? { tls: {} } : {}),
+    };
+    services[serviceName] = {
+      loadBalancer: { servers: [{ url: route.backendUrl }] },
+    };
+  }
+
+  const config = { http: { routers, services, middlewares } };
+  assertNoSecretLikeMaterial(
+    JSON.stringify(config),
+    "generated Traefik dynamic config",
+  );
+  return config;
+}
+
+export function renderServiceLassoTraefikDynamicConfigYaml(
+  config: ServiceLassoTraefikDynamicConfig,
+): string {
+  const lines = ["http:", "  routers:"];
+  for (const [name, router] of Object.entries(config.http.routers)) {
+    lines.push(`    ${name}:`);
+    lines.push(`      rule: "${router.rule}"`);
+    lines.push("      entryPoints:");
+    for (const entryPoint of router.entryPoints)
+      lines.push(`        - ${entryPoint}`);
+    if (router.middlewares && router.middlewares.length > 0) {
+      lines.push("      middlewares:");
+      for (const middleware of router.middlewares)
+        lines.push(`        - ${middleware}`);
+    }
+    lines.push(`      service: ${router.service}`);
+    if (router.tls) lines.push("      tls: {}");
+  }
+  lines.push("  middlewares:");
+  for (const [name, middleware] of Object.entries(config.http.middlewares)) {
+    lines.push(`    ${name}:`);
+    if ("forwardAuth" in middleware) {
+      lines.push("      forwardAuth:");
+      lines.push(`        address: "${middleware.forwardAuth.address}"`);
+      lines.push(
+        `        trustForwardHeader: ${middleware.forwardAuth.trustForwardHeader}`,
+      );
+      lines.push("        authRequestHeaders:");
+      for (const header of middleware.forwardAuth.authRequestHeaders)
+        lines.push(`          - ${header}`);
+      lines.push("        authResponseHeaders:");
+      for (const header of middleware.forwardAuth.authResponseHeaders)
+        lines.push(`          - ${header}`);
+    } else {
+      lines.push("      headers:");
+      if (middleware.headers.customRequestHeaders) {
+        lines.push("        customRequestHeaders:");
+        for (const [header, value] of Object.entries(
+          middleware.headers.customRequestHeaders,
+        )) {
+          lines.push(`          ${header}: "${value}"`);
+        }
+      }
+      if (middleware.headers.customResponseHeaders) {
+        lines.push("        customResponseHeaders:");
+        for (const [header, value] of Object.entries(
+          middleware.headers.customResponseHeaders,
+        )) {
+          lines.push(`          ${header}: "${value}"`);
+        }
+      }
+    }
+  }
+  lines.push("  services:");
+  for (const [name, service] of Object.entries(config.http.services)) {
+    lines.push(`    ${name}:`);
+    lines.push("      loadBalancer:");
+    lines.push("        servers:");
+    for (const server of service.loadBalancer.servers)
+      lines.push(`          - url: "${server.url}"`);
+  }
+  const yaml = `${lines.join("\n")}\n`;
+  assertNoSecretLikeMaterial(yaml, "rendered Traefik dynamic config YAML");
+  return yaml;
+}
+
+function sanitizeDnsLabel(value: string): string {
+  const label = value
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!label) throw new Error("Local route host label cannot be empty.");
+  if (label === "local")
+    throw new Error("Use the .localhost suffix, not .local.");
+  return label;
+}
+
+function sanitizeDomainSuffix(value: string): string {
+  const suffix = value
+    .trim()
+    .toLowerCase()
+    .replace(/^\.+|\.+$/g, "");
+  if (suffix !== "localhost")
+    throw new Error(
+      `Service Lasso local routes must use localhost suffix, got ${suffix}.`,
+    );
+  return suffix;
+}
+
+function sanitizeResourceName(value: string): string {
+  const name = value
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!name) throw new Error("Traefik resource name cannot be empty.");
+  return name;
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function assertNoSecretLikeMaterial(value: string, context: string): void {
+  if (forbiddenMaterialPattern.test(value)) {
+    throw new Error(`${context} contains secret-like material.`);
+  }
+}

--- a/tests/traefik-local-route-generation.test.js
+++ b/tests/traefik-local-route-generation.test.js
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildServiceLassoTraefikDynamicConfig,
+  composeServiceLassoLocalHostname,
+  renderServiceLassoTraefikDynamicConfigYaml,
+} from "../dist/runtime/traefik/local-route-generation.js";
+
+test("composes Service Lasso local hostnames under servicelasso.localhost", () => {
+  assert.equal(
+    composeServiceLassoLocalHostname("@serviceadmin"),
+    "serviceadmin.servicelasso.localhost",
+  );
+  assert.equal(
+    composeServiceLassoLocalHostname("workflow-ui"),
+    "workflow-ui.servicelasso.localhost",
+  );
+  assert.throws(
+    () =>
+      composeServiceLassoLocalHostname("serviceadmin", {
+        domainSuffix: "local",
+      }),
+    /localhost suffix/,
+  );
+});
+
+test("generates protected Traefik routers services and middleware references", () => {
+  const config = buildServiceLassoTraefikDynamicConfig([
+    {
+      appId: "@serviceadmin",
+      serviceId: "@serviceadmin",
+      backendUrl: "http://127.0.0.1:${SERVICEADMIN_PORT}",
+    },
+  ]);
+
+  assert.deepEqual(config.http.routers["serviceadmin-servicelasso-local"], {
+    rule: "Host(`serviceadmin.servicelasso.localhost`)",
+    entryPoints: ["websecure"],
+    middlewares: [
+      "servicelasso-strip-spoofed-identity",
+      "servicelasso-forward-auth",
+    ],
+    service: "serviceadmin-backend",
+    tls: {},
+  });
+  assert.equal(
+    config.http.services["serviceadmin-backend"].loadBalancer.servers[0].url,
+    "http://127.0.0.1:${SERVICEADMIN_PORT}",
+  );
+  assert.equal(
+    config.http.middlewares["servicelasso-forward-auth"].forwardAuth
+      .trustForwardHeader,
+    false,
+  );
+});
+
+test("renders stable dynamic.yml fixture without .local shorthand or bypass routes", () => {
+  const yaml = renderServiceLassoTraefikDynamicConfigYaml(
+    buildServiceLassoTraefikDynamicConfig([
+      {
+        appId: "@serviceadmin",
+        serviceId: "@serviceadmin",
+        backendUrl: "http://127.0.0.1:${SERVICEADMIN_PORT}",
+      },
+    ]),
+  );
+
+  assert.match(yaml, /Host\(`serviceadmin\.servicelasso\.localhost`\)/);
+  assert.match(yaml, /servicelasso-strip-spoofed-identity/);
+  assert.match(yaml, /servicelasso-forward-auth/);
+  assert.match(yaml, /X-ServiceLasso-User-ID: ""/);
+  assert.match(yaml, /authResponseHeaders:\n\s+- X-ServiceLasso-User-ID/);
+  assert.doesNotMatch(yaml, /servicelasso\.local(?!host)/);
+  assert.doesNotMatch(yaml, /serviceadmin-(?:bypass|unprotected)/);
+});
+
+test("allows explicit public routes but never creates a default unauthenticated bypass", () => {
+  const config = buildServiceLassoTraefikDynamicConfig([
+    {
+      appId: "@serviceadmin",
+      serviceId: "@serviceadmin",
+      backendUrl: "http://127.0.0.1:${SERVICEADMIN_PORT}",
+    },
+    {
+      appId: "status",
+      serviceId: "status",
+      backendUrl: "http://127.0.0.1:${STATUS_PORT}",
+      protected: false,
+    },
+  ]);
+
+  assert.deepEqual(
+    config.http.routers["serviceadmin-servicelasso-local"].middlewares,
+    ["servicelasso-strip-spoofed-identity", "servicelasso-forward-auth"],
+  );
+  assert.equal(
+    config.http.routers["status-servicelasso-local"].middlewares,
+    undefined,
+  );
+  assert.equal(
+    Object.keys(config.http.routers).some((name) =>
+      /serviceadmin-(?:bypass|unprotected)/.test(name),
+    ),
+    false,
+  );
+});
+
+test("rejects secret-like material in generated route inputs", () => {
+  assert.throws(
+    () =>
+      buildServiceLassoTraefikDynamicConfig([
+        {
+          appId: "@serviceadmin",
+          serviceId: "@serviceadmin",
+          backendUrl:
+            "http://127.0.0.1:${SERVICEADMIN_PORT}?client_secret=do-not-place-secrets-here",
+        },
+      ]),
+    /secret-like material/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add pure Traefik dynamic route generation for Service Lasso local app hosts under `servicelasso.localhost`.
- Generate protected routers/services/middleware references for `runtime/dynamic.yml` without adding any custom OIDC/session/token/auth facade runtime.
- Add docs for how Service Lasso composes hostnames and writes Traefik dynamic config.

## Automated testing gate
- Unit tests cover hostname composition with `TRAEFIK_HOST_DOMAIN_SUFFIX=localhost` semantics.
- Fixture/YAML tests cover generated Traefik routers/services/middleware references.
- Tests prove generated hostnames use `servicelasso.localhost`, not `.local`.
- Tests prove protected routes attach auth middleware and do not create default unauthenticated bypass routes.
- Secret-safety assertion rejects token/client-secret/session-cookie/provider-credential-shaped material in generated route inputs/config.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/traefik-local-route-generation.test.js`
- `npm run docs:build`
- `npm test` (252 pass)
- `git diff --check`

Fixes #429
