### PR TITLE
ISS-529 add acknowledgement history API

### DIFF
--- a/docs/reference/operator-action-queue.md
+++ b/docs/reference/operator-action-queue.md
@@ -19,6 +19,10 @@ Each item contains:
 
 Repeated records with the same dedupeKey update the existing item, preserve firstSeenAt, refresh lastSeenAt, and reopen an acknowledged item.
 
+The queue also contains acknowledgementHistory: sanitized acknowledgement audit entries with itemId, actor, reason, acknowledgedAt, previousStatus, and currentStatus.
+
+Acknowledging an item appends an acknowledgementHistory entry even when the item was already acknowledged. History actor and reason values are sanitized before persistence and API output.
+
 ## API
 
 List queue:
@@ -61,7 +65,29 @@ POST /api/operator/actions/{actionId}/defer
 POST /api/operator/actions/{actionId}/reopen
 ~~~
 
-defer accepts an optional deferredUntil string.
+acknowledge accepts optional actor and reason strings. defer accepts an optional deferredUntil string.
+
+Retrieve acknowledgement history for one item:
+
+~~~http
+GET /api/operator/actions/{actionId}/acknowledgements
+~~~
+
+~~~json
+{
+  "itemId": "action-recovery:-node:doctor",
+  "acknowledgements": [
+    {
+      "itemId": "action-recovery:-node:doctor",
+      "acknowledgedAt": "2026-05-22T00:00:00.000Z",
+      "actor": "operator@example.com",
+      "reason": "Reviewed recovery warning.",
+      "previousStatus": "open",
+      "currentStatus": "acknowledged"
+    }
+  ]
+}
+~~~
 
 ## CLI
 
@@ -77,4 +103,3 @@ The CLI uses the same --services-root and --workspace-root options as the other 
 ## Safety
 
 Producers must pass only safe summaries and references. The queue writer also redacts common credential-like patterns from title, summary, and evidence fields before persistence, but that is a guardrail rather than permission to submit secret-bearing data.
-

--- a/src/runtime/operator/action-queue.ts
+++ b/src/runtime/operator/action-queue.ts
@@ -44,9 +44,19 @@ export interface OperatorActionItem {
   reopenedAt: string | null;
 }
 
+export interface OperatorActionAcknowledgementHistoryEntry {
+  itemId: string;
+  acknowledgedAt: string;
+  actor: string;
+  reason: string | null;
+  previousStatus: OperatorActionStatus;
+  currentStatus: "acknowledged";
+}
+
 export interface OperatorActionQueueState {
   updatedAt: string;
   items: OperatorActionItem[];
+  acknowledgementHistory: OperatorActionAcknowledgementHistoryEntry[];
 }
 
 export interface OperatorActionInput {
@@ -62,9 +72,12 @@ export interface OperatorActionInput {
 export interface OperatorActionMutationInput {
   now?: string;
   deferredUntil?: string | null;
+  actor?: string | null;
+  reason?: string | null;
 }
 
 const queueWriteQueues = new Map<string, Promise<void>>();
+const OPERATOR_ACTION_ACKNOWLEDGEMENT_HISTORY_LIMIT = 1000;
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -185,9 +198,32 @@ function normalizeItem(value: unknown): OperatorActionItem | null {
   };
 }
 
+function normalizeAcknowledgementHistoryEntry(value: unknown): OperatorActionAcknowledgementHistoryEntry | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const itemId = sanitizeText(stringOr(record.itemId, ""));
+  const acknowledgedAt = stringOr(record.acknowledgedAt, "");
+  const previousStatus = isStatus(record.previousStatus) ? record.previousStatus : null;
+  if (!itemId || !acknowledgedAt || !previousStatus) {
+    return null;
+  }
+
+  return {
+    itemId,
+    acknowledgedAt,
+    actor: sanitizeText(stringOr(record.actor, "unknown")) || "unknown",
+    reason: stringOrNull(record.reason) === null ? null : sanitizeText(stringOr(record.reason, "")),
+    previousStatus,
+    currentStatus: "acknowledged",
+  };
+}
+
 export function normalizeOperatorActionQueueState(input: unknown): OperatorActionQueueState {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
-    return { updatedAt: nowIso(), items: [] };
+    return { updatedAt: nowIso(), items: [], acknowledgementHistory: [] };
   }
 
   const record = input as Record<string, unknown>;
@@ -197,6 +233,12 @@ export function normalizeOperatorActionQueueState(input: unknown): OperatorActio
       ? record.items.flatMap((entry) => {
           const item = normalizeItem(entry);
           return item ? [item] : [];
+        })
+      : [],
+    acknowledgementHistory: Array.isArray(record.acknowledgementHistory)
+      ? record.acknowledgementHistory.flatMap((entry) => {
+          const historyEntry = normalizeAcknowledgementHistoryEntry(entry);
+          return historyEntry ? [historyEntry] : [];
         })
       : [],
   };
@@ -222,6 +264,11 @@ async function writeOperatorActionQueueWithoutQueue(
       .flatMap((item) => item ? [item] : [])
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
       .slice(0, OPERATOR_ACTION_QUEUE_LIMIT),
+    acknowledgementHistory: state.acknowledgementHistory
+      .map((entry) => normalizeAcknowledgementHistoryEntry(entry))
+      .flatMap((entry) => entry ? [entry] : [])
+      .sort((a, b) => b.acknowledgedAt.localeCompare(a.acknowledgedAt))
+      .slice(0, OPERATOR_ACTION_ACKNOWLEDGEMENT_HISTORY_LIMIT),
   };
 
   const filePath = queuePath(workspaceRoot);
@@ -285,6 +332,7 @@ export async function upsertOperatorActionItem(
     return await writeOperatorActionQueueWithoutQueue(workspaceRoot, {
       updatedAt: observedAt,
       items: [nextItem, ...existing.items.filter((item) => item.id !== nextItem.id)],
+      acknowledgementHistory: existing.acknowledgementHistory,
     });
   });
 }
@@ -300,6 +348,7 @@ export async function mutateOperatorActionItem(
     const existing = await readOperatorActionQueue(workspaceRoot);
     const now = input.now ?? nowIso();
     let found = false;
+    const acknowledgementHistory: OperatorActionAcknowledgementHistoryEntry[] = [...existing.acknowledgementHistory];
     const items = existing.items.map((item) => {
       if (item.id !== itemId) {
         return item;
@@ -307,6 +356,14 @@ export async function mutateOperatorActionItem(
 
       found = true;
       if (action === "acknowledge") {
+        acknowledgementHistory.push({
+          itemId: item.id,
+          acknowledgedAt: now,
+          actor: sanitizeText(input.actor ?? "unknown") || "unknown",
+          reason: input.reason === undefined || input.reason === null ? null : sanitizeText(input.reason),
+          previousStatus: item.status,
+          currentStatus: "acknowledged",
+        });
         return {
           ...item,
           status: "acknowledged" as const,
@@ -342,7 +399,15 @@ export async function mutateOperatorActionItem(
     return await writeOperatorActionQueueWithoutQueue(workspaceRoot, {
       updatedAt: now,
       items,
+      acknowledgementHistory,
     });
   });
 }
 
+export async function readOperatorActionAcknowledgementHistory(
+  workspaceRoot: string,
+  itemId: string,
+): Promise<OperatorActionAcknowledgementHistoryEntry[]> {
+  const queue = await readOperatorActionQueue(workspaceRoot);
+  return queue.acknowledgementHistory.filter((entry) => entry.itemId === itemId);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -62,9 +62,11 @@ import {
 } from "../runtime/operator/secret-audit.js";
 import {
   mutateOperatorActionItem,
+  readOperatorActionAcknowledgementHistory,
   readOperatorActionQueue,
   upsertOperatorActionItem,
   type OperatorActionInput,
+  type OperatorActionMutationInput,
 } from "../runtime/operator/action-queue.js";
 import { buildDiagnosticsBundle } from "../runtime/diagnostics/bundle.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
@@ -217,7 +219,7 @@ function parseOperatorActionRecordBody(input: unknown): OperatorActionInput {
   };
 }
 
-function parseOperatorActionMutationBody(input: unknown): { deferredUntil?: string | null } {
+function parseOperatorActionMutationBody(input: unknown): OperatorActionMutationInput {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return {};
   }
@@ -225,7 +227,17 @@ function parseOperatorActionMutationBody(input: unknown): { deferredUntil?: stri
   if (candidate.deferredUntil !== undefined && candidate.deferredUntil !== null && typeof candidate.deferredUntil !== "string") {
     throw new ApiError("invalid_body", 400, '"deferredUntil" must be a string or null when present.');
   }
-  return { deferredUntil: typeof candidate.deferredUntil === "string" ? candidate.deferredUntil : null };
+  if (candidate.actor !== undefined && candidate.actor !== null && typeof candidate.actor !== "string") {
+    throw new ApiError("invalid_body", 400, '"actor" must be a string or null when present.');
+  }
+  if (candidate.reason !== undefined && candidate.reason !== null && typeof candidate.reason !== "string") {
+    throw new ApiError("invalid_body", 400, '"reason" must be a string or null when present.');
+  }
+  return {
+    deferredUntil: typeof candidate.deferredUntil === "string" ? candidate.deferredUntil : null,
+    actor: typeof candidate.actor === "string" ? candidate.actor : null,
+    reason: typeof candidate.reason === "string" ? candidate.reason : null,
+  };
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -938,6 +950,19 @@ async function routeRequest(
       queue: await readOperatorActionQueue(config.workspaceRoot),
     });
     return;
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/api/operator/actions/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const actionId = decodeURIComponent(pathParts[3] ?? "");
+    const resource = pathParts[4];
+    if (actionId && resource === "acknowledgements") {
+      writeJson(response, 200, {
+        itemId: actionId,
+        acknowledgements: await readOperatorActionAcknowledgementHistory(config.workspaceRoot, actionId),
+      });
+      return;
+    }
   }
 
   if (request.method === "POST" && url.pathname === "/api/operator/actions/record") {

--- a/tests/operator-action-queue.test.js
+++ b/tests/operator-action-queue.test.js
@@ -6,6 +6,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import {
   mutateOperatorActionItem,
+  readOperatorActionAcknowledgementHistory,
   readOperatorActionQueue,
   upsertOperatorActionItem,
 } from "../dist/runtime/operator/action-queue.js";
@@ -94,9 +95,34 @@ test("operator action queue persists deduped actions and safe mutations", async 
 
     queue = await mutateOperatorActionItem(workspaceRoot, queue.items[0].id, "acknowledge", {
       now: "2026-05-21T18:06:00.000Z",
+      actor: "operator@example.com",
+      reason: "Reviewed failed check.",
     });
     assert.equal(queue.items[0].status, "acknowledged");
     assert.equal(queue.items[0].acknowledgedAt, "2026-05-21T18:06:00.000Z");
+    assert.equal(queue.acknowledgementHistory.length, 1);
+    assert.deepEqual(queue.acknowledgementHistory[0], {
+      itemId: queue.items[0].id,
+      acknowledgedAt: "2026-05-21T18:06:00.000Z",
+      actor: "operator@example.com",
+      reason: "Reviewed failed check.",
+      previousStatus: "open",
+      currentStatus: "acknowledged",
+    });
+
+    queue = await mutateOperatorActionItem(workspaceRoot, queue.items[0].id, "acknowledge", {
+      now: "2026-05-21T18:06:30.000Z",
+      actor: "token=ghp_historySecret",
+      reason: "credential=hunter2 already reviewed",
+    });
+    assert.equal(queue.items[0].status, "acknowledged");
+    assert.equal(queue.acknowledgementHistory.length, 2);
+    assert.equal(queue.acknowledgementHistory[0].previousStatus, "acknowledged");
+    assert.equal(queue.acknowledgementHistory[0].actor, "token=[redacted]");
+    assert.equal(queue.acknowledgementHistory[0].reason, "credential=[redacted] already reviewed");
+
+    const history = await readOperatorActionAcknowledgementHistory(workspaceRoot, queue.items[0].id);
+    assert.equal(history.length, 2);
 
     queue = await mutateOperatorActionItem(workspaceRoot, queue.items[0].id, "defer", {
       now: "2026-05-21T18:07:00.000Z",
@@ -115,7 +141,7 @@ test("operator action queue persists deduped actions and safe mutations", async 
     assert.equal(reread.items.length, 1);
 
     const persisted = await readFile(path.join(workspaceRoot, ".state", "operator-actions.json"), "utf8");
-    assert.doesNotMatch(persisted, /hunter2|ghp_exampleSecret|abcdef123456/);
+    assert.doesNotMatch(persisted, /hunter2|ghp_exampleSecret|abcdef123456|ghp_historySecret/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
@@ -154,9 +180,30 @@ test("operator action queue is available through API and CLI", async () => {
     assert.equal(response.status, 200);
     assert.equal(payload.queue.items[0].id, actionId);
 
-    const acknowledged = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledge");
+    const acknowledged = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledge", {
+      actor: "operator@example.com",
+      reason: "Reviewed token=ghp_apiSecret.",
+    });
     assert.equal(acknowledged.status, 200);
     assert.equal(acknowledged.body.queue.items[0].status, "acknowledged");
+    assert.equal(acknowledged.body.queue.acknowledgementHistory[0].actor, "operator@example.com");
+    assert.equal(acknowledged.body.queue.acknowledgementHistory[0].reason, "Reviewed token=[redacted]");
+
+    const acknowledgedAgain = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledge", {
+      actor: "operator@example.com",
+      reason: "Repeated acknowledgement.",
+    });
+    assert.equal(acknowledgedAgain.status, 200);
+    assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory.length, 2);
+    assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory[0].previousStatus, "acknowledged");
+
+    response = await fetch(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledgements");
+    payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.itemId, actionId);
+    assert.equal(payload.acknowledgements.length, 2);
+    assert.equal(payload.acknowledgements[1].previousStatus, "open");
+    assert.doesNotMatch(JSON.stringify(payload), /ghp_apiSecret/);
 
     const cliListOut = await runCli([
       "operator",


### PR DESCRIPTION
## Summary
- add persisted, sanitized acknowledgement history entries for operator action acknowledgements
- expose ``GET /api/operator/actions/{actionId}/acknowledgements``
- document the queue/history contract and cover repeated acknowledgement/redaction

## Validation
- ``npm run build``
- ``node --test --test-concurrency=1 tests/operator-action-queue.test.js``
- ``npm test`` (319 passing tests)

Closes #529
