### PR TITLE
ISS-469 verify release artifact checksums

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -810,11 +810,22 @@ Pinned example:
   "platforms": {
     "win32": {
       "assetName": "echo-service-win32.zip",
-      "archiveType": "zip"
+      "archiveType": "zip",
+      "checksum": {
+        "algorithm": "sha256",
+        "assetName": "SHA256SUMS.txt"
+      }
     }
   }
 }
 ```
+
+`artifact.platforms.<platform>.checksum` is optional for compatibility with older manifests, but release-backed services should declare it when checksum evidence exists. Supported checksum forms:
+
+- `{"algorithm": "sha256", "value": "<64-hex-sha256>"}` verifies against a checksum embedded directly in `service.json`.
+- `{"algorithm": "sha256", "assetName": "SHA256SUMS.txt"}` downloads that release asset, parses a SHA-256 entry for the selected archive, and verifies before extraction.
+
+Checksum verification happens before archive extraction and before install state is written. Missing checksum assets, malformed checksum files, unsupported algorithms, or digest mismatches fail closed with an actionable error. Successful installs persist safe verification evidence in install state: algorithm, source, expected digest, actual digest, artifact asset name, checksum asset name when used, and verification timestamp.
 
 If `artifact.source.tag` is present and no active `updates` policy is declared, Service Lasso treats the service as pinned.
 

--- a/docs/service-authoring/02-write-service-json.md
+++ b/docs/service-authoring/02-write-service-json.md
@@ -91,6 +91,16 @@ The manifest must point to a real release asset:
       "type": "github-release",
       "repo": "service-lasso/lasso-example",
       "tag": "2026.4.29-abc1234"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-example-win32.zip",
+        "archiveType": "zip",
+        "checksum": {
+          "algorithm": "sha256",
+          "assetName": "SHA256SUMS.txt"
+        }
+      }
     }
   }
 }
@@ -98,10 +108,13 @@ The manifest must point to a real release asset:
 
 The release tag uses `yyyy.m.d-<shortsha>`. Artifact names should include the exact upstream service, runtime, framework, or tool version.
 
+For release-backed services, declare checksum verification per platform whenever the release publishes a checksum. Use either a direct SHA-256 `checksum.value` or a release checksum asset such as `checksum.assetName: "SHA256SUMS.txt"`. Service Lasso verifies the archive before extraction or install state mutation and fails closed on missing, malformed, unsupported, or mismatched checksum evidence.
+
 ## Exit Criteria
 
 Move to step 3 only when:
 
 - `service.json` can identify the exact GitHub release asset to download
+- release-backed archive checksums are declared when the release publishes them
 - commands, env, dependencies, ports, and health checks match the planned service shape
 - the manifest can be copied into `services/<service-id>/service.json` without needing a second hidden metadata file

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -121,6 +121,11 @@ export interface ServiceArtifactPlatform {
   archiveType: ServiceArtifactArchiveType;
   command?: string;
   args?: string[];
+  checksum?: {
+    algorithm: "sha256";
+    value?: string;
+    assetName?: string;
+  };
 }
 
 export interface ServiceArchiveArtifact {

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -816,6 +816,42 @@ function readArtifact(value: unknown, manifestPath: string): ServiceManifest["ar
         );
       }
 
+      let checksum: { algorithm: "sha256"; value?: string; assetName?: string } | undefined;
+      if (platformRecord.checksum !== undefined) {
+        if (!platformRecord.checksum || typeof platformRecord.checksum !== "object" || Array.isArray(platformRecord.checksum)) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "artifact.platforms.${platform}.checksum" to be an object when present.`,
+          );
+        }
+
+        const checksumRecord = platformRecord.checksum as Record<string, unknown>;
+        if (checksumRecord.algorithm !== "sha256") {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "artifact.platforms.${platform}.checksum.algorithm" to be "sha256".`,
+          );
+        }
+
+        const checksumValue =
+          typeof checksumRecord.value === "string" && checksumRecord.value.trim().length > 0
+            ? checksumRecord.value.trim()
+            : undefined;
+        const checksumAssetName =
+          typeof checksumRecord.assetName === "string" && checksumRecord.assetName.trim().length > 0
+            ? checksumRecord.assetName.trim()
+            : undefined;
+        if ((checksumValue === undefined && checksumAssetName === undefined) || (checksumValue !== undefined && checksumAssetName !== undefined)) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "artifact.platforms.${platform}.checksum" to define exactly one of "value" or "assetName".`,
+          );
+        }
+
+        checksum = {
+          algorithm: "sha256",
+          value: checksumValue,
+          assetName: checksumAssetName,
+        };
+      }
+
       if (platformRecord.assetName === undefined && platformRecord.assetUrl === undefined) {
         throw new Error(
           `Invalid service manifest at ${manifestPath}: expected "artifact.platforms.${platform}" to define "assetName" and/or "assetUrl".`,
@@ -830,6 +866,7 @@ function readArtifact(value: unknown, manifestPath: string): ServiceManifest["ar
           archiveType: archiveType as "zip" | "tar.gz" | "tgz",
           command: typeof platformRecord.command === "string" ? platformRecord.command.trim() : undefined,
           args: Array.isArray(platformRecord.args) ? platformRecord.args.map((entry) => entry.trim()) : undefined,
+          ...(checksum ? { checksum } : {}),
         },
       ];
     }),

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -42,9 +42,10 @@ function createInitialState(): ServiceLifecycleState {
         archiveType: null,
         archivePath: null,
         extractedPath: null,
-        command: null,
-        args: [],
-      },
+      command: null,
+      args: [],
+      checksum: null,
+    },
     },
     configArtifacts: {
       files: [],
@@ -113,6 +114,9 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
               extractedPath: current.installArtifacts.artifact.extractedPath,
               command: current.installArtifacts.artifact.command,
               args: [...current.installArtifacts.artifact.args],
+              checksum: current.installArtifacts.artifact.checksum
+                ? { ...current.installArtifacts.artifact.checksum }
+                : null,
             },
           }
         : {}),
@@ -187,6 +191,9 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
               extractedPath: nextState.installArtifacts.artifact.extractedPath,
               command: nextState.installArtifacts.artifact.command,
               args: [...nextState.installArtifacts.artifact.args],
+              checksum: nextState.installArtifacts.artifact.checksum
+                ? { ...nextState.installArtifacts.artifact.checksum }
+                : null,
             },
           }
         : {}),

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -48,6 +48,15 @@ export interface ServiceMaterializedArtifactsState {
     extractedPath: string | null;
     command: string | null;
     args: string[];
+    checksum: {
+      algorithm: "sha256";
+      source: "manifest" | "release-asset";
+      expected: string;
+      actual: string;
+      assetName: string;
+      checksumAssetName: string | null;
+      verifiedAt: string;
+    } | null;
   };
 }
 

--- a/src/runtime/setup/acquire.ts
+++ b/src/runtime/setup/acquire.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { access, mkdir, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import AdmZip from "adm-zip";
 import * as tar from "tar";
 import type { DiscoveredService, ServiceArchiveArtifact, ServiceArtifactPlatform } from "../../contracts/service.js";
@@ -17,6 +18,17 @@ export interface AcquiredArtifactState {
   extractedPath: string;
   command: string | null;
   args: string[];
+  checksum: AcquiredArtifactChecksumState | null;
+}
+
+export interface AcquiredArtifactChecksumState {
+  algorithm: "sha256";
+  source: "manifest" | "release-asset";
+  expected: string;
+  actual: string;
+  assetName: string;
+  checksumAssetName: string | null;
+  verifiedAt: string;
 }
 
 interface GitHubReleaseAsset {
@@ -33,6 +45,8 @@ interface ResolvedArtifactDownload {
   assetName: string;
   assetUrl: string;
   releaseTag: string | null;
+  checksumAssetName: string | null;
+  checksumAssetUrl: string | null;
 }
 
 function normalizeApiBaseUrl(candidate: string | undefined): string {
@@ -75,6 +89,8 @@ async function resolveGitHubReleaseDownload(
       assetName: platform.assetName ?? path.basename(new URL(platform.assetUrl).pathname),
       assetUrl: platform.assetUrl,
       releaseTag: artifact.source.tag ?? artifact.source.channel ?? null,
+      checksumAssetName: null,
+      checksumAssetUrl: null,
     };
   }
 
@@ -106,11 +122,22 @@ async function resolveGitHubReleaseDownload(
       `Release metadata for "${artifact.source.repo}" did not contain asset "${platform.assetName}".`,
     );
   }
+  const checksumAssetName = platform.checksum?.assetName?.trim() || null;
+  const checksumAsset = checksumAssetName
+    ? payload.assets?.find((candidate) => candidate.name === checksumAssetName)
+    : null;
+  if (checksumAssetName && !checksumAsset) {
+    throw new Error(
+      `Release metadata for "${artifact.source.repo}" did not contain checksum asset "${checksumAssetName}".`,
+    );
+  }
 
   return {
     assetName: asset.name,
     assetUrl: asset.browser_download_url,
     releaseTag: typeof payload.tag_name === "string" ? payload.tag_name : artifact.source.tag ?? artifact.source.channel ?? null,
+    checksumAssetName,
+    checksumAssetUrl: checksumAsset?.browser_download_url ?? null,
   };
 }
 
@@ -123,6 +150,106 @@ async function downloadToFile(assetUrl: string, destinationPath: string): Promis
   const bytes = Buffer.from(await response.arrayBuffer());
   await mkdir(path.dirname(destinationPath), { recursive: true });
   await writeFile(destinationPath, bytes);
+}
+
+async function downloadText(assetUrl: string): Promise<string> {
+  const response = await fetch(assetUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to download service artifact checksum from "${assetUrl}": ${response.status} ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+function normalizeSha256(value: string, context: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(normalized)) {
+    throw new Error(`Malformed SHA-256 checksum for ${context}.`);
+  }
+  return normalized;
+}
+
+function findSha256InChecksumFile(content: string, artifactAssetName: string, checksumAssetName: string): string {
+  let parsedEntries = 0;
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const match = line.match(/^([A-Fa-f0-9]{64})\s+\*?(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    parsedEntries += 1;
+    const [, checksum, filename] = match;
+    const normalizedFilename = filename.trim().replace(/^\.\//, "");
+    if (normalizedFilename === artifactAssetName || path.basename(normalizedFilename) === artifactAssetName) {
+      return normalizeSha256(checksum, `artifact "${artifactAssetName}" in checksum asset "${checksumAssetName}"`);
+    }
+  }
+
+  if (parsedEntries === 0) {
+    throw new Error(`Malformed checksum asset "${checksumAssetName}": no SHA-256 entries were found.`);
+  }
+
+  throw new Error(`Checksum asset "${checksumAssetName}" did not contain an entry for "${artifactAssetName}".`);
+}
+
+async function verifyArchiveChecksum(
+  archivePath: string,
+  assetName: string,
+  checksum: ServiceArtifactPlatform["checksum"],
+  resolved: ResolvedArtifactDownload,
+): Promise<AcquiredArtifactChecksumState | null> {
+  if (!checksum) {
+    return null;
+  }
+
+  if (checksum.algorithm !== "sha256") {
+    throw new Error(`Unsupported service artifact checksum algorithm "${checksum.algorithm}".`);
+  }
+
+  if (checksum.value && checksum.assetName) {
+    throw new Error("Artifact checksum must declare either value or assetName, not both.");
+  }
+
+  if (!checksum.value && !checksum.assetName) {
+    throw new Error("Artifact checksum must declare value or assetName.");
+  }
+
+  let expected: string;
+  let source: AcquiredArtifactChecksumState["source"];
+  if (checksum.value) {
+    expected = normalizeSha256(checksum.value, `artifact "${assetName}"`);
+    source = "manifest";
+  } else {
+    if (!checksum.assetName || !resolved.checksumAssetUrl) {
+      throw new Error(`Artifact checksum asset "${checksum.assetName}" could not be resolved from release metadata.`);
+    }
+    expected = findSha256InChecksumFile(
+      await downloadText(resolved.checksumAssetUrl),
+      assetName,
+      checksum.assetName,
+    );
+    source = "release-asset";
+  }
+
+  const actual = createHash("sha256").update(await readFile(archivePath)).digest("hex");
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for service artifact "${assetName}".`);
+  }
+
+  return {
+    algorithm: "sha256",
+    source,
+    expected,
+    actual,
+    assetName,
+    checksumAssetName: resolved.checksumAssetName,
+    verifiedAt: new Date().toISOString(),
+  };
 }
 
 async function extractArchive(
@@ -171,6 +298,7 @@ export async function acquireInstallArtifact(service: DiscoveredService): Promis
   if (!(await fileExists(archivePath))) {
     await downloadToFile(resolved.assetUrl, archivePath);
   }
+  const checksum = await verifyArchiveChecksum(archivePath, resolved.assetName, definition.checksum, resolved);
   await extractArchive(archivePath, definition.archiveType, extractedPath);
 
   return {
@@ -185,5 +313,6 @@ export async function acquireInstallArtifact(service: DiscoveredService): Promis
     extractedPath,
     command: definition.command ?? null,
     args: definition.args ?? [],
+    checksum,
   };
 }

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -23,6 +23,15 @@ interface StoredInstallState {
     extractedPath?: string | null;
     command?: string | null;
     args?: string[];
+    checksum?: {
+      algorithm?: "sha256" | null;
+      source?: "manifest" | "release-asset" | null;
+      expected?: string | null;
+      actual?: string | null;
+      assetName?: string | null;
+      checksumAssetName?: string | null;
+      verifiedAt?: string | null;
+    } | null;
   };
 }
 
@@ -268,6 +277,26 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
         args: Array.isArray(install?.artifact?.args)
           ? install.artifact.args.filter((entry): entry is string => typeof entry === "string")
           : [],
+        checksum:
+          install?.artifact?.checksum?.algorithm === "sha256" &&
+          (install.artifact.checksum.source === "manifest" || install.artifact.checksum.source === "release-asset") &&
+          typeof install.artifact.checksum.expected === "string" &&
+          typeof install.artifact.checksum.actual === "string" &&
+          typeof install.artifact.checksum.assetName === "string" &&
+          typeof install.artifact.checksum.verifiedAt === "string"
+            ? {
+                algorithm: "sha256",
+                source: install.artifact.checksum.source,
+                expected: install.artifact.checksum.expected,
+                actual: install.artifact.checksum.actual,
+                assetName: install.artifact.checksum.assetName,
+                checksumAssetName:
+                  typeof install.artifact.checksum.checksumAssetName === "string"
+                    ? install.artifact.checksum.checksumAssetName
+                    : null,
+                verifiedAt: install.artifact.checksum.verifiedAt,
+              }
+            : null,
       },
     },
     configArtifacts: {

--- a/src/runtime/updates/actions.ts
+++ b/src/runtime/updates/actions.ts
@@ -435,6 +435,7 @@ export async function installServiceUpdateCandidate(
         extractedPath,
         command: platform.command ?? null,
         args: platform.args ?? [],
+        checksum: null,
       },
     },
   });

--- a/tests/install-acquire.test.js
+++ b/tests/install-acquire.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, readFile, writeFile, rm } from "node:fs/promises";
@@ -76,6 +77,8 @@ async function startFakeGitHubReleaseServer(assetName, assetBytes, options = {})
   let requestCount = 0;
   const releaseAssetName = options.releaseAssetName ?? assetName;
   const downloadStatus = options.downloadStatus ?? 200;
+  const checksumAssetName = options.checksumAssetName;
+  const checksumAssetBytes = options.checksumAssetBytes;
   const server = createServer((request, response) => {
     if (!request.url) {
       response.statusCode = 404;
@@ -95,6 +98,12 @@ async function startFakeGitHubReleaseServer(assetName, assetBytes, options = {})
             name: releaseAssetName,
             browser_download_url: `${baseUrl}/downloads/${releaseAssetName}`,
           },
+          ...(checksumAssetName
+            ? [{
+                name: checksumAssetName,
+                browser_download_url: `${baseUrl}/downloads/${checksumAssetName}`,
+              }]
+            : []),
         ],
       }));
       return;
@@ -104,6 +113,11 @@ async function startFakeGitHubReleaseServer(assetName, assetBytes, options = {})
       requestCount += 1;
       response.statusCode = downloadStatus;
       response.end(assetBytes);
+      return;
+    }
+
+    if (checksumAssetName && url.pathname === `/downloads/${checksumAssetName}`) {
+      response.end(checksumAssetBytes);
       return;
     }
 
@@ -158,6 +172,10 @@ function createReleaseBackedManifest(releaseServer, assetName, description = "Se
   };
 }
 
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
 test("install can acquire and unpack a manifest-owned release artifact without starting the service", async () => {
   resetLifecycleState();
   const { root, servicesRoot } = await makeTempServicesRoot();
@@ -184,6 +202,164 @@ test("install can acquire and unpack a manifest-owned release artifact without s
     assert.equal(typeof stored.install?.artifact?.extractedPath, "string");
     const scriptStat = await import("node:fs/promises").then(({ stat }) => stat(extractedScript));
     assert.equal(scriptStat.isFile(), true);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install verifies and records a manifest-declared artifact checksum before extraction", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const archiveBytes = createZipWithRuntimeScript();
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, archiveBytes);
+  const manifest = createReleaseBackedManifest(releaseServer, assetName);
+  manifest.artifact.platforms.default.checksum = {
+    algorithm: "sha256",
+    value: sha256(archiveBytes),
+  };
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", manifest);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 200);
+    assert.equal(stored.install?.artifact?.checksum?.algorithm, "sha256");
+    assert.equal(stored.install?.artifact?.checksum?.source, "manifest");
+    assert.equal(stored.install?.artifact?.checksum?.assetName, assetName);
+    assert.equal(stored.install?.artifact?.checksum?.expected, sha256(archiveBytes));
+    assert.equal(stored.install?.artifact?.checksum?.actual, sha256(archiveBytes));
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install verifies a release SHA256SUMS asset before extraction", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const archiveBytes = createZipWithRuntimeScript();
+  const checksumAssetName = "SHA256SUMS.txt";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, archiveBytes, {
+    checksumAssetName,
+    checksumAssetBytes: Buffer.from(`${sha256(archiveBytes)}  ${assetName}\n`, "utf8"),
+  });
+  const manifest = createReleaseBackedManifest(releaseServer, assetName);
+  manifest.artifact.platforms.default.checksum = {
+    algorithm: "sha256",
+    assetName: checksumAssetName,
+  };
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", manifest);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 200);
+    assert.equal(stored.install?.artifact?.checksum?.source, "release-asset");
+    assert.equal(stored.install?.artifact?.checksum?.checksumAssetName, checksumAssetName);
+    assert.equal(stored.install?.artifact?.checksum?.actual, sha256(archiveBytes));
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install fails before state mutation when the artifact checksum mismatches", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const archiveBytes = createZipWithRuntimeScript();
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, archiveBytes);
+  const manifest = createReleaseBackedManifest(releaseServer, assetName);
+  manifest.artifact.platforms.default.checksum = {
+    algorithm: "sha256",
+    value: "0".repeat(64),
+  };
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", manifest);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 500);
+    assert.match(install.body.message, /Checksum mismatch/);
+    assert.equal(stored.install, null);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install fails before state mutation when the release checksum asset is missing or malformed", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const archiveBytes = createZipWithRuntimeScript();
+  const checksumAssetName = "SHA256SUMS.txt";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, archiveBytes, {
+    checksumAssetName,
+    checksumAssetBytes: Buffer.from("not a checksum file\n", "utf8"),
+  });
+  const manifest = createReleaseBackedManifest(releaseServer, assetName);
+  manifest.artifact.platforms.default.checksum = {
+    algorithm: "sha256",
+    assetName: checksumAssetName,
+  };
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", manifest);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 500);
+    assert.match(install.body.message, /Malformed checksum asset/);
+    assert.equal(stored.install, null);
+  } finally {
+    await apiServer.stop();
+    await releaseServer.stop();
+    resetLifecycleState();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("install fails before state mutation when the release checksum asset is missing", async () => {
+  resetLifecycleState();
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const assetName = "downloaded-service.zip";
+  const archiveBytes = createZipWithRuntimeScript();
+  const checksumAssetName = "SHA256SUMS.txt";
+  const releaseServer = await startFakeGitHubReleaseServer(assetName, archiveBytes);
+  const manifest = createReleaseBackedManifest(releaseServer, assetName);
+  manifest.artifact.platforms.default.checksum = {
+    algorithm: "sha256",
+    assetName: checksumAssetName,
+  };
+  const serviceRoot = await writeManifest(servicesRoot, "downloaded-service", manifest);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const install = await postJson(`${apiServer.url}/api/services/downloaded-service/install`);
+    const stored = await readStoredState(serviceRoot);
+
+    assert.equal(install.status, 500);
+    assert.match(install.body.message, /did not contain checksum asset/);
+    assert.equal(stored.install, null);
   } finally {
     await apiServer.stop();
     await releaseServer.stop();


### PR DESCRIPTION
## Issue
Closes #469

## Summary
- Added platform-level release artifact checksum metadata to service.json manifests.
- Verified downloaded or preloaded release archives before extraction/install state mutation.
- Persisted safe checksum evidence in install state: algorithm, source, expected/actual digest, artifact asset, checksum asset, and verification timestamp.
- Added install-acquire coverage for direct manifest SHA-256, release SHA256SUMS.txt, mismatch, missing checksum asset, and malformed checksum asset.

## Scope
- In scope: release-backed install/acquire checksum verification and manifest docs.
- Out of scope: update-candidate checksum enforcement; update state currently records checksum: null until that path gets its own checksum policy work.

## Spec / contract / fixture impact
- Updated: docs/service-authoring/02-write-service-json.md
- Updated: docs/reference/service-json-reference.md
- Updated manifest validation for rtifact.platforms.<platform>.checksum.

## Service Lasso invariant impact
- Invariant: release-backed services remain acquired from GitHub release artifacts.
- Preservation proof: checksum verification is optional for compatibility but fail-closed when declared; raw secrets/provider credentials are not involved or logged.

## Validation
- PASS 
pm run build
- PASS 
ode --test --test-concurrency=1 tests/install-acquire.test.js
- PASS 
ode --test --test-concurrency=1 tests/install-acquire.test.js tests/manifest-discovery.test.js for #469-affected paths
- BLOCKED 
pm test: unrelated existing registry runtime expectations fail because current services/ discovers 11 services while 	ests/registry-runtime-state.test.js expects 10. Failure is not in checksum/install path. Evidence log: .work-agent/logs/issue-469-run-20260520-082531Z/27-npm-test.txt

## Approval trail
- Required: no
- Evidence: issue is Ready / Ready for Agent on Project #1.

## Cleanup
- Local branch remains issue-469-release-checksum-verification for PR checks.
- Local dirty state after commit is only untracked .work-agent/ evidence logs.
