### PR TITLE
ISS-495 add bounded runtime log search API

### DIFF
--- a/docs/reference/runtime-log-api.md
+++ b/docs/reference/runtime-log-api.md
@@ -1,0 +1,34 @@
+---
+title: Runtime Log API
+---
+
+# Runtime Log API
+
+Service Lasso exposes runtime-owned service logs through read-only API routes for admin consumers.
+
+## Log metadata
+
+`GET /api/services/log-info?service=<serviceId>&type=default`
+
+Returns the current combined runtime log path and available log types. The only supported type in this slice is `default`.
+
+## Paged reads
+
+`GET /api/logs/read?service=<serviceId>&type=default&limit=100&before=<lineNumber>`
+
+Reads the current combined runtime log with a bounded line limit. `before` is a line-number cursor; omit it for the latest page. The response includes `start`, `end`, `hasMore`, and `nextBefore` so callers can continue backward without rereading the whole file.
+
+## Bounded search
+
+`GET /api/logs/search?service=<serviceId>&type=default&query=<text>&limit=50&includeArchives=true`
+
+Search is a case-insensitive substring search, not a regular expression. It is bounded to at most 100 matches per request and returns truncated message snippets with source metadata:
+
+- `source`: `current` or `archive`
+- `archiveId`: archive identifier when the match came from a retained archive
+- `lineNumber`: one-based line number inside the source log
+- `level`: parsed `stdout`, `stderr`, or `unknown`
+- `snippet`: at most 240 characters
+- `truncated`: whether the snippet was shortened
+
+Archive search is opt-in with `includeArchives=true`; the default searches only the current combined runtime log.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,6 +68,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/runtime-log-api",
+          label: "Runtime Log API",
+        },
+        {
+          type: "doc",
           id: "reference/startup-broker-resolution",
           label: "Startup Broker Resolution",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -315,3 +315,25 @@ export interface ServiceLogChunkResponse {
   limit: number;
   lines: string[];
 }
+
+export interface ServiceLogSearchMatchResponse {
+  serviceId: string;
+  type: "default";
+  source: "current" | "archive";
+  archiveId: string | null;
+  path: string;
+  lineNumber: number;
+  level: "info" | "stdout" | "stderr" | "unknown";
+  snippet: string;
+  truncated: boolean;
+}
+
+export interface ServiceLogSearchResponse {
+  serviceId: string;
+  type: "default";
+  query: string;
+  limit: number;
+  includeArchives: boolean;
+  truncated: boolean;
+  matches: ServiceLogSearchMatchResponse[];
+}

--- a/src/runtime/operator/logs.ts
+++ b/src/runtime/operator/logs.ts
@@ -52,6 +52,28 @@ export interface ServiceLogChunkPayload {
   lines: string[];
 }
 
+export interface ServiceLogSearchMatchPayload {
+  serviceId: string;
+  type: "default";
+  source: "current" | "archive";
+  archiveId: string | null;
+  path: string;
+  lineNumber: number;
+  level: "info" | "stdout" | "stderr" | "unknown";
+  snippet: string;
+  truncated: boolean;
+}
+
+export interface ServiceLogSearchPayload {
+  serviceId: string;
+  type: "default";
+  query: string;
+  limit: number;
+  includeArchives: boolean;
+  truncated: boolean;
+  matches: ServiceLogSearchMatchPayload[];
+}
+
 interface PersistedRuntimeLogEntry {
   level?: "stdout" | "stderr";
   message?: string;
@@ -229,6 +251,40 @@ async function readRuntimeLogLines(logPath: string): Promise<string[]> {
   }
 }
 
+function normalizeLogSearchLimit(limit = 50): number {
+  return Number.isFinite(limit) ? Math.max(1, Math.min(100, Math.trunc(limit))) : 50;
+}
+
+function parseSearchLine(line: string): { level: ServiceLogSearchMatchPayload["level"]; message: string } {
+  try {
+    const entry = JSON.parse(line) as PersistedRuntimeLogEntry;
+    if ((entry.level === "stdout" || entry.level === "stderr") && typeof entry.message === "string") {
+      return {
+        level: entry.level,
+        message: entry.message,
+      };
+    }
+  } catch {
+    // Fall through to raw line search for legacy/plaintext runtime logs.
+  }
+
+  return {
+    level: "unknown",
+    message: line,
+  };
+}
+
+function buildSearchSnippet(message: string, maxLength = 240): { snippet: string; truncated: boolean } {
+  if (message.length <= maxLength) {
+    return { snippet: message, truncated: false };
+  }
+
+  return {
+    snippet: `${message.slice(0, maxLength)}...`,
+    truncated: true,
+  };
+}
+
 export async function buildServiceLogs(
   service: DiscoveredService,
   lifecycle: ServiceLifecycleState,
@@ -283,5 +339,78 @@ export async function readServiceLogChunk(
     nextBefore: start,
     limit: safeLimit,
     lines: slice,
+  };
+}
+
+export async function searchServiceLogs(
+  service: DiscoveredService,
+  query: string,
+  options: { limit?: number; includeArchives?: boolean } = {},
+): Promise<ServiceLogSearchPayload> {
+  const normalizedQuery = query.trim();
+  const safeLimit = normalizeLogSearchLimit(options.limit);
+  const includeArchives = options.includeArchives === true;
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const sources: Array<{
+    source: "current" | "archive";
+    archiveId: string | null;
+    path: string;
+  }> = [
+    {
+      source: "current",
+      archiveId: null,
+      path: runtimeLogPaths.logPath,
+    },
+  ];
+
+  if (includeArchives) {
+    const archives = await listRuntimeLogArchives(service.serviceRoot);
+    sources.push(...archives.map((archive) => ({ source: "archive" as const, archiveId: archive.archiveId, path: archive.logPath })));
+  }
+
+  const lowerQuery = normalizedQuery.toLocaleLowerCase();
+  const matches: ServiceLogSearchMatchPayload[] = [];
+  let truncated = false;
+
+  for (const source of sources) {
+    const lines = await readRuntimeLogLines(source.path);
+    for (const [index, line] of lines.entries()) {
+      const parsed = parseSearchLine(line);
+      if (!parsed.message.toLocaleLowerCase().includes(lowerQuery)) {
+        continue;
+      }
+
+      if (matches.length >= safeLimit) {
+        truncated = true;
+        break;
+      }
+
+      const snippet = buildSearchSnippet(parsed.message);
+      matches.push({
+        serviceId: service.manifest.id,
+        type: "default",
+        source: source.source,
+        archiveId: source.archiveId,
+        path: source.path,
+        lineNumber: index + 1,
+        level: parsed.level,
+        snippet: snippet.snippet,
+        truncated: snippet.truncated,
+      });
+    }
+
+    if (truncated) {
+      break;
+    }
+  }
+
+  return {
+    serviceId: service.manifest.id,
+    type: "default",
+    query: normalizedQuery,
+    limit: safeLimit,
+    includeArchives,
+    truncated,
+    matches,
   };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,11 @@ import { createDependenciesResponse } from "./routes/dependencies.js";
 import { createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
-import { createServiceLogChunkResponse, createServiceLogInfoResponse } from "./routes/log-reader.js";
+import {
+  createServiceLogChunkResponse,
+  createServiceLogInfoResponse,
+  createServiceLogSearchResponse,
+} from "./routes/log-reader.js";
 import { createServiceMetricsResponse } from "./routes/metrics.js";
 import { createServiceVariablesResponse } from "./routes/variables.js";
 import { createServiceNetworkResponse } from "./routes/network.js";
@@ -36,6 +40,7 @@ import {
   buildServiceLogs,
   getServiceRuntimeLogPaths,
   readServiceLogChunk,
+  searchServiceLogs,
 } from "../runtime/operator/logs.js";
 import { buildDashboardService, buildDashboardSummary } from "../runtime/operator/dashboard.js";
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
@@ -619,6 +624,42 @@ async function routeRequest(
     const limit = limitParam === null ? undefined : Number(limitParam);
 
     writeJson(response, 200, createServiceLogChunkResponse(await readServiceLogChunk(service, before, limit)));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/logs/search") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const serviceId = url.searchParams.get("service");
+    const type = url.searchParams.get("type") ?? "default";
+    const query = url.searchParams.get("query") ?? "";
+    const limitParam = url.searchParams.get("limit");
+    const includeArchives = url.searchParams.get("includeArchives") === "true";
+
+    if (!serviceId) {
+      throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
+    }
+
+    if (type !== "default") {
+      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
+    }
+
+    if (query.trim().length === 0) {
+      throw new ApiError("invalid_request", 400, "Missing required \"query\" query parameter.");
+    }
+
+    const service = runtimeModel.registry.getById(serviceId);
+    if (!service) {
+      notFound(response);
+      return;
+    }
+
+    const limit = limitParam === null ? undefined : Number(limitParam);
+
+    writeJson(
+      response,
+      200,
+      createServiceLogSearchResponse(await searchServiceLogs(service, query, { limit, includeArchives })),
+    );
     return;
   }
 

--- a/src/server/routes/log-reader.ts
+++ b/src/server/routes/log-reader.ts
@@ -1,5 +1,9 @@
-import type { ServiceLogChunkResponse, ServiceLogInfoResponse } from "../../contracts/api.js";
-import type { ServiceLogChunkPayload, ServiceLogInfoPayload } from "../../runtime/operator/logs.js";
+import type { ServiceLogChunkResponse, ServiceLogInfoResponse, ServiceLogSearchResponse } from "../../contracts/api.js";
+import type {
+  ServiceLogChunkPayload,
+  ServiceLogInfoPayload,
+  ServiceLogSearchPayload,
+} from "../../runtime/operator/logs.js";
 
 export function createServiceLogInfoResponse(info: ServiceLogInfoPayload): ServiceLogInfoResponse {
   return info;
@@ -7,4 +11,8 @@ export function createServiceLogInfoResponse(info: ServiceLogInfoPayload): Servi
 
 export function createServiceLogChunkResponse(chunk: ServiceLogChunkPayload): ServiceLogChunkResponse {
   return chunk;
+}
+
+export function createServiceLogSearchResponse(search: ServiceLogSearchPayload): ServiceLogSearchResponse {
+  return search;
 }

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -230,6 +230,10 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     const infoBody = await infoResponse.json();
     const chunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=50`);
     const chunkBody = await chunkResponse.json();
+    const searchResponse = await fetch(
+      `${apiServer.url}/api/logs/search?service=reader-service&type=default&query=reader&limit=1`,
+    );
+    const searchBody = await searchResponse.json();
 
     assert.equal(infoResponse.status, 200);
     assert.equal(infoBody.serviceId, "reader-service");
@@ -245,6 +249,16 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     assert.equal(chunkBody.path.endsWith(path.join("reader-service", "logs", "runtime", "service.log")), true);
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stdout\"")));
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stderr\"")));
+
+    assert.equal(searchResponse.status, 200);
+    assert.equal(searchBody.serviceId, "reader-service");
+    assert.equal(searchBody.type, "default");
+    assert.equal(searchBody.query, "reader");
+    assert.equal(searchBody.limit, 1);
+    assert.equal(searchBody.truncated, true);
+    assert.equal(searchBody.matches.length, 1);
+    assert.equal(searchBody.matches[0].source, "current");
+    assert.equal(searchBody.matches[0].snippet.includes("reader"), true);
 
     await postJson(`${apiServer.url}/api/services/reader-service/stop`);
   } finally {
@@ -308,6 +322,22 @@ test("runtime logs archive previous runs and enforce bounded retention", async (
       assert.match(archivedStdout, /archive stdout/);
       assert.match(archivedStderr, /archive stderr/);
     }
+
+    const currentOnlySearch = await fetch(
+      `${apiServer.url}/api/logs/search?service=archive-loggy-service&type=default&query=archive&limit=10`,
+    );
+    const currentOnlySearchBody = await currentOnlySearch.json();
+    const archiveSearch = await fetch(
+      `${apiServer.url}/api/logs/search?service=archive-loggy-service&type=default&query=archive&limit=10&includeArchives=true`,
+    );
+    const archiveSearchBody = await archiveSearch.json();
+
+    assert.equal(currentOnlySearch.status, 200);
+    assert.equal(currentOnlySearchBody.includeArchives, false);
+    assert.equal(currentOnlySearchBody.matches.every((match) => match.source === "current"), true);
+    assert.equal(archiveSearch.status, 200);
+    assert.equal(archiveSearchBody.includeArchives, true);
+    assert.equal(archiveSearchBody.matches.some((match) => match.source === "archive"), true);
 
     const archiveDirectories = await readdir(path.join(serviceRoot, "logs", "archive"), { withFileTypes: true });
     assert.equal(archiveDirectories.filter((entry) => entry.isDirectory()).length, 3);


### PR DESCRIPTION
## Issue
Closes #495

## Summary
- Add GET /api/logs/search for bounded, case-insensitive current runtime log search.
- Support opt-in retained archive matching with source, archive id, path, line number, level, and truncated snippet metadata.
- Document runtime log metadata, paged reads, and bounded search behavior.

## Scope
- In scope: read-only runtime log API contract, server route, operator log search helper, focused API tests, docs.
- Out of scope: UI log viewer, unbounded regex search, mutation/retention policy changes.

## Spec / contract / fixture impact
- Updated: docs/reference/runtime-log-api.md, docs/sidebars.js, and API response contracts in src/contracts/api.ts.
- Search returns bounded snippets only; archive search is opt-in via includeArchives=true.

## Service Lasso invariant impact
- Invariant: secrets and sensitive runtime values must not be exposed broadly through diagnostics.
- Preservation proof: search is bounded, does not support regex or whole-workspace search, and returns max 240-character snippets instead of dumping whole log files.

## Validation
- PASS 
pm run build
- PASS 
ode --test --test-concurrency=1 tests/operator-data.test.js
- PASS 
pm run docs:build
- PASS git diff --check
- Evidence logs: .work-agent/logs/issue-495-20260521-072836/

## Approval trail
- Required: no local approval required for this bounded read-only API slice.
- Evidence: Project #1 item #495 was Ready and no existing #495 branch/PR was present.

## Cleanup
- Branch: issue-495-bounded-log-api
- Local cleanup after PR/check handoff: return to develop; untracked .work-agent/ evidence logs remain only.