### PR TITLE
fix(test): guard multi-instance service ranges against API ports

### DIFF
--- a/scripts/verify-multi-instance-ports.mjs
+++ b/scripts/verify-multi-instance-ports.mjs
@@ -49,6 +49,17 @@ async function reservePort() {
   throw new Error(`No free ports remain in ${portStart}-${portEnd}.`);
 }
 
+function assertServiceRangesExcludeApiPorts(instances, apiPorts) {
+  for (const instance of instances) {
+    for (const apiPort of apiPorts) {
+      assert(
+        apiPort < instance.servicePortStart || apiPort > instance.servicePortEnd,
+        `${instance.label} service port range ${instance.servicePortStart}-${instance.servicePortEnd} overlaps reserved API port ${apiPort}.`,
+      );
+    }
+  }
+}
+
 async function fetchWithTimeout(url, options = {}, timeoutMs = 30_000) {
   return fetch(url, { ...options, signal: AbortSignal.timeout(timeoutMs) });
 }
@@ -169,6 +180,7 @@ const instances = [
   await createInstance("a", apiPorts[0], firstServicePort, midpoint),
   await createInstance("b", apiPorts[1], midpoint + 1, portEnd),
 ];
+assertServiceRangesExcludeApiPorts(instances, apiPorts);
 
 try {
   console.error(`[service-lasso multi-instance] reserved API ports ${apiPorts.join(", ")}; service port ranges ${instances.map((instance) => `${instance.label}:${instance.servicePortStart}-${instance.servicePortEnd}`).join(", ")}`);


### PR DESCRIPTION
## Issue
Closes #458

## Summary
- Adds an explicit pre-start guard proving multi-instance service port ranges do not include reserved runtime API ports.
- Keeps the existing runtime/startup behavior unchanged; this is a verifier hardening patch for the #458 overlap failure mode.

## Scope
- In scope: `scripts/verify-multi-instance-ports.mjs` multi-instance port validation.
- Out of scope: runtime port negotiation behavior, Service Admin behavior, baseline smoke fixture drift tracked separately by #475.

## Spec / contract / fixture impact
- Updated: verifier contract now fails before startup if any service range overlaps a reserved API port.
- Not required: no public API, manifest schema, or service contract changes.

## Service Lasso invariant impact
- Invariant: fixed local Service Lasso port range must keep API and service-negotiated ports unique.
- Preservation proof: `npm run verify:multi-instance-ports` passed and reported API 17880/17881 with service ranges 17882-17931 and 17932-17980.

## Validation
- PASS `git diff --check` — no whitespace errors.
- PASS `npm run verify:multi-instance-ports` — build passed; two instances passed in 17880-17980.

## Approval trail
- Required: no
- Evidence: Ready Project #1 issue #458.

## Cleanup
- Local branch: `issue-458-multi-instance-port-reservation`.
- Evidence logs: `C:\projects\service-lasso\service-lasso\.work-agent\logs\issue-458-20260519-114600`.
