### PR TITLE
ISS-431 add local SSO loop smoke fixture

### DIFF
--- a/docs/reference/local-sso-loop-smoke.md
+++ b/docs/reference/local-sso-loop-smoke.md
@@ -1,0 +1,65 @@
+# Local SSO loop smoke fixture
+
+Service Lasso validates the local `servicelasso.localhost` SSO loop with a deterministic fixture that can run in CI without real provider credentials or a live browser login.
+
+The fixture is intentionally a smoke/regression contract, not an auth runtime. Auth mechanics remain owned by Traefik, the external/plugin-owned `traefik-oidc-auth` middleware, and ZITADEL/service-owned configuration. Service Lasso core only verifies the generated route/config shape and safe evidence surfaces.
+
+## Covered route loop
+
+The smoke fixture covers:
+
+```text
+GET https://serviceadmin.servicelasso.localhost
+-> protected Traefik route
+-> traefik-oidc-auth redirects to ZITADEL
+-> callback at https://auth.servicelasso.localhost/oauth2/callback
+-> fixture session established by traefik-oidc-auth
+-> Service Admin receives safe trusted identity metadata
+```
+
+It also covers the fail-closed path when the auth middleware is unavailable or no trusted identity context exists.
+
+## Generated evidence
+
+Run:
+
+```powershell
+npm run test:local-sso-loop
+```
+
+To write the fixture evidence directly:
+
+```powershell
+node scripts/local-sso-loop-smoke.mjs
+```
+
+By default this writes:
+
+```text
+runtime/local-sso-loop-smoke.evidence.json
+```
+
+The evidence contains only metadata:
+
+- Service Admin, auth callback, and ZITADEL `servicelasso.localhost` routes
+- protected route middleware chain
+- spoofable identity header stripping
+- trusted identity header allowlist returned by `traefik-oidc-auth`
+- browser-flow expectations for redirect, callback, authenticated return, and fail-closed behavior
+- captured page text/log/diagnostic examples with no credential material
+
+## Safety assertions
+
+Tests reject evidence containing:
+
+- `.local` shorthand
+- unauthenticated Service Admin bypass route names
+- `trustForwardHeader: true`
+- ID/access/refresh tokens
+- client secrets
+- session cookie values
+- provider credentials
+- raw secret values
+- private keys or bearer tokens
+
+The fixture uses deterministic fake states only and must not require real provider credentials.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -88,6 +88,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/local-sso-loop-smoke",
+          label: "Local SSO Loop Smoke",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "release:assets:expected": "node scripts/check-release-assets.mjs --expected",
     "release:assets:check": "node scripts/check-release-assets.mjs",
     "bootstrap:local-sso": "node scripts/local-sso-bootstrap.mjs",
-    "test:local-sso": "npm run build && node --test --test-concurrency=1 tests/local-sso-bootstrap.test.js"
+    "test:local-sso": "npm run build && node --test --test-concurrency=1 tests/local-sso-bootstrap.test.js",
+    "test:local-sso-loop": "npm run build && node --test --test-concurrency=1 tests/local-sso-loop-smoke.test.js"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/scripts/local-sso-loop-smoke.mjs
+++ b/scripts/local-sso-loop-smoke.mjs
@@ -1,0 +1,235 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const localSsoLoopSmokeDefaults = Object.freeze({
+  serviceAdminHost: "serviceadmin.servicelasso.localhost",
+  authHost: "auth.servicelasso.localhost",
+  zitadelHost: "zitadel.servicelasso.localhost",
+  serviceAdminBackendUrl: "http://127.0.0.1:${SERVICEADMIN_PORT}",
+  oidcMiddlewareAuthUrl: "http://127.0.0.1:${TRAEFIK_OIDC_AUTH_PORT}/auth",
+  oidcMiddlewareCallbackUrl: "http://127.0.0.1:${TRAEFIK_OIDC_AUTH_PORT}/oauth2/callback",
+  zitadelBackendUrl: "http://127.0.0.1:${ZITADEL_PORT}",
+  outputPath: "runtime/local-sso-loop-smoke.evidence.json",
+});
+
+const trustedIdentityHeaders = Object.freeze([
+  "X-ServiceLasso-User-ID",
+  "X-ServiceLasso-Workspace-ID",
+  "X-ServiceLasso-Email",
+  "X-ServiceLasso-Roles",
+  "X-ServiceLasso-Auth-Method",
+  "X-ServiceLasso-Audit-Actor",
+]);
+
+const spoofableIdentityHeaders = Object.freeze([
+  ...trustedIdentityHeaders,
+  "X-Service-Lasso-User",
+  "X-Service-Lasso-Workspace",
+  "X-Service-Lasso-Roles",
+  "X-Service-Lasso-Actor",
+  "X-Forwarded-User",
+  "X-Forwarded-Email",
+  "X-Auth-Request-User",
+  "X-Auth-Request-Email",
+]);
+
+const forbiddenMaterialPattern =
+  /(?:ACTUAL_SECRET|BEGIN PRIVATE KEY|id_token\s*[:=]|access_token\s*[:=]|refresh_token\s*[:=]|client_secret\s*[:=]|session_cookie\s*[:=]|provider_credential\s*[:=]|raw_secret\s*[:=]|password\s*[:=]|Bearer\s+[A-Za-z0-9._~+/-]{24,})/i;
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort();
+}
+
+export function assertSafeLocalSsoSmokeConfig(config = {}) {
+  const merged = { ...localSsoLoopSmokeDefaults, ...config };
+  const hostValues = [merged.serviceAdminHost, merged.authHost, merged.zitadelHost];
+  for (const value of hostValues) {
+    if (!String(value).endsWith(".servicelasso.localhost")) {
+      throw new Error(`Local SSO smoke hosts must use servicelasso.localhost: ${value}`);
+    }
+    if (/\.local(\/|$)/.test(String(value))) {
+      throw new Error(`Use servicelasso.localhost, not .local, for local SSO smoke: ${value}`);
+    }
+  }
+
+  assertNoSecretMaterial(merged, "local SSO smoke config");
+
+  const text = JSON.stringify(merged);
+  if (/auth[-_ ]facade|service-lasso-auth/i.test(text)) {
+    throw new Error("Local SSO smoke must use the external OIDC middleware boundary, not a core-owned auth runtime.");
+  }
+
+  return merged;
+}
+
+export function buildLocalSsoLoopSmokeFixture(config = {}) {
+  const safeConfig = assertSafeLocalSsoSmokeConfig(config);
+  const stripHeaders = Object.fromEntries(spoofableIdentityHeaders.map((header) => [header, ""]));
+
+  const traefikDynamicConfig = {
+    http: {
+      routers: {
+        "serviceadmin-protected": {
+          rule: `Host(\`${safeConfig.serviceAdminHost}\`)`,
+          entryPoints: ["websecure"],
+          middlewares: ["strip-browser-identity-headers", "traefik-oidc-auth"],
+          service: "serviceadmin-backend",
+          tls: {},
+        },
+        "auth-callback": {
+          rule: `Host(\`${safeConfig.authHost}\`) && PathPrefix(\`/oauth2/callback\`)`,
+          entryPoints: ["websecure"],
+          middlewares: ["strip-browser-identity-headers"],
+          service: "traefik-oidc-auth-callback",
+          tls: {},
+        },
+        "zitadel-login": {
+          rule: `Host(\`${safeConfig.zitadelHost}\`)`,
+          entryPoints: ["websecure"],
+          service: "zitadel-backend",
+          tls: {},
+        },
+      },
+      middlewares: {
+        "strip-browser-identity-headers": {
+          headers: { customRequestHeaders: stripHeaders },
+        },
+        "traefik-oidc-auth": {
+          forwardAuth: {
+            address: safeConfig.oidcMiddlewareAuthUrl,
+            trustForwardHeader: false,
+            authRequestHeaders: ["Cookie", "Authorization", "X-Forwarded-Proto", "X-Forwarded-Host", "X-Forwarded-Uri"],
+            authResponseHeaders: [...trustedIdentityHeaders],
+          },
+        },
+      },
+      services: {
+        "serviceadmin-backend": {
+          loadBalancer: { servers: [{ url: safeConfig.serviceAdminBackendUrl }] },
+        },
+        "traefik-oidc-auth-callback": {
+          loadBalancer: { servers: [{ url: safeConfig.oidcMiddlewareCallbackUrl }] },
+        },
+        "zitadel-backend": {
+          loadBalancer: { servers: [{ url: safeConfig.zitadelBackendUrl }] },
+        },
+      },
+    },
+  };
+
+  const fixture = {
+    status: "ready",
+    boundary: "Traefik + traefik-oidc-auth + ZITADEL; Service Lasso core provides deterministic smoke evidence only.",
+    domains: {
+      serviceAdmin: `https://${safeConfig.serviceAdminHost}`,
+      authCallback: `https://${safeConfig.authHost}/oauth2/callback`,
+      zitadel: `https://${safeConfig.zitadelHost}`,
+    },
+    traefikDynamicConfig,
+    browserFlow: [
+      {
+        step: "unauthenticated_serviceadmin_request",
+        request: `GET https://${safeConfig.serviceAdminHost}`,
+        expect: {
+          status: 302,
+          locationStartsWith: `https://${safeConfig.zitadelHost}`,
+          reason: "protected route redirects to ZITADEL through the external OIDC middleware",
+        },
+      },
+      {
+        step: "oidc_callback_fixture",
+        request: `GET https://${safeConfig.authHost}/oauth2/callback?code=fixture-code&state=fixture-state`,
+        expect: {
+          status: 302,
+          location: `https://${safeConfig.serviceAdminHost}`,
+          session: "established by traefik-oidc-auth fixture; value redacted",
+        },
+      },
+      {
+        step: "authenticated_serviceadmin_return",
+        request: `GET https://${safeConfig.serviceAdminHost}`,
+        expect: {
+          status: 200,
+          pageTextIncludes: ["Trusted SSO identity context", "workspace:service-lasso/local-dev", "serviceadmin.operator"],
+          forwardedIdentityHeaders: [...trustedIdentityHeaders],
+        },
+      },
+      {
+        step: "auth_unavailable_fail_closed",
+        request: `GET https://${safeConfig.serviceAdminHost}`,
+        expect: {
+          status: 503,
+          pageTextIncludes: ["Login required", "No trusted user metadata"],
+          upstreamServiceAdminReached: false,
+        },
+      },
+    ],
+    capturedEvidence: {
+      pageText: "Trusted SSO identity context workspace:service-lasso/local-dev serviceadmin.operator audit-actor://zitadel/max",
+      console: ["local-sso-smoke fixture completed without credential output"],
+      logs: ["redirect_to_zitadel", "callback_session_fixture_redacted", "serviceadmin_authenticated", "auth_unavailable_fail_closed"],
+      diagnostics: [
+        "generated Traefik dynamic config contains Service Admin, auth callback, and ZITADEL routes",
+        "spoofable identity headers are stripped before protected upstream forwarding",
+        "only trusted identity headers from traefik-oidc-auth are forwarded",
+        "auth unavailable path fails closed before Service Admin upstream is reached",
+      ],
+    },
+  };
+
+  assertLocalSsoLoopSmokeEvidence(fixture);
+  return fixture;
+}
+
+export function assertLocalSsoLoopSmokeEvidence(fixture) {
+  assertNoSecretMaterial(fixture, "local SSO loop smoke evidence");
+
+  const text = JSON.stringify(fixture);
+  for (const required of [
+    "serviceadmin.servicelasso.localhost",
+    "auth.servicelasso.localhost",
+    "zitadel.servicelasso.localhost",
+    "traefik-oidc-auth",
+    "strip-browser-identity-headers",
+    "Trusted SSO identity context",
+  ]) {
+    if (!text.includes(required)) {
+      throw new Error(`Local SSO loop smoke fixture missing ${required}`);
+    }
+  }
+
+  if (/servicelasso\.local(?!host)/.test(text)) {
+    throw new Error("Local SSO loop smoke fixture must use servicelasso.localhost, not .local.");
+  }
+  if (/serviceadmin-(?:bypass|unprotected)|trustForwardHeader\":true/.test(text)) {
+    throw new Error("Local SSO loop smoke fixture contains unsafe bypass behavior.");
+  }
+
+  return true;
+}
+
+export function assertNoSecretMaterial(value, context = "value") {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (forbiddenMaterialPattern.test(text)) {
+    throw new Error(`${context} contains secret-like material.`);
+  }
+  return true;
+}
+
+export async function writeLocalSsoLoopSmokeEvidence(outputPath, fixture = buildLocalSsoLoopSmokeFixture()) {
+  assertLocalSsoLoopSmokeEvidence(fixture);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(fixture, null, 2)}\n`, "utf8");
+}
+
+async function main() {
+  const outputPath = process.env.SERVICE_LASSO_LOCAL_SSO_SMOKE ?? localSsoLoopSmokeDefaults.outputPath;
+  const fixture = buildLocalSsoLoopSmokeFixture();
+  await writeLocalSsoLoopSmokeEvidence(outputPath, fixture);
+  console.log(JSON.stringify({ status: fixture.status, outputPath, domains: fixture.domains }, null, 2));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/tests/local-sso-loop-smoke.test.js
+++ b/tests/local-sso-loop-smoke.test.js
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertLocalSsoLoopSmokeEvidence,
+  assertSafeLocalSsoSmokeConfig,
+  buildLocalSsoLoopSmokeFixture,
+  writeLocalSsoLoopSmokeEvidence,
+} from "../scripts/local-sso-loop-smoke.mjs";
+
+const forbiddenOutput =
+  /ACTUAL_SECRET|BEGIN PRIVATE KEY|access_token\s*[:=]|refresh_token\s*[:=]|id_token\s*[:=]|session_cookie\s*[:=]|client_secret\s*[:=]|provider_credential\s*[:=]|raw_secret\s*[:=]|password\s*[:=]|Bearer\s+[A-Za-z0-9._~+/-]{24,}/i;
+
+test("local SSO loop smoke fixture contains Service Admin auth callback and ZITADEL routes", () => {
+  const fixture = buildLocalSsoLoopSmokeFixture();
+  const routers = fixture.traefikDynamicConfig.http.routers;
+
+  assert.equal(routers["serviceadmin-protected"].rule, "Host(`serviceadmin.servicelasso.localhost`)");
+  assert.equal(
+    routers["auth-callback"].rule,
+    "Host(`auth.servicelasso.localhost`) && PathPrefix(`/oauth2/callback`)",
+  );
+  assert.equal(routers["zitadel-login"].rule, "Host(`zitadel.servicelasso.localhost`)");
+  assert.deepEqual(routers["serviceadmin-protected"].middlewares, [
+    "strip-browser-identity-headers",
+    "traefik-oidc-auth",
+  ]);
+});
+
+test("local SSO loop smoke fixture strips spoofed identity headers and forwards only trusted headers", () => {
+  const fixture = buildLocalSsoLoopSmokeFixture();
+  const middlewares = fixture.traefikDynamicConfig.http.middlewares;
+  const stripped = middlewares["strip-browser-identity-headers"].headers.customRequestHeaders;
+  const forwardAuth = middlewares["traefik-oidc-auth"].forwardAuth;
+
+  assert.equal(stripped["X-ServiceLasso-User-ID"], "");
+  assert.equal(stripped["X-Service-Lasso-User"], "");
+  assert.equal(stripped["X-Forwarded-User"], "");
+  assert.equal(stripped["X-Auth-Request-Email"], "");
+  assert.equal(forwardAuth.trustForwardHeader, false);
+  assert.deepEqual(forwardAuth.authResponseHeaders, [
+    "X-ServiceLasso-User-ID",
+    "X-ServiceLasso-Workspace-ID",
+    "X-ServiceLasso-Email",
+    "X-ServiceLasso-Roles",
+    "X-ServiceLasso-Auth-Method",
+    "X-ServiceLasso-Audit-Actor",
+  ]);
+});
+
+test("local SSO loop smoke fixture covers redirect callback authenticated return and fail closed", () => {
+  const fixture = buildLocalSsoLoopSmokeFixture();
+
+  assert.deepEqual(
+    fixture.browserFlow.map((step) => step.step),
+    [
+      "unauthenticated_serviceadmin_request",
+      "oidc_callback_fixture",
+      "authenticated_serviceadmin_return",
+      "auth_unavailable_fail_closed",
+    ],
+  );
+  assert.equal(
+    fixture.browserFlow[0].expect.locationStartsWith,
+    "https://zitadel.servicelasso.localhost",
+  );
+  assert.equal(
+    fixture.browserFlow[1].expect.location,
+    "https://serviceadmin.servicelasso.localhost",
+  );
+  assert.ok(
+    fixture.browserFlow[2].expect.pageTextIncludes.includes("workspace:service-lasso/local-dev"),
+  );
+  assert.equal(fixture.browserFlow[3].expect.upstreamServiceAdminReached, false);
+});
+
+test("local SSO loop smoke evidence is metadata-only and leak checked across captured surfaces", () => {
+  const fixture = buildLocalSsoLoopSmokeFixture();
+  const text = JSON.stringify(fixture);
+
+  assertLocalSsoLoopSmokeEvidence(fixture);
+  assert.doesNotMatch(text, forbiddenOutput);
+  assert.doesNotMatch(text, /auth facade|service-lasso-auth/i);
+  assert.doesNotMatch(text, /servicelasso\.local(?!host)/);
+  assert.doesNotMatch(text, /serviceadmin-(?:bypass|unprotected)/);
+  assert.match(text, /local-sso-smoke fixture completed without credential output/);
+});
+
+test("local SSO loop smoke rejects .local and secret-like config", () => {
+  assert.throws(
+    () =>
+      assertSafeLocalSsoSmokeConfig({
+        serviceAdminHost: "serviceadmin.servicelasso.local",
+      }),
+    /servicelasso\.localhost|\.local/,
+  );
+
+  assert.throws(
+    () =>
+      assertSafeLocalSsoSmokeConfig({
+        oidcMiddlewareAuthUrl: "http://127.0.0.1/auth?client_secret=ACTUAL_SECRET",
+      }),
+    /secret-like material/,
+  );
+});
+
+test("local SSO loop smoke evidence can be written for PR validation", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-sso-loop-"));
+  try {
+    const outputPath = path.join(tempRoot, "local-sso-loop-smoke.evidence.json");
+    await writeLocalSsoLoopSmokeEvidence(outputPath);
+    const written = await readFile(outputPath, "utf8");
+
+    assert.match(written, /serviceadmin\.servicelasso\.localhost/);
+    assert.match(written, /auth\.servicelasso\.localhost/);
+    assert.match(written, /zitadel\.servicelasso\.localhost/);
+    assert.match(written, /traefik-oidc-auth/);
+    assert.doesNotMatch(written, forbiddenOutput);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add a deterministic local SSO loop smoke fixture for `serviceadmin.servicelasso.localhost`
- verify generated Traefik route config for Service Admin, auth callback, and ZITADEL routes
- cover unauthenticated redirect, callback fixture, authenticated return, and auth-unavailable fail-closed behavior
- assert captured page text, console, logs, generated config, and diagnostics stay free of token/secret material

Boundary: this is fixture/mocked smoke evidence around Traefik + external/plugin-owned `traefik-oidc-auth` + ZITADEL. It does **not** add a Service Lasso-owned OIDC/session/token/auth runtime.

## Validation

- `npm run test:local-sso-loop` — passed (6 tests)
- `npm run test:local-sso` — passed (5 tests)
- `npm test -- --test-reporter=spec tests/local-sso-loop-smoke.test.js tests/local-sso-bootstrap.test.js tests/traefik-local-route-generation.test.js` — passed (258 tests; npm emitted existing warning that `--test-reporter` is an unknown npm config)
- `npm run docs:build` — passed
- `git diff --check` — passed

Closes #431
