### PR TITLE
feat(api): expose workflow package catalog and repo sync routes

### DIFF
--- a/docs/reference/workflow-package-catalog.md
+++ b/docs/reference/workflow-package-catalog.md
@@ -134,8 +134,14 @@ POST /api/platform/workflow-packages/validate
 ```
 
 `GET` returns safe package metadata that UI and workflow layers can display.
+When workflow repo sync state has an active revision, the API lists packages
+from that active mounted revision; otherwise it returns the built-in example
+catalog contract.
+
 `POST /validate` validates local package metadata before a package is added to
-the catalog.
+the catalog. The request body may contain `metadata`, `packages`, or
+`entries`; responses include diagnostics and omit package payloads if secret-like
+material is detected.
 
 ## Validation diagnostics
 

--- a/docs/reference/workflow-repo-sync-activation.md
+++ b/docs/reference/workflow-repo-sync-activation.md
@@ -11,7 +11,12 @@ The platform surface is intentionally small and state-oriented:
 - `POST /api/platform/workflow-repos/activate` validates staged workflow package metadata and promotes a complete activation.
 - `POST /api/platform/workflow-repos/rollback` restores the previous-good revision pointer when an activated revision must be backed out.
 
-The initial implementation exposes this as a platform controller contract in `src/platform/workflowSyncController.ts`; runtime route binding can wrap the same state shape later.
+The runtime API now binds this shape directly. The current HTTP fetch adapter is
+intentionally local-first for deterministic validation: `sync` and `activate`
+accept local absolute paths or `file://` workflow repo sources, then reuse the
+same activation controller and state file under the runtime workspace. Remote
+Git/release fetching can be added behind the same source contract without
+changing the response shape.
 
 ## Source configuration
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,8 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { once } from "node:events";
+import { cp } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createHealthResponse } from "./routes/health.js";
 import { createServicesResponse } from "./routes/services.js";
 import { createDependenciesResponse } from "./routes/dependencies.js";
@@ -51,6 +54,20 @@ import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
 import { createRuntimeServiceMonitor, type RuntimeServiceMonitor } from "../runtime/recovery/monitor.js";
 import { readServiceUpdateState } from "../runtime/updates/state.js";
 import { createRuntimeUpdateScheduler, type RuntimeUpdateScheduler } from "../runtime/updates/scheduler.js";
+import {
+  exampleWorkflowPackageCatalog,
+  listWorkflowPackagesSecretSafe,
+  loadWorkflowCatalogFromDirectories,
+  validateWorkflowCatalogEntries,
+  type WorkflowCatalogEntry,
+  type WorkflowPackageSourceKind,
+} from "../platform/workflowCatalog.js";
+import {
+  activateWorkflowRepoSources,
+  readWorkflowRepoSyncState,
+  rollbackWorkflowRepoActivation,
+  type WorkflowRepoSource,
+} from "../platform/workflowSyncController.js";
 import {
   checkServiceUpdatesForCli,
   downloadServiceUpdateCandidate,
@@ -199,6 +216,90 @@ function parseUpdateInstallBody(input: unknown): { force?: boolean } {
   return {
     force: typeof candidate.force === "boolean" ? candidate.force : undefined,
   };
+}
+
+function parseWorkflowCatalogValidateBody(input: unknown): WorkflowCatalogEntry[] {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Workflow package validation body must be a JSON object.");
+  }
+
+  const candidate = input as Record<string, unknown>;
+  const rawEntries = Array.isArray(candidate.entries)
+    ? candidate.entries
+    : Array.isArray(candidate.packages)
+      ? candidate.packages.map((metadata, index) => ({ metadata, metadataPath: `request.packages[${index}]` }))
+      : candidate.metadata
+        ? [{ metadata: candidate.metadata, metadataPath: "request.metadata" }]
+        : undefined;
+
+  if (!rawEntries) {
+    throw new ApiError("invalid_body", 400, "Workflow package validation requires entries, packages, or metadata.");
+  }
+
+  return rawEntries.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new ApiError("invalid_body", 400, `Workflow package entry ${index} must be a JSON object.`);
+    }
+    const record = entry as Record<string, unknown>;
+    const metadata = "metadata" in record ? record.metadata : record;
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      throw new ApiError("invalid_body", 400, `Workflow package entry ${index} must include metadata.`);
+    }
+    return {
+      metadata: metadata as WorkflowCatalogEntry["metadata"],
+      metadataPath: typeof record.metadataPath === "string" ? record.metadataPath : `request.entries[${index}]`,
+    };
+  });
+}
+
+function parseWorkflowRepoSourcesBody(input: unknown): WorkflowRepoSource[] {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Workflow repo request body must be a JSON object.");
+  }
+
+  const sources = (input as Record<string, unknown>).sources;
+  if (!Array.isArray(sources)) {
+    throw new ApiError("invalid_body", 400, "Workflow repo request requires a sources array.");
+  }
+
+  return sources.map((source, index) => {
+    if (!source || typeof source !== "object" || Array.isArray(source)) {
+      throw new ApiError("invalid_body", 400, `Workflow repo source ${index} must be a JSON object.`);
+    }
+    return source as WorkflowRepoSource;
+  });
+}
+
+function workflowRepoWorkspaceRoot(config: RuntimeConfig): string {
+  return path.join(config.workspaceRoot, "workflow-repos");
+}
+
+function workflowRepoStatePath(config: RuntimeConfig): string {
+  return path.join(workflowRepoWorkspaceRoot(config), "state.json");
+}
+
+function resolveLocalWorkflowRepo(repo: string): string {
+  if (repo.startsWith("file:")) {
+    return fileURLToPath(repo);
+  }
+  if (path.isAbsolute(repo)) {
+    return repo;
+  }
+  throw new ApiError(
+    "unsupported_workflow_repo_source",
+    400,
+    "Workflow repo HTTP sync currently accepts local absolute paths or file:// sources only.",
+  );
+}
+
+function countWorkflowPackageSources(packages: Array<{ source: WorkflowPackageSourceKind }>): Record<WorkflowPackageSourceKind, number> {
+  return packages.reduce<Record<WorkflowPackageSourceKind, number>>(
+    (counts, workflowPackage) => {
+      counts[workflowPackage.source] += 1;
+      return counts;
+    },
+    { official: 0, custom: 0 },
+  );
 }
 
 async function loadRuntimeModel(servicesRoot: string) {
@@ -505,6 +606,71 @@ async function routeRequest(
         }))
         .filter((service) => service.steps.length > 0),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/platform/workflow-packages") {
+    const state = await readWorkflowRepoSyncState(workflowRepoStatePath(config));
+    const activeSources = state.active?.sources ?? [];
+    const catalog = activeSources.length > 0
+      ? await loadWorkflowCatalogFromDirectories(activeSources.map((source) => ({ root: source.packageRoot, source: source.source })))
+      : validateWorkflowCatalogEntries(exampleWorkflowPackageCatalog);
+    const packages = listWorkflowPackagesSecretSafe(catalog.entries);
+    writeJson(response, 200, {
+      ok: catalog.ok,
+      packages,
+      diagnostics: catalog.diagnostics,
+      sources: countWorkflowPackageSources(packages),
+      activeRevision: state.active?.revision ?? null,
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/platform/workflow-packages/validate") {
+    const entries = parseWorkflowCatalogValidateBody(await readJsonBody(request));
+    const validation = validateWorkflowCatalogEntries(entries);
+    let packages: ReturnType<typeof listWorkflowPackagesSecretSafe> = [];
+    try {
+      packages = listWorkflowPackagesSecretSafe(validation.entries);
+    } catch {
+      packages = [];
+    }
+    writeJson(response, 200, {
+      ok: validation.ok,
+      packages,
+      diagnostics: validation.diagnostics,
+      sources: countWorkflowPackageSources(packages),
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/platform/workflow-repos/state") {
+    writeJson(response, 200, await readWorkflowRepoSyncState(workflowRepoStatePath(config)));
+    return;
+  }
+
+  if (
+    request.method === "POST" &&
+    (url.pathname === "/api/platform/workflow-repos/sync" || url.pathname === "/api/platform/workflow-repos/activate")
+  ) {
+    const sources = parseWorkflowRepoSourcesBody(await readJsonBody(request));
+    const result = await activateWorkflowRepoSources(sources, {
+      workspaceRoot: workflowRepoWorkspaceRoot(config),
+      statePath: workflowRepoStatePath(config),
+      fetcher: async ({ source, destination }) => {
+        await cp(resolveLocalWorkflowRepo(source.repo), destination, { recursive: true, force: true });
+        return { revision: source.ref, packageRoot: source.path ?? "." };
+      },
+    });
+    writeJson(response, result.ok ? 200 : 400, result);
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/platform/workflow-repos/rollback") {
+    writeJson(response, 200, await rollbackWorkflowRepoActivation({
+      workspaceRoot: workflowRepoWorkspaceRoot(config),
+      statePath: workflowRepoStatePath(config),
+    }));
     return;
   }
 

--- a/tests/workflow-platform-api.test.js
+++ b/tests/workflow-platform-api.test.js
@@ -1,0 +1,192 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { exampleWorkflowPackageCatalog } from "../dist/platform/workflowCatalog.js";
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function writePackage(root, packageDir, metadata, options = {}) {
+  const packageRoot = path.join(root, packageDir);
+  await mkdir(packageRoot, { recursive: true });
+  await writeFile(path.join(packageRoot, "workflow-package.json"), JSON.stringify(metadata, null, 2));
+  if (options.withDaguDefinitions !== false) {
+    await mkdir(path.join(packageRoot, "workflows"), { recursive: true });
+    for (const workflowId of metadata.workflows ?? []) {
+      const workflowName = workflowId.split("/").at(-1);
+      await writeFile(path.join(packageRoot, "workflows", `${workflowName}.yaml`), `name: ${workflowName}\nsteps: []\n`);
+    }
+  }
+}
+
+async function startTestApi() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-workflow-platform-api-"));
+  const servicesRoot = path.join(tempRoot, "services");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  await mkdir(servicesRoot, { recursive: true });
+  await mkdir(workspaceRoot, { recursive: true });
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+  return { apiServer, tempRoot };
+}
+
+async function readJson(response) {
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function sourceFor(root, metadata) {
+  return {
+    id: metadata.id,
+    source: metadata.source,
+    repo: pathToFileURL(root).href,
+    ref: metadata.repository.ref,
+    channel: "stable",
+  };
+}
+
+test("workflow platform API lists and validates workflow package catalog metadata", async () => {
+  const { apiServer, tempRoot } = await startTestApi();
+  try {
+    const listed = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-packages`));
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.ok, true);
+    assert.deepEqual(listed.body.sources, { official: 1, custom: 1 });
+    assert.equal(JSON.stringify(listed.body).includes("raw-workflow-secret"), false);
+
+    const valid = clone(exampleWorkflowPackageCatalog[0].metadata);
+    const colliding = clone(exampleWorkflowPackageCatalog[1].metadata);
+    colliding.workflows = [valid.workflows[0]];
+    const validation = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-packages/validate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ packages: [valid, colliding] }),
+    }));
+    assert.equal(validation.status, 200);
+    assert.equal(validation.body.ok, false);
+    assert.equal(validation.body.diagnostics.some((diagnostic) => diagnostic.code === "workflow-collision"), true);
+
+    const unsafe = clone(valid);
+    unsafe.validation = [{ name: "unsafe", command: "echo", args: ["raw-workflow-secret"] }];
+    const unsafeValidation = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-packages/validate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ metadata: unsafe }),
+    }));
+    assert.equal(unsafeValidation.status, 200);
+    assert.equal(unsafeValidation.body.ok, false);
+    assert.equal(unsafeValidation.body.packages.length, 0);
+    assert.equal(JSON.stringify(unsafeValidation.body).includes("raw-workflow-secret"), false);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow platform API exposes repo state activate sync and rollback over HTTP", async () => {
+  const { apiServer, tempRoot } = await startTestApi();
+  const firstRoot = path.join(tempRoot, "first-source");
+  const secondRoot = path.join(tempRoot, "second-source");
+  const first = clone(exampleWorkflowPackageCatalog[0].metadata);
+  const second = clone(first);
+  first.repository.repo = pathToFileURL(firstRoot).href;
+  second.version = "2026.5.9";
+  second.repository.ref = "2026.5.9";
+  second.repository.repo = pathToFileURL(secondRoot).href;
+  try {
+    await writePackage(firstRoot, first.id, first);
+    await writePackage(secondRoot, second.id, second);
+
+    const emptyState = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/state`));
+    assert.equal(emptyState.status, 200);
+    assert.deepEqual(emptyState.body.history, []);
+
+    const firstActivation = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [sourceFor(firstRoot, first)] }),
+    }));
+    assert.equal(firstActivation.status, 200);
+    assert.equal(firstActivation.body.ok, true);
+    assert.equal(firstActivation.body.active.revision, "official.core.maintenance@2026.5.8");
+
+    const secondActivation = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/sync`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [sourceFor(secondRoot, second)] }),
+    }));
+    assert.equal(secondActivation.status, 200);
+    assert.equal(secondActivation.body.ok, true);
+    assert.equal(secondActivation.body.state.previousGood.revision, firstActivation.body.active.revision);
+
+    const rollback = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/rollback`, { method: "POST" }));
+    assert.equal(rollback.status, 200);
+    assert.equal(rollback.body.active.revision, firstActivation.body.active.revision);
+    assert.equal(rollback.body.history.at(-1).result, "rolled-back");
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("workflow platform API rejects unsafe repo activation inputs before promotion", async () => {
+  const { apiServer, tempRoot } = await startTestApi();
+  const officialRoot = path.join(tempRoot, "official-source");
+  const customRoot = path.join(tempRoot, "custom-source");
+  const missingDaguRoot = path.join(tempRoot, "missing-dagu-source");
+  const official = clone(exampleWorkflowPackageCatalog[0].metadata);
+  const custom = clone(exampleWorkflowPackageCatalog[1].metadata);
+  official.repository.repo = pathToFileURL(officialRoot).href;
+  custom.repository.ref = "v0.1.0";
+  custom.repository.repo = pathToFileURL(customRoot).href;
+  custom.workflows = [official.workflows[0]];
+  const missingDagu = clone(official);
+  missingDagu.repository.ref = "2026.5.10";
+  missingDagu.repository.repo = pathToFileURL(missingDaguRoot).href;
+  try {
+    await writePackage(officialRoot, official.id, official);
+    await writePackage(customRoot, custom.id, custom);
+    await writePackage(missingDaguRoot, missingDagu.id, missingDagu, { withDaguDefinitions: false });
+
+    const empty = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [] }),
+    }));
+    assert.equal(empty.status, 400);
+    assert.equal(empty.body.diagnostics.some((diagnostic) => diagnostic.field === "sources"), true);
+
+    const mutable = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [{ ...sourceFor(officialRoot, official), ref: "main" }] }),
+    }));
+    assert.equal(mutable.status, 400);
+    assert.equal(mutable.body.diagnostics.some((diagnostic) => diagnostic.field === "ref"), true);
+
+    const collision = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [sourceFor(officialRoot, official), sourceFor(customRoot, custom)] }),
+    }));
+    assert.equal(collision.status, 400);
+    assert.equal(collision.body.diagnostics.some((diagnostic) => diagnostic.code === "workflow-collision"), true);
+
+    const missingDaguDefinition = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sources: [sourceFor(missingDaguRoot, missingDagu)] }),
+    }));
+    assert.equal(missingDaguDefinition.status, 400);
+    assert.equal(missingDaguDefinition.body.diagnostics.some((diagnostic) => /Dagu workflow definition/.test(diagnostic.message)), true);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Issue
Closes #466

## Summary
- Adds runtime HTTP handlers for workflow package catalog list/validate.
- Adds workflow repo state, sync/activate, and rollback HTTP handlers backed by the existing sync controller.
- Adds route-level tests for catalog list/validate, activation/state/sync/rollback, and fail-closed empty source, mutable ref, collision, missing Dagu definition, and secret-material cases.
- Updates reference docs for the newly bound HTTP surface and current local/file source adapter.

## Scope
- In scope: workflow package/repo HTTP route binding for the existing platform contracts.
- Out of scope: broad remote Git/release fetch implementation; the current route adapter accepts local absolute paths and file:// sources, preserving the response shape for a future remote fetch adapter.

## Spec / contract / fixture impact
- Updated: docs/reference/workflow-package-catalog.md
- Updated: docs/reference/workflow-repo-sync-activation.md

## Service Lasso invariant impact
- Invariant: workflow and secret metadata stays safe for operator/API display.
- Preservation proof: validation omits package payloads when secret-like material is detected and focused tests assert no raw secret fixture text appears in API responses.

## Validation
- PASS: npm run build
  - .work-agent/logs/issue-466-20260520-042700/14-npm-run-build-after-docs.txt
- PASS: node --test --test-concurrency=1 tests/workflow-package-catalog.test.js tests/workflow-sync-controller.test.js tests/workflow-platform-api.test.js
  - .work-agent/logs/issue-466-20260520-042700/15-focused-workflow-tests-after-docs.txt

## Approval trail
- Required: no special approval identified.

## Cleanup
- Local branch remains issue-466-workflow-package-api for PR review; working tree has only untracked .work-agent evidence logs.