### PR TITLE
ISS-495 add bounded runtime log search cursors

### DIFF
--- a/docs/reference/runtime-log-api.md
+++ b/docs/reference/runtime-log-api.md
@@ -1,0 +1,45 @@
+---
+title: Runtime Log API
+sidebar_label: Runtime Log API
+---
+
+# Runtime Log API
+
+Service Lasso exposes runtime-owned service logs through bounded read and search endpoints. The endpoints only read the selected service's managed runtime log files; they do not search arbitrary workspace paths.
+
+## Log metadata
+
+~~~text
+GET /api/services/log-info?service=<serviceId>&type=default
+~~~
+
+Returns the current combined runtime log path and the supported log types for a service. The only supported type is default, which maps to logs/runtime/service.log.
+
+## Paged reads
+
+~~~text
+GET /api/logs/read?service=<serviceId>&type=default&limit=<n>&cursor=<cursor>
+~~~
+
+limit defaults to 100 and is clamped to 1..500. cursor is the opaque continuation value returned from nextCursor. The legacy before query still accepts a numeric line number for compatibility.
+
+The response includes:
+
+- lines: truncated raw line text for compatibility with existing consumers.
+- entries: structured line metadata with source.kind, source.path, source.lineNumber, stream, message, text, and truncated.
+- cursor / nextCursor: continuation values for reading older lines.
+- hasMore: whether another page is available.
+
+Line text and parsed messages are truncated to 2000 characters per field so large log writes cannot create unbounded API payloads.
+
+## Search
+
+~~~text
+GET /api/logs/search?service=<serviceId>&type=default&q=<text>&limit=<n>&cursor=<cursor>&includeArchives=true
+~~~
+
+Search uses a bounded case-insensitive substring match. It does not evaluate regular expressions. limit defaults to 50 and is clamped to 1..100; query text is capped at 200 characters. cursor continues from the previous nextCursor.
+
+By default search scans only the current logs/runtime/service.log. Set includeArchives=true to also scan retained combined logs under logs/archive/*/service.log. Archive retention is still governed by the runtime log retention policy.
+
+The response includes the normalized query, whether archives were included, totalScanned for the page, matches, and nextCursor when more service-owned log lines remain.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -93,6 +93,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/runtime-log-api",
+          label: "Runtime Log API",
+        },
+        {
+          type: "doc",
           id: "reference/servicelasso-localhost-sso-test-matrix",
           label: "SSO Test Matrix",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -312,6 +312,36 @@ export interface ServiceLogChunkResponse {
   end: number;
   hasMore: boolean;
   nextBefore: number;
+  cursor: string;
+  nextCursor: string | null;
   limit: number;
+  entries: ServiceLogLineResponse[];
   lines: string[];
+}
+
+export interface ServiceLogLineResponse {
+  source: {
+    kind: "current" | "archive";
+    archiveId?: string;
+    path: string;
+    lineNumber: number;
+  };
+  stream: "stdout" | "stderr" | "unknown";
+  message: string;
+  text: string;
+  truncated: boolean;
+}
+
+export interface ServiceLogSearchResponse {
+  serviceId: string;
+  type: "default";
+  path: string;
+  query: string;
+  includeArchives: boolean;
+  limit: number;
+  cursor: string;
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalScanned: number;
+  matches: ServiceLogLineResponse[];
 }

--- a/src/runtime/operator/logs.ts
+++ b/src/runtime/operator/logs.ts
@@ -48,8 +48,38 @@ export interface ServiceLogChunkPayload {
   end: number;
   hasMore: boolean;
   nextBefore: number;
+  cursor: string;
+  nextCursor: string | null;
   limit: number;
+  entries: ServiceLogLinePayload[];
   lines: string[];
+}
+
+export interface ServiceLogLinePayload {
+  source: {
+    kind: "current" | "archive";
+    archiveId?: string;
+    path: string;
+    lineNumber: number;
+  };
+  stream: "stdout" | "stderr" | "unknown";
+  message: string;
+  text: string;
+  truncated: boolean;
+}
+
+export interface ServiceLogSearchPayload {
+  serviceId: string;
+  type: "default";
+  path: string;
+  query: string;
+  includeArchives: boolean;
+  limit: number;
+  cursor: string;
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalScanned: number;
+  matches: ServiceLogLinePayload[];
 }
 
 interface PersistedRuntimeLogEntry {
@@ -58,6 +88,12 @@ interface PersistedRuntimeLogEntry {
 }
 
 export const SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION = 3;
+const DEFAULT_LOG_CHUNK_LIMIT = 100;
+const MAX_LOG_CHUNK_LIMIT = 500;
+const DEFAULT_LOG_SEARCH_LIMIT = 50;
+const MAX_LOG_SEARCH_LIMIT = 100;
+const MAX_LOG_SEARCH_QUERY_LENGTH = 200;
+const MAX_LOG_LINE_TEXT_LENGTH = 2_000;
 
 export function getServiceRuntimeLogsRoot(serviceRoot: string): string {
   return path.join(serviceRoot, "logs");
@@ -229,6 +265,60 @@ async function readRuntimeLogLines(logPath: string): Promise<string[]> {
   }
 }
 
+function sanitizePositiveInteger(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.min(max, Math.trunc(value)));
+}
+
+function sanitizeCursor(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.min(max, Math.trunc(value)));
+}
+
+function truncateLogText(value: string): { text: string; truncated: boolean } {
+  if (value.length <= MAX_LOG_LINE_TEXT_LENGTH) {
+    return { text: value, truncated: false };
+  }
+
+  return { text: value.slice(0, MAX_LOG_LINE_TEXT_LENGTH), truncated: true };
+}
+
+function parseRuntimeLogLine(text: string): { stream: ServiceLogLinePayload["stream"]; message: string } {
+  try {
+    const entry = JSON.parse(text) as PersistedRuntimeLogEntry;
+    if ((entry.level === "stdout" || entry.level === "stderr") && typeof entry.message === "string") {
+      return { stream: entry.level, message: entry.message };
+    }
+  } catch {
+    // Plain text service logs are still searchable/readable, just not structured.
+  }
+
+  return { stream: "unknown", message: text };
+}
+
+function createLogLinePayload(
+  text: string,
+  source: { kind: "current" | "archive"; archiveId?: string; path: string; lineNumber: number },
+): ServiceLogLinePayload {
+  const parsed = parseRuntimeLogLine(text);
+  const safeText = truncateLogText(text);
+  const safeMessage = truncateLogText(parsed.message);
+
+  return {
+    source,
+    stream: parsed.stream,
+    message: safeMessage.text,
+    text: safeText.text,
+    truncated: safeText.truncated || safeMessage.truncated,
+  };
+}
+
 export async function buildServiceLogs(
   service: DiscoveredService,
   lifecycle: ServiceLifecycleState,
@@ -262,15 +352,22 @@ export function buildServiceLogInfo(service: DiscoveredService): ServiceLogInfoP
 export async function readServiceLogChunk(
   service: DiscoveredService,
   before?: number,
-  limit = 100,
+  limit = DEFAULT_LOG_CHUNK_LIMIT,
 ): Promise<ServiceLogChunkPayload> {
   const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
   const lines = await readRuntimeLogLines(runtimeLogPaths.logPath);
   const totalLines = lines.length;
-  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(500, Math.trunc(limit))) : 100;
-  const end = typeof before === "number" ? Math.max(0, Math.min(totalLines, before)) : totalLines;
+  const safeLimit = sanitizePositiveInteger(limit, DEFAULT_LOG_CHUNK_LIMIT, MAX_LOG_CHUNK_LIMIT);
+  const end = sanitizeCursor(before, totalLines, totalLines);
   const start = Math.max(0, end - safeLimit);
   const slice = lines.slice(start, end);
+  const entries = slice.map((line, index) =>
+    createLogLinePayload(line, {
+      kind: "current",
+      path: runtimeLogPaths.logPath,
+      lineNumber: start + index + 1,
+    }),
+  );
 
   return {
     serviceId: service.manifest.id,
@@ -281,7 +378,94 @@ export async function readServiceLogChunk(
     end,
     hasMore: start > 0,
     nextBefore: start,
+    cursor: String(end),
+    nextCursor: start > 0 ? String(start) : null,
     limit: safeLimit,
-    lines: slice,
+    entries,
+    lines: entries.map((entry) => entry.text),
+  };
+}
+
+async function collectSearchableLogLines(
+  service: DiscoveredService,
+  includeArchives: boolean,
+): Promise<ServiceLogLinePayload[]> {
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const currentLines = await readRuntimeLogLines(runtimeLogPaths.logPath);
+  const currentEntries = currentLines.map((line, index) =>
+    createLogLinePayload(line, {
+      kind: "current",
+      path: runtimeLogPaths.logPath,
+      lineNumber: index + 1,
+    }),
+  );
+
+  if (!includeArchives) {
+    return currentEntries;
+  }
+
+  const archives = await listRuntimeLogArchives(service.serviceRoot);
+  const archivedEntries = await Promise.all(
+    archives.map(async (archive) => {
+      const archivedLines = await readRuntimeLogLines(archive.logPath);
+      return archivedLines.map((line, index) =>
+        createLogLinePayload(line, {
+          kind: "archive",
+          archiveId: archive.archiveId,
+          path: archive.logPath,
+          lineNumber: index + 1,
+        }),
+      );
+    }),
+  );
+
+  return [...currentEntries, ...archivedEntries.flat()];
+}
+
+export async function searchServiceLogs(
+  service: DiscoveredService,
+  query: string,
+  options: {
+    cursor?: number;
+    includeArchives?: boolean;
+    limit?: number;
+  } = {},
+): Promise<ServiceLogSearchPayload> {
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const safeQuery = query.trim().slice(0, MAX_LOG_SEARCH_QUERY_LENGTH);
+  const includeArchives = options.includeArchives === true;
+  const limit = sanitizePositiveInteger(options.limit, DEFAULT_LOG_SEARCH_LIMIT, MAX_LOG_SEARCH_LIMIT);
+  const lines = await collectSearchableLogLines(service, includeArchives);
+  const cursor = sanitizeCursor(options.cursor, 0, lines.length);
+  const normalizedQuery = safeQuery.toLocaleLowerCase();
+  const matches: ServiceLogLinePayload[] = [];
+  let nextIndex = cursor;
+
+  for (; nextIndex < lines.length; nextIndex += 1) {
+    const entry = lines[nextIndex];
+    const haystack = `${entry.text}\n${entry.message}`.toLocaleLowerCase();
+
+    if (haystack.includes(normalizedQuery)) {
+      matches.push(entry);
+    }
+
+    if (matches.length >= limit) {
+      nextIndex += 1;
+      break;
+    }
+  }
+
+  return {
+    serviceId: service.manifest.id,
+    type: "default",
+    path: runtimeLogPaths.logPath,
+    query: safeQuery,
+    includeArchives,
+    limit,
+    cursor: String(cursor),
+    nextCursor: nextIndex < lines.length ? String(nextIndex) : null,
+    hasMore: nextIndex < lines.length,
+    totalScanned: Math.max(0, nextIndex - cursor),
+    matches,
   };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,7 @@ import { createDependenciesResponse } from "./routes/dependencies.js";
 import { createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
-import { createServiceLogChunkResponse, createServiceLogInfoResponse } from "./routes/log-reader.js";
+import { createServiceLogChunkResponse, createServiceLogInfoResponse, createServiceLogSearchResponse } from "./routes/log-reader.js";
 import { createServiceMetricsResponse } from "./routes/metrics.js";
 import { createServiceVariablesResponse } from "./routes/variables.js";
 import { createServiceNetworkResponse } from "./routes/network.js";
@@ -36,6 +36,7 @@ import {
   buildServiceLogs,
   getServiceRuntimeLogPaths,
   readServiceLogChunk,
+  searchServiceLogs,
 } from "../runtime/operator/logs.js";
 import { buildDashboardService, buildDashboardSummary } from "../runtime/operator/dashboard.js";
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
@@ -100,6 +101,19 @@ function notFound(response: ServerResponse): void {
     message: "Route not found.",
     statusCode: 404,
   });
+}
+
+function parseOptionalInteger(value: string | null): number | undefined {
+  if (value === null || value.trim().length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : undefined;
+}
+
+function parseBooleanQuery(value: string | null): boolean {
+  return value === "1" || value?.toLocaleLowerCase() === "true";
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -598,6 +612,7 @@ async function routeRequest(
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
     const type = url.searchParams.get("type") ?? "default";
+    const cursorParam = url.searchParams.get("cursor");
     const beforeParam = url.searchParams.get("before");
     const limitParam = url.searchParams.get("limit");
 
@@ -615,10 +630,45 @@ async function routeRequest(
       return;
     }
 
-    const before = beforeParam === null ? undefined : Number(beforeParam);
-    const limit = limitParam === null ? undefined : Number(limitParam);
+    const before = parseOptionalInteger(cursorParam) ?? parseOptionalInteger(beforeParam);
+    const limit = parseOptionalInteger(limitParam);
 
     writeJson(response, 200, createServiceLogChunkResponse(await readServiceLogChunk(service, before, limit)));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/logs/search") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const serviceId = url.searchParams.get("service");
+    const type = url.searchParams.get("type") ?? "default";
+    const query = url.searchParams.get("q") ?? url.searchParams.get("query");
+    const cursor = parseOptionalInteger(url.searchParams.get("cursor"));
+    const limit = parseOptionalInteger(url.searchParams.get("limit"));
+    const includeArchives = parseBooleanQuery(url.searchParams.get("includeArchives"));
+
+    if (!serviceId) {
+      throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
+    }
+
+    if (type !== "default") {
+      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
+    }
+
+    if (query === null || query.trim().length === 0) {
+      throw new ApiError("invalid_request", 400, "Missing required \"q\" query parameter.");
+    }
+
+    const service = runtimeModel.registry.getById(serviceId);
+    if (!service) {
+      notFound(response);
+      return;
+    }
+
+    writeJson(
+      response,
+      200,
+      createServiceLogSearchResponse(await searchServiceLogs(service, query, { cursor, includeArchives, limit })),
+    );
     return;
   }
 

--- a/src/server/routes/log-reader.ts
+++ b/src/server/routes/log-reader.ts
@@ -1,5 +1,5 @@
-import type { ServiceLogChunkResponse, ServiceLogInfoResponse } from "../../contracts/api.js";
-import type { ServiceLogChunkPayload, ServiceLogInfoPayload } from "../../runtime/operator/logs.js";
+import type { ServiceLogChunkResponse, ServiceLogInfoResponse, ServiceLogSearchResponse } from "../../contracts/api.js";
+import type { ServiceLogChunkPayload, ServiceLogInfoPayload, ServiceLogSearchPayload } from "../../runtime/operator/logs.js";
 
 export function createServiceLogInfoResponse(info: ServiceLogInfoPayload): ServiceLogInfoResponse {
   return info;
@@ -7,4 +7,8 @@ export function createServiceLogInfoResponse(info: ServiceLogInfoPayload): Servi
 
 export function createServiceLogChunkResponse(chunk: ServiceLogChunkPayload): ServiceLogChunkResponse {
   return chunk;
+}
+
+export function createServiceLogSearchResponse(search: ServiceLogSearchPayload): ServiceLogSearchResponse {
+  return search;
 }

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -230,6 +230,16 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     const infoBody = await infoResponse.json();
     const chunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=50`);
     const chunkBody = await chunkResponse.json();
+    const cursorResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=1`);
+    const cursorBody = await cursorResponse.json();
+    const nextCursorResponse = await fetch(
+      `${apiServer.url}/api/logs/read?service=reader-service&type=default&cursor=${cursorBody.nextCursor}&limit=1`,
+    );
+    const nextCursorBody = await nextCursorResponse.json();
+    const searchResponse = await fetch(
+      `${apiServer.url}/api/logs/search?service=reader-service&type=default&q=reader%20stdout&limit=5`,
+    );
+    const searchBody = await searchResponse.json();
 
     assert.equal(infoResponse.status, 200);
     assert.equal(infoBody.serviceId, "reader-service");
@@ -245,6 +255,22 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     assert.equal(chunkBody.path.endsWith(path.join("reader-service", "logs", "runtime", "service.log")), true);
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stdout\"")));
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stderr\"")));
+    assert.equal(chunkBody.cursor, String(chunkBody.end));
+    assert.equal(chunkBody.entries.some((entry) => entry.stream === "stdout" && entry.message === "reader stdout"), true);
+
+    assert.equal(cursorResponse.status, 200);
+    assert.equal(cursorBody.lines.length, 1);
+    assert.equal(typeof cursorBody.nextCursor, "string");
+    assert.equal(nextCursorResponse.status, 200);
+    assert.equal(nextCursorBody.lines.length, 1);
+
+    assert.equal(searchResponse.status, 200);
+    assert.equal(searchBody.serviceId, "reader-service");
+    assert.equal(searchBody.query, "reader stdout");
+    assert.equal(searchBody.includeArchives, false);
+    assert.equal(searchBody.matches.length, 1);
+    assert.equal(searchBody.matches[0].stream, "stdout");
+    assert.equal(searchBody.matches[0].message, "reader stdout");
 
     await postJson(`${apiServer.url}/api/services/reader-service/stop`);
   } finally {
@@ -308,6 +334,23 @@ test("runtime logs archive previous runs and enforce bounded retention", async (
       assert.match(archivedStdout, /archive stdout/);
       assert.match(archivedStderr, /archive stderr/);
     }
+
+    const currentSearchResponse = await fetch(
+      `${apiServer.url}/api/logs/search?service=archive-loggy-service&type=default&q=archive%20stdout&limit=10`,
+    );
+    const currentSearchBody = await currentSearchResponse.json();
+    const archiveSearchResponse = await fetch(
+      `${apiServer.url}/api/logs/search?service=archive-loggy-service&type=default&q=archive%20stdout&includeArchives=true&limit=10`,
+    );
+    const archiveSearchBody = await archiveSearchResponse.json();
+
+    assert.equal(currentSearchResponse.status, 200);
+    assert.equal(currentSearchBody.includeArchives, false);
+    assert.equal(currentSearchBody.matches.length, 1);
+    assert.equal(archiveSearchResponse.status, 200);
+    assert.equal(archiveSearchBody.includeArchives, true);
+    assert.equal(archiveSearchBody.matches.length >= 4, true);
+    assert.equal(archiveSearchBody.matches.some((entry) => entry.source.kind === "archive"), true);
 
     const archiveDirectories = await readdir(path.join(serviceRoot, "logs", "archive"), { withFileTypes: true });
     assert.equal(archiveDirectories.filter((entry) => entry.isDirectory()).length, 3);


### PR DESCRIPTION
## Issue
Closes #495

## Summary
- Added cursor metadata and structured line entries to the existing runtime log read route while preserving the compatible lines payload.
- Added a bounded substring log search route with optional retained archive scanning.
- Documented the Runtime Log API limits and response shape.

## Scope
- In scope: service-owned runtime log reads/search, cursor continuation, source metadata, archive inclusion, docs and focused API tests.
- Out of scope: regex search, whole-workspace search, UI changes, or changing runtime log retention policy.

## Spec / contract / fixture impact
- Updated: API contract types for log chunks, log line entries, and search responses.
- Updated: docs/reference/runtime-log-api.md and docs sidebar.
- Fixtures: targeted runtime log tests now cover cursor reads, structured metadata, current-log search, and archive-inclusive search.

## Service Lasso invariant impact
- Invariant: logs are scoped to the selected service's runtime-owned log files only.
- Preservation proof: search uses bounded substring matching over current service.log and retained service archive service.log files; no arbitrary paths or regex execution are accepted.

## Validation
- PASS npm run build
- PASS node --test --test-concurrency=1 tests/operator-data.test.js
- PASS npm run docs:build
- PASS git diff --check
- Evidence logs: .work-agent/logs/issue-495-2026-05-22T16-27-32-798Z/

## Approval trail
- Required: no special approval identified for this bounded runtime API slice.
- Evidence: Project #1 item #495 is Ready / agent-ready.

## Cleanup
- Local branch remains checked out for PR creation; untracked .work-agent/ evidence logs remain local only.
