### PR TITLE
feat(api): expose workflow run facade routes

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,6 +57,20 @@ import {
   installServiceUpdateCandidate,
   listServiceUpdateStates,
 } from "../runtime/updates/actions.js";
+import {
+  assertWorkflowRunFacadeSecretSafe,
+  cancelWorkflowFacadeRun,
+  exampleWorkflowRunFacadeState,
+  getWorkflowFacadeDefinition,
+  getWorkflowFacadeRun,
+  listWorkflowFacadeDefinitions,
+  retryWorkflowFacadeRun,
+  startWorkflowFacadeRun,
+  type WorkflowFacadeErrorCode,
+  type WorkflowFacadeRun,
+  type WorkflowRunFacadeState,
+} from "../platform/workflowRunFacade.js";
+import type { PlatformEntitlement, PlatformRequestContext } from "../platform/facade.js";
 import { ApiError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
@@ -77,6 +91,7 @@ export interface ApiServerOptions {
   monitorIntervalMs?: number;
   updateScheduler?: boolean;
   updateSchedulerIntervalMs?: number;
+  workflowRunFacadeState?: WorkflowRunFacadeState;
 }
 
 export interface RunningApiServer {
@@ -100,6 +115,10 @@ function notFound(response: ServerResponse): void {
     message: "Route not found.",
     statusCode: 404,
   });
+}
+
+function cloneWorkflowRunFacadeState(state: WorkflowRunFacadeState): WorkflowRunFacadeState {
+  return JSON.parse(JSON.stringify(state)) as WorkflowRunFacadeState;
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -199,6 +218,87 @@ function parseUpdateInstallBody(input: unknown): { force?: boolean } {
   return {
     force: typeof candidate.force === "boolean" ? candidate.force : undefined,
   };
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function parseEntitlements(request: IncomingMessage): PlatformEntitlement[] {
+  const header = firstHeader(request.headers["x-service-lasso-entitlements"]);
+  if (header === undefined) {
+    return ["workspace:read", "secrets-broker-source:use", "secrets-broker:resolve", "workflow:run"];
+  }
+
+  return header
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean) as PlatformEntitlement[];
+}
+
+function createWorkflowPlatformContext(request: IncomingMessage, workspaceId: string): PlatformRequestContext {
+  const contextWorkspaceId = firstHeader(request.headers["x-service-lasso-workspace-id"]) ?? workspaceId;
+  const instanceId = firstHeader(request.headers["x-service-lasso-instance-id"]) ?? "inst_local_demo";
+  const userId = firstHeader(request.headers["x-service-lasso-user-id"]) ?? "usr_01hzy9operator";
+  const linkedIdentityId = firstHeader(request.headers["x-service-lasso-linked-identity-id"]) ?? "lid_zitadel_operator";
+
+  return {
+    userId,
+    workspaceId: contextWorkspaceId,
+    instanceId,
+    linkedIdentityId,
+    entitlements: parseEntitlements(request),
+    actor: {
+      kind: "user",
+      id: userId,
+      displayName: "Operator Example",
+    },
+    authMethod: "zitadel-session",
+    audit: {
+      actorKind: "user",
+      actorId: userId,
+      workspaceId: contextWorkspaceId,
+      instanceId,
+      linkedIdentityId,
+      authMethod: "zitadel-session",
+    },
+  };
+}
+
+function workflowFacadeStatusCode(code: WorkflowFacadeErrorCode): number {
+  if (code === "workflow-not-found" || code === "run-not-found") return 404;
+  if (code === "invalid-transition") return 409;
+  return 403;
+}
+
+function throwWorkflowFacadeError(result: { ok: false; error: { code: WorkflowFacadeErrorCode; message: string } }): never {
+  throw new ApiError(result.error.code, workflowFacadeStatusCode(result.error.code), result.error.message);
+}
+
+function upsertWorkflowRun(state: WorkflowRunFacadeState, run: WorkflowFacadeRun): void {
+  const index = state.runs.findIndex((candidate) => candidate.facadeRunId === run.facadeRunId);
+  if (index === -1) {
+    state.runs.push(run);
+    return;
+  }
+
+  state.runs[index] = run;
+}
+
+async function parseStartWorkflowRunInput(request: IncomingMessage): Promise<Record<string, unknown> | undefined> {
+  const body = await readJsonBody(request);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ApiError("invalid_request", 400, "Workflow run start body must be a JSON object.");
+  }
+
+  const input = (body as { input?: unknown }).input;
+  if (input === undefined) return undefined;
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_request", 400, "Workflow run input must be an object when provided.");
+  }
+
+  return input as Record<string, unknown>;
 }
 
 async function loadRuntimeModel(servicesRoot: string) {
@@ -448,12 +548,110 @@ async function executeRuntimeOrchestrationAction(
   };
 }
 
+async function routeWorkflowFacadeRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  url: URL,
+  state: WorkflowRunFacadeState,
+): Promise<boolean> {
+  if (!url.pathname.startsWith("/api/platform/workspaces/")) return false;
+
+  const pathParts = url.pathname.split("/").filter(Boolean).map((part) => decodeURIComponent(part));
+  const workspaceId = pathParts[3] ?? "";
+  const resource = pathParts[4];
+  const context = createWorkflowPlatformContext(request, workspaceId);
+
+  if (!workspaceId || !resource) {
+    notFound(response);
+    return true;
+  }
+
+  if (resource === "workflows") {
+    const workflowId = pathParts[5];
+
+    if (request.method === "GET" && pathParts.length === 5) {
+      const result = listWorkflowFacadeDefinitions(context, workspaceId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      writeJson(response, 200, { workflows: result.value });
+      return true;
+    }
+
+    if (request.method === "GET" && pathParts.length === 6 && workflowId) {
+      const result = getWorkflowFacadeDefinition(context, workspaceId, workflowId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      writeJson(response, 200, { workflow: result.value });
+      return true;
+    }
+
+    if (request.method === "POST" && pathParts.length === 7 && workflowId && pathParts[6] === "runs") {
+      const input = await parseStartWorkflowRunInput(request);
+      const result = startWorkflowFacadeRun(context, { workspaceId, workflowId, input }, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      upsertWorkflowRun(state, result.value);
+      writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
+      return true;
+    }
+  }
+
+  if (resource === "workflow-runs") {
+    const runId = pathParts[5];
+    const action = pathParts[6];
+
+    if (request.method === "GET" && pathParts.length === 6 && runId) {
+      const result = getWorkflowFacadeRun(context, workspaceId, runId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      writeJson(response, 200, { run: result.value });
+      return true;
+    }
+
+    if (request.method === "POST" && pathParts.length === 7 && runId && action === "cancel") {
+      const result = cancelWorkflowFacadeRun(context, workspaceId, runId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      upsertWorkflowRun(state, result.value);
+      writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
+      return true;
+    }
+
+    if (request.method === "POST" && pathParts.length === 7 && runId && action === "retry") {
+      const result = retryWorkflowFacadeRun(context, workspaceId, runId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      upsertWorkflowRun(state, result.value);
+      writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
+      return true;
+    }
+
+    if (request.method === "GET" && pathParts.length === 7 && runId && action === "logs") {
+      const result = getWorkflowFacadeRun(context, workspaceId, runId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      assertWorkflowRunFacadeSecretSafe(result.value);
+      writeJson(response, 200, { runId: result.value.facadeRunId, logs: result.value.logsSummary ?? { available: false } });
+      return true;
+    }
+
+    if (request.method === "GET" && pathParts.length === 7 && runId && action === "artifacts") {
+      const result = getWorkflowFacadeRun(context, workspaceId, runId, state);
+      if (!result.ok) throwWorkflowFacadeError(result);
+      assertWorkflowRunFacadeSecretSafe(result.value);
+      writeJson(response, 200, { runId: result.value.facadeRunId, artifacts: result.value.artifactsSummary ?? [] });
+      return true;
+    }
+  }
+
+  notFound(response);
+  return true;
+}
+
 async function routeRequest(
   request: IncomingMessage,
   response: ServerResponse,
   config: RuntimeConfig,
+  workflowRunFacadeState: WorkflowRunFacadeState,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
+
+  if (await routeWorkflowFacadeRequest(request, response, url, workflowRunFacadeState)) {
+    return;
+  }
 
   if (request.method === "GET" && url.pathname === "/api/health") {
     writeJson(response, 200, createHealthResponse(config.version));
@@ -864,9 +1062,10 @@ async function routeRequest(
 
 export function createApiServer(options: ApiServerOptions = {}): Server {
   const resolvedConfig = resolveRuntimeConfig(options);
+  const workflowRunFacadeState = cloneWorkflowRunFacadeState(options.workflowRunFacadeState ?? exampleWorkflowRunFacadeState);
 
   return createServer((request, response) => {
-    void routeRequest(request, response, resolvedConfig).catch((error: unknown) => {
+    void routeRequest(request, response, resolvedConfig, workflowRunFacadeState).catch((error: unknown) => {
       const body = toApiErrorBody(error);
       writeJson(response, body.statusCode, body);
     });
@@ -894,7 +1093,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
         intervalMs: options.updateSchedulerIntervalMs,
       })
     : null;
-  const server = createApiServer(config);
+  const server = createApiServer({ ...config, workflowRunFacadeState: options.workflowRunFacadeState });
   const port = options.port ?? 18080;
 
   server.listen(port, bindHost);

--- a/tests/workflow-run-facade.test.js
+++ b/tests/workflow-run-facade.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { startApiServer } from "../dist/server/index.js";
 import {
   assertWorkflowRunFacadeSecretSafe,
   cancelWorkflowFacadeRun,
@@ -14,6 +15,7 @@ import {
   startWorkflowFacadeRun,
   workflowRunFacadeEndpoints,
 } from "../dist/platform/workflowRunFacade.js";
+import { makeTempServicesRoot } from "./test-helpers.js";
 
 const repoRoot = process.cwd();
 const context = {
@@ -25,6 +27,29 @@ const context = {
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+async function getJson(url, headers = {}) {
+  const response = await fetch(url, { headers });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function postJson(url, body = {}, headers = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
 }
 
 test("workflow run facade exposes product-facing endpoint contract", () => {
@@ -142,5 +167,130 @@ test("workflow run facade docs cover endpoints status policy and no-secret rende
     "raw secret values",
   ]) {
     assert.ok(docs.includes(requiredText), `Expected docs to include ${requiredText}`);
+  }
+});
+
+test("workflow run facade is exposed through runtime HTTP routes", async () => {
+  const { servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-api-");
+  const state = clone(exampleWorkflowRunFacadeState);
+  state.runs[0].status = "failed";
+  state.runs[0].engine.status = "error";
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: state });
+  const workspaceId = "wks_local_demo";
+  const workflowId = encodeURIComponent("official.core.maintenance/backup-check");
+
+  try {
+    const list = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows`);
+    assert.equal(list.status, 200);
+    assert.equal(list.body.workflows[0].id, "official.core.maintenance/backup-check");
+
+    const workflow = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}`);
+    assert.equal(workflow.status, 200);
+    assert.equal(workflow.body.workflow.engine.dagu.workflowName, "backup-check");
+
+    const started = await postJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`, { input: { dryRun: true } });
+    assert.equal(started.status, 200);
+    assert.equal(started.body.run.status, "queued");
+    assert.match(started.body.run.facadeRunId, /^wfr_/);
+    assert.equal(started.body.auditEvent.engineRunId, started.body.run.engine.runId);
+
+    const runId = encodeURIComponent(started.body.run.facadeRunId);
+    const fetchedRun = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/${runId}`);
+    assert.equal(fetchedRun.status, 200);
+    assert.equal(fetchedRun.body.run.facadeRunId, started.body.run.facadeRunId);
+
+    const logs = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/${runId}/logs`);
+    assert.equal(logs.status, 200);
+    assert.deepEqual(logs.body.logs, { available: false });
+
+    const artifacts = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/${runId}/artifacts`);
+    assert.equal(artifacts.status, 200);
+    assert.deepEqual(artifacts.body.artifacts, []);
+
+    const cancelled = await postJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/${runId}/cancel`);
+    assert.equal(cancelled.status, 200);
+    assert.equal(cancelled.body.run.status, "cancelling");
+    assert.equal(cancelled.body.auditEvent.action, "workflow.run.cancel");
+
+    const retried = await postJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/wfr_20260508_backup_check_01/retry`);
+    assert.equal(retried.status, 200);
+    assert.equal(retried.body.run.status, "retrying");
+    assert.equal(retried.body.auditEvent.action, "workflow.run.retry");
+
+    const serialized = JSON.stringify([list.body, workflow.body, started.body, fetchedRun.body, logs.body, artifacts.body, cancelled.body, retried.body]);
+    assert.equal(serialized.includes("raw-workflow-secret"), false);
+    assert.equal(serialized.includes("access-token-value"), false);
+    assert.equal(serialized.includes("refresh-token-value"), false);
+    assert.equal(serialized.includes("private-key-material"), false);
+  } finally {
+    await apiServer.stop();
+  }
+});
+
+test("workflow runtime HTTP routes fail closed for policy and request errors", async () => {
+  const { servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-api-denied-");
+  const connectionState = clone(exampleWorkflowRunFacadeState);
+  connectionState.providerConnections[0].status = "needs-auth";
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: connectionState });
+  const workspaceId = "wks_local_demo";
+  const workflowId = encodeURIComponent("official.core.maintenance/backup-check");
+  const errorBodies = [];
+
+  try {
+    const mismatch = await getJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows`, {
+      "x-service-lasso-workspace-id": "wks_other",
+    });
+    assert.equal(mismatch.status, 403);
+    assert.equal(mismatch.body.error, "workspace-mismatch");
+    errorBodies.push(mismatch.body);
+
+    const missingEntitlement = await postJson(
+      `${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`,
+      {},
+      { "x-service-lasso-entitlements": "workspace:read,secrets-broker-source:use,secrets-broker:resolve" },
+    );
+    assert.equal(missingEntitlement.status, 403);
+    assert.equal(missingEntitlement.body.error, "missing-entitlement");
+    errorBodies.push(missingEntitlement.body);
+
+    const connectionNotReady = await postJson(`${apiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`);
+    assert.equal(connectionNotReady.status, 403);
+    assert.equal(connectionNotReady.body.error, "connection-not-ready");
+    errorBodies.push(connectionNotReady.body);
+  } finally {
+    await apiServer.stop();
+  }
+
+  const secretState = clone(exampleWorkflowRunFacadeState);
+  secretState.workflows[0].secretDependencies[0].status = "missing";
+  const secretApiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: secretState });
+
+  try {
+    const missingSecret = await postJson(`${secretApiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`);
+    assert.equal(missingSecret.status, 403);
+    assert.equal(missingSecret.body.error, "missing-secret");
+    errorBodies.push(missingSecret.body);
+
+    const missingWorkflow = await getJson(`${secretApiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${encodeURIComponent("official.core.missing/nope")}`);
+    assert.equal(missingWorkflow.status, 404);
+    assert.equal(missingWorkflow.body.error, "workflow-not-found");
+    errorBodies.push(missingWorkflow.body);
+
+    const invalidBody = await postJson(`${secretApiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`, { input: "not-object" });
+    assert.equal(invalidBody.status, 400);
+    assert.equal(invalidBody.body.error, "invalid_request");
+    errorBodies.push(invalidBody.body);
+
+    const invalidTransition = await postJson(`${secretApiServer.url}/api/platform/workspaces/${workspaceId}/workflow-runs/wfr_20260508_backup_check_01/retry`);
+    assert.equal(invalidTransition.status, 409);
+    assert.equal(invalidTransition.body.error, "invalid-transition");
+    errorBodies.push(invalidTransition.body);
+
+    const serialized = JSON.stringify(errorBodies);
+    assert.equal(serialized.includes("raw-workflow-secret"), false);
+    assert.equal(serialized.includes("access-token-value"), false);
+    assert.equal(serialized.includes("private-key-material"), false);
+  } finally {
+    await secretApiServer.stop();
   }
 });


### PR DESCRIPTION
## Summary
- Binds the existing workflow run facade contract under /api/platform/workspaces/:workspaceId/....
- Adds runtime HTTP tests for list/get/start/get-run/cancel/retry/logs/artifacts.
- Covers fail-closed HTTP responses for workspace mismatch, missing entitlement, provider not ready, missing secret, missing workflow, invalid request body, and invalid transition.
- Preserves metadata-only/no-secret serialization checks for success and error responses.

## Validation
- PASS: 
pm run build
- PASS: 
ode --test --test-concurrency=1 tests/workflow-run-facade.test.js (9/9)
- FAIL unrelated: 
pm test reaches the #465 tests but fails existing 	ests/registry-runtime-state.test.js assertions that expect 10 services while discovery reports 11. Evidence is in .work-agent/logs/issue-465-20260519-172724/16-npm-test.txt.

Fixes #465
