### PR TITLE
ISS-517 add port conflict explanation API

### DIFF
--- a/docs/reference/runtime-port-reservations.md
+++ b/docs/reference/runtime-port-reservations.md
@@ -27,3 +27,28 @@ At runtime startup, callers should build the active set from:
 - service runtime ports rehydrated from `.state/runtime.json`
 
 Reconciliation keeps active reservations fresh and marks missing historical entries stale instead of deleting them. Stale evidence gives operators a safe recovery path without silently forgetting why a port was previously considered unavailable.
+
+## Conflict explanation API
+
+`GET /api/runtime/ports/conflict?port={port}&host={host}&serviceId={serviceId}&portName={portName}` is a read-only operator diagnostic for a requested service port.
+
+Required query:
+
+- `port`: integer TCP port from `1` to `65535`
+
+Optional query:
+
+- `host`: listener host to test, defaulting to `127.0.0.1`
+- `serviceId`: requesting service id for context
+- `portName`: requesting logical port name for context
+
+The response reports:
+
+- `conflict`: whether the requested `host:port` is currently unavailable
+- `reason`: `ledger_reserved`, `live_listener`, or `none`
+- `owner`: safe Service Lasso ledger owner details when a non-stale reservation owns the port
+- `ledger.activeReservations` and `ledger.staleReservations`: safe ledger evidence for the requested port
+- `liveListener`: whether a bounded bind probe found an occupied listener
+- `remediation`: safe operator hints such as stopping the owning service/runtime instance, choosing another port, or running reconcile/doctor flow
+
+The endpoint must not expose process IDs, command lines, environment values, credentials, or raw diagnostics payloads. Unknown live listeners are reported only as occupied `host:port` evidence.

--- a/src/runtime/ports/conflicts.ts
+++ b/src/runtime/ports/conflicts.ts
@@ -1,0 +1,156 @@
+import net from "node:net";
+import { readPortReservationLedger, type PortReservation } from "./reservations.js";
+
+const DEFAULT_HOST = "127.0.0.1";
+
+export type PortConflictReason = "none" | "ledger_reserved" | "live_listener";
+
+export interface PortConflictExplanation {
+  requested: {
+    host: string;
+    port: number;
+    serviceId?: string;
+    portName?: string;
+  };
+  conflict: boolean;
+  reason: PortConflictReason;
+  owner: {
+    kind: PortReservation["kind"];
+    ownerId: string;
+    portName: string;
+    host: string;
+    port: number;
+    stale: boolean;
+  } | null;
+  ledger: {
+    checked: boolean;
+    activeReservations: Array<Pick<PortReservation, "host" | "port" | "kind" | "ownerId" | "portName">>;
+    staleReservations: Array<Pick<PortReservation, "host" | "port" | "kind" | "ownerId" | "portName" | "staleReason">>;
+  };
+  liveListener: {
+    checked: boolean;
+    host: string;
+    port: number;
+    occupied: boolean;
+  };
+  remediation: string[];
+}
+
+export interface ExplainPortConflictOptions {
+  workspaceRoot: string;
+  host?: string | null;
+  port: number;
+  serviceId?: string | null;
+  portName?: string | null;
+}
+
+function normalizeHost(host: string | null | undefined): string {
+  return typeof host === "string" && host.trim().length > 0 ? host.trim() : DEFAULT_HOST;
+}
+
+function hostMatches(left: string, right: string): boolean {
+  return left === right || left === "0.0.0.0" || right === "0.0.0.0";
+}
+
+function sameRequestedPort(reservation: PortReservation, host: string, port: number): boolean {
+  return reservation.port === port && hostMatches(reservation.host, host);
+}
+
+async function canBindPort(port: number, host: string): Promise<boolean> {
+  const server = net.createServer();
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, host, () => resolve());
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }).catch(() => undefined);
+    }
+  }
+}
+
+function remediationFor(reason: PortConflictReason): string[] {
+  if (reason === "ledger_reserved") {
+    return [
+      "Stop the owning Service Lasso service or runtime instance if it should release the port.",
+      "Choose a different service port if the owner is expected to keep running.",
+      "Run runtime reconcile or doctor flow if the reservation is stale.",
+    ];
+  }
+
+  if (reason === "live_listener") {
+    return [
+      "Stop the external listener using the port if it is not expected.",
+      "Choose a different service port if the listener should keep running.",
+      "Start with a fresh port negotiation range when running multiple instances.",
+    ];
+  }
+
+  return [];
+}
+
+export async function explainPortConflict(options: ExplainPortConflictOptions): Promise<PortConflictExplanation> {
+  const host = normalizeHost(options.host);
+  const ledger = await readPortReservationLedger(options.workspaceRoot);
+  const matchingReservations = ledger.reservations.filter((reservation) =>
+    sameRequestedPort(reservation, host, options.port),
+  );
+  const activeReservations = matchingReservations.filter((reservation) => reservation.stale !== true);
+  const staleReservations = matchingReservations.filter((reservation) => reservation.stale === true);
+  const owner = activeReservations[0] ?? null;
+  const livePortFree = await canBindPort(options.port, host);
+  const reason: PortConflictReason = owner ? "ledger_reserved" : livePortFree ? "none" : "live_listener";
+
+  return {
+    requested: {
+      host,
+      port: options.port,
+      serviceId: options.serviceId?.trim() || undefined,
+      portName: options.portName?.trim() || undefined,
+    },
+    conflict: reason !== "none",
+    reason,
+    owner: owner
+      ? {
+          kind: owner.kind,
+          ownerId: owner.ownerId,
+          portName: owner.portName,
+          host: owner.host,
+          port: owner.port,
+          stale: owner.stale === true,
+        }
+      : null,
+    ledger: {
+      checked: true,
+      activeReservations: activeReservations.map(({ host, port, kind, ownerId, portName }) => ({
+        host,
+        port,
+        kind,
+        ownerId,
+        portName,
+      })),
+      staleReservations: staleReservations.map(({ host, port, kind, ownerId, portName, staleReason }) => ({
+        host,
+        port,
+        kind,
+        ownerId,
+        portName,
+        staleReason,
+      })),
+    },
+    liveListener: {
+      checked: true,
+      host,
+      port: options.port,
+      occupied: !livePortFree,
+    },
+    remediation: remediationFor(reason),
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -74,6 +74,7 @@ import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from ".
 import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
 import { stopAllManagedProcesses } from "../runtime/execution/supervisor.js";
 import { reconcilePortReservationLedger, reservePorts, type PortReservationInput } from "../runtime/ports/reservations.js";
+import { explainPortConflict } from "../runtime/ports/conflicts.js";
 import { runAndRecordDoctorPreflight } from "../runtime/recovery/doctor.js";
 import { readServiceRecoveryHistory } from "../runtime/recovery/history.js";
 import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
@@ -1430,6 +1431,26 @@ async function routeRequest(
         version: config.version,
         services: runtimeModel.discovered,
         features: config.features,
+      }),
+    );
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/runtime/ports/conflict") {
+    const port = parseOptionalInteger(url.searchParams.get("port"));
+    if (!isUsablePort(port)) {
+      throw new ApiError("invalid_request", 400, '"port" query parameter must be an integer between 1 and 65535.');
+    }
+
+    writeJson(
+      response,
+      200,
+      await explainPortConflict({
+        workspaceRoot: config.workspaceRoot,
+        host: url.searchParams.get("host"),
+        port,
+        serviceId: url.searchParams.get("serviceId"),
+        portName: url.searchParams.get("portName"),
       }),
     );
     return;

--- a/tests/api-port-conflicts.test.js
+++ b/tests/api-port-conflicts.test.js
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import path from "node:path";
+import { once } from "node:events";
+import { rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { reconcilePortReservationLedger, reservePorts } from "../dist/runtime/ports/reservations.js";
+import { makeTempServicesRoot } from "./test-helpers.js";
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+test("GET /api/runtime/ports/conflict explains ledger-owned port conflicts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-port-conflict-ledger-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    await reservePorts(workspaceRoot, [
+      {
+        kind: "service-negotiated",
+        ownerId: "alpha-service",
+        portName: "http",
+        port: 18191,
+      },
+    ]);
+
+    const result = await getJson(
+      `${apiServer.url}/api/runtime/ports/conflict?port=18191&serviceId=bravo-service&portName=http`,
+    );
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.conflict, true);
+    assert.equal(result.body.reason, "ledger_reserved");
+    assert.equal(result.body.requested.serviceId, "bravo-service");
+    assert.equal(result.body.owner.ownerId, "alpha-service");
+    assert.equal(result.body.owner.kind, "service-negotiated");
+    assert.equal(result.body.ledger.activeReservations.length, 1);
+    assert.equal(result.body.liveListener.checked, true);
+    assert.ok(result.body.remediation.some((hint) => hint.includes("owning Service Lasso service")));
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/runtime/ports/conflict reports unknown live-listener conflicts without process secrets", async () => {
+  resetLifecycleState();
+  const listener = net.createServer();
+  listener.listen(0, "127.0.0.1");
+  await once(listener, "listening");
+  const address = listener.address();
+  assert.ok(address && typeof address !== "string");
+
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-port-conflict-live-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const result = await getJson(
+      `${apiServer.url}/api/runtime/ports/conflict?host=127.0.0.1&port=${address.port}`,
+    );
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.conflict, true);
+    assert.equal(result.body.reason, "live_listener");
+    assert.equal(result.body.owner, null);
+    assert.deepEqual(result.body.ledger.activeReservations, []);
+    assert.equal(result.body.liveListener.occupied, true);
+    assert.ok(result.body.remediation.some((hint) => hint.includes("external listener")));
+    assert.equal(JSON.stringify(result.body).includes("pid"), false);
+    assert.equal(JSON.stringify(result.body).includes("process"), false);
+  } finally {
+    await apiServer.stop();
+    await new Promise((resolve) => listener.close(() => resolve()));
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/runtime/ports/conflict separates stale ledger state from active conflicts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-port-conflict-stale-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    await reservePorts(workspaceRoot, [
+      {
+        kind: "service-fixed",
+        ownerId: "stale-service",
+        portName: "http",
+        port: 18192,
+      },
+    ]);
+    await reconcilePortReservationLedger(workspaceRoot, [], "not present in rehydrated runtime state");
+
+    const result = await getJson(`${apiServer.url}/api/runtime/ports/conflict?port=18192`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.conflict, false);
+    assert.equal(result.body.reason, "none");
+    assert.equal(result.body.owner, null);
+    assert.equal(result.body.ledger.activeReservations.length, 0);
+    assert.equal(result.body.ledger.staleReservations[0].ownerId, "stale-service");
+    assert.equal(result.body.liveListener.occupied, false);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- adds `GET /api/runtime/ports/conflict` for read-only port conflict diagnostics
- reports active/stale ledger evidence, unknown live-listener occupancy, and safe remediation hints
- documents the endpoint in the runtime port reservation reference

## Validation
- `npm test` PASS (335 tests)
- focused coverage added for ledger-owned, unknown live-listener, and stale-ledger/no-active-conflict cases

Closes #517