### PR TITLE
feat(catalog): add provider manifest provenance fields

### DIFF
--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -19,6 +19,10 @@ Runtime API consumers can also read host-specific compatibility data from
 `GET /api/services`. Each service summary includes a `compatibility` block
 with the current host platform, declared artifact platforms, required runtime
 providers, declared ports, requirement status, and operator-safe blockers.
+Each service summary also includes a `catalogProvenance` block derived from
+the checked-in manifest: source path, release repo/tag, artifact asset names,
+checksum presence, and packaged runtime version. The provenance block is
+read-only catalog metadata for UI and drift checks.
 This is read-only catalog metadata; it does not change install or start
 behavior.
 

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -6,6 +6,7 @@ import type { ServiceUpdateState } from "../runtime/updates/state.js";
 import type { ServiceRecoveryHistoryState } from "../runtime/recovery/history.js";
 import type { ServiceHealthHistoryState } from "../runtime/health/history.js";
 import type { ConfigDriftReport } from "../runtime/operator/config-drift.js";
+import type { ServiceCatalogProvenance } from "./service.js";
 
 export interface HealthResponse {
   service: "service-lasso";
@@ -40,6 +41,7 @@ export interface ServiceSummary {
   healthHistory?: ServiceHealthHistoryState;
   updates?: ServiceUpdateState;
   recovery?: ServiceRecoveryHistoryState;
+  catalogProvenance?: ServiceCatalogProvenance;
   statePaths?: ServiceStatePaths;
   provider?: ProviderExecutionPlan;
   compatibility?: ServiceCompatibilityReport;

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -135,6 +135,16 @@ export interface ServiceArchiveArtifact {
   platforms: Record<string, ServiceArtifactPlatform>;
 }
 
+export interface ServiceCatalogProvenance {
+  sourcePath: string;
+  sourceType: ServiceArtifactSource["type"] | null;
+  repo: string | null;
+  releaseTag: string | null;
+  assetNames: string[];
+  checksumPresent: boolean;
+  packagedRuntimeVersion: string | null;
+}
+
 export type ServiceRole = "service" | "provider";
 
 export type ServiceBrokerBucketKind = "service" | "app" | "shared" | "global";
@@ -221,4 +231,5 @@ export interface DiscoveredService {
   manifest: ServiceManifest;
   manifestPath: string;
   serviceRoot: string;
+  catalogProvenance: ServiceCatalogProvenance;
 }

--- a/src/runtime/discovery/discoverServices.ts
+++ b/src/runtime/discovery/discoverServices.ts
@@ -1,7 +1,32 @@
 import { readdir } from "node:fs/promises";
 import path from "node:path";
-import type { DiscoveredService } from "../../contracts/service.js";
+import type { DiscoveredService, ServiceCatalogProvenance, ServiceManifest } from "../../contracts/service.js";
 import { loadServiceManifest } from "./loadManifest.js";
+
+function toPortableRelativePath(root: string, target: string): string {
+  return path.relative(root, target).split(path.sep).join("/");
+}
+
+export function buildServiceCatalogProvenance(
+  manifest: ServiceManifest,
+  manifestPath: string,
+  servicesRoot: string,
+): ServiceCatalogProvenance {
+  const platforms = Object.values(manifest.artifact?.platforms ?? {});
+  const assetNames = Array.from(
+    new Set(platforms.flatMap((platform) => (platform.assetName ? [platform.assetName] : []))),
+  ).sort((left, right) => left.localeCompare(right));
+
+  return {
+    sourcePath: toPortableRelativePath(servicesRoot, manifestPath),
+    sourceType: manifest.artifact?.source.type ?? null,
+    repo: manifest.artifact?.source.repo ?? null,
+    releaseTag: manifest.artifact?.source.tag ?? null,
+    assetNames,
+    checksumPresent: platforms.some((platform) => Boolean(platform.sha256 || platform.checksum)),
+    packagedRuntimeVersion: manifest.version ?? null,
+  };
+}
 
 export async function discoverServices(servicesRoot: string): Promise<DiscoveredService[]> {
   const entries = await readdir(servicesRoot, { withFileTypes: true });
@@ -20,6 +45,7 @@ export async function discoverServices(servicesRoot: string): Promise<Discovered
       manifest,
       manifestPath,
       serviceRoot,
+      catalogProvenance: buildServiceCatalogProvenance(manifest, manifestPath, servicesRoot),
     });
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -586,6 +586,7 @@ async function createServiceSummary(
     healthHistory,
     updates,
     recovery,
+    catalogProvenance: service.catalogProvenance,
     statePaths: getServiceStatePaths(service.serviceRoot),
     provider,
     compatibility: buildServiceCompatibilityReport(service, registry, { updateState: updates }),

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -48,9 +48,61 @@ test("discoverServices loads valid service manifests from a services root", asyn
   }
 });
 
+test("discoverServices records safe provider manifest provenance from artifacts", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "@node", {
+      id: "@node",
+      name: "Node Runtime",
+      description: "Runtime provider",
+      version: "v24.15.0",
+      role: "provider",
+      artifact: {
+        kind: "archive",
+        source: {
+          type: "github-release",
+          repo: "service-lasso/lasso-node",
+          tag: "2026.4.27-eca215a",
+        },
+        platforms: {
+          win32: {
+            assetName: "lasso-node-v24.15.0-win32.zip",
+            archiveType: "zip",
+            checksum: {
+              algorithm: "sha256",
+              assetName: "SHA256SUMS",
+            },
+          },
+          linux: {
+            assetName: "lasso-node-v24.15.0-linux.tar.gz",
+            archiveType: "tar.gz",
+            sha256: "a".repeat(64),
+          },
+        },
+      },
+    });
+
+    const [provider] = await discoverServices(servicesRoot);
+
+    assert.deepEqual(provider.catalogProvenance, {
+      sourcePath: "@node/service.json",
+      sourceType: "github-release",
+      repo: "service-lasso/lasso-node",
+      releaseTag: "2026.4.27-eca215a",
+      assetNames: ["lasso-node-v24.15.0-linux.tar.gz", "lasso-node-v24.15.0-win32.zip"],
+      checksumPresent: true,
+      packagedRuntimeVersion: "v24.15.0",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("core services root declares the clean-clone baseline inventory", async () => {
   const services = await discoverServices(path.join(repoRoot, "services"));
   const byId = new Map(services.map((service) => [service.manifest.id, service.manifest]));
+  const byServiceId = new Map(services.map((service) => [service.manifest.id, service]));
 
   assert.deepEqual(
     ["@java", "@localcert", "@nginx", "@node", "@secretsbroker", "@traefik", "echo-service", "@serviceadmin"].filter((serviceId) => !byId.has(serviceId)),
@@ -96,6 +148,19 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@node")?.artifact?.source.repo, "service-lasso/lasso-node");
   assert.equal(byId.get("@node")?.artifact?.source.tag, "2026.4.27-eca215a");
   assert.equal(byId.get("@node")?.artifact?.platforms.win32?.assetName, "lasso-node-v24.15.0-win32.zip");
+  assert.deepEqual(byServiceId.get("@node")?.catalogProvenance, {
+    sourcePath: "@node/service.json",
+    sourceType: "github-release",
+    repo: "service-lasso/lasso-node",
+    releaseTag: "2026.4.27-eca215a",
+    assetNames: [
+      "lasso-node-v24.15.0-darwin.tar.gz",
+      "lasso-node-v24.15.0-linux.tar.gz",
+      "lasso-node-v24.15.0-win32.zip",
+    ],
+    checksumPresent: false,
+    packagedRuntimeVersion: "v24.15.0",
+  });
   assert.deepEqual(byId.get("@node")?.globalenv, {
     NODE: "${SERVICE_ARTIFACT_COMMAND}",
     NODE_HOME: "${SERVICE_ARTIFACT_ROOT}",
@@ -107,6 +172,15 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@python")?.role, "provider");
   assert.equal(byId.get("@python")?.artifact?.source.repo, "service-lasso/lasso-python");
   assert.equal(byId.get("@python")?.artifact?.source.tag, "2026.4.27-63f915c");
+  assert.deepEqual(byServiceId.get("@python")?.catalogProvenance, {
+    sourcePath: "@python/service.json",
+    sourceType: "github-release",
+    repo: "service-lasso/lasso-python",
+    releaseTag: "2026.4.27-63f915c",
+    assetNames: ["lasso-python-3.11.5-win32.zip"],
+    checksumPresent: false,
+    packagedRuntimeVersion: "3.11.5",
+  });
   assert.equal(byId.get("@traefik")?.enabled, true);
   assert.deepEqual(byId.get("@traefik")?.depend_on, ["@localcert", "@nginx"]);
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -50,6 +50,36 @@ test("service detail includes richer operator metadata", async () => {
   }
 });
 
+test("service detail exposes read-only catalog provenance", async () => {
+  resetLifecycleState();
+  await clearPersistedFixtureState(servicesRoot);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/${encodeURIComponent("@node")}`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.service.catalogProvenance, {
+      sourcePath: "@node/service.json",
+      sourceType: "github-release",
+      repo: "service-lasso/lasso-node",
+      releaseTag: "2026.4.27-eca215a",
+      assetNames: [
+        "lasso-node-v24.15.0-darwin.tar.gz",
+        "lasso-node-v24.15.0-linux.tar.gz",
+        "lasso-node-v24.15.0-win32.zip",
+      ],
+      checksumPresent: false,
+      packagedRuntimeVersion: "v24.15.0",
+    });
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await clearPersistedFixtureState(servicesRoot);
+  }
+});
+
 test("GET /api/services/:id/logs returns operator log payload", async () => {
   resetLifecycleState();
   await clearPersistedFixtureState(servicesRoot);


### PR DESCRIPTION
## Summary
- Add read-only `catalogProvenance` derived during service discovery from each checked-in `service.json`.
- Expose provenance on service API summaries for Service Admin/runtime catalog consumers.
- Document the API field and add fixture coverage for baseline and optional provider manifests.

## Validation
- PASS: `npm run build`
- PASS: `node --test --test-concurrency=1 tests/manifest-discovery.test.js`
- PASS: `node --test --test-concurrency=1 tests/operator-data.test.js`
- PASS: `npm test` (332 tests)

## Known local drift
- `npm run verify:service-catalog` currently fails on pre-existing README/new-lasso-service-guide baseline drift and the `@serviceadmin` README release tag mismatch. This PR does not modify those sources.

Closes #521