### PR TITLE
ISS-523 add config apply preflight

### DIFF
--- a/docs/reference/config-apply-preflight.md
+++ b/docs/reference/config-apply-preflight.md
@@ -1,0 +1,19 @@
+# Config Apply Preflight
+
+`service-lasso config-apply preflight` is a dry-run-only operator gate for applying service configuration.
+
+The preflight reports:
+
+- lifecycle and policy gates that would allow, warn, or block config apply
+- whether a running service may need restart after materialized config changes
+- unsupported manifest fields for this bounded slice
+- secret references used by config materialization by ref name and status only
+- expected operator impact without writing manifests, state, logs, config files, or runtime data
+
+The report does not include raw secret values, provider credentials, tokens, cookies, private keys, environment values, or generated file content.
+
+```bash
+service-lasso config-apply preflight [serviceId] --services-root ./services --workspace-root ./workspace --json
+```
+
+The command is non-mutating. A blocked report means operators should resolve the reported policy gate before any later apply implementation is allowed to mutate configuration.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -78,6 +78,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/config-apply-preflight",
+          label: "Config Apply Preflight",
+        },
+        {
+          type: "doc",
           id: "reference/workspace-backup-restore",
           label: "Workspace Backup and Restore",
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { runSecretsCliAction, type SecretsCliAction, type SecretsCliResult } fro
 import { runSetupCliAction, type SetupCliAction, type SetupCliResult } from "./runtime/cli/setup.js";
 import { runUpdatesCliAction, type UpdateCliAction, type UpdatesCliResult } from "./runtime/cli/updates.js";
 import { runConfigDriftCliAction, type ConfigDriftCliResult } from "./runtime/cli/config-drift.js";
+import { runConfigApplyCliAction, type ConfigApplyCliAction, type ConfigApplyCliResult } from "./runtime/cli/config-apply.js";
 import { runConfigSnapshotCliAction, type ConfigSnapshotCliAction, type ConfigSnapshotCliResult } from "./runtime/cli/config-snapshot.js";
 import { readRuntimeInstanceForCli } from "./runtime/cli/instance.js";
 import { runRuntimePlanCliAction, type RuntimePlanCliAction, type RuntimePlanCliResult } from "./runtime/cli/plan.js";
@@ -20,7 +21,7 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-snapshot" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
   updateAction?: UpdateCliAction;
@@ -28,6 +29,7 @@ interface ParsedCliOptions {
   healthAction?: HealthCliAction;
   planAction?: RuntimePlanCliAction;
   lockfileAction?: LockfileCliAction;
+  configApplyAction?: ConfigApplyCliAction;
   configSnapshotAction?: ConfigSnapshotCliAction;
   secretsAction?: SecretsCliAction;
   backupAction?: BackupCliAction;
@@ -78,6 +80,7 @@ function usageText(): string {
     "  service-lasso lockfile generate [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso lockfile verify [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-drift [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso config-apply preflight [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-snapshot export [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-snapshot import <snapshotPath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso secrets audit [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -141,6 +144,7 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "lockfile" ||
       commandToken === "instance" ||
       commandToken === "config-drift" ||
+      commandToken === "config-apply" ||
       commandToken === "config-snapshot" ||
       commandToken === "secrets" ||
       commandToken === "backup" ||
@@ -272,6 +276,18 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     parsed.serviceId = remaining.shift();
   }
 
+  if (command === "config-apply") {
+    const action = remaining.shift();
+    if (action !== "preflight") {
+      throw new Error('The "config-apply" command requires: preflight.');
+    }
+
+    parsed.configApplyAction = action;
+    if (remaining[0] && !remaining[0].startsWith("-")) {
+      parsed.serviceId = remaining.shift();
+    }
+  }
+
   if (command === "config-snapshot") {
     const action = remaining.shift();
     if (action !== "export" && action !== "import") {
@@ -386,8 +402,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-snapshot, secrets, backup, operator, and services commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-apply, config-snapshot, secrets, backup, operator, and services commands.");
         }
         parsed.json = true;
         break;
@@ -619,6 +635,32 @@ function printConfigDriftResult(result: ConfigDriftCliResult, asJson: boolean): 
     console.log(`- ${service.serviceId}: ${service.summary.drifted} drifted / ${service.summary.total} files`);
     for (const file of service.files.filter((entry) => entry.status !== "unchanged")) {
       console.log(`  - ${file.path}: ${file.status}`);
+    }
+  }
+}
+
+function printConfigApplyResult(result: ConfigApplyCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log("[service-lasso] config apply preflight");
+  console.log("- ok: " + result.ok);
+  console.log("- mutated: " + result.mutated);
+  console.log(
+    "- services: allowed=" +
+      result.summary.allowed +
+      " warning=" +
+      result.summary.warning +
+      " blocked=" +
+      result.summary.blocked,
+  );
+  for (const service of result.services) {
+    console.log("- " + service.serviceId + ": " + service.status);
+    console.log("  restartRequired: " + service.restartRequirement.required);
+    for (const gate of service.policyGates.filter((entry) => entry.status !== "allowed")) {
+      console.log("  gate " + gate.gate + ": " + gate.status + " (" + gate.reason + ")");
     }
   }
 }
@@ -977,6 +1019,21 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printConfigDriftResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "config-apply") {
+    const result = await runConfigApplyCliAction({
+      action: parsed.configApplyAction!,
+      serviceId: parsed.serviceId,
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+    });
+    printConfigApplyResult(result, parsed.json);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/runtime/cli/config-apply.ts
+++ b/src/runtime/cli/config-apply.ts
@@ -1,0 +1,37 @@
+import { discoverServices } from "../discovery/discoverServices.js";
+import { createServiceRegistry } from "../manager/DependencyGraph.js";
+import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
+import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
+import { buildConfigApplyPreflightReport, type ConfigApplyPreflightReport } from "../operator/config-apply-preflight.js";
+
+export type ConfigApplyCliAction = "preflight";
+
+export interface ConfigApplyCliOptions extends RuntimeConfigOptions {
+  action: ConfigApplyCliAction;
+  serviceId?: string;
+}
+
+export interface ConfigApplyCliResult extends ConfigApplyPreflightReport {
+  servicesRoot: string;
+  workspaceRoot: string;
+}
+
+export async function runConfigApplyCliAction(options: ConfigApplyCliOptions): Promise<ConfigApplyCliResult> {
+  const runtimeConfig = await ensureRuntimeConfig(
+    resolveRuntimeConfig({
+      servicesRoot: options.servicesRoot,
+      workspaceRoot: options.workspaceRoot,
+      version: options.version,
+    }),
+  );
+  const discovered = await discoverServices(runtimeConfig.servicesRoot);
+  await rehydrateDiscoveredServices(discovered);
+  const registry = createServiceRegistry(discovered);
+  const report = await buildConfigApplyPreflightReport(registry, options.serviceId);
+
+  return {
+    servicesRoot: runtimeConfig.servicesRoot,
+    workspaceRoot: runtimeConfig.workspaceRoot,
+    ...report,
+  };
+}

--- a/src/runtime/operator/config-apply-preflight.ts
+++ b/src/runtime/operator/config-apply-preflight.ts
@@ -1,0 +1,307 @@
+import { readFile } from "node:fs/promises";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { buildServiceConfigDriftReport, type ConfigDriftReport } from "./config-drift.js";
+import { buildServiceSecretReferenceAudit, type SecretReferenceAuditFinding } from "./secret-audit.js";
+
+export type ConfigApplyPreflightStatus = "allowed" | "warning" | "blocked";
+
+export interface ConfigApplyPreflightGate {
+  gate: string;
+  status: ConfigApplyPreflightStatus;
+  reason: string;
+}
+
+export interface ConfigApplyPreflightSecretRef {
+  ref: string;
+  source: SecretReferenceAuditFinding["source"];
+  location: string;
+  status: SecretReferenceAuditFinding["status"];
+  required?: boolean;
+}
+
+export interface ConfigApplyPreflightUnsupportedField {
+  location: string;
+  reason: string;
+}
+
+export interface ConfigApplyPreflightServiceReport {
+  serviceId: string;
+  status: ConfigApplyPreflightStatus;
+  dryRun: true;
+  mutated: false;
+  generatedAt: string;
+  configured: boolean;
+  running: boolean;
+  policyGates: ConfigApplyPreflightGate[];
+  restartRequirement: {
+    required: boolean;
+    reason: string;
+  };
+  unsupportedFields: ConfigApplyPreflightUnsupportedField[];
+  secretRefChanges: {
+    count: number;
+    refs: ConfigApplyPreflightSecretRef[];
+  };
+  expectedOperatorImpact: string[];
+  configDrift?: ConfigDriftReport;
+}
+
+export interface ConfigApplyPreflightReport {
+  action: "preflight";
+  ok: boolean;
+  dryRun: true;
+  mutated: false;
+  generatedAt: string;
+  summary: {
+    services: number;
+    allowed: number;
+    warning: number;
+    blocked: number;
+  };
+  services: ConfigApplyPreflightServiceReport[];
+}
+
+const CONFIG_APPLY_SUPPORTED_FIELDS = new Set(["files"]);
+
+function worstStatus(statuses: ConfigApplyPreflightStatus[]): ConfigApplyPreflightStatus {
+  if (statuses.includes("blocked")) {
+    return "blocked";
+  }
+  if (statuses.includes("warning")) {
+    return "warning";
+  }
+  return "allowed";
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+async function collectUnsupportedConfigFields(service: DiscoveredService): Promise<ConfigApplyPreflightUnsupportedField[]> {
+  let config: unknown = service.manifest.config;
+  try {
+    const rawManifest = JSON.parse(await readFile(service.manifestPath, "utf8")) as unknown;
+    if (isPlainRecord(rawManifest) && rawManifest.config !== undefined) {
+      config = rawManifest.config;
+    }
+  } catch {
+    config = service.manifest.config;
+  }
+
+  if (!isPlainRecord(config)) {
+    return [];
+  }
+
+  return Object.keys(config)
+    .filter((field) => !CONFIG_APPLY_SUPPORTED_FIELDS.has(field))
+    .sort()
+    .map((field) => ({
+      location: "config." + field,
+      reason: "The config apply preflight only supports config.files in this slice.",
+    }));
+}
+
+function collectConfigSecretRefs(service: DiscoveredService): ConfigApplyPreflightSecretRef[] {
+  const configRelevantSources = new Set<SecretReferenceAuditFinding["source"]>([
+    "env",
+    "globalenv",
+    "config",
+    "broker.import",
+    "broker.export",
+    "broker.writeback",
+  ]);
+
+  return buildServiceSecretReferenceAudit(service).findings
+    .filter((finding) => configRelevantSources.has(finding.source))
+    .map((finding) => ({
+      ref: finding.ref,
+      source: finding.source,
+      location: finding.location,
+      status: finding.status,
+      required: finding.required,
+    }));
+}
+
+function configChangesRequireRestart(drift: ConfigDriftReport | undefined): boolean {
+  return Boolean(drift && drift.summary.drifted > 0);
+}
+
+function buildImpact(drift: ConfigDriftReport | undefined, restartRequired: boolean): string[] {
+  if (!drift) {
+    return ["Config apply is blocked before file impact can be calculated."];
+  }
+
+  const impact: string[] = [];
+  if (drift.summary.missing > 0) {
+    impact.push(`${drift.summary.missing} config file(s) would be created.`);
+  }
+  if (drift.summary.changed > 0) {
+    impact.push(`${drift.summary.changed} config file(s) would be updated.`);
+  }
+  if (drift.summary.unmanaged > 0) {
+    impact.push(`${drift.summary.unmanaged} previously materialized file(s) are no longer declared.`);
+  }
+  if (drift.summary.drifted === 0) {
+    impact.push("No materialized config file changes are expected.");
+  }
+  if (restartRequired) {
+    impact.push("Running service may need restart after config apply.");
+  }
+  impact.push("No raw secret values are included in this dry-run report.");
+  return impact;
+}
+
+export async function buildServiceConfigApplyPreflightReport(
+  service: DiscoveredService,
+  services: DiscoveredService[],
+): Promise<ConfigApplyPreflightServiceReport> {
+  const lifecycle = getLifecycleState(service.manifest.id);
+  const unsupportedFields = await collectUnsupportedConfigFields(service);
+  const secretRefs = collectConfigSecretRefs(service);
+  const policyGates: ConfigApplyPreflightGate[] = [];
+  let drift: ConfigDriftReport | undefined;
+
+  if (!lifecycle.installed) {
+    policyGates.push({
+      gate: "lifecycle.installed",
+      status: "blocked",
+      reason: "Config apply requires the service to be installed first.",
+    });
+  } else {
+    policyGates.push({
+      gate: "lifecycle.installed",
+      status: "allowed",
+      reason: "Service is installed.",
+    });
+  }
+
+  if (service.manifest.enabled === false) {
+    policyGates.push({
+      gate: "service.enabled",
+      status: "warning",
+      reason: "Service is disabled; config can be planned but operators should confirm intent before applying.",
+    });
+  }
+
+  if (unsupportedFields.length > 0) {
+    policyGates.push({
+      gate: "config.supported_fields",
+      status: "warning",
+      reason: "Unsupported config fields are present and will not be applied by this preflight slice.",
+    });
+  } else {
+    policyGates.push({
+      gate: "config.supported_fields",
+      status: "allowed",
+      reason: "Only supported config fields are present.",
+    });
+  }
+
+  const secretBlockers = secretRefs.filter((ref) => ref.status !== "present" && ref.required !== false);
+  if (secretBlockers.length > 0) {
+    policyGates.push({
+      gate: "secret_refs",
+      status: "blocked",
+      reason: "Required secret references used by config materialization are missing or malformed.",
+    });
+  } else if (secretRefs.length > 0) {
+    policyGates.push({
+      gate: "secret_refs",
+      status: "allowed",
+      reason: "Secret references are declared without exposing values.",
+    });
+  } else {
+    policyGates.push({
+      gate: "secret_refs",
+      status: "allowed",
+      reason: "No secret references are used by config materialization.",
+    });
+  }
+
+  try {
+    drift = await buildServiceConfigDriftReport(service, services);
+    policyGates.push({
+      gate: "materialization_paths",
+      status: "allowed",
+      reason: "Config file paths stay inside the service root.",
+    });
+  } catch (error) {
+    policyGates.push({
+      gate: "materialization_paths",
+      status: "blocked",
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const restartRequired = lifecycle.running && configChangesRequireRestart(drift);
+  if (restartRequired) {
+    policyGates.push({
+      gate: "restart",
+      status: "warning",
+      reason: "The service is running and materialized config would change.",
+    });
+  }
+
+  const status = worstStatus(policyGates.map((gate) => gate.status));
+
+  return {
+    serviceId: service.manifest.id,
+    status,
+    dryRun: true,
+    mutated: false,
+    generatedAt: new Date().toISOString(),
+    configured: lifecycle.configured,
+    running: lifecycle.running,
+    policyGates,
+    restartRequirement: {
+      required: restartRequired,
+      reason: restartRequired
+        ? "Apply would change materialized config for a running service."
+        : "No restart requirement detected by this dry-run preflight.",
+    },
+    unsupportedFields,
+    secretRefChanges: {
+      count: secretRefs.length,
+      refs: secretRefs,
+    },
+    expectedOperatorImpact: buildImpact(drift, restartRequired),
+    configDrift: drift,
+  };
+}
+
+export async function buildConfigApplyPreflightReport(
+  registry: ServiceRegistry,
+  serviceId?: string,
+): Promise<ConfigApplyPreflightReport> {
+  const services = serviceId
+    ? [registry.getById(serviceId)].filter((service) => service !== undefined)
+    : registry.list();
+
+  if (serviceId && services.length === 0) {
+    const available = registry.list().map((entry) => entry.manifest.id).sort();
+    const hint = available.length > 0 ? ` Available services: ${available.join(", ")}.` : "";
+    throw new Error(`Unknown service id: ${serviceId}.${hint}`);
+  }
+
+  const reports = await Promise.all(
+    services.map((service) => buildServiceConfigApplyPreflightReport(service, registry.list())),
+  );
+  const summary = {
+    services: reports.length,
+    allowed: reports.filter((service) => service.status === "allowed").length,
+    warning: reports.filter((service) => service.status === "warning").length,
+    blocked: reports.filter((service) => service.status === "blocked").length,
+  };
+
+  return {
+    action: "preflight",
+    ok: summary.blocked === 0,
+    dryRun: true,
+    mutated: false,
+    generatedAt: new Date().toISOString(),
+    summary,
+    services: reports,
+  };
+}

--- a/tests/config-apply-preflight.test.js
+++ b/tests/config-apply-preflight.test.js
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rm } from "node:fs/promises";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
+import { installService } from "../dist/runtime/lifecycle/actions.js";
+import { getLifecycleState, resetLifecycleState, setLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { buildConfigApplyPreflightReport } from "../dist/runtime/operator/config-apply-preflight.js";
+import { runConfigApplyCliAction } from "../dist/runtime/cli/config-apply.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function prepareRegistry(servicesRoot) {
+  const discovered = await discoverServices(servicesRoot);
+  return createServiceRegistry(discovered);
+}
+
+test("config apply preflight allows installed config that would create files", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-apply-allowed-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "allowed-config-service", {
+      config: {
+        files: [{ path: "runtime/app.conf", content: "mode=local\n" }],
+      },
+    });
+    const registry = await prepareRegistry(servicesRoot);
+    const service = registry.getById("allowed-config-service");
+    assert.ok(service);
+    await installService(service, registry);
+
+    const report = await buildConfigApplyPreflightReport(registry, "allowed-config-service");
+
+    assert.equal(report.ok, true);
+    assert.equal(report.mutated, false);
+    assert.equal(report.summary.allowed, 1);
+    assert.equal(report.services[0].status, "allowed");
+    assert.equal(report.services[0].configDrift?.summary.missing, 1);
+    assert.equal(report.services[0].secretRefChanges.count, 0);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config apply preflight warns when running config would change and unsupported fields exist", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-apply-warning-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "warning-config-service", {
+      config: {
+        files: [{ path: "runtime/app.conf", content: "mode=changed\n" }],
+        template: "unsupported",
+      },
+    });
+    const registry = await prepareRegistry(servicesRoot);
+    const service = registry.getById("warning-config-service");
+    assert.ok(service);
+    await installService(service, registry);
+    const currentState = getLifecycleState("warning-config-service");
+    setLifecycleState("warning-config-service", {
+      ...currentState,
+      installed: true,
+      configured: true,
+      running: true,
+    });
+
+    const report = await buildConfigApplyPreflightReport(registry, "warning-config-service");
+
+    assert.equal(report.ok, true);
+    assert.equal(report.summary.warning, 1);
+    assert.equal(report.services[0].restartRequirement.required, true);
+    assert.deepEqual(report.services[0].unsupportedFields, [
+      {
+        location: "config.template",
+        reason: "The config apply preflight only supports config.files in this slice.",
+      },
+    ]);
+    assert.ok(report.services[0].policyGates.some((gate) => gate.gate === "restart" && gate.status === "warning"));
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config apply preflight blocks missing required secret refs without leaking values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-apply-blocked-");
+  const rawSecretValue = "super-secret-token";
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "blocked-config-service", {
+      env: {
+        API_TOKEN: rawSecretValue,
+      },
+      config: {
+        files: [{ path: "runtime/app.conf", content: "token=${missing.token}\n" }],
+      },
+    });
+    const registry = await prepareRegistry(servicesRoot);
+    const service = registry.getById("blocked-config-service");
+    assert.ok(service);
+    await installService(service, registry);
+
+    const report = await runConfigApplyCliAction({
+      action: "preflight",
+      servicesRoot,
+      workspaceRoot: path.join(tempRoot, "workspace"),
+      serviceId: "blocked-config-service",
+    });
+    const serialized = JSON.stringify(report);
+
+    assert.equal(report.ok, false);
+    assert.equal(report.summary.blocked, 1);
+    assert.equal(report.services[0].secretRefChanges.refs[0].ref, "missing.token");
+    assert.equal(report.services[0].secretRefChanges.refs[0].status, "missing");
+    assert.equal(serialized.includes(rawSecretValue), false);
+    assert.equal(serialized.includes("super-secret-token"), false);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary\n- add service-lasso config-apply preflight [serviceId] as a dry-run-only CLI/runtime report\n- report lifecycle/policy gates, restart requirement, unsupported config fields, safe secret-ref metadata, and operator impact without raw values\n- document the new preflight surface and add focused fixture coverage\n\n## Validation\n- 
pm test -> 326 tests passed\n- 
ode --test --test-concurrency=1 tests/config-apply-preflight.test.js -> 3 tests passed\n\nCloses #523