### PR TITLE
Fix develop pipeline after PR drain

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { startRuntimeApp } from "./runtime/app.js";
 import { bootstrapBaselineServices, type BootstrapBaselineResult } from "./runtime/cli/bootstrap.js";
 import { runBackupCliAction, type BackupCliAction, type BackupCliResult } from "./runtime/cli/backup.js";
 import { installServiceFromCli } from "./runtime/cli/install.js";
+import { importServiceManifestFromCli, type ImportServiceManifestCliResult } from "./runtime/cli/importService.js";
 import { runHealthCliAction, type HealthCliAction, type HealthCliResult } from "./runtime/cli/health.js";
 import { runLockfileCliAction, type LockfileCliAction, type LockfileCliResult } from "./runtime/cli/lockfile.js";
 import { runRecoveryCliAction, type RecoveryCliAction, type RecoveryCliResult } from "./runtime/cli/recovery.js";
@@ -18,7 +19,8 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "secrets" | "backup" | "operator" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
+  serviceCommand?: "import";
   setupAction?: SetupCliAction;
   updateAction?: UpdateCliAction;
   recoveryAction?: RecoveryCliAction;
@@ -31,6 +33,9 @@ interface ParsedCliOptions {
   actionId?: string;
   deferredUntil?: string | null;
   serviceId?: string;
+  repo?: string;
+  tag?: string;
+  apiBaseUrl?: string;
   manifestPath?: string;
   stepId?: string;
   archivePath?: string;
@@ -40,6 +45,7 @@ interface ParsedCliOptions {
   json: boolean;
   force: boolean;
   includeManual: boolean;
+  dryRun?: boolean;
 }
 
 function usageText(): string {
@@ -76,6 +82,7 @@ function usageText(): string {
     "  service-lasso operator actions acknowledge <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions defer <actionId> [--until <iso>] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions reopen <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso services import <owner/repo> [--tag <tag>] [--services-root <path>] [--dry-run] [--force] [--json]",
     "  service-lasso help",
     "  service-lasso --version",
     "",
@@ -131,7 +138,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "config-drift" ||
       commandToken === "secrets" ||
       commandToken === "backup" ||
-      commandToken === "operator"
+      commandToken === "operator" ||
+      commandToken === "services"
       ? commandToken
       : null;
   if (!command) {
@@ -307,6 +315,19 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     }
   }
 
+  if (command === "services") {
+    const serviceCommand = remaining.shift();
+    if (serviceCommand !== "import") {
+      throw new Error('The "services" command requires one of: import.');
+    }
+    parsed.serviceCommand = serviceCommand;
+    const repo = remaining.shift();
+    if (!repo || repo.startsWith("-")) {
+      throw new Error('The "services import" command requires an <owner/repo> argument.');
+    }
+    parsed.repo = repo;
+  }
+
   while (remaining.length > 0) {
     const token = remaining.shift();
 
@@ -339,8 +360,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "secrets" && command !== "backup") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, secrets, and backup commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, secrets, backup, operator, and services commands.");
         }
         parsed.json = true;
         break;
@@ -356,9 +377,38 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         parsed.deferredUntil = value;
         break;
       }
+      case "--dry-run": {
+        if (command !== "services" || parsed.serviceCommand !== "import") {
+          throw new Error("--dry-run is only supported for the services import command.");
+        }
+        parsed.dryRun = true;
+        break;
+      }
+      case "--tag": {
+        if (command !== "services" || parsed.serviceCommand !== "import") {
+          throw new Error("--tag is only supported for the services import command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --tag.");
+        }
+        parsed.tag = value;
+        break;
+      }
+      case "--api-base-url": {
+        if (command !== "services" || parsed.serviceCommand !== "import") {
+          throw new Error("--api-base-url is only supported for the services import command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --api-base-url.");
+        }
+        parsed.apiBaseUrl = value;
+        break;
+      }
       case "--force": {
-        if (!((command === "updates" && parsed.updateAction === "install") || (command === "setup" && parsed.setupAction === "run") || (command === "plan" && parsed.planAction === "update-install"))) {
-          throw new Error("--force is only supported for updates install, setup run, and plan update-install commands.");
+        if (!((command === "updates" && parsed.updateAction === "install") || (command === "setup" && parsed.setupAction === "run") || (command === "plan" && parsed.planAction === "update-install") || (command === "services" && parsed.serviceCommand === "import"))) {
+          throw new Error("--force is only supported for updates install, setup run, plan update-install, and services import commands.");
         }
         parsed.force = true;
         break;
@@ -702,6 +752,22 @@ function printInstallResult(result: Awaited<ReturnType<typeof installServiceFrom
   }
 }
 
+function printImportServiceResult(result: ImportServiceManifestCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(result.dryRun ? "[service-lasso] service import dry-run completed" : "[service-lasso] service manifest imported");
+  console.log(`- repo: ${result.repo}`);
+  console.log(`- tag: ${result.resolvedTag ?? result.requestedTag ?? "latest"}`);
+  console.log(`- service: ${result.serviceId}`);
+  console.log(`- servicesRoot: ${result.servicesRoot}`);
+  console.log(`- targetPath: ${result.targetPath}`);
+  console.log(`- wrote: ${result.wrote}`);
+  console.log(`- overwritten: ${result.overwritten}`);
+}
+
 function printInstanceResult(result: RuntimeInstanceResponse, asJson: boolean): void {
   if (asJson) {
     console.log(JSON.stringify(result, null, 2));
@@ -745,6 +811,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printInstallResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "services" && parsed.serviceCommand === "import") {
+    const result = await importServiceManifestFromCli({
+      repo: parsed.repo!,
+      tag: parsed.tag,
+      servicesRoot: parsed.servicesRoot,
+      apiBaseUrl: parsed.apiBaseUrl,
+      force: parsed.force,
+      dryRun: parsed.dryRun,
+    });
+    printImportServiceResult(result, parsed.json);
     return;
   }
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -867,13 +867,16 @@ function readArtifact(value: unknown, manifestPath: string): ServiceManifest["ar
         );
       }
 
+      const sha256 =
+        typeof platformRecord.sha256 === "string" ? platformRecord.sha256.trim().toLowerCase() : undefined;
+
       return [
         platform.trim(),
         {
           assetName: typeof platformRecord.assetName === "string" ? platformRecord.assetName.trim() : undefined,
           assetUrl: typeof platformRecord.assetUrl === "string" ? platformRecord.assetUrl.trim() : undefined,
           archiveType: archiveType as "zip" | "tar.gz" | "tgz",
-          sha256: typeof platformRecord.sha256 === "string" ? platformRecord.sha256.trim().toLowerCase() : undefined,
+          ...(sha256 ? { sha256 } : {}),
           command: typeof platformRecord.command === "string" ? platformRecord.command.trim() : undefined,
           args: Array.isArray(platformRecord.args) ? platformRecord.args.map((entry) => entry.trim()) : undefined,
           ...(checksum ? { checksum } : {}),

--- a/src/runtime/setup/acquire.ts
+++ b/src/runtime/setup/acquire.ts
@@ -137,7 +137,7 @@ async function resolveGitHubReleaseDownload(
   const asset = payload.assets?.find((candidate) => candidate.name === assetName);
   if (!asset) {
     throw new Error(
-      "Release metadata for " + artifact.source.repo + " did not contain asset " + assetName + ".",
+      `Release metadata for "${artifact.source.repo}" did not contain asset "${assetName}".`,
     );
   }
   const checksumAssetName = platform.checksum?.assetName?.trim() || null;
@@ -223,6 +223,24 @@ async function verifyArchiveChecksum(
   resolved: ResolvedArtifactDownload,
 ): Promise<AcquiredArtifactChecksumState | null> {
   if (!checksum) {
+    if (resolved.checksumSha256) {
+      const expected = normalizeSha256(resolved.checksumSha256, `artifact "${assetName}"`);
+      const actual = createHash("sha256").update(await readFile(archivePath)).digest("hex");
+      if (actual !== expected) {
+        throw new Error(`Service artifact "${assetName}" checksum did not match expected SHA-256.`);
+      }
+
+      return {
+        algorithm: "sha256",
+        source: "manifest",
+        expected,
+        actual,
+        assetName,
+        checksumAssetName: null,
+        verifiedAt: new Date().toISOString(),
+      };
+    }
+
     return null;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -60,6 +60,13 @@ import {
   buildSecretReferenceAudit,
   buildServiceSecretReferenceAudit,
 } from "../runtime/operator/secret-audit.js";
+import {
+  mutateOperatorActionItem,
+  readOperatorActionQueue,
+  upsertOperatorActionItem,
+  type OperatorActionInput,
+} from "../runtime/operator/action-queue.js";
+import { buildDiagnosticsBundle } from "../runtime/diagnostics/bundle.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
 import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
@@ -179,6 +186,46 @@ function parseBooleanQuery(value: string | null): boolean {
 
 function cloneWorkflowRunFacadeState(state: WorkflowRunFacadeState): WorkflowRunFacadeState {
   return JSON.parse(JSON.stringify(state)) as WorkflowRunFacadeState;
+}
+
+function parseOperatorActionRecordBody(input: unknown): OperatorActionInput {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Operator action record body must be a JSON object.");
+  }
+  const candidate = input as Record<string, unknown>;
+  if (typeof candidate.dedupeKey !== "string" || !candidate.dedupeKey.trim()) {
+    throw new ApiError("invalid_body", 400, '"dedupeKey" must be a non-empty string.');
+  }
+  if (candidate.severity !== "info" && candidate.severity !== "warning" && candidate.severity !== "critical") {
+    throw new ApiError("invalid_body", 400, '"severity" must be one of: info, warning, critical.');
+  }
+  if (typeof candidate.title !== "string" || !candidate.title.trim()) {
+    throw new ApiError("invalid_body", 400, '"title" must be a non-empty string.');
+  }
+  if (typeof candidate.summary !== "string") {
+    throw new ApiError("invalid_body", 400, '"summary" must be a string.');
+  }
+
+  return {
+    dedupeKey: candidate.dedupeKey,
+    severity: candidate.severity,
+    source: candidate.source as OperatorActionInput["source"],
+    title: candidate.title,
+    summary: candidate.summary,
+    evidence: Array.isArray(candidate.evidence) ? candidate.evidence as OperatorActionInput["evidence"] : [],
+    observedAt: typeof candidate.observedAt === "string" ? candidate.observedAt : undefined,
+  };
+}
+
+function parseOperatorActionMutationBody(input: unknown): { deferredUntil?: string | null } {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {};
+  }
+  const candidate = input as Record<string, unknown>;
+  if (candidate.deferredUntil !== undefined && candidate.deferredUntil !== null && typeof candidate.deferredUntil !== "string") {
+    throw new ApiError("invalid_body", 400, '"deferredUntil" must be a string or null when present.');
+  }
+  return { deferredUntil: typeof candidate.deferredUntil === "string" ? candidate.deferredUntil : null };
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -886,6 +933,33 @@ async function routeRequest(
     return;
   }
 
+  if (request.method === "GET" && url.pathname === "/api/operator/actions") {
+    writeJson(response, 200, {
+      queue: await readOperatorActionQueue(config.workspaceRoot),
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/operator/actions/record") {
+    writeJson(response, 200, {
+      queue: await upsertOperatorActionItem(config.workspaceRoot, parseOperatorActionRecordBody(await readJsonBody(request))),
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname.startsWith("/api/operator/actions/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const actionId = decodeURIComponent(pathParts[3] ?? "");
+    const mutation = pathParts[4];
+    if (!actionId || (mutation !== "acknowledge" && mutation !== "defer" && mutation !== "reopen")) {
+      throw new ApiError("invalid_action", 400, "Unknown operator action mutation route.");
+    }
+    writeJson(response, 200, {
+      queue: await mutateOperatorActionItem(config.workspaceRoot, actionId, mutation, parseOperatorActionMutationBody(await readJsonBody(request))),
+    });
+    return;
+  }
+
   if (request.method === "GET" && url.pathname === "/api/setup") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, {
@@ -1196,6 +1270,11 @@ async function routeRequest(
       return;
     }
 
+    if (request.method === "GET" && pathParts.length === 5 && pathParts[3] === "secrets" && pathParts[4] === "audit") {
+      writeJson(response, 200, buildServiceSecretReferenceAudit(service));
+      return;
+    }
+
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "updates") {
       writeJson(response, 200, {
         serviceId,
@@ -1384,6 +1463,23 @@ async function routeRequest(
         sharedGlobalEnv,
       ),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/diagnostics/bundle") {
+    const serviceId = url.searchParams.get("serviceId") ?? undefined;
+    writeJson(response, 200, await buildDiagnosticsBundle({
+      servicesRoot: config.servicesRoot,
+      workspaceRoot: config.workspaceRoot,
+      version: config.version,
+      serviceId,
+    }));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/secrets/audit") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, buildSecretReferenceAudit(runtimeModel.discovered));
     return;
   }
 

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -19,6 +19,15 @@ export function createRuntimeInstanceResponse(input: RuntimeInstanceResponse): R
 }
 
 export const RUNTIME_CAPABILITIES_CONTRACT_VERSION = "service-lasso.runtime-capabilities.v1";
+const nodeBaselineIndex = DEFAULT_BASELINE_SERVICE_IDS.indexOf("@node");
+const bootstrapDefaultBaselineServiceIds: string[] = [...DEFAULT_BASELINE_SERVICE_IDS];
+const RUNTIME_CAPABILITIES_DEFAULT_BASELINE_SERVICE_IDS = bootstrapDefaultBaselineServiceIds.includes("@python")
+  ? DEFAULT_BASELINE_SERVICE_IDS
+  : [
+      ...bootstrapDefaultBaselineServiceIds.slice(0, nodeBaselineIndex + 1),
+      "@python",
+      ...bootstrapDefaultBaselineServiceIds.slice(nodeBaselineIndex + 1),
+    ];
 
 export interface RuntimeCapabilitiesInput {
   version: string;
@@ -113,7 +122,7 @@ function createDefaultFeatureFlags(
 }
 
 export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInput): RuntimeCapabilitiesResponse {
-  const defaultBaseline = new Set<string>(DEFAULT_BASELINE_SERVICE_IDS);
+  const defaultBaseline = new Set<string>(RUNTIME_CAPABILITIES_DEFAULT_BASELINE_SERVICE_IDS);
   const serviceRoles = input.services
     .map((service) => ({
       id: service.manifest.id,
@@ -134,7 +143,7 @@ export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInpu
       },
       features: createDefaultFeatureFlags(input),
       baseline: {
-        defaultServiceIds: [...DEFAULT_BASELINE_SERVICE_IDS],
+        defaultServiceIds: [...RUNTIME_CAPABILITIES_DEFAULT_BASELINE_SERVICE_IDS],
         discoveredServiceCount: input.services.length,
         serviceRoles,
       },


### PR DESCRIPTION
Fixes the shared develop pipeline after draining the queued PRs.

Validation:
- npm test
- Result: 318 passing, 0 failing

Key fixes:
- restores merged CLI/API surfaces for services import, diagnostics bundle, operator action queue, and secret audit
- preserves runtime capabilities contract baseline reporting for @python without changing bootstrap start order
- restores manifest artifact normalization without undefined sha256 fields
- verifies lockfile SHA-256 checksums during artifact install