### PR TITLE
ISS-474 add operator notifications API

### DIFF
--- a/docs/reference/operator-notifications.md
+++ b/docs/reference/operator-notifications.md
@@ -1,0 +1,63 @@
+---
+title: Operator Notifications API
+sidebar_label: Operator Notifications
+---
+
+# Operator Notifications API
+
+GET /api/operator/notifications returns a read-only, operator-facing feed of
+current attention items for Service Admin and other local consumers. It merges
+runtime state that otherwise lives behind separate update, recovery, lifecycle,
+health, and dashboard/diagnostic surfaces.
+
+The feed is safe metadata only. Notification messages must not echo raw logs,
+environment values, provider credentials, secret values, command stdout/stderr,
+private keys, tokens, cookies, passwords, or recovery material. Source-specific
+details remain available through their owning APIs where already permitted.
+
+## Response shape
+
+~~~json
+{
+  "notifications": [
+    {
+      "dedupeKey": "lifecycle_crashed:echo-service",
+      "kind": "lifecycle_crashed",
+      "severity": "critical",
+      "serviceId": "echo-service",
+      "message": "Service \"echo-service\" crashed and is not running.",
+      "firstSeenAt": "2026-05-20T00:00:00.000Z",
+      "lastSeenAt": "2026-05-20T00:00:00.000Z",
+      "relatedActionEndpoint": "/api/services/echo-service/restart",
+      "source": "lifecycle"
+    }
+  ],
+  "summary": {
+    "generatedAt": "2026-05-20T00:01:00.000Z",
+    "total": 1,
+    "critical": 1,
+    "warning": 0,
+    "info": 0
+  }
+}
+~~~
+
+## Notification contract
+
+Each item includes:
+
+| Field | Meaning |
+| --- | --- |
+| dedupeKey | Stable key for merging equivalent source events. |
+| kind | One of update_available, update_failed, install_deferred, recovery_review, lifecycle_crashed, health_unhealthy, blocked_start, or diagnostic_warning. |
+| severity | critical, warning, or info. |
+| serviceId | Owning service id, or null for aggregate diagnostics. |
+| message | Safe operator summary. It must not include raw source payload values. |
+| firstSeenAt / lastSeenAt | Oldest and newest source timestamps after dedupe. |
+| relatedActionEndpoint | Owning API endpoint for follow-up, or null if none exists. |
+| source | Source family: updates, recovery, lifecycle, health, or diagnostics. |
+
+The endpoint sorts notifications by severity first, then newest lastSeenAt,
+then dedupeKey. Multiple recovery events for the same service/kind are merged
+into a single current notification with the earliest first-seen and latest
+last-seen timestamps.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -217,6 +217,41 @@ export interface DashboardServiceDetailResponse {
   service: DashboardServiceResponse;
 }
 
+export type OperatorNotificationSeverity = "critical" | "warning" | "info";
+
+export type OperatorNotificationKind =
+  | "update_available"
+  | "update_failed"
+  | "install_deferred"
+  | "recovery_review"
+  | "lifecycle_crashed"
+  | "health_unhealthy"
+  | "blocked_start"
+  | "diagnostic_warning";
+
+export interface OperatorNotificationResponse {
+  dedupeKey: string;
+  kind: OperatorNotificationKind;
+  severity: OperatorNotificationSeverity;
+  serviceId: string | null;
+  message: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  relatedActionEndpoint: string | null;
+  source: "updates" | "recovery" | "lifecycle" | "health" | "diagnostics";
+}
+
+export interface OperatorNotificationsResponse {
+  notifications: OperatorNotificationResponse[];
+  summary: {
+    generatedAt: string;
+    total: number;
+    critical: number;
+    warning: number;
+    info: number;
+  };
+}
+
 export interface DependenciesResponse {
   dependencies: {
     nodes: { id: string; name: string }[];

--- a/src/runtime/operator/notifications.ts
+++ b/src/runtime/operator/notifications.ts
@@ -1,0 +1,279 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import type {
+  OperatorNotificationResponse,
+  OperatorNotificationSeverity,
+} from "../../contracts/api.js";
+import type { ServiceHealthResult } from "../health/types.js";
+import { evaluateServiceHealth } from "../health/evaluateHealth.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import type { ServiceLifecycleState } from "../lifecycle/types.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { readServiceRecoveryHistory, type ServiceRecoveryHistoryEvent } from "../recovery/history.js";
+import { readServiceUpdateState } from "../updates/state.js";
+
+const SEVERITY_RANK: Record<OperatorNotificationSeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
+function serviceEndpoint(serviceId: string, suffix: string): string {
+  return "/api/services/" + encodeURIComponent(serviceId) + suffix;
+}
+
+function pickFirstSeen(a: string, b: string): string {
+  return a <= b ? a : b;
+}
+
+function pickLastSeen(a: string, b: string): string {
+  return a >= b ? a : b;
+}
+
+function mergeNotification(
+  notifications: Map<string, OperatorNotificationResponse>,
+  notification: OperatorNotificationResponse,
+): void {
+  const existing = notifications.get(notification.dedupeKey);
+  if (!existing) {
+    notifications.set(notification.dedupeKey, notification);
+    return;
+  }
+
+  const severity =
+    SEVERITY_RANK[notification.severity] > SEVERITY_RANK[existing.severity]
+      ? notification.severity
+      : existing.severity;
+  const lastSeenAt = pickLastSeen(existing.lastSeenAt, notification.lastSeenAt);
+
+  notifications.set(notification.dedupeKey, {
+    ...existing,
+    severity,
+    firstSeenAt: pickFirstSeen(existing.firstSeenAt, notification.firstSeenAt),
+    lastSeenAt,
+    message: lastSeenAt === notification.lastSeenAt ? notification.message : existing.message,
+    relatedActionEndpoint: notification.relatedActionEndpoint ?? existing.relatedActionEndpoint,
+  });
+}
+
+function add(
+  notifications: Map<string, OperatorNotificationResponse>,
+  notification: Omit<OperatorNotificationResponse, "firstSeenAt" | "lastSeenAt"> & {
+    seenAt: string;
+  },
+): void {
+  const { seenAt, ...rest } = notification;
+  mergeNotification(notifications, {
+    ...rest,
+    firstSeenAt: seenAt,
+    lastSeenAt: seenAt,
+  });
+}
+
+function isRecoveryEventNeedingReview(event: ServiceRecoveryHistoryEvent): boolean {
+  if (event.kind === "doctor" || event.kind === "hook") {
+    return event.blocked || !event.ok || event.steps.some((step) => !step.ok);
+  }
+
+  if (event.kind === "restart") {
+    return !event.ok;
+  }
+
+  return event.action === "skip" && (
+    event.reason === "not_installed" ||
+    event.reason === "not_configured" ||
+    event.reason === "backoff" ||
+    event.reason === "max_attempts" ||
+    event.reason === "restart_failed"
+  );
+}
+
+function addRecoveryNotification(
+  notifications: Map<string, OperatorNotificationResponse>,
+  event: ServiceRecoveryHistoryEvent,
+): void {
+  if (!isRecoveryEventNeedingReview(event)) {
+    return;
+  }
+
+  const kind = event.kind === "monitor" ? "blocked_start" : "recovery_review";
+  const severity: OperatorNotificationSeverity =
+    event.kind === "monitor" && (event.reason === "max_attempts" || event.reason === "restart_failed")
+      ? "critical"
+      : event.kind === "doctor" && event.blocked
+        ? "critical"
+        : "warning";
+
+  add(notifications, {
+    dedupeKey: kind + ":" + event.serviceId,
+    kind,
+    severity,
+    serviceId: event.serviceId,
+    message:
+      kind === "blocked_start"
+        ? "Service \"" + event.serviceId + "\" has a monitored start/restart blocker."
+        : "Recovery history for service \"" + event.serviceId + "\" needs review.",
+    seenAt: event.at,
+    relatedActionEndpoint: serviceEndpoint(event.serviceId, "/recovery"),
+    source: "recovery",
+  });
+}
+
+function addLifecycleNotifications(
+  notifications: Map<string, OperatorNotificationResponse>,
+  service: DiscoveredService,
+  lifecycle: ServiceLifecycleState,
+  nowIso: string,
+): void {
+  if (lifecycle.runtime.lastTermination === "crashed" && !lifecycle.running) {
+    add(notifications, {
+      dedupeKey: "lifecycle_crashed:" + service.manifest.id,
+      kind: "lifecycle_crashed",
+      severity: "critical",
+      serviceId: service.manifest.id,
+      message: "Service \"" + service.manifest.id + "\" crashed and is not running.",
+      seenAt: lifecycle.runtime.finishedAt ?? nowIso,
+      relatedActionEndpoint: serviceEndpoint(service.manifest.id, "/restart"),
+      source: "lifecycle",
+    });
+  }
+}
+
+function shouldReportUnhealthy(lifecycle: ServiceLifecycleState, health: ServiceHealthResult): boolean {
+  if (health.healthy) {
+    return false;
+  }
+
+  return lifecycle.running || lifecycle.runtime.lastTermination !== null || lifecycle.lastAction !== null;
+}
+
+function addHealthNotifications(
+  notifications: Map<string, OperatorNotificationResponse>,
+  service: DiscoveredService,
+  lifecycle: ServiceLifecycleState,
+  health: ServiceHealthResult,
+  nowIso: string,
+): void {
+  if (!shouldReportUnhealthy(lifecycle, health)) {
+    return;
+  }
+
+  add(notifications, {
+    dedupeKey: "health_unhealthy:" + service.manifest.id,
+    kind: "health_unhealthy",
+    severity: lifecycle.runtime.lastTermination === "crashed" ? "critical" : "warning",
+    serviceId: service.manifest.id,
+    message: "Service \"" + service.manifest.id + "\" healthcheck is unhealthy.",
+    seenAt: lifecycle.runtime.finishedAt ?? nowIso,
+    relatedActionEndpoint: serviceEndpoint(service.manifest.id, "/health"),
+    source: "health",
+  });
+}
+
+function addDiagnosticWarnings(
+  notifications: Map<string, OperatorNotificationResponse>,
+  services: Array<{ service: DiscoveredService; lifecycle: ServiceLifecycleState; health: ServiceHealthResult }>,
+  nowIso: string,
+): void {
+  const unhealthyCount = services.filter(({ lifecycle, health }) => shouldReportUnhealthy(lifecycle, health)).length;
+  const crashedCount = services.filter(({ lifecycle }) => lifecycle.runtime.lastTermination === "crashed" && !lifecycle.running).length;
+
+  if (unhealthyCount > 0) {
+    add(notifications, {
+      dedupeKey: "diagnostic_warning:unhealthy-services",
+      kind: "diagnostic_warning",
+      severity: crashedCount > 0 ? "critical" : "warning",
+      serviceId: null,
+      message: "One or more services need operator attention.",
+      seenAt: nowIso,
+      relatedActionEndpoint: "/api/dashboard",
+      source: "diagnostics",
+    });
+  }
+}
+
+export async function buildOperatorNotifications(
+  services: DiscoveredService[],
+  registry: ServiceRegistry,
+  sharedGlobalEnv: Record<string, string>,
+  nowIso = new Date().toISOString(),
+): Promise<OperatorNotificationResponse[]> {
+  const notifications = new Map<string, OperatorNotificationResponse>();
+  const serviceStates: Array<{
+    service: DiscoveredService;
+    lifecycle: ServiceLifecycleState;
+    health: ServiceHealthResult;
+  }> = [];
+
+  void registry;
+
+  for (const service of services) {
+    const serviceId = service.manifest.id;
+    const lifecycle = getLifecycleState(serviceId);
+    const updates = await readServiceUpdateState(service);
+    const recovery = await readServiceRecoveryHistory(service);
+    const health = await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service, sharedGlobalEnv);
+    serviceStates.push({ service, lifecycle, health });
+
+    if (updates.state === "available" && updates.available) {
+      add(notifications, {
+        dedupeKey: "update_available:" + serviceId,
+        kind: "update_available",
+        severity: "info",
+        serviceId,
+        message: "Update available for service \"" + serviceId + "\".",
+        seenAt: updates.updatedAt || nowIso,
+        relatedActionEndpoint: serviceEndpoint(serviceId, "/update/download"),
+        source: "updates",
+      });
+    }
+
+    if (updates.state === "failed" && updates.failed) {
+      add(notifications, {
+        dedupeKey: "update_failed:" + serviceId,
+        kind: "update_failed",
+        severity: "warning",
+        serviceId,
+        message: "Update check or install failed for service \"" + serviceId + "\".",
+        seenAt: updates.failed.failedAt || updates.updatedAt || nowIso,
+        relatedActionEndpoint: serviceEndpoint(serviceId, "/updates"),
+        source: "updates",
+      });
+    }
+
+    if (updates.state === "installDeferred" && updates.installDeferred) {
+      add(notifications, {
+        dedupeKey: "install_deferred:" + serviceId,
+        kind: "install_deferred",
+        severity: "warning",
+        serviceId,
+        message: "Update install is deferred for service \"" + serviceId + "\".",
+        seenAt: updates.installDeferred.deferredAt || updates.updatedAt || nowIso,
+        relatedActionEndpoint: serviceEndpoint(serviceId, "/update/install"),
+        source: "updates",
+      });
+    }
+
+    for (const event of recovery.events) {
+      addRecoveryNotification(notifications, event);
+    }
+
+    addLifecycleNotifications(notifications, service, lifecycle, nowIso);
+    addHealthNotifications(notifications, service, lifecycle, health, nowIso);
+  }
+
+  addDiagnosticWarnings(notifications, serviceStates, nowIso);
+
+  return [...notifications.values()].sort((left, right) => {
+    const severityDelta = SEVERITY_RANK[right.severity] - SEVERITY_RANK[left.severity];
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    const timeDelta = right.lastSeenAt.localeCompare(left.lastSeenAt);
+    if (timeDelta !== 0) {
+      return timeDelta;
+    }
+
+    return left.dedupeKey.localeCompare(right.dedupeKey);
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,6 +17,7 @@ import {
   createDashboardServicesResponse,
   createDashboardSummaryResponse,
 } from "./routes/dashboard.js";
+import { createOperatorNotificationsResponse } from "./routes/operator-notifications.js";
 import { discoverServices } from "../runtime/discovery/discoverServices.js";
 import { DependencyGraph, createServiceRegistry } from "../runtime/manager/DependencyGraph.js";
 import {
@@ -38,6 +39,7 @@ import {
   readServiceLogChunk,
 } from "../runtime/operator/logs.js";
 import { buildDashboardService, buildDashboardSummary } from "../runtime/operator/dashboard.js";
+import { buildOperatorNotifications } from "../runtime/operator/notifications.js";
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
@@ -490,6 +492,19 @@ async function routeRequest(
         recovery: await readServiceRecoveryHistory(service),
       }))),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/operator/notifications") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const sharedGlobalEnv = collectRuntimeGlobalEnv(runtimeModel.registry.list());
+    writeJson(
+      response,
+      200,
+      createOperatorNotificationsResponse(
+        await buildOperatorNotifications(runtimeModel.discovered, runtimeModel.registry, sharedGlobalEnv),
+      ),
+    );
     return;
   }
 

--- a/src/server/routes/operator-notifications.ts
+++ b/src/server/routes/operator-notifications.ts
@@ -1,0 +1,20 @@
+import type {
+  OperatorNotificationResponse,
+  OperatorNotificationsResponse,
+} from "../../contracts/api.js";
+
+export function createOperatorNotificationsResponse(
+  notifications: OperatorNotificationResponse[],
+  generatedAt = new Date().toISOString(),
+): OperatorNotificationsResponse {
+  return {
+    notifications,
+    summary: {
+      generatedAt,
+      total: notifications.length,
+      critical: notifications.filter((notification) => notification.severity === "critical").length,
+      warning: notifications.filter((notification) => notification.severity === "warning").length,
+      info: notifications.filter((notification) => notification.severity === "info").length,
+    },
+  };
+}

--- a/tests/operator-notifications.test.js
+++ b/tests/operator-notifications.test.js
@@ -1,0 +1,219 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { resetLifecycleState, setLifecycleState, getLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { writeServiceUpdateState } from "../dist/runtime/updates/state.js";
+import { appendServiceRecoveryHistoryEvents } from "../dist/runtime/recovery/history.js";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function getDiscoveredService(servicesRoot, serviceId) {
+  const services = await discoverServices(servicesRoot);
+  const service = services.find((entry) => entry.manifest.id === serviceId);
+  assert.ok(service, "Expected discovered service " + serviceId);
+  return service;
+}
+
+test("operator notifications merge update recovery lifecycle health and diagnostic items safely", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-operator-notifications-");
+  await writeExecutableFixtureService(servicesRoot, "update-fixture");
+  await writeExecutableFixtureService(servicesRoot, "blocked-fixture", {
+    monitoring: { enabled: true },
+    restartPolicy: { enabled: true, onCrash: true, maxAttempts: 1 },
+  });
+  await writeExecutableFixtureService(servicesRoot, "crashed-fixture");
+  const updateService = await getDiscoveredService(servicesRoot, "update-fixture");
+  const blockedService = await getDiscoveredService(servicesRoot, "blocked-fixture");
+
+  await writeServiceUpdateState(updateService, {
+    serviceId: "update-fixture",
+    state: "failed",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    lastCheck: {
+      checkedAt: "2026-05-20T00:00:00.000Z",
+      status: "check_failed",
+      reason: "password=SECRET_VALUE should never leave update state",
+      sourceRepo: "service-lasso/update-fixture",
+      track: "latest",
+      installedTag: "2026.5.1",
+      manifestTag: "2026.5.1",
+      latestTag: null,
+    },
+    available: null,
+    downloadedCandidate: null,
+    installDeferred: null,
+    failed: {
+      reason: "password=SECRET_VALUE should never leave update state",
+      failedAt: "2026-05-20T00:00:00.000Z",
+      sourceStatus: "check_failed",
+    },
+    hookResults: [],
+  });
+
+  await appendServiceRecoveryHistoryEvents(blockedService, [
+    {
+      kind: "monitor",
+      serviceId: "blocked-fixture",
+      action: "skip",
+      reason: "max_attempts",
+      message: "restart token SECRET_VALUE should not be serialized",
+      at: "2026-05-20T00:01:00.000Z",
+    },
+    {
+      kind: "monitor",
+      serviceId: "blocked-fixture",
+      action: "skip",
+      reason: "max_attempts",
+      message: "newer restart token SECRET_VALUE should not be serialized",
+      at: "2026-05-20T00:03:00.000Z",
+    },
+    {
+      kind: "hook",
+      serviceId: "blocked-fixture",
+      phase: "postInstall",
+      ok: false,
+      blocked: true,
+      at: "2026-05-20T00:02:00.000Z",
+      steps: [
+        {
+          phase: "postInstall",
+          name: "blocked-step",
+          command: "node safe-script.js",
+          ok: false,
+          exitCode: 1,
+          timedOut: false,
+          failurePolicy: "block",
+          stdout: "SECRET_VALUE from stdout",
+          stderr: "SECRET_VALUE from stderr",
+          startedAt: "2026-05-20T00:02:00.000Z",
+          finishedAt: "2026-05-20T00:02:01.000Z",
+        },
+      ],
+    },
+  ]);
+
+  const crashedState = getLifecycleState("crashed-fixture");
+  setLifecycleState("crashed-fixture", {
+    ...crashedState,
+    installed: true,
+    configured: true,
+    running: false,
+    lastAction: "start",
+    actionHistory: ["install", "config", "start"],
+    runtime: {
+      ...crashedState.runtime,
+      exitCode: 7,
+      finishedAt: "2026-05-20T00:04:00.000Z",
+      lastTermination: "crashed",
+      metrics: {
+        ...crashedState.runtime.metrics,
+        exitCount: 1,
+        crashCount: 1,
+      },
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await getJson(apiServer.url + "/api/operator/notifications");
+    const serialized = JSON.stringify(response.body);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.summary.total, response.body.notifications.length);
+    assert.equal(response.body.summary.critical >= 2, true);
+    assert.equal(serialized.includes("SECRET_VALUE"), false);
+    assert.equal(serialized.includes("password="), false);
+    assert.equal(serialized.includes("stdout"), false);
+    assert.equal(serialized.includes("stderr"), false);
+
+    const byKey = new Map(response.body.notifications.map((item) => [item.dedupeKey, item]));
+    assert.equal(byKey.get("update_failed:update-fixture").message, "Update check or install failed for service \"update-fixture\".");
+    assert.equal(byKey.get("blocked_start:blocked-fixture").firstSeenAt, "2026-05-20T00:01:00.000Z");
+    assert.equal(byKey.get("blocked_start:blocked-fixture").lastSeenAt, "2026-05-20T00:03:00.000Z");
+    assert.equal(byKey.get("recovery_review:blocked-fixture").relatedActionEndpoint, "/api/services/blocked-fixture/recovery");
+    assert.equal(byKey.get("lifecycle_crashed:crashed-fixture").severity, "critical");
+    assert.equal(byKey.get("health_unhealthy:crashed-fixture").kind, "health_unhealthy");
+    assert.equal(byKey.get("diagnostic_warning:unhealthy-services").serviceId, null);
+
+    const severities = response.body.notifications.map((item) => item.severity);
+    const firstWarningIndex = severities.indexOf("warning");
+    const lastCriticalIndex = severities.lastIndexOf("critical");
+    assert.equal(firstWarningIndex === -1 || lastCriticalIndex < firstWarningIndex, true);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("operator notifications return update availability and install deferral action endpoints", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-operator-notifications-update-");
+  await writeExecutableFixtureService(servicesRoot, "available-fixture");
+  await writeExecutableFixtureService(servicesRoot, "deferred-fixture");
+  const availableService = await getDiscoveredService(servicesRoot, "available-fixture");
+  const deferredService = await getDiscoveredService(servicesRoot, "deferred-fixture");
+
+  await writeServiceUpdateState(availableService, {
+    serviceId: "available-fixture",
+    state: "available",
+    updatedAt: "2026-05-20T00:05:00.000Z",
+    lastCheck: null,
+    available: {
+      tag: "2026.5.20",
+      version: "2026.5.20",
+      releaseUrl: "https://github.com/service-lasso/available-fixture/releases/tag/2026.5.20",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      assetName: "available-fixture.zip",
+      assetUrl: "https://github.com/service-lasso/available-fixture/releases/download/2026.5.20/available-fixture.zip",
+    },
+    downloadedCandidate: null,
+    installDeferred: null,
+    failed: null,
+    hookResults: [],
+  });
+
+  await writeServiceUpdateState(deferredService, {
+    serviceId: "deferred-fixture",
+    state: "installDeferred",
+    updatedAt: "2026-05-20T00:06:00.000Z",
+    lastCheck: null,
+    available: null,
+    downloadedCandidate: null,
+    installDeferred: {
+      reason: "outside maintenance window",
+      deferredAt: "2026-05-20T00:06:00.000Z",
+      nextEligibleAt: "2026-05-20T02:00:00.000Z",
+    },
+    failed: null,
+    hookResults: [],
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await getJson(apiServer.url + "/api/operator/notifications");
+    const byKey = new Map(response.body.notifications.map((item) => [item.dedupeKey, item]));
+
+    assert.equal(response.status, 200);
+    assert.equal(byKey.get("update_available:available-fixture").severity, "info");
+    assert.equal(byKey.get("update_available:available-fixture").relatedActionEndpoint, "/api/services/available-fixture/update/download");
+    assert.equal(byKey.get("install_deferred:deferred-fixture").severity, "warning");
+    assert.equal(byKey.get("install_deferred:deferred-fixture").relatedActionEndpoint, "/api/services/deferred-fixture/update/install");
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Issue
Closes #474

## Summary
- Adds GET /api/operator/notifications as a read-only merged operator attention feed.
- Merges update availability/failure/deferral, recovery events needing review, lifecycle crashes, unhealthy health checks, blocked monitor starts, and aggregate diagnostics.
- Adds a safe response contract and docs for severity, kind, timestamps, dedupe key, related action endpoint, and source.

## Scope
- In scope: core runtime API endpoint, response contract, operator notification builder, docs, focused API tests.
- Out of scope: Service Admin frontend rendering, mutating notification actions, changing existing update/recovery/lifecycle source APIs, and unrelated registry fixture count drift.

## Spec / contract / fixture impact
- Updated: src/contracts/api.ts and docs/reference/operator-notifications.md.
- Tests seed update, recovery, and lifecycle states directly to prove merge/order/dedupe/action endpoint behavior.

## Service Lasso invariant impact
- Invariant: secrets and credentials stay out of logs/API diagnostics.
- Preservation proof: notification messages do not echo update failure reasons, recovery monitor messages, hook stdout/stderr, raw logs, env values, tokens, passwords, provider credentials, or recovery material. Tests assert seeded SECRET_VALUE/password/stdout/stderr strings are absent from the response.

## Validation
- PASS npm run build
- PASS node --test --test-concurrency=1 tests/operator-notifications.test.js
- PASS node --test --test-concurrency=1 tests/operator-notifications.test.js tests/api-updates.test.js tests/api-recovery.test.js tests/operator-data.test.js
- FAIL npm test: unrelated pre-existing registry-runtime-state fixture count drift, 260 pass / 3 fail, assertions expect 10 services but runtime discovers 11. Log recorded at .work-agent/logs/issue-474-20260520-062736/16-npm-test.txt.

## Approval trail
- Required: no explicit approval required for this read-only API contract slice.
- Evidence: issue #474 is labeled agent-ready and Project #1 status Ready.

## Cleanup
- Branch: issue-474-operator-notification-feed.
- Local cleanup after merge: return to clean develop and remove local branch.
