### PR TITLE
Ignore agent scratch workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local reference material kept out of git history
 ref/
+.work-agent/
 
 # Runtime/build artifacts
 node_modules/


### PR DESCRIPTION
Adds .work-agent/ to .gitignore so local agent evidence and scratch logs do not show as untracked product files.