### PR TITLE
fix(runtime): pin Service Admin runtime API release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.5.14-0821754"
+      "tag": "2026.5.15-c66d8ce"
     },
     "platforms": {
       "win32": {

--- a/tests/bootstrap-start.test.js
+++ b/tests/bootstrap-start.test.js
@@ -1,11 +1,27 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { bootstrapBaselineServices } from "../dist/runtime/cli/bootstrap.js";
 import { stopAllManagedProcesses } from "../dist/runtime/execution/supervisor.js";
 import { getLifecycleState, resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function readJsonWhenReady(filePath, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(filePath, "utf8"));
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  throw lastError;
+}
 
 test("bootstrapBaselineServices installs, configures, and starts baseline services in dependency order", async () => {
   resetLifecycleState();
@@ -78,6 +94,47 @@ test("bootstrapBaselineServices installs, configures, and starts baseline servic
       );
     }
   } finally {
+    await stopAllManagedProcesses();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("bootstrapBaselineServices passes the owning runtime API URL to Service Admin", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-serviceadmin-runtime-api-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const previousRuntimeApiBaseUrl = process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL;
+  process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL = "http://127.0.0.1:19876";
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "@node", {
+      role: "provider",
+      healthcheck: null,
+    });
+    await writeExecutableFixtureService(servicesRoot, "@serviceadmin", {
+      depend_on: ["@node"],
+      captureEnvKeys: ["SERVICE_LASSO_RUNTIME_API_BASE_URL"],
+    });
+
+    const result = await bootstrapBaselineServices({
+      servicesRoot,
+      workspaceRoot,
+      version: "test-version",
+      serviceIds: ["@node", "@serviceadmin"],
+    });
+
+    assert.deepEqual(result.serviceOrder, ["@node", "@serviceadmin"]);
+    assert.equal(result.services.find((service) => service.serviceId === "@serviceadmin")?.state.running, true);
+
+    const envSnapshot = await readJsonWhenReady(path.join(servicesRoot, "@serviceadmin", "runtime", "env.json"));
+    assert.equal(envSnapshot.SERVICE_LASSO_RUNTIME_API_BASE_URL, "http://127.0.0.1:19876");
+  } finally {
+    if (previousRuntimeApiBaseUrl === undefined) {
+      delete process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL;
+    } else {
+      process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL = previousRuntimeApiBaseUrl;
+    }
     await stopAllManagedProcesses();
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -197,6 +197,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.5.15-c66d8ce");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
 });


### PR DESCRIPTION
## Issue
Closes #457

## Summary
- Pins the core @serviceadmin manifest to Service Admin release 2026.5.15-c66d8ce, which includes the merged production runtime API proxy/stub-fallback fix from service-lasso/lasso-serviceadmin#98.
- Adds manifest coverage so the core baseline inventory asserts the expected Service Admin release tag.
- Adds bootstrap coverage proving SERVICE_LASSO_RUNTIME_API_BASE_URL is passed into the managed @serviceadmin process during baseline start.

## Scope
- In scope: core @serviceadmin artifact pin and regression coverage for runtime API env propagation.
- Out of scope: broader Service Admin UI changes, baseline smoke fixture drift tracked by #475/#478, and unrelated dashboard/API test timing behavior.

## Validation
- PASS npm run build
- PASS node --test --test-concurrency=1 tests/bootstrap-start.test.js tests/manifest-discovery.test.js
- PASS git diff --check

## Evidence
- Logs: .work-agent/logs/issue-457-20260519-232917/
- Commit: b702a22d830978ece5e98ff43ff90df6bd051385