### PR TITLE
fix(runtime): defer python from default baseline on unsupported platforms

### DIFF
--- a/scripts/baseline-start-smoke.mjs
+++ b/scripts/baseline-start-smoke.mjs
@@ -575,14 +575,21 @@ try {
 
   const services = await waitForJson(`http://127.0.0.1:${apiPort}/api/services`);
   const serviceIds = services.services.map((service) => service.id).sort();
+  const expectedServiceIds = ["@archive", "@java", "@localcert", "@nginx", "@node", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service"];
+  if (serviceIds.includes("@python")) {
+    expectedServiceIds.splice(5, 0, "@python");
+  }
   assert(
-    JSON.stringify(serviceIds) === JSON.stringify(["@archive", "@java", "@localcert", "@nginx", "@node", "@python", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service"]),
+    JSON.stringify(serviceIds) === JSON.stringify(expectedServiceIds),
     `Unexpected service list: ${JSON.stringify(serviceIds)}`,
   );
 
   for (const serviceId of serviceIds) {
     const detail = await waitForJson(`http://127.0.0.1:${apiPort}/api/services/${encodeURIComponent(serviceId)}`);
     const service = detail.service;
+    if (!cliSummary.requestedServiceIds.includes(serviceId)) {
+      continue;
+    }
     assert(service?.lifecycle?.installed === true, `${serviceId} was not installed.`);
     assert(service.lifecycle?.configured === true, `${serviceId} was not configured.`);
     assert(service.health?.healthy === true, `${serviceId} health did not report healthy.`);

--- a/scripts/verify-real-app-e2e.mjs
+++ b/scripts/verify-real-app-e2e.mjs
@@ -7,8 +7,8 @@ import { startApiServer } from "../dist/server/index.js";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = path.join(repoRoot, "dist", "cli.js");
 const sourceServicesRoot = path.join(repoRoot, "services");
-const baselineServiceIds = ["@archive", "@java", "@localcert", "@nginx", "@node", "@python", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service", "node-sample-service"];
-const providerServiceIds = new Set(["@archive", "@java", "@localcert", "@node", "@python"]);
+const baselineServiceIds = ["@archive", "@java", "@localcert", "@nginx", "@node", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service", "node-sample-service"];
+const providerServiceIds = new Set(["@archive", "@java", "@localcert", "@node"]);
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/scripts/verify-real-app-e2e.mjs
+++ b/scripts/verify-real-app-e2e.mjs
@@ -334,6 +334,10 @@ try {
     assert(serviceIds.includes(serviceId), `Real app service list is missing ${serviceId}.`);
   }
 
+  for (const action of ["install", "config", "start"]) {
+    await postJson(`${apiUrl}/api/services/${encodeURIComponent("node-sample-service")}/${action}`);
+  }
+
   for (const serviceId of baselineServiceIds) {
     const isProvider = providerServiceIds.has(serviceId);
     await waitForServiceState(apiUrl, serviceId, { running: !isProvider, healthy: isProvider ? undefined : true });

--- a/src/runtime/cli/bootstrap.ts
+++ b/src/runtime/cli/bootstrap.ts
@@ -12,7 +12,7 @@ import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
 import { writeServiceState } from "../state/writeState.js";
 import { isProviderRole } from "../roles.js";
 
-export const DEFAULT_BASELINE_SERVICE_IDS = ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@python", "@secretsbroker", "echo-service", "@serviceadmin"] as const;
+export const DEFAULT_BASELINE_SERVICE_IDS = ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@secretsbroker", "echo-service", "@serviceadmin"] as const;
 
 export type BaselineServiceStatus = "completed" | "skipped";
 

--- a/tests/bootstrap-start.test.js
+++ b/tests/bootstrap-start.test.js
@@ -46,13 +46,13 @@ test("bootstrapBaselineServices installs, configures, and starts baseline servic
       version: "test-version",
     });
 
-    assert.deepEqual(result.requestedServiceIds, ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@python", "@secretsbroker", "echo-service", "@serviceadmin"]);
-    assert.deepEqual(result.serviceOrder, ["@archive", "@java", "@localcert", "@nginx", "@node", "@python", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service"]);
-    assert.equal(result.services.length, 10);
+    assert.deepEqual(result.requestedServiceIds, ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@secretsbroker", "echo-service", "@serviceadmin"]);
+    assert.deepEqual(result.serviceOrder, ["@archive", "@java", "@localcert", "@nginx", "@node", "@secretsbroker", "@serviceadmin", "@traefik", "echo-service"]);
+    assert.equal(result.services.length, 9);
 
     for (const service of result.services) {
       assert.equal(service.status, "completed");
-      const expectedActions = service.serviceId === "@archive" || service.serviceId === "@python"
+      const expectedActions = service.serviceId === "@archive"
         ? ["install:completed", "config:completed", "start:skipped"]
         : ["install:completed", "config:completed", "start:completed"];
       assert.deepEqual(
@@ -62,7 +62,7 @@ test("bootstrapBaselineServices installs, configures, and starts baseline servic
       const state = getLifecycleState(service.serviceId);
       assert.equal(state.installed, true, `${service.serviceId} installed`);
       assert.equal(state.configured, true, `${service.serviceId} configured`);
-      assert.equal(state.running, service.serviceId !== "@archive" && service.serviceId !== "@python", `${service.serviceId} running`);
+      assert.equal(state.running, service.serviceId !== "@archive", `${service.serviceId} running`);
     }
 
     const rerun = await bootstrapBaselineServices({
@@ -133,6 +133,7 @@ test("bootstrapBaselineServices skips managed start for provider-role baseline s
       servicesRoot,
       workspaceRoot,
       version: "test-version",
+      serviceIds: ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@python", "@secretsbroker", "echo-service", "@serviceadmin"],
     });
     const archive = result.services.find((service) => service.serviceId === "@archive");
     const node = result.services.find((service) => service.serviceId === "@node");


### PR DESCRIPTION
## Issue
Closes #478

## Summary
- Removes @python from the default baseline service list while keeping the checked-in disabled optional provider manifest available for explicit opt-in.
- Updates the real-app E2E baseline expectation so Linux does not try to acquire the Windows-only @python release artifact by default.
- Keeps explicit coverage for provider-role baseline semantics by passing @python as an opt-in service in bootstrap tests.

## Scope
- In scope: default baseline membership and tests for the @python Linux artifact gap.
- Out of scope: publishing Linux @python artifacts and the separate #475/#477 smoke fixture repair.

## Spec / contract / fixture impact
- Updated runtime default baseline contract in src/runtime/cli/bootstrap.ts.
- Updated real-app E2E and bootstrap tests.
- Existing docs already state @python is non-baseline/Windows-only optional provider inventory:
  - README.md says @python is not part of the default baseline start command.
  - docs/development/runtime-provider-release-services-delivery-plan.md says @python is Windows-only and non-baseline.

## Service Lasso invariant impact
- Keeps @python as a base/system service id with @ prefix.
- Keeps @python local-first and optional; it is not acquired by default on unsupported Linux hosts.
- Does not change Service Admin optionality or Secrets Broker behavior.

## Validation
- PASS `npm run build`
- PASS `node --test --test-concurrency=1 tests/bootstrap-start.test.js tests/api-spine.test.js`
- BLOCKED `npm run verify:baseline-start`: current develop still lacks the separate #475 smoke fixture repair, so the gate stops before #478's @python path with missing @archive.
- NOT RUN `npm run verify:real-app-e2e`: skipped because verify:baseline-start failed on the #475 dependency before this PR's path.
- Logs: `.work-agent/logs/issue-478-20260519-212721/`

## Approval trail
- Required: yes, because this is a draft until the #475/#477 dependency is resolved or the target branch includes that fixture repair.
- Evidence: #475 / PR #477 owns the missing @archive smoke fixture blocker.

## Cleanup
- Branch pushed: `issue-478-python-baseline-linux-gap`
- Local cleanup can return to `develop` after final handoff; `.work-agent/` evidence logs remain local only.