### PR TITLE
ISS-526 add health regression bundle summary

### DIFF
--- a/docs/reference/operator-diagnostics-bundle.md
+++ b/docs/reference/operator-diagnostics-bundle.md
@@ -23,6 +23,16 @@ Endpoints:
 
 The API returns the same redacted JSON shape as manifest.json.
 
+## Health Regression Summary
+
+Bundles include `healthRegression` at the top level and per service. It is derived from persisted service health transitions and is meant for review/support evidence:
+
+- `firstFailure`: earliest unhealthy transition in scope
+- `latestState`: latest observed transition in scope
+- `flappingCount`: count of healthy/unhealthy status changes
+- `impactedServiceIds`: service ids with any failure or flapping
+- per-service transition count, first failure, latest state, flapping count, and impacted flag
+
 ## Redaction Contract
 
 The bundle is operator evidence, not a secret export.

--- a/docs/reference/service-health-history.md
+++ b/docs/reference/service-health-history.md
@@ -49,6 +49,16 @@ service-lasso health history [serviceId] [--services-root <path>] [--workspace-r
 
 Without `serviceId`, the command lists persisted health history for all discovered services.
 
+## Regression Summary
+
+Diagnostics bundles derive a compact health regression summary from recent persisted transitions. The summary includes:
+
+- `firstFailure`: earliest unhealthy transition in the selected bundle scope, or `null`
+- `latestState`: latest transition in the selected bundle scope, or `null`
+- `flappingCount`: number of healthy/unhealthy status changes
+- `impactedServiceIds`: services with any failure or flapping
+- per-service transition count, first failure, latest state, flapping count, and impacted flag
+
 ## Safety
 
 Health history is operator-facing metadata only. It must not store raw secret values, credential payloads, provider tokens, private keys, cookies, passwords, environment values, or recovery material.

--- a/src/runtime/diagnostics/bundle.ts
+++ b/src/runtime/diagnostics/bundle.ts
@@ -10,6 +10,13 @@ import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
 import { readServiceRecoveryHistory } from "../recovery/history.js";
 import { readServiceUpdateState } from "../updates/state.js";
 import { getServiceRuntimeLogPaths } from "../operator/logs.js";
+import {
+  readServiceHealthHistory,
+  summarizeHealthRegression,
+  summarizeServiceHealthRegression,
+  type ServiceHealthRegressionServiceSummary,
+  type ServiceHealthRegressionSummary,
+} from "../health/history.js";
 import type { RuntimeConfigOptions } from "../config.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig } from "../config.js";
 
@@ -59,6 +66,7 @@ export interface DiagnosticsBundleService {
   };
   statePaths: ReturnType<typeof getServiceStatePaths>;
   lifecycle: ReturnType<typeof summarizeLifecycle>;
+  healthRegression: ServiceHealthRegressionServiceSummary;
   updates: Awaited<ReturnType<typeof readServiceUpdateState>>;
   recovery: Awaited<ReturnType<typeof readServiceRecoveryHistory>>;
   logs: DiagnosticsBundleLogExcerpt[];
@@ -77,6 +85,7 @@ export interface DiagnosticsBundle {
     workspaceRoot: string;
     serviceCount: number;
   };
+  healthRegression: ServiceHealthRegressionSummary;
   services: DiagnosticsBundleService[];
   redaction: {
     value: typeof REDACTED;
@@ -185,6 +194,7 @@ async function buildServiceBundle(
   const lifecycle = getLifecycleState(service.manifest.id);
   const logPaths = getServiceRuntimeLogPaths(service.serviceRoot);
   const dependencySummary = graph.getServiceDependencies(service.manifest.id);
+  const healthHistory = await readServiceHealthHistory(service);
 
   return {
     serviceId: service.manifest.id,
@@ -207,6 +217,9 @@ async function buildServiceBundle(
     },
     statePaths: getServiceStatePaths(service.serviceRoot),
     lifecycle: summarizeLifecycle(lifecycle),
+    healthRegression: redactDiagnosticsValue(
+      summarizeServiceHealthRegression(healthHistory),
+    ) as ServiceHealthRegressionServiceSummary,
     updates: redactDiagnosticsValue(await readServiceUpdateState(service)) as Awaited<ReturnType<typeof readServiceUpdateState>>,
     recovery: redactDiagnosticsValue(await readServiceRecoveryHistory(service)) as Awaited<ReturnType<typeof readServiceRecoveryHistory>>,
     logs: await Promise.all([
@@ -229,6 +242,9 @@ export async function buildDiagnosticsBundle(options: DiagnosticsBundleOptions =
     throw new Error("Unknown service id: " + options.serviceId);
   }
 
+  const healthHistories = await Promise.all(selected.map((service) => readServiceHealthHistory(service)));
+  const services = await Promise.all(selected.map((service) => buildServiceBundle(service, graph)));
+
   return {
     bundleVersion: 1,
     generatedAt: options.generatedAt ?? new Date().toISOString(),
@@ -242,7 +258,10 @@ export async function buildDiagnosticsBundle(options: DiagnosticsBundleOptions =
       workspaceRoot: config.workspaceRoot,
       serviceCount: selected.length,
     },
-    services: await Promise.all(selected.map((service) => buildServiceBundle(service, graph))),
+    healthRegression: redactDiagnosticsValue(
+      summarizeHealthRegression(healthHistories),
+    ) as ServiceHealthRegressionSummary,
+    services,
     redaction: {
       value: REDACTED,
       rules: [

--- a/src/runtime/health/history.ts
+++ b/src/runtime/health/history.ts
@@ -33,6 +33,24 @@ export interface ServiceHealthHistoryState {
   transitions: ServiceHealthTransitionEvent[];
 }
 
+export interface ServiceHealthRegressionServiceSummary {
+  serviceId: string;
+  transitionCount: number;
+  firstFailure: ServiceHealthTransitionEvent | null;
+  latestState: ServiceHealthTransitionEvent | null;
+  flappingCount: number;
+  impacted: boolean;
+}
+
+export interface ServiceHealthRegressionSummary {
+  serviceCount: number;
+  impactedServiceIds: string[];
+  firstFailure: ServiceHealthTransitionEvent | null;
+  latestState: ServiceHealthTransitionEvent | null;
+  flappingCount: number;
+  services: ServiceHealthRegressionServiceSummary[];
+}
+
 const healthHistoryAppendQueues = new Map<string, Promise<void>>();
 
 function nowIso(): string {
@@ -291,4 +309,74 @@ export async function recordServiceHealthTransition(
       healthHistoryAppendQueues.delete(paths.health);
     }
   }
+}
+
+function transitionTime(value: ServiceHealthTransitionEvent | null): number {
+  if (!value) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const parsed = Date.parse(value.at);
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function latestTransitionTime(value: ServiceHealthTransitionEvent | null): number {
+  const parsed = value ? Date.parse(value.at) : Number.NEGATIVE_INFINITY;
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+export function summarizeServiceHealthRegression(
+  history: ServiceHealthHistoryState,
+): ServiceHealthRegressionServiceSummary {
+  const transitions = [...history.transitions].sort((left, right) => {
+    const delta = latestTransitionTime(left) - latestTransitionTime(right);
+    return delta === 0 ? left.at.localeCompare(right.at) : delta;
+  });
+  const firstFailure = transitions
+    .filter((transition) => transition.status === "unhealthy")
+    .sort((left, right) => transitionTime(left) - transitionTime(right))[0] ?? null;
+  const latestState = transitions.at(-1) ?? null;
+  let flappingCount = 0;
+
+  for (let index = 1; index < transitions.length; index += 1) {
+    if (transitions[index - 1]?.status !== transitions[index]?.status) {
+      flappingCount += 1;
+    }
+  }
+
+  return {
+    serviceId: history.serviceId,
+    transitionCount: transitions.length,
+    firstFailure,
+    latestState,
+    flappingCount,
+    impacted: Boolean(firstFailure) || flappingCount > 0,
+  };
+}
+
+export function summarizeHealthRegression(
+  histories: ServiceHealthHistoryState[],
+): ServiceHealthRegressionSummary {
+  const services = histories
+    .map((history) => summarizeServiceHealthRegression(history))
+    .sort((left, right) => left.serviceId.localeCompare(right.serviceId));
+  const firstFailure = services
+    .map((service) => service.firstFailure)
+    .filter((transition): transition is ServiceHealthTransitionEvent => Boolean(transition))
+    .sort((left, right) => transitionTime(left) - transitionTime(right))[0] ?? null;
+  const latestState = services
+    .map((service) => service.latestState)
+    .filter((transition): transition is ServiceHealthTransitionEvent => Boolean(transition))
+    .sort((left, right) => latestTransitionTime(right) - latestTransitionTime(left))[0] ?? null;
+
+  return {
+    serviceCount: services.length,
+    impactedServiceIds: services
+      .filter((service) => service.impacted)
+      .map((service) => service.serviceId),
+    firstFailure,
+    latestState,
+    flappingCount: services.reduce((total, service) => total + service.flappingCount, 0),
+    services,
+  };
 }

--- a/tests/diagnostics-bundle.test.js
+++ b/tests/diagnostics-bundle.test.js
@@ -7,6 +7,7 @@ import {
   writeDiagnosticsBundleFolder,
 } from "../dist/runtime/diagnostics/bundle.js";
 import { getServiceRuntimeLogPaths } from "../dist/runtime/operator/logs.js";
+import { getServiceStatePaths } from "../dist/runtime/state/paths.js";
 import { startApiServer } from "../dist/server/index.js";
 import {
   assertNoSecretMaterial,
@@ -26,6 +27,19 @@ async function writeSecretBearingRuntimeLog(serviceRoot) {
         serviceLassoSecretLeakSentinels[0].value +
         " Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
     }) + "\n",
+  );
+}
+
+async function writeHealthHistory(serviceRoot, serviceId, transitions) {
+  const statePaths = getServiceStatePaths(serviceRoot);
+  await mkdir(statePaths.stateRoot, { recursive: true });
+  await writeFile(
+    statePaths.health,
+    JSON.stringify({
+      serviceId,
+      updatedAt: "2026-05-22T00:04:00.000Z",
+      transitions,
+    }, null, 2),
   );
 }
 
@@ -61,6 +75,77 @@ test("diagnostics bundle exports baseline shape without secret material", async 
     assert.match(serialized, /\[REDACTED\]/);
     assertNoSecretMaterial(bundle);
     assertNoSecretMaterial(serialized);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("diagnostics bundle includes compact health regression summary", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-diagnostics-health-");
+  try {
+    const { serviceRoot: alphaRoot } = await writeExecutableFixtureService(servicesRoot, "alpha-service");
+    const { serviceRoot: betaRoot } = await writeExecutableFixtureService(servicesRoot, "beta-service");
+
+    await writeHealthHistory(alphaRoot, "alpha-service", [
+      {
+        serviceId: "alpha-service",
+        status: "healthy",
+        checkType: "process",
+        observed: { type: "process" },
+        reason: "healthcheck_passed",
+        detail: "started",
+        at: "2026-05-22T00:00:00.000Z",
+      },
+      {
+        serviceId: "alpha-service",
+        status: "unhealthy",
+        checkType: "http",
+        observed: { type: "http", url: "https://user:secret@example.invalid/health?token=keep-out" },
+        reason: "healthcheck_failed",
+        detail: "failed with SERVICE_LASSO_FAKE_SECRET_SENTINEL_ALPHA_DO_NOT_USE",
+        at: "2026-05-22T00:01:00.000Z",
+      },
+      {
+        serviceId: "alpha-service",
+        status: "healthy",
+        checkType: "http",
+        observed: { type: "http", url: "https://example.invalid/health" },
+        reason: "healthcheck_passed",
+        detail: "recovered",
+        at: "2026-05-22T00:02:00.000Z",
+      },
+    ]);
+    await writeHealthHistory(betaRoot, "beta-service", [
+      {
+        serviceId: "beta-service",
+        status: "healthy",
+        checkType: "process",
+        observed: { type: "process" },
+        reason: "healthcheck_passed",
+        detail: "stable",
+        at: "2026-05-22T00:03:00.000Z",
+      },
+    ]);
+
+    const bundle = await buildDiagnosticsBundle({
+      servicesRoot,
+      workspaceRoot: path.join(tempRoot, "workspace"),
+      generatedAt: "2026-05-22T00:05:00.000Z",
+    });
+
+    assert.equal(bundle.healthRegression.serviceCount, 2);
+    assert.deepEqual(bundle.healthRegression.impactedServiceIds, ["alpha-service"]);
+    assert.equal(bundle.healthRegression.flappingCount, 2);
+    assert.equal(bundle.healthRegression.firstFailure?.serviceId, "alpha-service");
+    assert.equal(bundle.healthRegression.firstFailure?.observed.url, "https://example.invalid/health");
+    assert.equal(bundle.healthRegression.latestState?.serviceId, "beta-service");
+
+    const alphaSummary = bundle.services.find((service) => service.serviceId === "alpha-service")?.healthRegression;
+    assert.equal(alphaSummary?.transitionCount, 3);
+    assert.equal(alphaSummary?.flappingCount, 2);
+    assert.equal(alphaSummary?.impacted, true);
+    assert.equal(alphaSummary?.latestState?.status, "healthy");
+    assertNoSecretMaterial(bundle.healthRegression);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- adds health regression summarizers over persisted service health transitions
- includes top-level and per-service healthRegression evidence in diagnostics bundles
- documents the review/support bundle summary contract

## Validation
- npm run build
- node --test --test-concurrency=1 tests/health-state.test.js tests/diagnostics-bundle.test.js
  - 19 pass, 0 fail

Fixes #526