### PR TITLE
fix(runtime): force stop stubborn managed processes

### DIFF
--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -85,6 +85,35 @@ async function closeRuntimeLogStreams(streams: ManagedProcessRecord["logStreams"
   await Promise.all([closeWriteStream(streams.combined), closeWriteStream(streams.stdout), closeWriteStream(streams.stderr)]);
 }
 
+async function waitForCommandExit(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const child = spawn(command, args, {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.once("close", () => resolve());
+    child.once("error", () => resolve());
+  });
+}
+
+async function forceKillManagedProcessTree(child: ChildProcess): Promise<void> {
+  const pid = child.pid;
+  if (!pid) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    await waitForCommandExit("taskkill", ["/pid", String(pid), "/t", "/f"]);
+    return;
+  }
+
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // The process may have exited between the timeout and forced kill.
+  }
+}
+
 function writeCombinedLogEntry(stream: WriteStream, level: "stdout" | "stderr", message: string): void {
   stream.write(`${JSON.stringify({ level, message })}\n`);
 }
@@ -330,16 +359,20 @@ export async function stopManagedProcess(
     record.child.kill();
   }
 
+  let timeout: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-    setTimeout(() => {
-      if (!record.child.killed) {
-        record.child.kill("SIGKILL");
-      }
-      resolve({ exitCode: null, signal: "SIGKILL" });
-    }, timeoutMs).unref?.();
+    timeout = setTimeout(() => {
+      void forceKillManagedProcessTree(record.child).finally(() => {
+        resolve({ exitCode: null, signal: "SIGKILL" });
+      });
+    }, timeoutMs);
+    timeout.unref?.();
   });
 
   const result = await Promise.race([record.exitPromise, timeoutPromise]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
   const finalizer = managedProcessFinalizers.get(serviceId);
   if (finalizer) {
     await finalizer;

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -9,8 +9,14 @@ import {
   configService,
   startService,
 } from "../dist/runtime/lifecycle/actions.js";
+import {
+  hasManagedProcess,
+  startManagedProcess,
+  stopManagedProcess,
+} from "../dist/runtime/execution/supervisor.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
+import { createDirectExecutionPlan } from "../dist/runtime/providers/direct.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
 import {
   makeTempServicesRoot,
@@ -520,6 +526,39 @@ test("start waits for configured readiness and returns healthy once ready", asyn
     assert.ok(elapsedMs >= 75);
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("managed process stop escalates after timeout and clears supervisor state", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-managed-stop-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "stubborn-service", {
+    ignoreSignals: true,
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    const handle = await startManagedProcess({
+      service,
+      executionPlan: createDirectExecutionPlan(service.manifest),
+    });
+
+    assert.equal(handle.pid > 0, true);
+    assert.equal(hasManagedProcess("stubborn-service"), true);
+
+    const stopped = await stopManagedProcess("stubborn-service", 100);
+
+    assert.ok(stopped);
+    assert.equal(hasManagedProcess("stubborn-service"), false);
+    if (process.platform !== "win32") {
+      assert.equal(stopped.signal, "SIGKILL");
+    }
+  } finally {
+    await stopManagedProcess("stubborn-service", 100).catch(() => null);
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -78,6 +78,7 @@ export async function writeExecutableFixtureService(
     role = undefined,
     enabled = undefined,
     broker = undefined,
+    ignoreSignals = false,
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -123,8 +124,8 @@ async function writeEnvSnapshot() {
   await writeFile(targetPath, JSON.stringify(payload, null, 2));
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+process.on("SIGTERM", ${ignoreSignals ? "() => {}" : "shutdown"});
+process.on("SIGINT", ${ignoreSignals ? "() => {}" : "shutdown"});
 
 if (captureEnvPath && Array.isArray(captureEnvKeys) && captureEnvKeys.length > 0) {
   void writeEnvSnapshot();


### PR DESCRIPTION
## Issue
Closes #451

## Summary
- Force-kill stubborn managed processes after stop timeout instead of treating a sent termination signal as proof of exit.
- On Windows, timeout escalation uses taskkill /T /F so service-owned child processes are included where the OS still has the process tree.
- Added focused supervisor coverage with a fixture service that ignores termination signals.

## Scope
- In scope: managed-process stop escalation and focused lifecycle/supervisor test coverage.
- Out of scope: broad orphan discovery by port scan or persisted-state rehydration.

## Spec / contract / fixture impact
- Updated test fixture helper to support services that ignore SIGTERM/SIGINT.
- Runtime lifecycle public contract remains the same; stop now waits for real exit or forced termination.

## Service Lasso invariant impact
- Keeps managed service cleanup inside Service Lasso runtime ownership.
- No secret, env, credential, or raw value logging added.

## Validation
- PASS npm run build — .work-agent/logs/issue-451-20260520-013049/16-npm-build.txt
- PASS node --test --test-concurrency=1 tests/lifecycle-actions.test.js — .work-agent/logs/issue-451-20260520-013049/17-lifecycle-actions-test.txt
- PASS git diff --check — .work-agent/logs/issue-451-20260520-013049/18-git-diff-check.txt

## Approval trail
- Required: no
- Evidence: focused bug fix under service-lasso/service-lasso#451.

## Cleanup
- Branch: issue-451-orphan-process-reconcile
- Local checkout will be returned to develop after PR/handoff.