### PR TITLE
ISS-432 add servicelasso localhost SSO test matrix

### DIFF
--- a/docs/reference/servicelasso-localhost-sso-test-matrix.md
+++ b/docs/reference/servicelasso-localhost-sso-test-matrix.md
@@ -1,0 +1,51 @@
+# servicelasso.localhost SSO test matrix
+
+This matrix is the automated regression map for the local Service Lasso SSO stack.
+
+Corrected boundary: Service Lasso core owns route/config contracts and deterministic smoke evidence. Auth mechanics are owned by Traefik, external/plugin-owned `traefik-oidc-auth` / Service Lasso Traefik OIDC middleware, and ZITADEL/service-owned configuration. Service Lasso core must not implement a custom OIDC/session/token auth runtime.
+
+## CI/local entrypoints
+
+| Scope | Command | Repo | Evidence |
+| --- | --- | --- | --- |
+| Core full regression | `npm test` | `service-lasso/service-lasso` | Core API/runtime tests plus route generation, local SSO bootstrap, local SSO loop smoke, ZITADEL consumer fixtures, and leak harness tests. |
+| Core docs | `npm run docs:build` | `service-lasso/service-lasso` | Docusaurus reference docs build, including this matrix and SSO smoke docs. |
+| Traefik route generation | `npm run test:local-sso` and `node --test tests/traefik-local-route-generation.test.js` after `npm run build` | `service-lasso/service-lasso` | Hostname, route, middleware, `.localhost`, no-bypass, and no-secret route-generation assertions. |
+| Local SSO loop smoke | `npm run test:local-sso-loop` | `service-lasso/service-lasso` | Deterministic Service Admin -> auth callback -> ZITADEL -> authenticated return and fail-closed smoke evidence. |
+| ZITADEL bootstrap | `npm run test:oidc` and `npm test` | `service-lasso/lasso-zitadel` | Idempotent client bootstrap, redirect/post-logout/origin metadata, and metadata-only output. |
+| Traefik protected routes | `npm test` | `service-lasso/lasso-traefik` | Packaged Traefik fixture checks, protected route middleware, header stripping, and `/ping` smoke. |
+| Service Admin identity UI | targeted `vitest` auth-session/secrets-broker tests and `npm run build` | `service-lasso/lasso-serviceadmin` | Trusted identity UI states, safe actor/workspace metadata, and no-secret rendering. |
+
+## Requirement matrix
+
+| Requirement | Automated test location | Validation command | Notes |
+| --- | --- | --- | --- |
+| Hostname composition uses `servicelasso.localhost`. | `service-lasso/tests/traefik-local-route-generation.test.js`; `service-lasso/tests/local-sso-bootstrap.test.js`; `service-lasso/tests/local-sso-loop-smoke.test.js` | `npm run test:local-sso`; `npm run test:local-sso-loop`; full `npm test` | Tests reject `.local` shorthand and assert `serviceadmin.servicelasso.localhost`, `auth.servicelasso.localhost`, and `zitadel.servicelasso.localhost`. |
+| Generated Traefik dynamic config contains routers/services/middlewares. | `service-lasso/tests/traefik-local-route-generation.test.js`; `service-lasso/tests/local-sso-loop-smoke.test.js` | `node --test tests/traefik-local-route-generation.test.js`; `npm run test:local-sso-loop` | Covers Service Admin protected route, auth callback route, ZITADEL route, backend services, and middleware chain. |
+| Protected route allow/deny behavior. | `service-lasso/tests/local-sso-loop-smoke.test.js`; `service-lasso/lasso-traefik/runtime/protected-serviceadmin.example.yml` verified by `lasso-traefik/scripts/verify.mjs` | `npm run test:local-sso-loop`; `lasso-traefik` `npm test` | Fixture models unauthenticated redirect, authenticated return, and auth-unavailable fail-closed behavior. |
+| Header stripping and trusted identity forwarding. | `service-lasso/tests/traefik-local-route-generation.test.js`; `service-lasso/tests/local-sso-loop-smoke.test.js`; `lasso-traefik/scripts/verify.mjs` | `npm run test:local-sso-loop`; `lasso-traefik` `npm test` | Spoofable browser headers are blanked; trusted headers are allowlisted from `traefik-oidc-auth`. |
+| ZITADEL OIDC client bootstrap idempotency. | `lasso-zitadel/scripts/oidc-bootstrap.test.mjs` | `lasso-zitadel` `npm run test:oidc`; `npm test` | Covers create, verify existing, update drift, and no rotation of credentials unless explicitly requested. |
+| Redirect URI and post-logout URI correctness. | `lasso-zitadel/scripts/oidc-bootstrap.test.mjs`; `service-lasso/tests/local-sso-bootstrap.test.js` | `lasso-zitadel` `npm run test:oidc`; `service-lasso` `npm run test:local-sso` | Uses `https://auth.servicelasso.localhost/oauth2/callback` for ZITADEL client metadata and deterministic local smoke metadata. |
+| Callback/session validation boundary. | `service-lasso/tests/local-sso-loop-smoke.test.js` | `npm run test:local-sso-loop` | Covered as external/plugin-owned `traefik-oidc-auth` callback/session fixture evidence; core does not own session mechanics. |
+| Service Admin authenticated/unauthenticated/forbidden/expired/workspace mismatch states. | `lasso-serviceadmin/src/features/auth-session/zitadel-session.test.tsx` | targeted `vitest` auth-session tests; `npm run build` | Renders safe identity, workspace, role, permission, and audit actor metadata only. |
+| End-to-end Service Admin login return smoke path. | `service-lasso/tests/local-sso-loop-smoke.test.js` | `npm run test:local-sso-loop` | Deterministic smoke contract verifies redirect, callback return, and authenticated Service Admin page evidence. |
+| Fail-closed auth unavailable/ZITADEL unavailable behavior. | `service-lasso/tests/local-sso-loop-smoke.test.js`; `lasso-traefik/scripts/verify.mjs`; `lasso-serviceadmin/src/features/auth-session/zitadel-session.test.tsx` | `npm run test:local-sso-loop`; `lasso-traefik` `npm test`; Service Admin targeted tests | Protected apps must not have default unauthenticated bypass routes. Missing/invalid identity context fails closed. |
+| Secret-leak regression across page text, logs, generated config, diagnostics, snapshots, headers, and fixtures. | `service-lasso/tests/secret-leak-harness.test.js`; `service-lasso/tests/local-sso-loop-smoke.test.js`; `service-lasso/tests/local-sso-bootstrap.test.js`; `lasso-zitadel/scripts/oidc-bootstrap.test.mjs`; `lasso-serviceadmin/src/features/auth-session/zitadel-session.test.tsx`; `lasso-serviceadmin/src/features/secrets-broker/secrets-broker-setup.test.tsx` | Full repo tests and targeted SSO tests listed above | Deny-list covers ID/access/refresh tokens, client secrets, session cookies, provider credentials, raw secret values, private keys, bearer material, and raw env-like values. |
+
+## Implementation issue coverage
+
+| Issue | Current boundary/result | Automated gate |
+| --- | --- | --- |
+| `service-lasso/service-lasso#429` | Core Traefik dynamic route generation for `servicelasso.localhost`; no custom auth runtime. | `tests/traefik-local-route-generation.test.js`; `npm test`; docs build. |
+| `service-lasso/service-lasso#430` | Legacy custom auth-facade runtime concept is blocked/superseded. | Matrix intentionally maps callback/session checks to `traefik-oidc-auth` fixture evidence, not Service Lasso-owned runtime tests. |
+| `service-lasso/lasso-zitadel#2` | ZITADEL client bootstrap for external/plugin-owned OIDC middleware with metadata-only output. | `scripts/oidc-bootstrap.test.mjs`; `npm run test:oidc`; `npm test`. |
+| `service-lasso/lasso-serviceadmin#90` | Service Admin consumes trusted protected-route identity context and renders safe metadata. | `src/features/auth-session/zitadel-session.test.tsx`; Secrets Broker setup leak tests; `npm run build`. |
+| `service-lasso/lasso-traefik#13` | Protected Service Admin route middleware/templates/fixtures. | `runtime/protected-serviceadmin.example.yml` verified by `scripts/verify.mjs`; `npm test`. |
+| `service-lasso/service-lasso#431` | Deterministic local SSO loop smoke/regression evidence. | `tests/local-sso-loop-smoke.test.js`; `npm run test:local-sso-loop`. |
+
+## Required regression invariants
+
+- Any `.local` shorthand in this SSO path must fail a test.
+- Any token, cookie, client secret, provider credential, private key, raw env value, or raw secret material in generated config, docs examples, diagnostics, logs, page text, snapshots, headers, or fixtures must fail a test.
+- Any Service Admin default unauthenticated bypass route must fail a test.
+- Any reintroduction of Service Lasso-owned custom auth runtime language for this stack should be treated as boundary drift and corrected before implementation.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -93,6 +93,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/servicelasso-localhost-sso-test-matrix",
+          label: "SSO Test Matrix",
+        },
+        {
+          type: "doc",
           id: "reference/zitadel-consumer-integration",
           label: "ZITADEL Consumer Integration",
         },

--- a/tests/servicelasso-localhost-sso-test-matrix.test.js
+++ b/tests/servicelasso-localhost-sso-test-matrix.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const matrixPath = new URL("../docs/reference/servicelasso-localhost-sso-test-matrix.md", import.meta.url);
+
+const requiredSnippets = [
+  "service-lasso/service-lasso#429",
+  "service-lasso/service-lasso#430",
+  "service-lasso/lasso-zitadel#2",
+  "service-lasso/lasso-serviceadmin#90",
+  "service-lasso/lasso-traefik#13",
+  "service-lasso/service-lasso#431",
+  "tests/traefik-local-route-generation.test.js",
+  "tests/local-sso-bootstrap.test.js",
+  "tests/local-sso-loop-smoke.test.js",
+  "scripts/oidc-bootstrap.test.mjs",
+  "zitadel-session.test.tsx",
+  "protected-serviceadmin.example.yml",
+  "npm run test:local-sso-loop",
+  "npm run test:local-sso",
+  "npm run docs:build",
+  "traefik-oidc-auth",
+  "auth.servicelasso.localhost",
+  "serviceadmin.servicelasso.localhost",
+  "zitadel.servicelasso.localhost",
+];
+
+const forbiddenSecretPattern =
+  /(?:ACTUAL_SECRET|BEGIN PRIVATE KEY|id_token\s*[:=]|access_token\s*[:=]|refresh_token\s*[:=]|client_secret\s*[:=]|session_cookie\s*[:=]|provider_credential\s*[:=]|raw_secret\s*[:=]|password\s*[:=]|Bearer\s+[A-Za-z0-9._~+/-]{24,})/i;
+
+test("servicelasso.localhost SSO test matrix maps all implementation gates", async () => {
+  const matrix = await readFile(matrixPath, "utf8");
+
+  for (const snippet of requiredSnippets) {
+    assert.match(matrix, new RegExp(escapeRegExp(snippet)), `missing matrix snippet: ${snippet}`);
+  }
+});
+
+test("servicelasso.localhost SSO test matrix documents corrected auth boundary", async () => {
+  const matrix = await readFile(matrixPath, "utf8");
+
+  assert.match(matrix, /external\/plugin-owned `traefik-oidc-auth`/);
+  assert.match(matrix, /Service Lasso core must not implement a custom OIDC\/session\/token auth runtime/);
+  assert.match(matrix, /Legacy custom auth-facade runtime concept is blocked\/superseded/);
+  assert.doesNotMatch(matrix, /Service Lasso-owned custom OIDC\/session\/token\/forward-auth runtime/);
+});
+
+test("servicelasso.localhost SSO test matrix rejects local shorthand and secret material", async () => {
+  const matrix = await readFile(matrixPath, "utf8");
+
+  assert.doesNotMatch(matrix, /servicelasso\.local(?!host)/);
+  assert.doesNotMatch(matrix, forbiddenSecretPattern);
+  assert.match(matrix, /Any `\.local` shorthand in this SSO path must fail a test/);
+  assert.match(matrix, /Any token, cookie, client secret, provider credential, private key, raw env value, or raw secret material/);
+});
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

- add the documented `servicelasso.localhost` SSO automated test matrix
- map each SSO requirement and related issue to concrete test files and validation commands
- add a regression test that keeps the matrix aligned and rejects `.local`, secret material, and auth-boundary drift

Boundary: this preserves the corrected stack boundary. The legacy #430 auth-facade runtime concept is marked blocked/superseded; callback/session coverage maps to deterministic `traefik-oidc-auth` fixture evidence, not a Service Lasso-owned auth runtime.

## Validation

- `npm run build && node --test --test-concurrency=1 tests/servicelasso-localhost-sso-test-matrix.test.js tests/local-sso-loop-smoke.test.js tests/local-sso-bootstrap.test.js tests/traefik-local-route-generation.test.js` — passed (19 tests)
- `npm run test:local-sso-loop` — passed (6 tests)
- `npm run docs:build` — passed
- `npm test` — passed (261 tests)
- `git diff --check` — passed

Closes #432
