### PR TITLE
ISS-524 add config snapshot CLI

### DIFF
--- a/docs/reference/config-snapshot.md
+++ b/docs/reference/config-snapshot.md
@@ -1,0 +1,56 @@
+# Configuration Snapshot Export and Import
+
+Status: initial CLI contract.
+
+Service Lasso can export operator-safe service configuration snapshots and preview importing a snapshot without applying it.
+
+## Commands
+
+Export all discovered service configuration:
+
+```powershell
+service-lasso config-snapshot export --services-root ./services --workspace-root ./workspace --json
+```
+
+Export one service:
+
+```powershell
+service-lasso config-snapshot export @serviceadmin --services-root ./services --workspace-root ./workspace --json
+```
+
+Preview importing a snapshot:
+
+```powershell
+service-lasso config-snapshot import ./workspace/config-snapshots/service-lasso-config-snapshot-2026-05-27T00-00-00-000Z.json --services-root ./services --workspace-root ./workspace --json
+```
+
+The import command is dry-run only in this contract. It reports services that are unchanged, would be created, or would be updated, with version and manifest-diff reasons. It does not write manifests, state, logs, config files, or runtime data.
+
+## Snapshot Contract
+
+Snapshots are JSON documents with this shape:
+
+```json
+{
+  "schemaVersion": "service-lasso.config-snapshot.v1",
+  "createdAt": "2026-05-27T00:00:00.000Z",
+  "runtimeVersion": "0.1.0",
+  "policy": {
+    "runtimeState": "excluded",
+    "logs": "excluded",
+    "rawSecrets": "redacted",
+    "machineLocalPaths": "excluded",
+    "importDefault": "dry-run"
+  },
+  "serviceCount": 1,
+  "services": []
+}
+```
+
+Each service entry uses paths relative to `servicesRoot` and includes a redacted `service.json` view. Snapshot files do not include `.state` runtime files, log file contents, workspace paths, service root absolute paths, process ids, or runtime health/lifecycle records.
+
+## Secret-Safety Rules
+
+Manifest `env` and `globalenv` values are redacted by key. Sensitive fields such as passwords, secrets, tokens, credentials, private keys, cookies, API keys, DSNs, generated content, stdout, and stderr are recursively replaced with `[redacted]`.
+
+Because exported snapshots intentionally do not contain raw values, import currently produces a dry-run diff only. A future mutating import must require an explicit apply command and confirmation after a fresh preview.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -73,6 +73,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/config-snapshot",
+          label: "Configuration Snapshot",
+        },
+        {
+          type: "doc",
           id: "reference/workspace-backup-restore",
           label: "Workspace Backup and Restore",
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { runSecretsCliAction, type SecretsCliAction, type SecretsCliResult } fro
 import { runSetupCliAction, type SetupCliAction, type SetupCliResult } from "./runtime/cli/setup.js";
 import { runUpdatesCliAction, type UpdateCliAction, type UpdatesCliResult } from "./runtime/cli/updates.js";
 import { runConfigDriftCliAction, type ConfigDriftCliResult } from "./runtime/cli/config-drift.js";
+import { runConfigSnapshotCliAction, type ConfigSnapshotCliAction, type ConfigSnapshotCliResult } from "./runtime/cli/config-snapshot.js";
 import { readRuntimeInstanceForCli } from "./runtime/cli/instance.js";
 import { runRuntimePlanCliAction, type RuntimePlanCliAction, type RuntimePlanCliResult } from "./runtime/cli/plan.js";
 import type { ServiceUpdateState } from "./runtime/updates/state.js";
@@ -19,7 +20,7 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-snapshot" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
   updateAction?: UpdateCliAction;
@@ -27,6 +28,7 @@ interface ParsedCliOptions {
   healthAction?: HealthCliAction;
   planAction?: RuntimePlanCliAction;
   lockfileAction?: LockfileCliAction;
+  configSnapshotAction?: ConfigSnapshotCliAction;
   secretsAction?: SecretsCliAction;
   backupAction?: BackupCliAction;
   operatorActionsAction?: OperatorActionsCliAction;
@@ -39,6 +41,7 @@ interface ParsedCliOptions {
   manifestPath?: string;
   stepId?: string;
   archivePath?: string;
+  snapshotPath?: string;
   port?: number;
   servicesRoot?: string;
   workspaceRoot?: string;
@@ -75,6 +78,8 @@ function usageText(): string {
     "  service-lasso lockfile generate [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso lockfile verify [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-drift [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso config-snapshot export [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso config-snapshot import <snapshotPath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso secrets audit [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup create [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup restore-plan <archivePath> [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -136,6 +141,7 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "lockfile" ||
       commandToken === "instance" ||
       commandToken === "config-drift" ||
+      commandToken === "config-snapshot" ||
       commandToken === "secrets" ||
       commandToken === "backup" ||
       commandToken === "operator" ||
@@ -266,6 +272,26 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     parsed.serviceId = remaining.shift();
   }
 
+  if (command === "config-snapshot") {
+    const action = remaining.shift();
+    if (action !== "export" && action !== "import") {
+      throw new Error('The "config-snapshot" command requires one of: export, import.');
+    }
+
+    parsed.configSnapshotAction = action;
+    if (action === "export") {
+      if (remaining[0] && !remaining[0].startsWith("-")) {
+        parsed.serviceId = remaining.shift();
+      }
+    } else {
+      const snapshotPath = remaining.shift();
+      if (!snapshotPath || snapshotPath.startsWith("-")) {
+        throw new Error('The "config-snapshot import" command requires a <snapshotPath> argument.');
+      }
+      parsed.snapshotPath = snapshotPath;
+    }
+  }
+
   if (command === "secrets") {
     const action = remaining.shift();
     if (action !== "audit") {
@@ -360,8 +386,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, secrets, backup, operator, and services commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-snapshot, secrets, backup, operator, and services commands.");
         }
         parsed.json = true;
         break;
@@ -594,6 +620,32 @@ function printConfigDriftResult(result: ConfigDriftCliResult, asJson: boolean): 
     for (const file of service.files.filter((entry) => entry.status !== "unchanged")) {
       console.log(`  - ${file.path}: ${file.status}`);
     }
+  }
+}
+
+function printConfigSnapshotResult(result: ConfigSnapshotCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (result.action === "export") {
+    console.log("[service-lasso] config snapshot exported");
+    console.log("- snapshotPath: " + result.snapshotPath);
+    console.log("- services: " + result.snapshot.serviceCount);
+    console.log("- policy: runtime/logs excluded, raw secrets redacted, import dry-run by default");
+    return;
+  }
+
+  console.log("[service-lasso] config snapshot import dry-run");
+  console.log("- snapshotPath: " + result.snapshotPath);
+  console.log("- ok: " + result.ok);
+  console.log("- mutated: " + result.mutated);
+  for (const blocked of result.blocked) {
+    console.log("- blocked: " + blocked);
+  }
+  for (const service of result.services) {
+    console.log("- " + service.serviceId + ": " + service.action + " (" + service.reasons.join(", ") + ")");
   }
 }
 
@@ -925,6 +977,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printConfigDriftResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "config-snapshot") {
+    const result = await runConfigSnapshotCliAction({
+      action: parsed.configSnapshotAction!,
+      serviceId: parsed.serviceId,
+      snapshotPath: parsed.snapshotPath,
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+    });
+    printConfigSnapshotResult(result, parsed.json);
     return;
   }
 

--- a/src/runtime/cli/config-snapshot.ts
+++ b/src/runtime/cli/config-snapshot.ts
@@ -1,0 +1,287 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import type { ServiceManifest } from "../../contracts/service.js";
+import { discoverServices } from "../discovery/discoverServices.js";
+import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
+
+const CONFIG_SNAPSHOT_SCHEMA_VERSION = "service-lasso.config-snapshot.v1";
+const REDACTED = "[redacted]";
+
+export type ConfigSnapshotCliAction = "export" | "import";
+
+export interface ConfigSnapshotCliOptions extends RuntimeConfigOptions {
+  action: ConfigSnapshotCliAction;
+  serviceId?: string;
+  snapshotPath?: string;
+}
+
+export interface ConfigSnapshotServiceEntry {
+  serviceId: string;
+  name: string;
+  version: string | null;
+  serviceRoot: string;
+  manifestPath: string;
+  manifest: unknown;
+}
+
+export interface ConfigSnapshotDocument {
+  schemaVersion: typeof CONFIG_SNAPSHOT_SCHEMA_VERSION;
+  createdAt: string;
+  runtimeVersion: string;
+  policy: {
+    runtimeState: "excluded";
+    logs: "excluded";
+    rawSecrets: "redacted";
+    machineLocalPaths: "excluded";
+    importDefault: "dry-run";
+  };
+  serviceCount: number;
+  services: ConfigSnapshotServiceEntry[];
+}
+
+export interface ConfigSnapshotExportResult {
+  action: "export";
+  ok: true;
+  snapshotPath: string;
+  snapshot: ConfigSnapshotDocument;
+}
+
+export interface ConfigSnapshotImportServicePlan {
+  serviceId: string;
+  action: "unchanged" | "would_create" | "would_update";
+  reasons: string[];
+  currentVersion: string | null;
+  snapshotVersion: string | null;
+}
+
+export interface ConfigSnapshotImportResult {
+  action: "import";
+  ok: boolean;
+  dryRun: true;
+  mutated: false;
+  snapshotPath: string;
+  schemaVersion: string;
+  serviceCount: {
+    current: number;
+    snapshot: number;
+  };
+  services: ConfigSnapshotImportServicePlan[];
+  blocked: string[];
+}
+
+export type ConfigSnapshotCliResult = ConfigSnapshotExportResult | ConfigSnapshotImportResult;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function safeSnapshotTimestamp(value: string): string {
+  return value.replace(/[:.]/g, "-");
+}
+
+function relativePortable(root: string, candidate: string): string {
+  const relativePath = path.relative(root, candidate);
+  return relativePath.split(path.sep).join("/");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /secret|password|passwd|token|credential|private[_-]?key|api[_-]?key|cookie|dsn|content|stdout|stderr/i.test(key);
+}
+
+function redactValue(value: unknown, parentKey = ""): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (isSensitiveKey(parentKey)) {
+    return REDACTED;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry));
+  }
+
+  if (isPlainRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, redactValue(entry, key)]),
+    );
+  }
+
+  return value;
+}
+
+function redactEnvMap(value: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, REDACTED]));
+}
+
+function redactManifest(manifest: ServiceManifest): unknown {
+  const redacted = redactValue(manifest) as Record<string, unknown>;
+  return {
+    ...redacted,
+    env: redactEnvMap(manifest.env),
+    globalenv: redactEnvMap(manifest.globalenv),
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "[" + value.map((entry) => stableStringify(entry)).join(",") + "]";
+  }
+
+  if (isPlainRecord(value)) {
+    return "{" + Object.keys(value)
+      .sort()
+      .map((key) => JSON.stringify(key) + ":" + stableStringify(value[key]))
+      .join(",") + "}";
+  }
+
+  return JSON.stringify(value);
+}
+
+function isConfigSnapshotDocument(value: unknown): value is ConfigSnapshotDocument {
+  return (
+    isPlainRecord(value) &&
+    value.schemaVersion === CONFIG_SNAPSHOT_SCHEMA_VERSION &&
+    Array.isArray(value.services)
+  );
+}
+
+export async function exportConfigSnapshot(
+  options: Omit<ConfigSnapshotCliOptions, "action" | "snapshotPath">,
+): Promise<ConfigSnapshotExportResult> {
+  const config = await ensureRuntimeConfig(resolveRuntimeConfig(options));
+  const services = await discoverServices(config.servicesRoot);
+  const selectedServices = options.serviceId
+    ? services.filter((service) => service.manifest.id === options.serviceId)
+    : services;
+
+  if (options.serviceId && selectedServices.length === 0) {
+    throw new Error("Unknown service id: " + options.serviceId + ".");
+  }
+
+  const createdAt = nowIso();
+  const snapshotRoot = path.join(config.workspaceRoot, "config-snapshots");
+  const snapshotPath = path.join(snapshotRoot, "service-lasso-config-snapshot-" + safeSnapshotTimestamp(createdAt) + ".json");
+  await mkdir(snapshotRoot, { recursive: true });
+
+  const snapshot: ConfigSnapshotDocument = {
+    schemaVersion: CONFIG_SNAPSHOT_SCHEMA_VERSION,
+    createdAt,
+    runtimeVersion: config.version,
+    policy: {
+      runtimeState: "excluded",
+      logs: "excluded",
+      rawSecrets: "redacted",
+      machineLocalPaths: "excluded",
+      importDefault: "dry-run",
+    },
+    serviceCount: selectedServices.length,
+    services: selectedServices
+      .map((service) => ({
+        serviceId: service.manifest.id,
+        name: service.manifest.name,
+        version: service.manifest.version ?? null,
+        serviceRoot: relativePortable(config.servicesRoot, service.serviceRoot),
+        manifestPath: relativePortable(config.servicesRoot, service.manifestPath),
+        manifest: redactManifest(service.manifest),
+      }))
+      .sort((left, right) => left.serviceId.localeCompare(right.serviceId)),
+  };
+
+  await writeFile(snapshotPath, JSON.stringify(snapshot, null, 2) + "\n", "utf8");
+
+  return {
+    action: "export",
+    ok: true,
+    snapshotPath,
+    snapshot,
+  };
+}
+
+function buildImportPlan(snapshot: ConfigSnapshotDocument, current: Awaited<ReturnType<typeof discoverServices>>): ConfigSnapshotImportServicePlan[] {
+  const currentById = new Map(current.map((service) => [service.manifest.id, service]));
+
+  return snapshot.services.map((snapshotService) => {
+    const currentService = currentById.get(snapshotService.serviceId);
+    if (!currentService) {
+      return {
+        serviceId: snapshotService.serviceId,
+        action: "would_create",
+        reasons: ["service_missing_currently", "dry_run_only"],
+        currentVersion: null,
+        snapshotVersion: snapshotService.version,
+      };
+    }
+
+    const currentManifest = redactManifest(currentService.manifest);
+    const reasons: string[] = [];
+    if ((currentService.manifest.version ?? null) !== snapshotService.version) {
+      reasons.push("version_mismatch");
+    }
+    if (stableStringify(currentManifest) !== stableStringify(snapshotService.manifest)) {
+      reasons.push("manifest_diff");
+    }
+
+    return {
+      serviceId: snapshotService.serviceId,
+      action: reasons.length === 0 ? "unchanged" : "would_update",
+      reasons: reasons.length === 0 ? ["matches_snapshot"] : [...reasons, "dry_run_only"],
+      currentVersion: currentService.manifest.version ?? null,
+      snapshotVersion: snapshotService.version,
+    };
+  });
+}
+
+export async function importConfigSnapshotPlan(
+  options: Omit<ConfigSnapshotCliOptions, "action"> & { snapshotPath: string },
+): Promise<ConfigSnapshotImportResult> {
+  const config = await ensureRuntimeConfig(resolveRuntimeConfig(options));
+  const snapshotPath = path.resolve(options.snapshotPath);
+  const rawSnapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as unknown;
+  const currentServices = await discoverServices(config.servicesRoot);
+  const blocked: string[] = [];
+
+  if (!isConfigSnapshotDocument(rawSnapshot)) {
+    blocked.push("unsupported_config_snapshot_schema");
+  }
+
+  const snapshot = isConfigSnapshotDocument(rawSnapshot) ? rawSnapshot : null;
+
+  return {
+    action: "import",
+    ok: blocked.length === 0,
+    dryRun: true,
+    mutated: false,
+    snapshotPath,
+    schemaVersion: isPlainRecord(rawSnapshot) && typeof rawSnapshot.schemaVersion === "string" ? rawSnapshot.schemaVersion : "unknown",
+    serviceCount: {
+      current: currentServices.length,
+      snapshot: snapshot?.serviceCount ?? 0,
+    },
+    services: snapshot ? buildImportPlan(snapshot, currentServices) : [],
+    blocked,
+  };
+}
+
+export async function runConfigSnapshotCliAction(options: ConfigSnapshotCliOptions): Promise<ConfigSnapshotCliResult> {
+  if (options.action === "export") {
+    return await exportConfigSnapshot(options);
+  }
+
+  if (!options.snapshotPath) {
+    throw new Error("The config-snapshot import command requires a <snapshotPath> argument.");
+  }
+
+  return await importConfigSnapshotPlan({
+    ...options,
+    snapshotPath: options.snapshotPath,
+  });
+}

--- a/tests/cli-config-snapshot.test.js
+++ b/tests/cli-config-snapshot.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { writeManifest } from "./test-helpers.js";
+
+const execFile = promisify(execFileCallback);
+
+async function makeTempRuntime(prefix) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const servicesRoot = path.join(tempRoot, "services");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  await mkdir(servicesRoot, { recursive: true });
+  await mkdir(workspaceRoot, { recursive: true });
+  return { tempRoot, servicesRoot, workspaceRoot };
+}
+
+async function runCli(args, cwd = path.resolve(".")) {
+  const cliPath = path.join(cwd, "dist", "cli.js");
+  const result = await execFile(process.execPath, [cliPath, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      npm_package_version: "0.1.0-test",
+    },
+  });
+
+  return result.stdout.trim();
+}
+
+async function writeVolatileState(serviceRoot) {
+  const stateRoot = path.join(serviceRoot, ".state");
+  await mkdir(stateRoot, { recursive: true });
+  await writeFile(
+    path.join(stateRoot, "runtime.json"),
+    JSON.stringify({
+      running: true,
+      pid: 12345,
+      stdoutPath: path.join(serviceRoot, "logs", "stdout.log"),
+      credential: "runtime-raw-credential",
+    }, null, 2),
+  );
+  await mkdir(path.join(serviceRoot, "logs"), { recursive: true });
+  await writeFile(path.join(serviceRoot, "logs", "stdout.log"), "runtime log with raw-db-password");
+}
+
+test("CLI config-snapshot export writes redacted config snapshot without runtime state or machine-local paths", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempRuntime("service-lasso-config-snapshot-export-");
+  const serviceRoot = await writeManifest(servicesRoot, "snapshot-fixture", {
+    id: "snapshot-fixture",
+    name: "Snapshot Fixture",
+    description: "Fixture with raw config values that must not be exported.",
+    version: "1.0.0",
+    env: {
+      DB_PASSWORD: "raw-db-password",
+      PUBLIC_MODE: "local",
+    },
+    globalenv: {
+      API_TOKEN: "raw-api-token",
+    },
+    config: {
+      files: [
+        {
+          path: "runtime/app.conf",
+          content: "password=raw-config-password\nmode=local\n",
+        },
+      ],
+    },
+  });
+  await writeVolatileState(serviceRoot);
+
+  try {
+    const stdout = await runCli([
+      "config-snapshot",
+      "export",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const payload = JSON.parse(stdout);
+    const snapshotText = await readFile(payload.snapshotPath, "utf8");
+    const snapshot = JSON.parse(snapshotText);
+    const manifest = snapshot.services[0].manifest;
+
+    assert.equal(payload.action, "export");
+    assert.equal(payload.ok, true);
+    assert.equal(snapshot.policy.runtimeState, "excluded");
+    assert.equal(snapshot.policy.logs, "excluded");
+    assert.equal(snapshot.policy.importDefault, "dry-run");
+    assert.equal(snapshot.services[0].serviceRoot, "snapshot-fixture");
+    assert.equal(snapshot.services[0].manifestPath, "snapshot-fixture/service.json");
+    assert.equal(manifest.env.DB_PASSWORD, "[redacted]");
+    assert.equal(manifest.env.PUBLIC_MODE, "[redacted]");
+    assert.equal(manifest.globalenv.API_TOKEN, "[redacted]");
+    assert.equal(manifest.config.files[0].content, "[redacted]");
+    assert.doesNotMatch(snapshotText, /raw-db-password|raw-api-token|raw-config-password|runtime-raw-credential|runtime log/);
+    assert.equal(snapshotText.includes(tempRoot), false);
+    assert.equal(snapshotText.includes(".state"), false);
+    assert.equal(snapshotText.includes("logs/stdout.log"), false);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI config-snapshot import defaults to dry-run and reports manifest diffs without mutating", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempRuntime("service-lasso-config-snapshot-import-");
+  await writeManifest(servicesRoot, "snapshot-import-fixture", {
+    id: "snapshot-import-fixture",
+    name: "Snapshot Import Fixture",
+    description: "Original snapshot fixture.",
+    version: "1.0.0",
+  });
+
+  try {
+    const exportOut = await runCli([
+      "config-snapshot",
+      "export",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const snapshot = JSON.parse(exportOut);
+
+    const serviceRoot = await writeManifest(servicesRoot, "snapshot-import-fixture", {
+      id: "snapshot-import-fixture",
+      name: "Snapshot Import Fixture",
+      description: "Changed after export.",
+      version: "2.0.0",
+    });
+    const manifestPath = path.join(serviceRoot, "service.json");
+    const beforeImport = await readFile(manifestPath, "utf8");
+
+    const importOut = await runCli([
+      "config-snapshot",
+      "import",
+      snapshot.snapshotPath,
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const plan = JSON.parse(importOut);
+    const afterImport = await readFile(manifestPath, "utf8");
+
+    assert.equal(plan.action, "import");
+    assert.equal(plan.dryRun, true);
+    assert.equal(plan.mutated, false);
+    assert.equal(plan.services[0].serviceId, "snapshot-import-fixture");
+    assert.equal(plan.services[0].action, "would_update");
+    assert.deepEqual(plan.services[0].reasons, ["version_mismatch", "manifest_diff", "dry_run_only"]);
+    assert.equal(afterImport, beforeImport);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add `config-snapshot export` for redacted service configuration snapshots
- add dry-run-only `config-snapshot import` diff planning with `mutated:false`
- document the snapshot contract and add focused CLI round-trip coverage

## Safety contract
- snapshots exclude runtime state, logs, absolute machine-local roots, and raw secret values
- manifest `env`/`globalenv` values and sensitive fields are redacted
- import is non-mutating in this slice because exported data is intentionally redacted

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/cli-config-snapshot.test.js`
- `npm run docs:build`

Closes #524