### PR TITLE
fix(runtime): persist port reservation ledger across restarts

### DIFF
--- a/docs/reference/runtime-port-reservations.md
+++ b/docs/reference/runtime-port-reservations.md
@@ -1,0 +1,29 @@
+# Runtime port reservation ledger
+
+Service Lasso persists runtime port reservations under `workspaceRoot/runtime/port-reservations.json`.
+
+The ledger is separate from service manifests. It records the ports the current runtime considers reserved before install/config/start state is mutated, so a restarted API instance can rehydrate prior allocations and avoid assigning a service port over another runtime or service listener.
+
+## Reservation records
+
+Each reservation contains:
+
+- `host`: listener host, defaulting to `127.0.0.1`
+- `port`: TCP port number
+- `kind`: `api`, `service-fixed`, or `service-negotiated`
+- `ownerId`: `runtime-api` for the API server or the service id for service-owned ports
+- `portName`: logical port name such as `http`, `admin`, or `service`
+- `createdAt` and `updatedAt`: ISO timestamps
+- `stale` and `staleReason`: optional reconciliation evidence when a previous reservation is no longer present in rehydrated runtime state
+
+Reservation writes fail closed when a live, non-stale `host:port` is already owned by a different API/service reservation.
+
+## Reconciliation model
+
+At runtime startup, callers should build the active set from:
+
+- the API listener port
+- service-declared fixed ports
+- service runtime ports rehydrated from `.state/runtime.json`
+
+Reconciliation keeps active reservations fresh and marks missing historical entries stale instead of deleting them. Stale evidence gives operators a safe recovery path without silently forgetting why a port was previously considered unavailable.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -88,6 +88,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/runtime-port-reservations",
+          label: "Runtime Port Reservations",
+        },
+        {
+          type: "doc",
           id: "reference/local-sso-loop-smoke",
           label: "Local SSO Loop Smoke",
         },

--- a/src/runtime/cli/bootstrap.ts
+++ b/src/runtime/cli/bootstrap.ts
@@ -61,6 +61,7 @@ async function runLifecycleAction(
   service: DiscoveredService,
   registry: ServiceRegistry,
   action: LifecycleAction,
+  workspaceRoot?: string,
 ): Promise<LifecycleActionResult> {
   try {
     if (action === "install") {
@@ -68,11 +69,11 @@ async function runLifecycleAction(
     }
 
     if (action === "config") {
-      return await configService(service, registry);
+      return await configService(service, registry, { workspaceRoot });
     }
 
-  if (action === "start") {
-      return await startService(service, registry);
+    if (action === "start") {
+      return await startService(service, registry, { workspaceRoot });
     }
   } catch (error) {
     throw formatActionFailure(service.manifest.id, action, error);
@@ -129,7 +130,7 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
     if (state.installed) {
       actions.push({ action: "install", status: "skipped", message: "Already installed." });
     } else {
-      const result = await runLifecycleAction(service, registry, "install");
+      const result = await runLifecycleAction(service, registry, "install", runtimeConfig.workspaceRoot);
       await writeServiceState(service, result.state);
       state = result.state;
       actions.push({ action: "install", status: "completed", message: result.message });
@@ -138,7 +139,7 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
     if (state.configured) {
       actions.push({ action: "config", status: "skipped", message: "Already configured." });
     } else {
-      const result = await runLifecycleAction(service, registry, "config");
+      const result = await runLifecycleAction(service, registry, "config", runtimeConfig.workspaceRoot);
       await writeServiceState(service, result.state);
       state = result.state;
       actions.push({ action: "config", status: "completed", message: result.message });
@@ -169,7 +170,7 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
           : "No executable or artifact command is configured.",
       });
     } else {
-      const result = await runLifecycleAction(service, registry, "start");
+      const result = await runLifecycleAction(service, registry, "start", runtimeConfig.workspaceRoot);
       await writeServiceState(service, result.state);
       state = result.state;
       actions.push({ action: "start", status: "completed", message: result.message });

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -22,6 +22,7 @@ import {
   type ServiceVariableResolutionOptions,
 } from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
+import { reservePorts, type PortReservationInput } from "../ports/reservations.js";
 import { createDirectExecutionPlan } from "../providers/direct.js";
 import { resolveProviderExecution } from "../providers/resolveProvider.js";
 import { assertDoctorPreflightAllowsRestart } from "../recovery/doctor.js";
@@ -112,6 +113,40 @@ function applyProcessLaunchMetrics(
 export interface ServiceLifecycleActionOptions {
   variableResolution?: ServiceVariableResolutionOptions;
   brokerLookup?: BrokerLaunchLookup;
+  workspaceRoot?: string;
+}
+
+function isUsablePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+function toServicePortReservations(service: DiscoveredService, ports: Record<string, number>): PortReservationInput[] {
+  return Object.entries(ports)
+    .filter(([, port]) => isUsablePort(port))
+    .map(([portName, port]) => {
+      const desiredPort = service.manifest.ports?.[portName];
+      return {
+        kind: desiredPort === port && desiredPort !== 0 ? "service-fixed" : "service-negotiated",
+        ownerId: service.manifest.id,
+        portName,
+        port,
+      };
+    });
+}
+
+async function reserveServicePorts(
+  workspaceRoot: string | undefined,
+  service: DiscoveredService,
+  ports: Record<string, number>,
+): Promise<void> {
+  if (!workspaceRoot) {
+    return;
+  }
+
+  const reservations = toServicePortReservations(service, ports);
+  if (reservations.length > 0) {
+    await reservePorts(workspaceRoot, reservations);
+  }
 }
 
 function applyState(
@@ -274,6 +309,7 @@ export async function installService(
 export async function configService(
   service: DiscoveredService,
   registry?: ServiceRegistry,
+  options: ServiceLifecycleActionOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
@@ -284,8 +320,9 @@ export async function configService(
   }
 
   const resolvedPorts = registry
-    ? await negotiateServicePorts(service, registry.list())
+    ? await negotiateServicePorts(service, registry.list(), { workspaceRoot: options.workspaceRoot })
     : current.runtime.ports;
+  await reserveServicePorts(options.workspaceRoot, service, resolvedPorts);
   const sharedGlobalEnv = registry
     ? collectRuntimeGlobalEnv(registry.list())
     : {};
@@ -394,8 +431,9 @@ export async function startService(
     Object.keys(current.runtime.ports).length > 0
       ? current.runtime.ports
       : registry
-        ? await negotiateServicePorts(service, registry.list())
+        ? await negotiateServicePorts(service, registry.list(), { workspaceRoot: options.workspaceRoot })
         : {};
+  await reserveServicePorts(options.workspaceRoot, service, resolvedPorts);
   const variableResolution = await resolveLaunchVariableResolution(
     service,
     options,
@@ -576,8 +614,9 @@ export async function restartService(
     Object.keys(current.runtime.ports).length > 0
       ? current.runtime.ports
       : registry
-        ? await negotiateServicePorts(service, registry.list())
+        ? await negotiateServicePorts(service, registry.list(), { workspaceRoot: options.workspaceRoot })
         : {};
+  await reserveServicePorts(options.workspaceRoot, service, resolvedPorts);
   const variableResolution = await resolveLaunchVariableResolution(
     service,
     options,

--- a/src/runtime/ports/negotiate.ts
+++ b/src/runtime/ports/negotiate.ts
@@ -1,6 +1,7 @@
 import net from "node:net";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { getLifecycleState } from "../lifecycle/store.js";
+import { readPortReservationLedger } from "./reservations.js";
 
 const DEFAULT_DYNAMIC_PORT_START = 4000;
 const DEFAULT_PORT_HOST = "127.0.0.1";
@@ -53,7 +54,15 @@ async function isPortFree(port: number, host = DEFAULT_PORT_HOST): Promise<boole
   }
 }
 
-function collectReservedPorts(services: DiscoveredService[], currentServiceId: string): Set<number> {
+export interface ServicePortNegotiationOptions {
+  workspaceRoot?: string;
+}
+
+async function collectReservedPorts(
+  services: DiscoveredService[],
+  currentServiceId: string,
+  options: ServicePortNegotiationOptions = {},
+): Promise<Set<number>> {
   const reservedPorts = new Set<number>();
 
   for (const service of services) {
@@ -65,17 +74,27 @@ function collectReservedPorts(services: DiscoveredService[], currentServiceId: s
     }
   }
 
+  if (options.workspaceRoot) {
+    const ledger = await readPortReservationLedger(options.workspaceRoot);
+    for (const reservation of ledger.reservations) {
+      if (reservation.stale !== true && reservation.ownerId !== currentServiceId) {
+        reservedPorts.add(reservation.port);
+      }
+    }
+  }
+
   return reservedPorts;
 }
 
 export async function negotiateServicePorts(
   service: DiscoveredService,
   services: DiscoveredService[],
+  options: ServicePortNegotiationOptions = {},
 ): Promise<Record<string, number>> {
   const desiredPorts = service.manifest.ports ?? {};
   const currentPorts = getLifecycleState(service.manifest.id).runtime.ports;
   const negotiatedPorts: Record<string, number> = {};
-  const reservedPorts = collectReservedPorts(services, service.manifest.id);
+  const reservedPorts = await collectReservedPorts(services, service.manifest.id, options);
   const portRange = parseOptionalPortRange();
 
   for (const [name, desiredPort] of Object.entries(desiredPorts)) {

--- a/src/runtime/ports/reservations.ts
+++ b/src/runtime/ports/reservations.ts
@@ -1,0 +1,251 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type PortReservationKind = "api" | "service-fixed" | "service-negotiated";
+
+export interface PortReservation {
+  host: string;
+  port: number;
+  kind: PortReservationKind;
+  ownerId: string;
+  portName: string;
+  createdAt: string;
+  updatedAt: string;
+  stale?: boolean;
+  staleReason?: string;
+}
+
+export interface PortReservationLedger {
+  version: 1;
+  updatedAt: string;
+  reservations: PortReservation[];
+}
+
+export interface PortReservationInput {
+  host?: string;
+  port: number;
+  kind: PortReservationKind;
+  ownerId: string;
+  portName: string;
+}
+
+const DEFAULT_HOST = "127.0.0.1";
+
+export class PortReservationConflictError extends Error {
+  readonly code = "port_reservation_conflict";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "PortReservationConflictError";
+  }
+}
+
+export function getPortReservationLedgerPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, "runtime", "port-reservations.json");
+}
+
+function emptyLedger(now = new Date().toISOString()): PortReservationLedger {
+  return {
+    version: 1,
+    updatedAt: now,
+    reservations: [],
+  };
+}
+
+function isUsablePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+function normalizeHost(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value.trim() : DEFAULT_HOST;
+}
+
+function reservationKey(host: string, port: number): string {
+  return `${host}:${port}`;
+}
+
+function ownerKey(reservation: Pick<PortReservation, "ownerId" | "portName" | "kind">): string {
+  return `${reservation.kind}:${reservation.ownerId}:${reservation.portName}`;
+}
+
+function normalizeReservation(value: unknown): PortReservation | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Partial<PortReservation>;
+  if (
+    !isUsablePort(record.port) ||
+    (record.kind !== "api" && record.kind !== "service-fixed" && record.kind !== "service-negotiated") ||
+    typeof record.ownerId !== "string" ||
+    !record.ownerId.trim() ||
+    typeof record.portName !== "string" ||
+    !record.portName.trim()
+  ) {
+    return null;
+  }
+
+  const createdAt = typeof record.createdAt === "string" ? record.createdAt : new Date().toISOString();
+  const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : createdAt;
+
+  return {
+    host: normalizeHost(record.host),
+    port: record.port,
+    kind: record.kind,
+    ownerId: record.ownerId,
+    portName: record.portName,
+    createdAt,
+    updatedAt,
+    stale: record.stale === true || undefined,
+    staleReason: typeof record.staleReason === "string" ? record.staleReason : undefined,
+  };
+}
+
+function normalizeLedger(value: unknown, now = new Date().toISOString()): PortReservationLedger {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return emptyLedger(now);
+  }
+
+  const record = value as Partial<PortReservationLedger>;
+  return {
+    version: 1,
+    updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : now,
+    reservations: Array.isArray(record.reservations)
+      ? record.reservations.map(normalizeReservation).filter((entry): entry is PortReservation => entry !== null)
+      : [],
+  };
+}
+
+function normalizeInput(input: PortReservationInput, now: string): PortReservation {
+  if (!isUsablePort(input.port)) {
+    throw new Error(`Invalid port reservation for "${input.ownerId}" "${input.portName}": ${input.port}.`);
+  }
+  if (!input.ownerId.trim()) {
+    throw new Error("Port reservation ownerId must be non-empty.");
+  }
+  if (!input.portName.trim()) {
+    throw new Error("Port reservation portName must be non-empty.");
+  }
+
+  return {
+    host: normalizeHost(input.host),
+    port: input.port,
+    kind: input.kind,
+    ownerId: input.ownerId,
+    portName: input.portName,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function readPortReservationLedger(workspaceRoot: string): Promise<PortReservationLedger> {
+  try {
+    const parsed = JSON.parse(await readFile(getPortReservationLedgerPath(workspaceRoot), "utf8")) as unknown;
+    return normalizeLedger(parsed);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return emptyLedger();
+    }
+    throw error;
+  }
+}
+
+export async function writePortReservationLedger(
+  workspaceRoot: string,
+  ledger: PortReservationLedger,
+): Promise<PortReservationLedger> {
+  const ledgerPath = getPortReservationLedgerPath(workspaceRoot);
+  const normalized = normalizeLedger(ledger, ledger.updatedAt);
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+  const tempPath = `${ledgerPath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+  await rename(tempPath, ledgerPath);
+  return normalized;
+}
+
+export async function reservePorts(
+  workspaceRoot: string,
+  inputs: PortReservationInput[],
+  now = new Date().toISOString(),
+): Promise<PortReservationLedger> {
+  const ledger = await readPortReservationLedger(workspaceRoot);
+  const byPort = new Map<string, PortReservation>();
+  const byOwner = new Map<string, PortReservation>();
+
+  for (const reservation of ledger.reservations) {
+    byPort.set(reservationKey(reservation.host, reservation.port), reservation);
+    byOwner.set(ownerKey(reservation), reservation);
+  }
+
+  for (const input of inputs) {
+    const next = normalizeInput(input, now);
+    const existingPortOwner = byPort.get(reservationKey(next.host, next.port));
+    if (existingPortOwner && ownerKey(existingPortOwner) !== ownerKey(next) && existingPortOwner.stale !== true) {
+      throw new PortReservationConflictError(
+        `Port ${next.host}:${next.port} is already reserved by "${existingPortOwner.ownerId}" "${existingPortOwner.portName}".`,
+      );
+    }
+
+    const existingOwner = byOwner.get(ownerKey(next));
+    const merged: PortReservation = {
+      ...next,
+      createdAt: existingOwner?.createdAt ?? existingPortOwner?.createdAt ?? now,
+      updatedAt: now,
+    };
+    byOwner.set(ownerKey(merged), merged);
+    byPort.set(reservationKey(merged.host, merged.port), merged);
+  }
+
+  return await writePortReservationLedger(workspaceRoot, {
+    version: 1,
+    updatedAt: now,
+    reservations: [...byOwner.values()].sort((left, right) => left.port - right.port || left.ownerId.localeCompare(right.ownerId)),
+  });
+}
+
+export async function reconcilePortReservationLedger(
+  workspaceRoot: string,
+  activeReservations: PortReservationInput[],
+  staleReason: string,
+  now = new Date().toISOString(),
+): Promise<PortReservationLedger> {
+  const active = new Map(
+    activeReservations.map((input) => {
+      const normalized = normalizeInput(input, now);
+      return [ownerKey(normalized), normalized] as const;
+    }),
+  );
+  const ledger = await readPortReservationLedger(workspaceRoot);
+  const reconciled = new Map<string, PortReservation>();
+
+  for (const reservation of ledger.reservations) {
+    const activeReservation = active.get(ownerKey(reservation));
+    if (activeReservation) {
+      reconciled.set(ownerKey(activeReservation), {
+        ...activeReservation,
+        createdAt: reservation.createdAt,
+        updatedAt: now,
+      });
+      continue;
+    }
+
+    reconciled.set(ownerKey(reservation), {
+      ...reservation,
+      stale: true,
+      staleReason,
+      updatedAt: now,
+    });
+  }
+
+  for (const activeReservation of active.values()) {
+    if (!reconciled.has(ownerKey(activeReservation))) {
+      reconciled.set(ownerKey(activeReservation), activeReservation);
+    }
+  }
+
+  return await writePortReservationLedger(workspaceRoot, {
+    version: 1,
+    updatedAt: now,
+    reservations: [...reconciled.values()].sort((left, right) => left.port - right.port || left.ownerId.localeCompare(right.ownerId)),
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -45,6 +45,7 @@ import { resolveProviderExecution } from "../runtime/providers/resolveProvider.j
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
 import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
 import { stopAllManagedProcesses } from "../runtime/execution/supervisor.js";
+import { reconcilePortReservationLedger, reservePorts, type PortReservationInput } from "../runtime/ports/reservations.js";
 import { runAndRecordDoctorPreflight } from "../runtime/recovery/doctor.js";
 import { readServiceRecoveryHistory } from "../runtime/recovery/history.js";
 import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
@@ -216,6 +217,37 @@ async function loadRuntimeModel(servicesRoot: string) {
 
 type RuntimeModel = Awaited<ReturnType<typeof loadRuntimeModel>>;
 
+function isUsablePort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+function toServicePortReservations(runtimeModel: RuntimeModel): PortReservationInput[] {
+  return runtimeModel.discovered.flatMap((service) => {
+    const state = getLifecycleState(service.manifest.id);
+    return Object.entries(state.runtime.ports)
+      .filter(([, port]) => isUsablePort(port))
+      .map(([portName, port]) => {
+        const desiredPort = service.manifest.ports?.[portName];
+        return {
+          kind: desiredPort === port && desiredPort !== 0 ? "service-fixed" : "service-negotiated",
+          ownerId: service.manifest.id,
+          portName,
+          port,
+        };
+      });
+  });
+}
+
+function toApiPortReservation(port: number, bindHost: string): PortReservationInput {
+  return {
+    host: bindHost,
+    kind: "api",
+    ownerId: "runtime-api",
+    portName: "http",
+    port,
+  };
+}
+
 async function createServiceSummary(
   service: Awaited<ReturnType<typeof loadRuntimeModel>>["discovered"][number],
   graph: DependencyGraph,
@@ -269,19 +301,20 @@ async function executeLifecycleAction(
   action: string,
   service: RuntimeModel["discovered"][number],
   registry: RuntimeModel["registry"],
+  workspaceRoot?: string,
 ): Promise<LifecycleActionResponse> {
   const result = await (async () => {
     switch (action) {
       case "install":
         return await installService(service, registry);
       case "config":
-        return await configService(service, registry);
+        return await configService(service, registry, { workspaceRoot });
       case "start":
-        return await startService(service, registry);
+        return await startService(service, registry, { workspaceRoot });
       case "stop":
         return await stopService(service);
       case "restart":
-        return await restartService(service, registry);
+        return await restartService(service, registry, { workspaceRoot });
       default:
         throw new ApiError("invalid_action", 400, `Unknown lifecycle action: ${action}`);
     }
@@ -321,6 +354,7 @@ async function buildLifecycleActionResponse(
 async function executeRuntimeOrchestrationAction(
   action: "startAll" | "stopAll" | "autostart" | "reload",
   runtimeModel: RuntimeModel,
+  workspaceRoot?: string,
 ): Promise<RuntimeOrchestrationResponse> {
   if (action === "reload") {
     const stopped: LifecycleActionResponse[] = [];
@@ -376,7 +410,7 @@ async function executeRuntimeOrchestrationAction(
         continue;
       }
 
-      const result = await startService(service, reloadedModel.registry);
+      const result = await startService(service, reloadedModel.registry, { workspaceRoot });
       results.push(await buildLifecycleActionResponse(service, reloadedModel.registry, result));
     }
 
@@ -426,7 +460,7 @@ async function executeRuntimeOrchestrationAction(
         continue;
       }
 
-      const result = await startService(service, runtimeModel.registry);
+      const result = await startService(service, runtimeModel.registry, { workspaceRoot });
       results.push(await buildLifecycleActionResponse(service, runtimeModel.registry, result));
       continue;
     }
@@ -755,7 +789,7 @@ async function routeRequest(
 
     if (request.method === "POST" && pathParts.length === 4) {
       const action = pathParts[3];
-      writeJson(response, 200, await executeLifecycleAction(action, service, runtimeModel.registry));
+      writeJson(response, 200, await executeLifecycleAction(action, service, runtimeModel.registry, config.workspaceRoot));
       return;
     }
   }
@@ -795,7 +829,7 @@ async function routeRequest(
     }
 
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    writeJson(response, 200, await executeRuntimeOrchestrationAction(action, runtimeModel));
+    writeJson(response, 200, await executeRuntimeOrchestrationAction(action, runtimeModel, config.workspaceRoot));
     return;
   }
 
@@ -879,8 +913,19 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
   const config = await ensureRuntimeConfig(resolveRuntimeConfig(options));
   const bootModel = await loadRuntimeModel(config.servicesRoot);
   await rehydrateDiscoveredServices(bootModel.discovered);
+  const requestedPort = options.port ?? 18080;
+  const activeReservations = [...toServicePortReservations(bootModel)];
+  if (requestedPort !== 0) {
+    activeReservations.push(toApiPortReservation(requestedPort, bindHost));
+    await reservePorts(config.workspaceRoot, [toApiPortReservation(requestedPort, bindHost)]);
+  }
+  await reconcilePortReservationLedger(
+    config.workspaceRoot,
+    activeReservations,
+    "not present in rehydrated runtime state",
+  );
   if (options.autostart) {
-    await executeRuntimeOrchestrationAction("autostart", bootModel);
+    await executeRuntimeOrchestrationAction("autostart", bootModel, config.workspaceRoot);
   }
   const monitor = options.monitor
     ? createRuntimeServiceMonitor({
@@ -895,7 +940,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
       })
     : null;
   const server = createApiServer(config);
-  const port = options.port ?? 18080;
+  const port = requestedPort;
 
   server.listen(port, bindHost);
   await once(server, "listening");
@@ -908,6 +953,9 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
   }
 
   const resolvedPort = address.port;
+  if (requestedPort === 0) {
+    await reservePorts(config.workspaceRoot, [toApiPortReservation(resolvedPort, bindHost)]);
+  }
 
   return {
     server,

--- a/tests/port-reservations.test.js
+++ b/tests/port-reservations.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  PortReservationConflictError,
+  getPortReservationLedgerPath,
+  readPortReservationLedger,
+  reconcilePortReservationLedger,
+  reservePorts,
+} from "../dist/runtime/ports/reservations.js";
+
+async function makeWorkspaceRoot() {
+  return await mkdtemp(path.join(os.tmpdir(), "service-lasso-port-reservations-"));
+}
+
+test("port reservation ledger persists API and service reservations under workspace runtime state", async () => {
+  const workspaceRoot = await makeWorkspaceRoot();
+  try {
+    const ledger = await reservePorts(
+      workspaceRoot,
+      [
+        { kind: "api", ownerId: "runtime-api", portName: "http", port: 18080 },
+        { kind: "service-fixed", ownerId: "@nginx", portName: "http", port: 18081 },
+        { kind: "service-negotiated", ownerId: "echo-service", portName: "service", port: 18082 },
+      ],
+      "2026-05-20T00:00:00.000Z",
+    );
+
+    assert.equal(ledger.reservations.length, 3);
+    assert.deepEqual(
+      ledger.reservations.map((reservation) => [reservation.kind, reservation.ownerId, reservation.portName, reservation.port]),
+      [
+        ["api", "runtime-api", "http", 18080],
+        ["service-fixed", "@nginx", "http", 18081],
+        ["service-negotiated", "echo-service", "service", 18082],
+      ],
+    );
+
+    const raw = JSON.parse(await readFile(getPortReservationLedgerPath(workspaceRoot), "utf8"));
+    assert.equal(raw.version, 1);
+    assert.equal(raw.updatedAt, "2026-05-20T00:00:00.000Z");
+    assert.equal(raw.reservations[0].host, "127.0.0.1");
+
+    const reloaded = await readPortReservationLedger(workspaceRoot);
+    assert.deepEqual(reloaded, ledger);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("port reservation ledger fails closed when a live port is already owned", async () => {
+  const workspaceRoot = await makeWorkspaceRoot();
+  try {
+    await reservePorts(
+      workspaceRoot,
+      [{ kind: "api", ownerId: "runtime-api", portName: "http", port: 18080 }],
+      "2026-05-20T00:00:00.000Z",
+    );
+
+    await assert.rejects(
+      reservePorts(
+        workspaceRoot,
+        [{ kind: "service-negotiated", ownerId: "echo-service", portName: "service", port: 18080 }],
+        "2026-05-20T00:01:00.000Z",
+      ),
+      PortReservationConflictError,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("port reservation ledger marks missing active reservations stale during reconciliation", async () => {
+  const workspaceRoot = await makeWorkspaceRoot();
+  try {
+    await reservePorts(
+      workspaceRoot,
+      [
+        { kind: "api", ownerId: "runtime-api", portName: "http", port: 18080 },
+        { kind: "service-negotiated", ownerId: "echo-service", portName: "service", port: 18081 },
+      ],
+      "2026-05-20T00:00:00.000Z",
+    );
+
+    const reconciled = await reconcilePortReservationLedger(
+      workspaceRoot,
+      [{ kind: "api", ownerId: "runtime-api", portName: "http", port: 18080 }],
+      "not present in rehydrated runtime state",
+      "2026-05-20T00:02:00.000Z",
+    );
+
+    const api = reconciled.reservations.find((reservation) => reservation.ownerId === "runtime-api");
+    const stale = reconciled.reservations.find((reservation) => reservation.ownerId === "echo-service");
+    assert.equal(api?.stale, undefined);
+    assert.equal(stale?.stale, true);
+    assert.equal(stale?.staleReason, "not present in rehydrated runtime state");
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/port-reservations.test.js
+++ b/tests/port-reservations.test.js
@@ -3,6 +3,11 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { configService, installService } from "../dist/runtime/lifecycle/actions.js";
+import { resetLifecycleState, getLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import {
   PortReservationConflictError,
   getPortReservationLedgerPath,
@@ -10,6 +15,7 @@ import {
   reconcilePortReservationLedger,
   reservePorts,
 } from "../dist/runtime/ports/reservations.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
 
 async function makeWorkspaceRoot() {
   return await mkdtemp(path.join(os.tmpdir(), "service-lasso-port-reservations-"));
@@ -98,5 +104,86 @@ test("port reservation ledger marks missing active reservations stale during rec
     assert.equal(stale?.staleReason, "not present in rehydrated runtime state");
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("API startup reserves the resolved runtime port in the workspace ledger", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-api-port-reservation-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const ledger = await readPortReservationLedger(workspaceRoot);
+    assert.ok(
+      ledger.reservations.some(
+        (reservation) =>
+          reservation.kind === "api" &&
+          reservation.ownerId === "runtime-api" &&
+          reservation.portName === "http" &&
+          reservation.port === apiServer.port &&
+          reservation.stale !== true,
+      ),
+    );
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service port negotiation avoids active API ledger reservations", async () => {
+  resetLifecycleState();
+  const previousRangeStart = process.env.SERVICE_LASSO_PORT_RANGE_START;
+  const previousRangeEnd = process.env.SERVICE_LASSO_PORT_RANGE_END;
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-service-port-reservation-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+
+  process.env.SERVICE_LASSO_PORT_RANGE_START = "18180";
+  process.env.SERVICE_LASSO_PORT_RANGE_END = "18182";
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "echo-service", {
+      ports: { service: 18180 },
+    });
+    await reservePorts(workspaceRoot, [
+      { kind: "api", ownerId: "runtime-api", portName: "http", port: 18180 },
+    ]);
+
+    const discovered = await discoverServices(servicesRoot);
+    const registry = createServiceRegistry(discovered);
+    const service = registry.getById("echo-service");
+    assert.ok(service);
+
+    await installService(service, registry);
+    const result = await configService(service, registry, { workspaceRoot });
+    const state = getLifecycleState("echo-service");
+    const ledger = await readPortReservationLedger(workspaceRoot);
+
+    assert.equal(result.ok, true);
+    assert.equal(state.runtime.ports.service, 18181);
+    assert.ok(
+      ledger.reservations.some(
+        (reservation) =>
+          reservation.kind === "service-negotiated" &&
+          reservation.ownerId === "echo-service" &&
+          reservation.portName === "service" &&
+          reservation.port === 18181 &&
+          reservation.stale !== true,
+      ),
+    );
+  } finally {
+    if (previousRangeStart === undefined) {
+      delete process.env.SERVICE_LASSO_PORT_RANGE_START;
+    } else {
+      process.env.SERVICE_LASSO_PORT_RANGE_START = previousRangeStart;
+    }
+    if (previousRangeEnd === undefined) {
+      delete process.env.SERVICE_LASSO_PORT_RANGE_END;
+    } else {
+      process.env.SERVICE_LASSO_PORT_RANGE_END = previousRangeEnd;
+    }
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/tests/registry-runtime-state.test.js
+++ b/tests/registry-runtime-state.test.js
@@ -29,12 +29,13 @@ test("ServiceRegistry and DependencyGraph model dependencies and dependents", as
   const registry = createServiceRegistry(discovered);
   const graph = new DependencyGraph(registry);
 
-  assert.equal(registry.count(), 10);
-  assert.equal(registry.countEnabled(), 8);
+  assert.equal(registry.count(), 11);
+  assert.equal(registry.countEnabled(), 9);
   assert.ok(registry.getById("@archive"));
   assert.ok(registry.getById("echo-service"));
   assert.ok(registry.getById("node-sample-service"));
   assert.ok(registry.getById("@serviceadmin"));
+  assert.ok(registry.getById("@secretsbroker"));
   assert.ok(registry.getById("@java"));
   assert.equal(registry.getById("@archive")?.manifest.enabled, false);
   assert.equal(registry.getById("@archive")?.manifest.role, "provider");
@@ -106,8 +107,8 @@ test("GET /api/runtime returns runtime summary state", async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.runtime.totalServices, 10);
-    assert.equal(body.runtime.enabledServices, 8);
+    assert.equal(body.runtime.totalServices, 11);
+    assert.equal(body.runtime.enabledServices, 9);
     assert.equal(body.runtime.dependencyEdges, 5);
     assert.equal(body.runtime.servicesRoot, servicesRoot);
   } finally {
@@ -127,7 +128,7 @@ test("GET /api/dependencies returns graph nodes and edges", async () => {
     const body = await response.json();
 
     assert.equal(response.status, 200);
-    assert.equal(body.dependencies.nodes.length, 10);
+    assert.equal(body.dependencies.nodes.length, 11);
     assert.deepEqual(body.dependencies.edges, [
       { from: "@java", to: "@localcert" },
       { from: "@node", to: "@serviceadmin" },


### PR DESCRIPTION
## Summary
- wire the runtime port reservation ledger into API startup, service config/start/restart, orchestration, and bootstrap flows
- make service port negotiation avoid active ledger reservations from other owners
- add API/service reservation coverage and update the registry fixture baseline for the current @secretsbroker service set

## Validation
- `npm run build` passed
- `node --test --test-concurrency=1 tests/port-reservations.test.js` passed
- `npm run verify:multi-instance-ports` passed
- `node --test --test-concurrency=1 tests/registry-runtime-state.test.js` passed
- `npm test` passed after fixture-count repair
- `git diff --check` passed

## Evidence
- `.work-agent/logs/issue-468-20260520-124347/npm-run-build.log`
- `.work-agent/logs/issue-468-20260520-124347/node-test-port-reservations.log`
- `.work-agent/logs/issue-468-20260520-124347/npm-run-verify-multi-instance-ports.log`
- `.work-agent/logs/issue-468-20260520-124347/node-test-registry-runtime-state-after-fix.log`
- `.work-agent/logs/issue-468-20260520-124347/npm-test-after-fix.log`
- `.work-agent/logs/issue-468-20260520-124347/git-diff-check.log`

Closes #468
