### PR TITLE
ISS-467 add runtime capabilities endpoint

### DIFF
--- a/docs/reference/runtime-api-capabilities.md
+++ b/docs/reference/runtime-api-capabilities.md
@@ -1,0 +1,81 @@
+# Runtime API Capabilities
+
+Service Admin and app hosts can inspect `GET /api/runtime/capabilities` before enabling runtime-backed controls.
+
+The endpoint is read-only and returns a compact compatibility contract:
+
+```json
+{
+  "capabilities": {
+    "runtime": {
+      "version": "0.1.0",
+      "apiContractVersion": "2026-05-runtime-capabilities-v1",
+      "servicesRoot": "C:\\\\app\\\\services",
+      "workspaceRoot": "C:\\\\app\\\\.service-lasso"
+    },
+    "features": {
+      "lifecycleActions": true,
+      "runtimeOrchestration": true,
+      "dashboardAdapter": true,
+      "serviceMetadata": true,
+      "logReader": true,
+      "serviceMetrics": true,
+      "serviceVariables": true,
+      "serviceNetwork": true,
+      "updates": true,
+      "recovery": true,
+      "setupSteps": true,
+      "dependencyGraph": true,
+      "globalEnv": true,
+      "lanBinding": true,
+      "localRouteGeneration": true,
+      "autostartRequested": false,
+      "monitorEnabled": false,
+      "updateSchedulerEnabled": false
+    },
+    "endpointGroups": [
+      {
+        "id": "runtime",
+        "basePath": "/api/runtime",
+        "methods": ["GET /api/runtime", "GET /api/runtime/capabilities", "POST /api/runtime/actions/:action"]
+      }
+    ],
+    "baseline": {
+      "totalServices": 2,
+      "enabledServices": 2,
+      "roles": [
+        {
+          "role": "provider",
+          "count": 1,
+          "serviceIds": ["@node"]
+        },
+        {
+          "role": "service",
+          "count": 1,
+          "serviceIds": ["@serviceadmin"]
+        }
+      ]
+    },
+    "compatibility": {
+      "serviceAdmin": {
+        "minimumApiContractVersion": "2026-05-runtime-capabilities-v1",
+        "supportedDashboardAdapter": true,
+        "preferredRoutes": [
+          "/api/dashboard",
+          "/api/dashboard/services",
+          "/api/dashboard/services/:serviceId",
+          "/api/runtime/capabilities"
+        ],
+        "notes": [
+          "Use this endpoint before enabling runtime-backed UI controls.",
+          "Treat missing or false feature flags as unavailable and fail closed for mutating actions."
+        ]
+      }
+    }
+  }
+}
+```
+
+Consumers must treat unknown flags as unavailable. Mutating controls should stay disabled unless the required feature flag and route group are present.
+
+The response intentionally reports safe metadata only. It does not include service environment values, broker refs beyond service ids, tokens, private keys, cookies, passwords, or raw secret material.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,6 +68,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/runtime-api-capabilities",
+          label: "Runtime API Capabilities",
+        },
+        {
+          type: "doc",
           id: "reference/startup-broker-resolution",
           label: "Startup Broker Resolution",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -92,6 +92,59 @@ export interface RuntimeSummaryResponse {
   };
 }
 
+export interface RuntimeCapabilitiesResponse {
+  capabilities: {
+    runtime: {
+      version: string;
+      apiContractVersion: string;
+      servicesRoot: string;
+      workspaceRoot: string;
+    };
+    features: {
+      lifecycleActions: boolean;
+      runtimeOrchestration: boolean;
+      dashboardAdapter: boolean;
+      serviceMetadata: boolean;
+      logReader: boolean;
+      serviceMetrics: boolean;
+      serviceVariables: boolean;
+      serviceNetwork: boolean;
+      updates: boolean;
+      recovery: boolean;
+      setupSteps: boolean;
+      dependencyGraph: boolean;
+      globalEnv: boolean;
+      lanBinding: boolean;
+      localRouteGeneration: boolean;
+      autostartRequested: boolean;
+      monitorEnabled: boolean;
+      updateSchedulerEnabled: boolean;
+    };
+    endpointGroups: Array<{
+      id: string;
+      basePath: string;
+      methods: string[];
+    }>;
+    baseline: {
+      totalServices: number;
+      enabledServices: number;
+      roles: Array<{
+        role: string;
+        count: number;
+        serviceIds: string[];
+      }>;
+    };
+    compatibility: {
+      serviceAdmin: {
+        minimumApiContractVersion: string;
+        supportedDashboardAdapter: boolean;
+        preferredRoutes: string[];
+        notes: string[];
+      };
+    };
+  };
+}
+
 export interface DashboardLinkResponse {
   label: string;
   url: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { createHealthResponse } from "./routes/health.js";
 import { createServicesResponse } from "./routes/services.js";
 import { createDependenciesResponse } from "./routes/dependencies.js";
-import { createRuntimeSummaryResponse } from "./routes/runtime.js";
+import { createRuntimeCapabilitiesResponse, createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
 import { createServiceLogChunkResponse, createServiceLogInfoResponse } from "./routes/log-reader.js";
@@ -452,6 +452,7 @@ async function routeRequest(
   request: IncomingMessage,
   response: ServerResponse,
   config: RuntimeConfig,
+  options: ApiServerOptions,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
@@ -787,6 +788,26 @@ async function routeRequest(
     return;
   }
 
+  if (request.method === "GET" && url.pathname === "/api/runtime/capabilities") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+
+    writeJson(
+      response,
+      200,
+      createRuntimeCapabilitiesResponse({
+        version: config.version,
+        servicesRoot: config.servicesRoot,
+        workspaceRoot: config.workspaceRoot,
+        services: runtimeModel.discovered,
+        enabledServices: runtimeModel.registry.countEnabled(),
+        autostartRequested: options.autostart,
+        monitorEnabled: options.monitor,
+        updateSchedulerEnabled: options.updateScheduler,
+      }),
+    );
+    return;
+  }
+
   if (request.method === "POST" && url.pathname.startsWith("/api/runtime/actions/")) {
     const action = url.pathname.split("/").filter(Boolean)[3];
 
@@ -866,7 +887,7 @@ export function createApiServer(options: ApiServerOptions = {}): Server {
   const resolvedConfig = resolveRuntimeConfig(options);
 
   return createServer((request, response) => {
-    void routeRequest(request, response, resolvedConfig).catch((error: unknown) => {
+    void routeRequest(request, response, resolvedConfig, options).catch((error: unknown) => {
       const body = toApiErrorBody(error);
       writeJson(response, body.statusCode, body);
     });
@@ -894,7 +915,12 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
         intervalMs: options.updateSchedulerIntervalMs,
       })
     : null;
-  const server = createApiServer(config);
+  const server = createApiServer({
+    ...config,
+    autostart: options.autostart,
+    monitor: options.monitor,
+    updateScheduler: options.updateScheduler,
+  });
   const port = options.port ?? 18080;
 
   server.listen(port, bindHost);

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -1,7 +1,135 @@
-import type { RuntimeSummaryResponse } from "../../contracts/api.js";
+import type { DiscoveredService } from "../../contracts/service.js";
+import type { RuntimeCapabilitiesResponse, RuntimeSummaryResponse } from "../../contracts/api.js";
+
+export interface RuntimeCapabilitiesInput {
+  version: string;
+  servicesRoot: string;
+  workspaceRoot: string;
+  services: DiscoveredService[];
+  enabledServices: number;
+  autostartRequested?: boolean;
+  monitorEnabled?: boolean;
+  updateSchedulerEnabled?: boolean;
+}
+
+const API_CONTRACT_VERSION = "2026-05-runtime-capabilities-v1";
+
+const endpointGroups: RuntimeCapabilitiesResponse["capabilities"]["endpointGroups"] = [
+  {
+    id: "runtime",
+    basePath: "/api/runtime",
+    methods: ["GET /api/runtime", "GET /api/runtime/capabilities", "POST /api/runtime/actions/:action"],
+  },
+  {
+    id: "services",
+    basePath: "/api/services",
+    methods: ["GET /api/services", "GET /api/services/:serviceId", "POST /api/services/:serviceId/:action"],
+  },
+  {
+    id: "dashboard",
+    basePath: "/api/dashboard",
+    methods: ["GET /api/dashboard", "GET /api/dashboard/services", "GET /api/dashboard/services/:serviceId"],
+  },
+  {
+    id: "operator",
+    basePath: "/api",
+    methods: [
+      "GET /api/dependencies",
+      "GET /api/globalenv",
+      "GET /api/logs/read",
+      "GET /api/metrics",
+      "GET /api/network",
+      "GET /api/variables",
+    ],
+  },
+  {
+    id: "maintenance",
+    basePath: "/api",
+    methods: [
+      "GET /api/recovery",
+      "GET /api/setup",
+      "GET /api/updates",
+      "POST /api/updates/check",
+      "POST /api/services/:serviceId/recovery/doctor",
+      "POST /api/services/:serviceId/setup/run/:stepId?",
+      "POST /api/services/:serviceId/update/download",
+      "POST /api/services/:serviceId/update/install",
+    ],
+  },
+];
 
 export function createRuntimeSummaryResponse(input: RuntimeSummaryResponse["runtime"]): RuntimeSummaryResponse {
   return {
     runtime: input,
+  };
+}
+
+export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInput): RuntimeCapabilitiesResponse {
+  const roles = new Map<string, string[]>();
+
+  for (const service of input.services) {
+    const role = service.manifest.role ?? "service";
+    const serviceIds = roles.get(role) ?? [];
+    serviceIds.push(service.manifest.id);
+    roles.set(role, serviceIds);
+  }
+
+  return {
+    capabilities: {
+      runtime: {
+        version: input.version,
+        apiContractVersion: API_CONTRACT_VERSION,
+        servicesRoot: input.servicesRoot,
+        workspaceRoot: input.workspaceRoot,
+      },
+      features: {
+        lifecycleActions: true,
+        runtimeOrchestration: true,
+        dashboardAdapter: true,
+        serviceMetadata: true,
+        logReader: true,
+        serviceMetrics: true,
+        serviceVariables: true,
+        serviceNetwork: true,
+        updates: true,
+        recovery: true,
+        setupSteps: true,
+        dependencyGraph: true,
+        globalEnv: true,
+        lanBinding: true,
+        localRouteGeneration: true,
+        autostartRequested: input.autostartRequested === true,
+        monitorEnabled: input.monitorEnabled === true,
+        updateSchedulerEnabled: input.updateSchedulerEnabled === true,
+      },
+      endpointGroups,
+      baseline: {
+        totalServices: input.services.length,
+        enabledServices: input.enabledServices,
+        roles: Array.from(roles.entries())
+          .map(([role, serviceIds]) => ({
+            role,
+            count: serviceIds.length,
+            serviceIds: serviceIds.sort((left, right) => left.localeCompare(right)),
+          }))
+          .sort((left, right) => left.role.localeCompare(right.role)),
+      },
+      compatibility: {
+        serviceAdmin: {
+          minimumApiContractVersion: API_CONTRACT_VERSION,
+          supportedDashboardAdapter: true,
+          preferredRoutes: [
+            "/api/dashboard",
+            "/api/dashboard/services",
+            "/api/dashboard/services/:serviceId",
+            "/api/runtime/capabilities",
+          ],
+          notes: [
+            "Use this endpoint before enabling runtime-backed UI controls.",
+            "Treat missing or false feature flags as unavailable and fail closed for mutating actions.",
+          ],
+        },
+      },
+    },
   };
 }

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -227,6 +227,70 @@ test("runtime boots from explicit servicesRoot and workspaceRoot config", async 
   }
 });
 
+test("GET /api/runtime/capabilities exposes compact runtime compatibility flags and service roles", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-capabilities-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  await writeExecutableFixtureService(servicesRoot, "worker-service", {
+    env: {
+      PASSWORD: "must-not-leak",
+    },
+  });
+  await writeManifest(servicesRoot, "node-provider", {
+    id: "node-provider",
+    name: "Node Provider",
+    description: "Provider fixture for capability role summaries.",
+    role: "provider",
+  });
+  const apiServer = await startApiServer({
+    port: 0,
+    servicesRoot,
+    workspaceRoot,
+    version: "capability-test",
+    autostart: true,
+    monitor: true,
+    monitorIntervalMs: 60_000,
+    updateScheduler: true,
+    updateSchedulerIntervalMs: 60_000,
+  });
+
+  try {
+    const result = await getJson(`${apiServer.url}/api/runtime/capabilities`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.capabilities.runtime.version, "capability-test");
+    assert.equal(result.body.capabilities.runtime.servicesRoot, path.resolve(servicesRoot));
+    assert.equal(result.body.capabilities.runtime.workspaceRoot, path.resolve(workspaceRoot));
+    assert.equal(result.body.capabilities.runtime.apiContractVersion, "2026-05-runtime-capabilities-v1");
+    assert.equal(result.body.capabilities.features.dashboardAdapter, true);
+    assert.equal(result.body.capabilities.features.runtimeOrchestration, true);
+    assert.equal(result.body.capabilities.features.autostartRequested, true);
+    assert.equal(result.body.capabilities.features.monitorEnabled, true);
+    assert.equal(result.body.capabilities.features.updateSchedulerEnabled, true);
+    assert.ok(
+      result.body.capabilities.endpointGroups.some((group) =>
+        group.methods.includes("GET /api/runtime/capabilities"),
+      ),
+    );
+    assert.deepEqual(result.body.capabilities.baseline.roles, [
+      {
+        role: "provider",
+        count: 1,
+        serviceIds: ["node-provider"],
+      },
+      {
+        role: "service",
+        count: 1,
+        serviceIds: ["worker-service"],
+      },
+    ]);
+    assert.ok(result.body.capabilities.compatibility.serviceAdmin.preferredRoutes.includes("/api/dashboard/services"));
+    assert.equal(JSON.stringify(result.body).includes("must-not-leak"), false);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("runtime app honors servicesRoot and workspaceRoot environment overrides", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-app-env-config-"));
   const workspaceRoot = path.join(tempRoot, "workspace");


### PR DESCRIPTION
## Issue
Closes #467

## Summary
- Adds `GET /api/runtime/capabilities` as a read-only runtime compatibility endpoint.
- Reports runtime version/contract version, feature flags, endpoint groups, baseline service role summaries, and Service Admin compatibility hints.
- Documents the endpoint for UI/app consumers and adds focused API regression coverage.

## Scope
- In scope: capability endpoint contract, server route, API type, docs, and route test coverage.
- Out of scope: unrelated default-baseline test expectation cleanup tracked by #484.

## Spec / contract / fixture impact
- Updated: `src/contracts/api.ts` with `RuntimeCapabilitiesResponse`.
- Updated: `docs/reference/runtime-api-capabilities.md` and docs sidebar.
- Fixture/test coverage verifies service/provider role summaries and that env secret-like values are not serialized.

## Service Lasso invariant impact
- Invariant: secrets and provider credentials stay out of runtime diagnostics/API compatibility payloads.
- Preservation proof: route response uses manifest ids/roles and runtime metadata only; test fixture includes a secret-like env value and asserts it is not returned.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-467-20260520T042642Z/15-npm-build-rerun.txt`
- PASS `node --test --test-concurrency=1 tests/api-spine.test.js` — `.work-agent/logs/issue-467-20260520T042642Z/16-api-spine-test-rerun.txt`
- PASS `npm run docs:build` — `.work-agent/logs/issue-467-20260520T042642Z/33-docs-build-rerun.txt`
- BLOCKED `npm test` — `.work-agent/logs/issue-467-20260520T042642Z/18-npm-test.txt`
  - Existing repo-wide blocker: `tests/registry-runtime-state.test.js` expects 10 services while the current service inventory has 11.
  - Existing tracking issue: #484.

## Approval trail
- Required: yes
- Evidence: repo-wide merge gate depends on #484 or equivalent baseline expectation cleanup.

## Cleanup
- Local branch contains commit `c62803ddbee8183a62a9555fd83cb0e6951bbafd`.
- Local tree is clean except untracked `.work-agent/` evidence logs.
