### PR TITLE
feat(cli): add support bundle redaction preview

### DIFF
--- a/docs/reference/operator-diagnostics-bundle.md
+++ b/docs/reference/operator-diagnostics-bundle.md
@@ -6,9 +6,11 @@ Service Lasso can export a redacted diagnostics bundle for the full baseline or 
 
 Command:
 
-    service-lasso diagnostics bundle [serviceId|baseline] --services-root PATH --workspace-root PATH --output PATH --json
+    service-lasso diagnostics bundle [serviceId|baseline] --preview --services-root PATH --workspace-root PATH --json
 
-When serviceId is omitted, or when baseline is supplied, the bundle includes every discovered service. The command writes a deterministic folder with:
+Preview mode is non-mutating support-bundle planning evidence. It lists the files that would be written, the safe fields that would be included, bounded log segments that would be sampled, and the redaction decisions that protect env, globalenv, runtime command, broker, and log content. It does not write the bundle folder.
+
+When serviceId is omitted, or when baseline is supplied, the bundle scope includes every discovered service. The underlying written bundle shape is a deterministic folder with:
 
 - manifest.json: bundle metadata and service summaries
 - services/SERVICE_ID/summary.json: per-service manifest, state, update, recovery, and lifecycle evidence

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { runUpdatesCliAction, type UpdateCliAction, type UpdatesCliResult } from
 import { runConfigDriftCliAction, type ConfigDriftCliResult } from "./runtime/cli/config-drift.js";
 import { runConfigApplyCliAction, type ConfigApplyCliAction, type ConfigApplyCliResult } from "./runtime/cli/config-apply.js";
 import { runConfigSnapshotCliAction, type ConfigSnapshotCliAction, type ConfigSnapshotCliResult } from "./runtime/cli/config-snapshot.js";
+import { runDiagnosticsCliAction, type DiagnosticsCliAction, type DiagnosticsCliResult } from "./runtime/cli/diagnostics.js";
 import { readRuntimeInstanceForCli } from "./runtime/cli/instance.js";
 import { runRuntimePlanCliAction, type RuntimePlanCliAction, type RuntimePlanCliResult } from "./runtime/cli/plan.js";
 import type { ServiceUpdateState } from "./runtime/updates/state.js";
@@ -21,7 +22,7 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "operator" | "services" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "help" | "version";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
   updateAction?: UpdateCliAction;
@@ -33,6 +34,7 @@ interface ParsedCliOptions {
   configSnapshotAction?: ConfigSnapshotCliAction;
   secretsAction?: SecretsCliAction;
   backupAction?: BackupCliAction;
+  diagnosticsAction?: DiagnosticsCliAction;
   operatorActionsAction?: OperatorActionsCliAction;
   actionId?: string;
   deferredUntil?: string | null;
@@ -51,6 +53,7 @@ interface ParsedCliOptions {
   force: boolean;
   includeManual: boolean;
   dryRun?: boolean;
+  preview?: boolean;
 }
 
 function usageText(): string {
@@ -86,6 +89,7 @@ function usageText(): string {
     "  service-lasso secrets audit [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup create [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup restore-plan <archivePath> [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso diagnostics bundle [serviceId|baseline] --preview [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions list [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions acknowledge <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions defer <actionId> [--until <iso>] [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -148,6 +152,7 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "config-snapshot" ||
       commandToken === "secrets" ||
       commandToken === "backup" ||
+      commandToken === "diagnostics" ||
       commandToken === "operator" ||
       commandToken === "services"
       ? commandToken
@@ -336,6 +341,21 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     }
   }
 
+  if (command === "diagnostics") {
+    const action = remaining.shift();
+    if (action !== "bundle") {
+      throw new Error('The "diagnostics" command requires: bundle.');
+    }
+
+    parsed.diagnosticsAction = action;
+    if (remaining[0] && !remaining[0].startsWith("-")) {
+      const scope = remaining.shift();
+      if (scope && scope !== "baseline") {
+        parsed.serviceId = scope;
+      }
+    }
+  }
+
   if (command === "operator") {
     const scope = remaining.shift();
     if (scope !== "actions") {
@@ -402,8 +422,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "operator" && command !== "services") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-apply, config-snapshot, secrets, backup, operator, and services commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, and services commands.");
         }
         parsed.json = true;
         break;
@@ -420,10 +440,20 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--dry-run": {
-        if (command !== "services" || parsed.serviceCommand !== "import") {
-          throw new Error("--dry-run is only supported for the services import command.");
+        if ((command !== "services" || parsed.serviceCommand !== "import") && command !== "diagnostics") {
+          throw new Error("--dry-run is only supported for the services import and diagnostics bundle commands.");
         }
         parsed.dryRun = true;
+        if (command === "diagnostics") {
+          parsed.preview = true;
+        }
+        break;
+      }
+      case "--preview": {
+        if (command !== "diagnostics") {
+          throw new Error("--preview is only supported for the diagnostics bundle command.");
+        }
+        parsed.preview = true;
         break;
       }
       case "--tag": {
@@ -755,6 +785,27 @@ function printBackupResult(result: BackupCliResult, asJson: boolean): void {
   }
 }
 
+function printDiagnosticsResult(result: DiagnosticsCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log("[service-lasso] diagnostics bundle preview");
+  console.log("- scope: " + result.scope.kind + (result.scope.serviceId ? " " + result.scope.serviceId : ""));
+  console.log("- services: " + result.runtime.serviceCount);
+  console.log("- wouldWriteBundle: " + result.output.wouldWriteBundle);
+  console.log("- files: " + result.output.files.length);
+  console.log("- redaction: " + result.redaction.value);
+  for (const service of result.services) {
+    console.log("- " + service.serviceId + ": files=" + service.files.length + " logSegments=" + service.logSegments.length);
+    const envRedaction = service.redactions.find((entry) => entry.surface === "manifest.env");
+    const globalenvRedaction = service.redactions.find((entry) => entry.surface === "manifest.globalenv");
+    console.log("  envKeys: " + (envRedaction?.keys?.join(", ") || "none"));
+    console.log("  globalenvKeys: " + (globalenvRedaction?.keys?.join(", ") || "none"));
+  }
+}
+
 function printOperatorResult(result: OperatorCliResult, asJson: boolean): void {
   if (asJson) {
     console.log(JSON.stringify(result, null, 2));
@@ -1071,6 +1122,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printBackupResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "diagnostics") {
+    const result = await runDiagnosticsCliAction({
+      action: parsed.diagnosticsAction!,
+      serviceId: parsed.serviceId,
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+      preview: parsed.preview ?? false,
+    });
+    printDiagnosticsResult(result, parsed.json);
     return;
   }
 

--- a/src/runtime/cli/diagnostics.ts
+++ b/src/runtime/cli/diagnostics.ts
@@ -1,0 +1,29 @@
+import {
+  buildDiagnosticsBundle,
+  buildDiagnosticsBundlePreview,
+  type DiagnosticsBundlePreview,
+  type DiagnosticsBundleOptions,
+} from "../diagnostics/bundle.js";
+
+export type DiagnosticsCliAction = "bundle";
+
+export interface DiagnosticsCliOptions extends DiagnosticsBundleOptions {
+  action: DiagnosticsCliAction;
+  preview: boolean;
+}
+
+export interface DiagnosticsCliResult extends DiagnosticsBundlePreview {
+  action: "bundle-preview";
+}
+
+export async function runDiagnosticsCliAction(options: DiagnosticsCliOptions): Promise<DiagnosticsCliResult> {
+  if (!options.preview) {
+    throw new Error('The "diagnostics bundle" command currently requires --preview.');
+  }
+
+  const bundle = await buildDiagnosticsBundle(options);
+  return {
+    action: "bundle-preview",
+    ...buildDiagnosticsBundlePreview(bundle),
+  };
+}

--- a/src/runtime/diagnostics/bundle.ts
+++ b/src/runtime/diagnostics/bundle.ts
@@ -93,6 +93,52 @@ export interface DiagnosticsBundle {
   };
 }
 
+export interface DiagnosticsBundlePreviewFile {
+  path: string;
+  sourcePath: string | null;
+  wouldWrite: true;
+  contents: string[];
+}
+
+export interface DiagnosticsBundlePreviewLogSegment {
+  type: DiagnosticsBundleLogExcerpt["type"];
+  sourcePath: string;
+  totalLines: number;
+  includedLines: number;
+  redaction: "pattern-redacted";
+}
+
+export interface DiagnosticsBundlePreviewRedaction {
+  surface: string;
+  action: "keys-only" | "field-redacted" | "pattern-redacted";
+  keys?: string[];
+  redacted: boolean;
+}
+
+export interface DiagnosticsBundlePreviewService {
+  serviceId: string;
+  manifestPath: string;
+  serviceRoot: string;
+  files: DiagnosticsBundlePreviewFile[];
+  includedFields: string[];
+  logSegments: DiagnosticsBundlePreviewLogSegment[];
+  redactions: DiagnosticsBundlePreviewRedaction[];
+}
+
+export interface DiagnosticsBundlePreview {
+  previewVersion: 1;
+  generatedAt: string;
+  mutated: false;
+  scope: DiagnosticsBundle["scope"];
+  runtime: DiagnosticsBundle["runtime"];
+  output: {
+    wouldWriteBundle: false;
+    files: DiagnosticsBundlePreviewFile[];
+  };
+  services: DiagnosticsBundlePreviewService[];
+  redaction: DiagnosticsBundle["redaction"];
+}
+
 function redactString(value: string): string {
   return sensitiveValuePatterns.reduce((current, pattern) => current.replace(pattern, REDACTED), value);
 }
@@ -275,6 +321,117 @@ export async function buildDiagnosticsBundle(options: DiagnosticsBundleOptions =
 
 function safeServiceDirectoryName(serviceId: string): string {
   return encodeURIComponent(serviceId).replace(/%/g, "_");
+}
+
+function buildServicePreview(service: DiagnosticsBundleService): DiagnosticsBundlePreviewService {
+  const serviceDirectoryName = safeServiceDirectoryName(service.serviceId);
+  return {
+    serviceId: service.serviceId,
+    manifestPath: service.manifestPath,
+    serviceRoot: service.serviceRoot,
+    files: [
+      {
+        path: path.posix.join("services", serviceDirectoryName, "summary.json"),
+        sourcePath: service.manifestPath,
+        wouldWrite: true,
+        contents: [
+          "service manifest metadata",
+          "state paths",
+          "lifecycle summary",
+          "health regression summary",
+          "update and recovery summaries",
+        ],
+      },
+      {
+        path: path.posix.join("services", serviceDirectoryName, "logs.json"),
+        sourcePath: null,
+        wouldWrite: true,
+        contents: ["bounded redacted service/stdout/stderr log excerpts"],
+      },
+    ],
+    includedFields: [
+      "manifest.id",
+      "manifest.name",
+      "manifest.description",
+      "manifest.enabled",
+      "manifest.role",
+      "manifest.version",
+      "manifest.dependencies",
+      "manifest.dependents",
+      "manifest.ports",
+      "manifest.urlKeys",
+      "manifest.envKeys",
+      "manifest.globalenvKeys",
+      "manifest.broker",
+      "statePaths",
+      "lifecycle",
+      "healthRegression",
+      "updates",
+      "recovery",
+      "logs",
+    ],
+    logSegments: service.logs.map((log) => ({
+      type: log.type,
+      sourcePath: log.path,
+      totalLines: log.totalLines,
+      includedLines: log.lines.length,
+      redaction: "pattern-redacted",
+    })),
+    redactions: [
+      {
+        surface: "manifest.env",
+        action: "keys-only",
+        keys: service.manifest.envKeys,
+        redacted: service.manifest.envKeys.length > 0,
+      },
+      {
+        surface: "manifest.globalenv",
+        action: "keys-only",
+        keys: service.manifest.globalenvKeys,
+        redacted: service.manifest.globalenvKeys.length > 0,
+      },
+      {
+        surface: "manifest.broker",
+        action: "field-redacted",
+        redacted: service.manifest.broker !== null && service.manifest.broker !== undefined,
+      },
+      {
+        surface: "lifecycle.runtime.command",
+        action: "field-redacted",
+        redacted: service.lifecycle.runtime.command === REDACTED,
+      },
+      {
+        surface: "logs.lines",
+        action: "pattern-redacted",
+        redacted: service.logs.some((log) => log.lines.length > 0),
+      },
+    ],
+  };
+}
+
+export function buildDiagnosticsBundlePreview(bundle: DiagnosticsBundle): DiagnosticsBundlePreview {
+  const services = bundle.services.map((service) => buildServicePreview(service));
+  return {
+    previewVersion: 1,
+    generatedAt: bundle.generatedAt,
+    mutated: false,
+    scope: bundle.scope,
+    runtime: bundle.runtime,
+    output: {
+      wouldWriteBundle: false,
+      files: [
+        {
+          path: "manifest.json",
+          sourcePath: null,
+          wouldWrite: true,
+          contents: ["bundle metadata", "runtime summary", "service summaries", "redaction rules"],
+        },
+        ...services.flatMap((service) => service.files),
+      ],
+    },
+    services,
+    redaction: bundle.redaction,
+  };
 }
 
 export async function writeDiagnosticsBundleFolder(bundle: DiagnosticsBundle, outputRoot: string): Promise<string> {

--- a/tests/diagnostics-bundle.test.js
+++ b/tests/diagnostics-bundle.test.js
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { execFile as execFileCallback } from "node:child_process";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
 import {
   buildDiagnosticsBundle,
   writeDiagnosticsBundleFolder,
@@ -14,6 +16,8 @@ import {
   serviceLassoSecretLeakSentinels,
 } from "../dist/testing/secretLeakHarness.js";
 import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+const execFile = promisify(execFileCallback);
 
 async function writeSecretBearingRuntimeLog(serviceRoot) {
   const logPaths = getServiceRuntimeLogPaths(serviceRoot);
@@ -28,6 +32,28 @@ async function writeSecretBearingRuntimeLog(serviceRoot) {
         " Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
     }) + "\n",
   );
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runCli(args, cwd = path.resolve(".")) {
+  const cliPath = path.join(cwd, "dist", "cli.js");
+  const result = await execFile(process.execPath, [cliPath, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      npm_package_version: "0.1.0-test",
+    },
+  });
+
+  return result.stdout.trim();
 }
 
 async function writeHealthHistory(serviceRoot, serviceId, transitions) {
@@ -198,6 +224,53 @@ test("diagnostics bundle API returns redacted baseline evidence", async () => {
     assertNoSecretMaterial(body);
   } finally {
     await apiServer?.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI diagnostics bundle preview reports scope decisions without writing bundle or leaking secrets", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-diagnostics-cli-preview-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  try {
+    const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "alpha-service", {
+      env: {
+        SERVICE_TOKEN: serviceLassoSecretLeakSentinels[0].value,
+      },
+      globalenv: {
+        SERVICE_PASSWORD: serviceLassoSecretLeakSentinels[1].value,
+      },
+    });
+    await writeSecretBearingRuntimeLog(serviceRoot);
+
+    const stdout = await runCli([
+      "diagnostics",
+      "bundle",
+      "baseline",
+      "--preview",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const preview = JSON.parse(stdout);
+    const serialized = JSON.stringify(preview);
+
+    assert.equal(preview.action, "bundle-preview");
+    assert.equal(preview.mutated, false);
+    assert.equal(preview.output.wouldWriteBundle, false);
+    assert.deepEqual(preview.output.files.map((file) => file.path), [
+      "manifest.json",
+      "services/alpha-service/summary.json",
+      "services/alpha-service/logs.json",
+    ]);
+    assert.equal(preview.services[0].includedFields.includes("manifest.envKeys"), true);
+    assert.equal(preview.services[0].redactions.some((entry) => entry.surface === "manifest.env" && entry.action === "keys-only"), true);
+    assert.equal(preview.services[0].logSegments.some((entry) => entry.type === "service" && entry.includedLines === 1), true);
+    assert.equal(await pathExists(path.join(tempRoot, "bundle")), false);
+    assertNoSecretMaterial(preview);
+    assert.doesNotMatch(serialized, /abcdefghijklmnopqrstuvwxyz123456|SERVICE_LASSO_FAKE_SECRET_SENTINEL/);
+  } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Add `service-lasso diagnostics bundle [serviceId|baseline] --preview` as a non-mutating support-bundle planning command.
- Build structured preview metadata from the existing redacted diagnostics bundle: would-write files, safe included fields, sampled log segments, and redaction decisions.
- Update diagnostics bundle reference docs and add CLI regression coverage proving preview output does not write the bundle or leak raw secret/log values.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/diagnostics-bundle.test.js`

Evidence logs:
- `.work-agent/logs/issue-516-20260527-2125/03-build-after-preview-accuracy.txt`
- `.work-agent/logs/issue-516-20260527-2125/04-diagnostics-bundle-test-after-preview-accuracy.txt`

Closes #516