### PR TITLE
ISS-460 cover LAN bind defaults

### DIFF
--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -59,6 +59,28 @@ test("GET /api/health returns core API health", async () => {
   }
 });
 
+test("runtime API binds to all interfaces by default while reporting a local URL", async () => {
+  const previousHost = process.env.SERVICE_LASSO_HOST;
+  delete process.env.SERVICE_LASSO_HOST;
+
+  const apiServer = await startApiServer({ port: 0, version: "lan-bind-test" });
+
+  try {
+    const address = apiServer.server.address();
+
+    assert.ok(address && typeof address !== "string");
+    assert.equal(address.address, "0.0.0.0");
+    assert.equal(apiServer.url, `http://127.0.0.1:${apiServer.port}`);
+  } finally {
+    await apiServer.stop();
+    if (previousHost === undefined) {
+      delete process.env.SERVICE_LASSO_HOST;
+    } else {
+      process.env.SERVICE_LASSO_HOST = previousHost;
+    }
+  }
+});
+
 test("GET /api/services returns discovered services from the tracked services root", async () => {
   const servicesRoot = path.resolve("services");
   await clearPersistedFixtureState(servicesRoot);

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -199,6 +199,10 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
+  assert.deepEqual(byId.get("@serviceadmin")?.env, {
+    SERVICE_HOST: "0.0.0.0",
+    SERVICE_PORT: "${UI_PORT}",
+  });
 });
 
 test("loadServiceManifest fails explicitly for malformed manifests", async () => {


### PR DESCRIPTION
## Summary
- Adds regression coverage that verifies the runtime API binds to all interfaces by default while reporting a local URL for operators.
- Extends baseline manifest discovery coverage for the network endpoint contract that backs LAN demo validation.

## Validation
- PASS: npm run build && node --test --test-concurrency=1 tests/api-spine.test.js tests/manifest-discovery.test.js
  - Log: .work-agent/logs/issue-460/20260518-173207-focused-validation.log
- FAIL: npm test
  - Log: .work-agent/logs/issue-460/20260518-173235-npm-test.log
  - Failure is limited to tests/registry-runtime-state.test.js expecting 10 baseline services while current discovery returns 11. This file is not changed by this PR.

Closes #460