### PR TITLE
ISS-522 add catalog stale release warnings

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -62,6 +62,16 @@ export interface ServiceCompatibilityRequirementStatus {
   detail?: string;
 }
 
+export interface ServiceCompatibilityWarning {
+  kind: "release-stale" | "release-metadata-unavailable";
+  severity: "warning";
+  id: string;
+  detail: string;
+  sourceRepo?: string | null;
+  manifestTag?: string | null;
+  latestTag?: string | null;
+}
+
 export interface ServiceCompatibilityReport {
   hostPlatform: string;
   status: "compatible" | "unsupported" | "missing-requirements";
@@ -70,6 +80,7 @@ export interface ServiceCompatibilityReport {
   requiredPorts: ServiceCompatibilityPortRequirement[];
   requirements: ServiceCompatibilityRequirementStatus[];
   blockers: string[];
+  warnings: ServiceCompatibilityWarning[];
 }
 
 export interface GlobalEnvResponse {

--- a/src/runtime/operator/catalog-compatibility.ts
+++ b/src/runtime/operator/catalog-compatibility.ts
@@ -1,9 +1,16 @@
-import type { ServiceCompatibilityReport, ServiceCompatibilityRequirementStatus } from "../../contracts/api.js";
+import type {
+  ServiceCompatibilityReport,
+  ServiceCompatibilityRequirementStatus,
+  ServiceCompatibilityWarning,
+} from "../../contracts/api.js";
 import type { DiscoveredService, ServiceManifest } from "../../contracts/service.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { compareTimestampedReleaseTags } from "../updates/check.js";
+import type { ServiceUpdateState } from "../updates/state.js";
 
 export interface ServiceCompatibilityOptions {
   hostPlatform?: NodeJS.Platform | string;
+  updateState?: ServiceUpdateState | null;
 }
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -34,6 +41,52 @@ function platformIsSupported(supportedPlatforms: string[], hostPlatform: string)
   return supportedPlatforms.length === 0 || supportedPlatforms.includes(hostPlatform) || supportedPlatforms.includes("default");
 }
 
+function buildReleaseWarnings(
+  manifest: ServiceManifest,
+  updateState: ServiceUpdateState | null | undefined,
+): ServiceCompatibilityWarning[] {
+  const source = manifest.artifact?.source;
+  const lastCheck = updateState?.lastCheck;
+  if (!source?.repo || !source.tag || !lastCheck) {
+    return [];
+  }
+
+  const sourceRepo = lastCheck.sourceRepo ?? source.repo;
+  const manifestTag = lastCheck.manifestTag ?? source.tag;
+  const latestTag = lastCheck.latestTag;
+
+  if (lastCheck.status === "check_failed" || lastCheck.status === "unavailable") {
+    return [{
+      kind: "release-metadata-unavailable",
+      severity: "warning",
+      id: "release-metadata-unavailable",
+      detail: `Latest release metadata for "${sourceRepo}" is unavailable: ${lastCheck.reason}`,
+      sourceRepo,
+      manifestTag,
+      latestTag,
+    }];
+  }
+
+  if (!latestTag || manifestTag === latestTag) {
+    return [];
+  }
+
+  const timestampComparison = compareTimestampedReleaseTags(manifestTag, latestTag);
+  if (timestampComparison === 1 || (lastCheck.status === "update_available" && timestampComparison !== -1)) {
+    return [{
+      kind: "release-stale",
+      severity: "warning",
+      id: "release-stale",
+      detail: `Manifest release tag "${manifestTag}" is older than tracked release "${latestTag}".`,
+      sourceRepo,
+      manifestTag,
+      latestTag,
+    }];
+  }
+
+  return [];
+}
+
 export function buildServiceCompatibilityReport(
   service: DiscoveredService,
   registry: ServiceRegistry,
@@ -43,6 +96,7 @@ export function buildServiceCompatibilityReport(
   const supportedPlatforms = collectSupportedPlatforms(service.manifest);
   const requiredProviders = collectRequiredProviders(service.manifest);
   const requiredPorts = collectRequiredPorts(service.manifest);
+  const warnings = buildReleaseWarnings(service.manifest, options.updateState);
   const requirements: ServiceCompatibilityRequirementStatus[] = [
     ...(service.manifest.depend_on ?? []).map((dependencyId) => ({
       kind: "dependency" as const,
@@ -82,5 +136,6 @@ export function buildServiceCompatibilityReport(
     requiredPorts,
     requirements,
     blockers,
+    warnings,
   };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -588,7 +588,7 @@ async function createServiceSummary(
     recovery,
     statePaths: getServiceStatePaths(service.serviceRoot),
     provider,
-    compatibility: buildServiceCompatibilityReport(service, registry),
+    compatibility: buildServiceCompatibilityReport(service, registry, { updateState: updates }),
     operator: {
       logPath: lifecycle.runtime.logs.logPath ?? runtimeLogs.logPath,
       variableCount: variables.variables.length,

--- a/tests/service-compatibility.test.js
+++ b/tests/service-compatibility.test.js
@@ -19,6 +19,20 @@ async function loadRegistry(servicesRoot) {
   return { services, registry: createServiceRegistry(services) };
 }
 
+function createUpdateState(serviceId, lastCheck) {
+  return {
+    serviceId,
+    state: lastCheck.status === "update_available" ? "available" : "installed",
+    updatedAt: lastCheck.checkedAt,
+    lastCheck,
+    available: null,
+    downloadedCandidate: null,
+    installDeferred: null,
+    failed: null,
+    hookResults: [],
+  };
+}
+
 test("service compatibility report classifies supported platform providers and ports", async () => {
   const servicesRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-compat-ok-"));
 
@@ -101,6 +115,146 @@ test("service compatibility report identifies platform mismatch and missing prov
     assert.ok(report.blockers.some((blocker) => blocker.includes("Host platform")));
     assert.ok(report.blockers.some((blocker) => blocker.includes("@python")));
     assert.ok(report.requirements.some((requirement) => requirement.kind === "provider" && requirement.status === "missing"));
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("service compatibility report does not warn when pinned release metadata is current", async () => {
+  const servicesRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-compat-release-current-"));
+
+  try {
+    await writeManifest(servicesRoot, "current-service", {
+      id: "current-service",
+      name: "Current Service",
+      description: "Service pinned to the tracked release.",
+      artifact: {
+        kind: "archive",
+        source: {
+          type: "github-release",
+          repo: "service-lasso/current-service",
+          tag: "2026.5.20-current",
+        },
+        platforms: {
+          default: {
+            assetName: "current-service.zip",
+            archiveType: "zip",
+          },
+        },
+      },
+    });
+    const { services, registry } = await loadRegistry(servicesRoot);
+
+    const report = buildServiceCompatibilityReport(services[0], registry, {
+      updateState: createUpdateState("current-service", {
+        checkedAt: "2026-05-20T00:00:00.000Z",
+        status: "latest",
+        reason: "Installed release tag matches the tracked release.",
+        sourceRepo: "service-lasso/current-service",
+        track: "latest",
+        installedTag: null,
+        manifestTag: "2026.5.20-current",
+        latestTag: "2026.5.20-current",
+      }),
+    });
+
+    assert.deepEqual(report.warnings, []);
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("service compatibility report warns when catalog release metadata is stale", async () => {
+  const servicesRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-compat-release-stale-"));
+
+  try {
+    await writeManifest(servicesRoot, "stale-service", {
+      id: "stale-service",
+      name: "Stale Service",
+      description: "Service pinned behind the tracked release.",
+      artifact: {
+        kind: "archive",
+        source: {
+          type: "github-release",
+          repo: "service-lasso/stale-service",
+          tag: "2026.5.10-old",
+        },
+        platforms: {
+          default: {
+            assetName: "stale-service.zip",
+            archiveType: "zip",
+          },
+        },
+      },
+    });
+    const { services, registry } = await loadRegistry(servicesRoot);
+
+    const report = buildServiceCompatibilityReport(services[0], registry, {
+      updateState: createUpdateState("stale-service", {
+        checkedAt: "2026-05-20T00:00:00.000Z",
+        status: "update_available",
+        reason: "Tracked release differs from the installed release tag.",
+        sourceRepo: "service-lasso/stale-service",
+        track: "latest",
+        installedTag: null,
+        manifestTag: "2026.5.10-old",
+        latestTag: "2026.5.20-current",
+      }),
+    });
+
+    assert.equal(report.status, "compatible");
+    assert.equal(report.warnings.length, 1);
+    assert.equal(report.warnings[0].kind, "release-stale");
+    assert.equal(report.warnings[0].sourceRepo, "service-lasso/stale-service");
+    assert.equal(report.warnings[0].manifestTag, "2026.5.10-old");
+    assert.equal(report.warnings[0].latestTag, "2026.5.20-current");
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("service compatibility report warns when latest release metadata is unavailable", async () => {
+  const servicesRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-compat-release-unavailable-"));
+
+  try {
+    await writeManifest(servicesRoot, "unavailable-service", {
+      id: "unavailable-service",
+      name: "Unavailable Service",
+      description: "Service with unavailable release metadata.",
+      artifact: {
+        kind: "archive",
+        source: {
+          type: "github-release",
+          repo: "service-lasso/unavailable-service",
+          tag: "2026.5.10-old",
+        },
+        platforms: {
+          default: {
+            assetName: "unavailable-service.zip",
+            archiveType: "zip",
+          },
+        },
+      },
+    });
+    const { services, registry } = await loadRegistry(servicesRoot);
+
+    const report = buildServiceCompatibilityReport(services[0], registry, {
+      updateState: createUpdateState("unavailable-service", {
+        checkedAt: "2026-05-20T00:00:00.000Z",
+        status: "check_failed",
+        reason: "500 Internal Server Error",
+        sourceRepo: "service-lasso/unavailable-service",
+        track: "latest",
+        installedTag: null,
+        manifestTag: "2026.5.10-old",
+        latestTag: null,
+      }),
+    });
+
+    assert.equal(report.status, "compatible");
+    assert.equal(report.warnings.length, 1);
+    assert.equal(report.warnings[0].kind, "release-metadata-unavailable");
+    assert.match(report.warnings[0].detail, /500 Internal Server Error/);
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Adds read-only catalog compatibility warnings for stale GitHub release metadata and unavailable latest-release metadata.
- Wires persisted update-check state into `/api/services` compatibility metadata without triggering install/download behavior.
- Covers current pinned, stale, unavailable, and API compatibility cases.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/service-compatibility.test.js tests/update-discovery.test.js`

Closes #522.