### PR TITLE
ISS-467 add runtime capabilities endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Common endpoints:
 GET  /api/health
 GET  /api/services
 GET  /api/services/:id
+GET  /api/runtime
+GET  /api/runtime/capabilities
 POST /api/services/:id/install
 POST /api/services/:id/config
 POST /api/services/:id/start

--- a/docs/reference/runtime-capabilities.md
+++ b/docs/reference/runtime-capabilities.md
@@ -1,0 +1,83 @@
+# Runtime Capabilities API
+
+`GET /api/runtime/capabilities` is the read-only compatibility contract for app hosts and Service Admin. Consumers should call it before enabling runtime-dependent controls.
+
+The response includes:
+
+- runtime version
+- API contract version
+- supported endpoint groups
+- feature flags for available runtime surfaces
+- option-derived flags for autostart, monitor, and update scheduler state
+- discovered service roles and default-baseline membership
+- Service Admin compatibility hints
+
+The endpoint exposes metadata only. It must not include raw environment values, provider credentials, secret payloads, tokens, cookies, private keys, or recovery material.
+
+Example shape:
+
+```json
+{
+  "capabilities": {
+    "runtime": {
+      "version": "0.1.0"
+    },
+    "api": {
+      "contractVersion": "service-lasso.runtime-capabilities.v1",
+      "endpointGroups": [
+        {
+          "id": "runtime",
+          "label": "Runtime",
+          "methods": ["GET", "POST"],
+          "pathPrefix": "/api/runtime",
+          "mutating": true
+        }
+      ]
+    },
+    "features": {
+      "serviceDiscovery": true,
+      "lifecycleActions": true,
+      "runtimeOrchestration": true,
+      "dashboardAdapter": true,
+      "serviceMetadata": true,
+      "updates": true,
+      "recovery": true,
+      "setupSteps": true,
+      "dependencyGraph": true,
+      "operatorVariables": true,
+      "operatorNetwork": true,
+      "operatorMetrics": true,
+      "operatorLogs": true,
+      "providerConnections": false,
+      "workflowFacade": false,
+      "localRouteGeneration": true,
+      "lanBinding": true,
+      "autostart": false,
+      "monitor": false,
+      "updateScheduler": false
+    },
+    "baseline": {
+      "defaultServiceIds": ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@python", "@secretsbroker", "echo-service", "@serviceadmin"],
+      "discoveredServiceCount": 2,
+      "serviceRoles": [
+        {
+          "id": "@serviceadmin",
+          "role": "service",
+          "enabled": true,
+          "defaultBaseline": true
+        }
+      ]
+    },
+    "compatibility": {
+      "serviceAdmin": {
+        "minimumApiContractVersion": "service-lasso.runtime-capabilities.v1",
+        "runtimeApiBaseUrlRequired": true,
+        "supportsDashboardAdapter": true,
+        "supportsSafeSecretMetadataOnly": true,
+        "preferredEndpointGroups": ["runtime", "dashboard", "services", "dependencies", "updates", "recovery"],
+        "notes": ["Use this endpoint before enabling runtime-dependent controls."]
+      }
+    }
+  }
+}
+```

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -92,6 +92,72 @@ export interface RuntimeSummaryResponse {
   };
 }
 
+export interface RuntimeFeatureFlags {
+  serviceDiscovery: boolean;
+  lifecycleActions: boolean;
+  runtimeOrchestration: boolean;
+  dashboardAdapter: boolean;
+  serviceMetadata: boolean;
+  updates: boolean;
+  recovery: boolean;
+  setupSteps: boolean;
+  dependencyGraph: boolean;
+  operatorVariables: boolean;
+  operatorNetwork: boolean;
+  operatorMetrics: boolean;
+  operatorLogs: boolean;
+  providerConnections: boolean;
+  workflowFacade: boolean;
+  localRouteGeneration: boolean;
+  lanBinding: boolean;
+  autostart: boolean;
+  monitor: boolean;
+  updateScheduler: boolean;
+}
+
+export interface RuntimeEndpointGroupResponse {
+  id: string;
+  label: string;
+  methods: string[];
+  pathPrefix: string;
+  mutating: boolean;
+}
+
+export interface RuntimeBaselineServiceRoleResponse {
+  id: string;
+  role: "service" | "provider";
+  enabled: boolean;
+  defaultBaseline: boolean;
+}
+
+export interface RuntimeCapabilitiesResponse {
+  capabilities: {
+    runtime: {
+      version: string;
+    };
+    api: {
+      contractVersion: string;
+      endpointGroups: RuntimeEndpointGroupResponse[];
+    };
+    features: RuntimeFeatureFlags;
+    baseline: {
+      defaultServiceIds: string[];
+      discoveredServiceCount: number;
+      serviceRoles: RuntimeBaselineServiceRoleResponse[];
+    };
+    compatibility: {
+      serviceAdmin: {
+        minimumApiContractVersion: string;
+        runtimeApiBaseUrlRequired: boolean;
+        supportsDashboardAdapter: boolean;
+        supportsSafeSecretMetadataOnly: boolean;
+        preferredEndpointGroups: string[];
+        notes: string[];
+      };
+    };
+  };
+}
+
 export interface DashboardLinkResponse {
   label: string;
   url: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { createHealthResponse } from "./routes/health.js";
 import { createServicesResponse } from "./routes/services.js";
 import { createDependenciesResponse } from "./routes/dependencies.js";
-import { createRuntimeSummaryResponse } from "./routes/runtime.js";
+import { createRuntimeCapabilitiesResponse, createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
 import { createServiceLogChunkResponse, createServiceLogInfoResponse } from "./routes/log-reader.js";
@@ -77,6 +77,14 @@ export interface ApiServerOptions {
   monitorIntervalMs?: number;
   updateScheduler?: boolean;
   updateSchedulerIntervalMs?: number;
+}
+
+interface ApiRouteConfig extends RuntimeConfig {
+  features: {
+    autostart: boolean;
+    monitor: boolean;
+    updateScheduler: boolean;
+  };
 }
 
 export interface RunningApiServer {
@@ -451,7 +459,7 @@ async function executeRuntimeOrchestrationAction(
 async function routeRequest(
   request: IncomingMessage,
   response: ServerResponse,
-  config: RuntimeConfig,
+  config: ApiRouteConfig,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
@@ -787,6 +795,20 @@ async function routeRequest(
     return;
   }
 
+  if (request.method === "GET" && url.pathname === "/api/runtime/capabilities") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(
+      response,
+      200,
+      createRuntimeCapabilitiesResponse({
+        version: config.version,
+        services: runtimeModel.discovered,
+        features: config.features,
+      }),
+    );
+    return;
+  }
+
   if (request.method === "POST" && url.pathname.startsWith("/api/runtime/actions/")) {
     const action = url.pathname.split("/").filter(Boolean)[3];
 
@@ -864,9 +886,17 @@ async function routeRequest(
 
 export function createApiServer(options: ApiServerOptions = {}): Server {
   const resolvedConfig = resolveRuntimeConfig(options);
+  const routeConfig: ApiRouteConfig = {
+    ...resolvedConfig,
+    features: {
+      autostart: options.autostart === true,
+      monitor: options.monitor === true,
+      updateScheduler: options.updateScheduler === true,
+    },
+  };
 
   return createServer((request, response) => {
-    void routeRequest(request, response, resolvedConfig).catch((error: unknown) => {
+    void routeRequest(request, response, routeConfig).catch((error: unknown) => {
       const body = toApiErrorBody(error);
       writeJson(response, body.statusCode, body);
     });
@@ -894,7 +924,12 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
         intervalMs: options.updateSchedulerIntervalMs,
       })
     : null;
-  const server = createApiServer(config);
+  const server = createApiServer({
+    ...config,
+    autostart: options.autostart,
+    monitor: options.monitor,
+    updateScheduler: options.updateScheduler,
+  });
   const port = options.port ?? 18080;
 
   server.listen(port, bindHost);

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -1,7 +1,151 @@
-import type { RuntimeSummaryResponse } from "../../contracts/api.js";
+import type {
+  RuntimeCapabilitiesResponse,
+  RuntimeEndpointGroupResponse,
+  RuntimeFeatureFlags,
+  RuntimeSummaryResponse,
+} from "../../contracts/api.js";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { DEFAULT_BASELINE_SERVICE_IDS } from "../../runtime/cli/bootstrap.js";
 
 export function createRuntimeSummaryResponse(input: RuntimeSummaryResponse["runtime"]): RuntimeSummaryResponse {
   return {
     runtime: input,
+  };
+}
+
+export const RUNTIME_CAPABILITIES_CONTRACT_VERSION = "service-lasso.runtime-capabilities.v1";
+
+export interface RuntimeCapabilitiesInput {
+  version: string;
+  services: DiscoveredService[];
+  features?: Partial<Pick<RuntimeFeatureFlags, "autostart" | "monitor" | "updateScheduler">>;
+}
+
+const endpointGroups: RuntimeEndpointGroupResponse[] = [
+  {
+    id: "health",
+    label: "Health",
+    methods: ["GET"],
+    pathPrefix: "/api/health",
+    mutating: false,
+  },
+  {
+    id: "runtime",
+    label: "Runtime",
+    methods: ["GET", "POST"],
+    pathPrefix: "/api/runtime",
+    mutating: true,
+  },
+  {
+    id: "services",
+    label: "Services",
+    methods: ["GET", "POST", "PATCH"],
+    pathPrefix: "/api/services",
+    mutating: true,
+  },
+  {
+    id: "dashboard",
+    label: "Dashboard adapter",
+    methods: ["GET"],
+    pathPrefix: "/api/dashboard",
+    mutating: false,
+  },
+  {
+    id: "dependencies",
+    label: "Dependency graph",
+    methods: ["GET"],
+    pathPrefix: "/api/dependencies",
+    mutating: false,
+  },
+  {
+    id: "updates",
+    label: "Service updates",
+    methods: ["GET", "POST"],
+    pathPrefix: "/api/updates",
+    mutating: true,
+  },
+  {
+    id: "recovery",
+    label: "Recovery",
+    methods: ["GET", "POST"],
+    pathPrefix: "/api/recovery",
+    mutating: true,
+  },
+  {
+    id: "operator-data",
+    label: "Operator data",
+    methods: ["GET"],
+    pathPrefix: "/api/variables",
+    mutating: false,
+  },
+];
+
+function createDefaultFeatureFlags(
+  input: RuntimeCapabilitiesInput,
+): RuntimeCapabilitiesResponse["capabilities"]["features"] {
+  return {
+    serviceDiscovery: true,
+    lifecycleActions: true,
+    runtimeOrchestration: true,
+    dashboardAdapter: true,
+    serviceMetadata: true,
+    updates: true,
+    recovery: true,
+    setupSteps: true,
+    dependencyGraph: true,
+    operatorVariables: true,
+    operatorNetwork: true,
+    operatorMetrics: true,
+    operatorLogs: true,
+    providerConnections: false,
+    workflowFacade: false,
+    localRouteGeneration: true,
+    lanBinding: true,
+    autostart: input.features?.autostart === true,
+    monitor: input.features?.monitor === true,
+    updateScheduler: input.features?.updateScheduler === true,
+  };
+}
+
+export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInput): RuntimeCapabilitiesResponse {
+  const defaultBaseline = new Set<string>(DEFAULT_BASELINE_SERVICE_IDS);
+  const serviceRoles = input.services
+    .map((service) => ({
+      id: service.manifest.id,
+      role: service.manifest.role === "provider" ? "provider" as const : "service" as const,
+      enabled: service.manifest.enabled !== false,
+      defaultBaseline: defaultBaseline.has(service.manifest.id),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    capabilities: {
+      runtime: {
+        version: input.version,
+      },
+      api: {
+        contractVersion: RUNTIME_CAPABILITIES_CONTRACT_VERSION,
+        endpointGroups,
+      },
+      features: createDefaultFeatureFlags(input),
+      baseline: {
+        defaultServiceIds: [...DEFAULT_BASELINE_SERVICE_IDS],
+        discoveredServiceCount: input.services.length,
+        serviceRoles,
+      },
+      compatibility: {
+        serviceAdmin: {
+          minimumApiContractVersion: RUNTIME_CAPABILITIES_CONTRACT_VERSION,
+          runtimeApiBaseUrlRequired: true,
+          supportsDashboardAdapter: true,
+          supportsSafeSecretMetadataOnly: true,
+          preferredEndpointGroups: ["runtime", "dashboard", "services", "dependencies", "updates", "recovery"],
+          notes: [
+            "Use this endpoint before enabling runtime-dependent controls.",
+            "Use Secrets Broker references and metadata only; do not request or render raw secret values from capability discovery.",
+          ],
+        },
+      },
+    },
   };
 }

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -227,6 +227,89 @@ test("runtime boots from explicit servicesRoot and workspaceRoot config", async 
   }
 });
 
+test("GET /api/runtime/capabilities returns versioned runtime capability metadata", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-capabilities-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service", {
+    role: "provider",
+  });
+  await writeExecutableFixtureService(servicesRoot, "@serviceadmin");
+  const apiServer = await startApiServer({
+    port: 0,
+    servicesRoot,
+    version: "capability-test-version",
+  });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/runtime/capabilities");
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.capabilities.runtime.version, "capability-test-version");
+    assert.equal(result.body.capabilities.api.contractVersion, "service-lasso.runtime-capabilities.v1");
+    assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "runtime"));
+    assert.equal(result.body.capabilities.features.lifecycleActions, true);
+    assert.equal(result.body.capabilities.features.dashboardAdapter, true);
+    assert.equal(result.body.capabilities.features.providerConnections, false);
+    assert.equal(result.body.capabilities.features.workflowFacade, false);
+    assert.equal(result.body.capabilities.features.autostart, false);
+    assert.equal(result.body.capabilities.features.monitor, false);
+    assert.equal(result.body.capabilities.features.updateScheduler, false);
+    assert.deepEqual(result.body.capabilities.baseline.defaultServiceIds, [
+      "@archive",
+      "@java",
+      "@localcert",
+      "@nginx",
+      "@traefik",
+      "@node",
+      "@python",
+      "@secretsbroker",
+      "echo-service",
+      "@serviceadmin",
+    ]);
+    assert.deepEqual(result.body.capabilities.baseline.serviceRoles, [
+      {
+        id: "@serviceadmin",
+        role: "service",
+        enabled: true,
+        defaultBaseline: true,
+      },
+      {
+        id: "alpha-service",
+        role: "provider",
+        enabled: true,
+        defaultBaseline: false,
+      },
+    ]);
+    assert.equal(result.body.capabilities.compatibility.serviceAdmin.runtimeApiBaseUrlRequired, true);
+    assert.equal(result.body.capabilities.compatibility.serviceAdmin.supportsSafeSecretMetadataOnly, true);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/runtime/capabilities reflects configured runtime option flags", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-capability-flags-");
+  const apiServer = await startApiServer({
+    port: 0,
+    servicesRoot,
+    version: "capability-flags-test",
+    monitor: true,
+    updateScheduler: true,
+  });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/runtime/capabilities");
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.capabilities.features.monitor, true);
+    assert.equal(result.body.capabilities.features.updateScheduler, true);
+    assert.equal(result.body.capabilities.features.autostart, false);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("runtime app honors servicesRoot and workspaceRoot environment overrides", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-app-env-config-"));
   const workspaceRoot = path.join(tempRoot, "workspace");


### PR DESCRIPTION
## Summary

- Adds `GET /api/runtime/capabilities` for Service Admin/app hosts.
- Adds typed runtime capability contract metadata covering runtime/API versions, endpoint groups, feature flags, baseline service roles, and Service Admin compatibility hints.
- Adds focused API spine tests for the default capability payload and option-derived monitor/update scheduler flags.
- Documents the endpoint in README and `docs/reference/runtime-capabilities.md`.

## Validation

Passed:

```powershell
npm run build
node --test --test-concurrency=1 tests/api-spine.test.js
```

Evidence log: `.work-agent/logs/issue-467-20260519T192759Z/04-validation.txt`

Full suite run:

```powershell
npm test
```

Result: failed on unrelated registry/runtime-state inventory expectations (`11 !== 10`) in `tests/registry-runtime-state.test.js`.
Evidence log: `.work-agent/logs/issue-467-20260519T192759Z/05-npm-test.txt`

Follow-up blocker filed: #484.

## Safety

The new endpoint returns metadata only. It does not expose raw env values, provider credentials, secret payloads, tokens, cookies, private keys, or recovery material.

Closes #467