### PR TITLE
ISS-519 add update candidate provenance summary

### DIFF
--- a/docs/development/service-update-management-plan.md
+++ b/docs/development/service-update-management-plan.md
@@ -21,6 +21,7 @@ The first implemented slices are intentionally bounded:
 - `#127` adds maintenance-window and running-service safety for update installs
 - `#128` surfaces update notifications and bounded update actions in Service Admin
 - `#129` adds deterministic E2E verification and an opt-in live Echo Service release verifier
+- `#519` adds an operator-safe provenance summary for discovered update candidates
 
 ## Manifest Shape
 
@@ -116,6 +117,7 @@ services/<service-id>/.state/updates.json
 This file records:
 
 - `lastCheck`: checked time, status, reason, source repo, track, installed tag, manifest tag, and latest tag
+- `provenance`: source repo, candidate tag, matched asset name, checksum availability, release URL, discovery time, and current-vs-candidate comparison
 - `available`: latest release/candidate metadata from discovery
 - `downloadedCandidate`: candidate archive/extract metadata once later download work stores a candidate
 - `installDeferred`: operator-facing reason and next eligible time when install must wait
@@ -146,7 +148,7 @@ Current behavior:
 - `install` installs a downloaded or resolvable candidate when `updates.mode` is `install`
 - `install --force` allows an explicit operator override when policy is not install mode
 - human output distinguishes latest, update available, downloaded candidate, deferred install, and failed checks
-- JSON output includes machine-readable status, version/source fields, and recommended action for checks
+- JSON output includes machine-readable status, version/source fields, provenance, and recommended action for checks
 
 ## Runtime API Surface
 
@@ -168,6 +170,7 @@ Current behavior:
 - `POST /api/services/:id/update/download` downloads a candidate without mutating active install metadata
 - `POST /api/services/:id/update/install` accepts optional `{ "force": true }`
 - invalid request bodies and missing services use the existing API error body shape
+- update state responses include the same safe provenance object used by CLI JSON output; raw secrets, tokens, and credential payloads are not part of update provenance
 
 ## Scheduler Surface
 

--- a/src/runtime/updates/actions.ts
+++ b/src/runtime/updates/actions.ts
@@ -697,6 +697,26 @@ export async function installServiceUpdateCandidate(
       matchedAssetName: candidate.assetName,
       assetUrl: candidate.assetUrl,
     },
+    provenance: {
+      sourceRepo: artifact.source.repo,
+      tag: candidate.tag,
+      assetName: candidate.assetName,
+      checksum: {
+        available: Boolean(platform.checksum?.value),
+        source: platform.checksum?.value ? "manifest" : platform.checksum?.assetName ? "release-asset" : null,
+        algorithm: platform.checksum?.algorithm ?? null,
+        assetName: platform.checksum?.assetName ?? null,
+      },
+      releaseUrl: update.available?.releaseUrl ?? null,
+      discoveredAt: installedAt,
+      current: {
+        manifestTag: artifact.source.tag ?? null,
+        installedTag: candidate.tag,
+        version: service.manifest.version ?? null,
+        assetName: candidate.assetName,
+        comparison: "same",
+      },
+    },
     checkedAt: installedAt,
   });
   await writeServiceUpdateState(service, {

--- a/src/runtime/updates/check.ts
+++ b/src/runtime/updates/check.ts
@@ -34,6 +34,31 @@ export interface ServiceUpdateAvailableSummary {
   assetUrl: string | null;
 }
 
+export type ServiceUpdateCurrentComparison =
+  | "same"
+  | "different"
+  | "installed_newer"
+  | "unknown";
+
+export interface ServiceUpdateChecksumAvailability {
+  available: boolean;
+  source: "manifest" | "release-asset" | null;
+  algorithm: "sha256" | null;
+  assetName: string | null;
+}
+
+export interface ServiceUpdateProvenanceSummary {
+  sourceRepo: string | null;
+  tag: string | null;
+  assetName: string | null;
+  checksum: ServiceUpdateChecksumAvailability;
+  releaseUrl: string | null;
+  discoveredAt: string;
+  current: ServiceUpdateCurrentSummary & {
+    comparison: ServiceUpdateCurrentComparison;
+  };
+}
+
 export interface ServiceUpdateCheckResult {
   serviceId: string;
   status: ServiceUpdateStatus;
@@ -42,6 +67,7 @@ export interface ServiceUpdateCheckResult {
   source: ServiceUpdateSourceSummary | null;
   current: ServiceUpdateCurrentSummary;
   available: ServiceUpdateAvailableSummary | null;
+  provenance: ServiceUpdateProvenanceSummary;
   checkedAt: string;
 }
 
@@ -100,6 +126,77 @@ function getExpectedAssetName(platform: ServiceArtifactPlatform): string | null 
   return null;
 }
 
+function summarizeChecksumAvailability(
+  platform: ServiceArtifactPlatform | null,
+  releaseAssetNames: string[] = [],
+): ServiceUpdateChecksumAvailability {
+  const checksum = platform?.checksum;
+  if (!checksum) {
+    return {
+      available: false,
+      source: null,
+      algorithm: null,
+      assetName: null,
+    };
+  }
+
+  if (checksum.value) {
+    return {
+      available: true,
+      source: "manifest",
+      algorithm: checksum.algorithm,
+      assetName: null,
+    };
+  }
+
+  const assetName = checksum.assetName ?? null;
+  return {
+    available: Boolean(assetName && releaseAssetNames.includes(assetName)),
+    source: "release-asset",
+    algorithm: checksum.algorithm,
+    assetName,
+  };
+}
+
+function compareCurrentToCandidate(
+  current: ServiceUpdateCurrentSummary,
+  candidateTag: string | null,
+): ServiceUpdateCurrentComparison {
+  const currentTag = current.installedTag ?? current.manifestTag;
+  if (!currentTag || !candidateTag) {
+    return "unknown";
+  }
+
+  if (currentTag === candidateTag) {
+    return "same";
+  }
+
+  return compareTimestampedReleaseTags(currentTag, candidateTag) === -1 ? "installed_newer" : "different";
+}
+
+function createProvenanceSummary(input: {
+  sourceRepo: string | null;
+  tag: string | null;
+  assetName: string | null;
+  checksum: ServiceUpdateChecksumAvailability;
+  releaseUrl: string | null;
+  discoveredAt: string;
+  current: ServiceUpdateCurrentSummary;
+}): ServiceUpdateProvenanceSummary {
+  return {
+    sourceRepo: input.sourceRepo,
+    tag: input.tag,
+    assetName: input.assetName,
+    checksum: input.checksum,
+    releaseUrl: input.releaseUrl,
+    discoveredAt: input.discoveredAt,
+    current: {
+      ...input.current,
+      comparison: compareCurrentToCandidate(input.current, input.tag),
+    },
+  };
+}
+
 function getUpdateMode(manifest: ServiceManifest): ServiceUpdateMode {
   if (manifest.updates?.enabled === false || manifest.updates?.mode === "disabled") {
     return "disabled";
@@ -147,6 +244,9 @@ function createPinnedResult(
   reason: string,
 ): ServiceUpdateCheckResult {
   const source = service.manifest.artifact?.source;
+  const platform = service.manifest.artifact ? getCurrentPlatformArtifact(service.manifest.artifact) : null;
+  const tag = current.installedTag ?? current.manifestTag ?? source?.tag ?? source?.channel ?? null;
+  const assetName = platform ? getExpectedAssetName(platform) : current.assetName;
 
   return {
     serviceId: service.manifest.id,
@@ -163,6 +263,15 @@ function createPinnedResult(
       : null,
     current,
     available: null,
+    provenance: createProvenanceSummary({
+      sourceRepo: source?.repo ?? null,
+      tag,
+      assetName,
+      checksum: summarizeChecksumAvailability(platform),
+      releaseUrl: null,
+      discoveredAt: checkedAt,
+      current,
+    }),
     checkedAt,
   };
 }
@@ -284,6 +393,15 @@ export async function checkServiceUpdate(service: DiscoveredService): Promise<Se
       },
       current,
       available: null,
+      provenance: createProvenanceSummary({
+        sourceRepo: artifact.source.repo,
+        tag: current.installedTag ?? current.manifestTag ?? null,
+        assetName: current.assetName,
+        checksum: summarizeChecksumAvailability(null),
+        releaseUrl: null,
+        discoveredAt: checkedAt,
+        current,
+      }),
       checkedAt,
     };
   }
@@ -293,9 +411,13 @@ export async function checkServiceUpdate(service: DiscoveredService): Promise<Se
   try {
     const release = await fetchGitHubRelease(artifact.source, track);
     const assets = release.assets ?? [];
+    const assetNames = assets.map((asset) => asset.name);
     const matchedAsset = expectedAssetName
       ? assets.find((asset) => asset.name === expectedAssetName)
       : undefined;
+    const releaseTag = release.tag_name ?? null;
+    const releaseUrl = release.html_url ?? null;
+    const checksum = summarizeChecksumAvailability(platform, assetNames);
 
     if (expectedAssetName && !matchedAsset) {
       return {
@@ -311,19 +433,28 @@ export async function checkServiceUpdate(service: DiscoveredService): Promise<Se
         },
         current,
         available: {
-          tag: release.tag_name ?? null,
-          version: release.tag_name ?? release.name ?? null,
-          releaseUrl: release.html_url ?? null,
+          tag: releaseTag,
+          version: releaseTag ?? release.name ?? null,
+          releaseUrl,
           publishedAt: release.published_at ?? release.created_at ?? null,
-          assetNames: assets.map((asset) => asset.name),
+          assetNames,
           matchedAssetName: null,
           assetUrl: null,
         },
+        provenance: createProvenanceSummary({
+          sourceRepo: artifact.source.repo,
+          tag: releaseTag,
+          assetName: expectedAssetName,
+          checksum,
+          releaseUrl,
+          discoveredAt: checkedAt,
+          current,
+        }),
         checkedAt,
       };
     }
 
-    const availableTag = release.tag_name ?? null;
+    const availableTag = releaseTag;
     const classification = classifyUpdate(current.installedTag ?? current.manifestTag, availableTag);
 
     return {
@@ -341,12 +472,21 @@ export async function checkServiceUpdate(service: DiscoveredService): Promise<Se
       available: {
         tag: availableTag,
         version: availableTag ?? release.name ?? null,
-        releaseUrl: release.html_url ?? null,
+        releaseUrl,
         publishedAt: release.published_at ?? release.created_at ?? null,
-        assetNames: assets.map((asset) => asset.name),
+        assetNames,
         matchedAssetName: matchedAsset?.name ?? expectedAssetName,
         assetUrl: matchedAsset?.browser_download_url ?? platform.assetUrl ?? null,
       },
+      provenance: createProvenanceSummary({
+        sourceRepo: artifact.source.repo,
+        tag: availableTag,
+        assetName: matchedAsset?.name ?? expectedAssetName,
+        checksum,
+        releaseUrl,
+        discoveredAt: checkedAt,
+        current,
+      }),
       checkedAt,
     };
   } catch (error: unknown) {
@@ -363,6 +503,15 @@ export async function checkServiceUpdate(service: DiscoveredService): Promise<Se
       },
       current,
       available: null,
+      provenance: createProvenanceSummary({
+        sourceRepo: artifact.source.repo,
+        tag: current.installedTag ?? current.manifestTag ?? track,
+        assetName: expectedAssetName,
+        checksum: summarizeChecksumAvailability(platform),
+        releaseUrl: null,
+        discoveredAt: checkedAt,
+        current,
+      }),
       checkedAt,
     };
   }

--- a/src/runtime/updates/state.ts
+++ b/src/runtime/updates/state.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { appendServiceRecoveryHistoryEvents } from "../recovery/history.js";
 import { getServiceStatePaths } from "../state/paths.js";
-import type { ServiceUpdateCheckResult } from "./check.js";
+import type { ServiceUpdateCheckResult, ServiceUpdateProvenanceSummary } from "./check.js";
 
 export type ServiceUpdateStateKind =
   | "installed"
@@ -80,6 +80,7 @@ export interface ServiceUpdateState {
   state: ServiceUpdateStateKind;
   updatedAt: string;
   lastCheck: ServiceUpdateLastCheckState | null;
+  provenance: ServiceUpdateProvenanceSummary | null;
   available: ServiceUpdateAvailableState | null;
   downloadedCandidate: ServiceUpdateDownloadedCandidateState | null;
   installDeferred: ServiceUpdateDeferredState | null;
@@ -113,6 +114,7 @@ export const EMPTY_UPDATE_STATE: Omit<ServiceUpdateState, "serviceId"> = {
   state: "installed",
   updatedAt: "",
   lastCheck: null,
+  provenance: null,
   available: null,
   downloadedCandidate: null,
   installDeferred: null,
@@ -246,6 +248,60 @@ function normalizeLastCheck(value: unknown): ServiceUpdateLastCheckState | null 
   };
 }
 
+function normalizeProvenance(value: unknown): ServiceUpdateProvenanceSummary | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const checksum = record.checksum;
+  const current = record.current;
+  if (
+    !checksum ||
+    typeof checksum !== "object" ||
+    Array.isArray(checksum) ||
+    !current ||
+    typeof current !== "object" ||
+    Array.isArray(current) ||
+    typeof record.discoveredAt !== "string"
+  ) {
+    return null;
+  }
+
+  const checksumRecord = checksum as Record<string, unknown>;
+  const currentRecord = current as Record<string, unknown>;
+  const comparison = currentRecord.comparison;
+  if (
+    typeof checksumRecord.available !== "boolean" ||
+    (checksumRecord.source !== null && checksumRecord.source !== "manifest" && checksumRecord.source !== "release-asset") ||
+    (checksumRecord.algorithm !== null && checksumRecord.algorithm !== "sha256") ||
+    (comparison !== "same" && comparison !== "different" && comparison !== "installed_newer" && comparison !== "unknown")
+  ) {
+    return null;
+  }
+
+  return {
+    sourceRepo: stringOrNull(record.sourceRepo),
+    tag: stringOrNull(record.tag),
+    assetName: stringOrNull(record.assetName),
+    checksum: {
+      available: checksumRecord.available,
+      source: checksumRecord.source,
+      algorithm: checksumRecord.algorithm,
+      assetName: stringOrNull(checksumRecord.assetName),
+    },
+    releaseUrl: stringOrNull(record.releaseUrl),
+    discoveredAt: record.discoveredAt,
+    current: {
+      manifestTag: stringOrNull(currentRecord.manifestTag),
+      installedTag: stringOrNull(currentRecord.installedTag),
+      version: stringOrNull(currentRecord.version),
+      assetName: stringOrNull(currentRecord.assetName),
+      comparison,
+    },
+  };
+}
+
 function normalizeHookStep(value: unknown): ServiceUpdateHookStepState | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -335,6 +391,7 @@ export function normalizeServiceUpdateState(input: unknown, serviceId: string): 
     state: isStateKind(record.state) ? record.state : "installed",
     updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : nowIso(),
     lastCheck: normalizeLastCheck(record.lastCheck),
+    provenance: normalizeProvenance(record.provenance),
     available: normalizeAvailable(record.available),
     downloadedCandidate: normalizeDownloadedCandidate(record.downloadedCandidate),
     installDeferred: normalizeDeferred(record.installDeferred),
@@ -409,6 +466,7 @@ export async function persistUpdateCheckResult(
       manifestTag: result.current.manifestTag,
       latestTag: result.available?.tag ?? null,
     },
+    provenance: result.provenance,
     available,
     downloadedCandidate: state === "installed" ? null : existing.downloadedCandidate,
     installDeferred: existing.installDeferred,

--- a/tests/api-updates.test.js
+++ b/tests/api-updates.test.js
@@ -174,11 +174,14 @@ test("update API checks and returns persisted update status", async () => {
     assert.equal(check.status, 200);
     assert.equal(check.body.action, "check");
     assert.equal(check.body.services[0].result.status, "update_available");
+    assert.equal(check.body.services[0].result.provenance.sourceRepo, "service-lasso/update-fixture");
     assert.equal(single.status, 200);
     assert.equal(single.body.update.state, "available");
     assert.equal(single.body.update.available.tag, "2026.4.24-new");
+    assert.equal(single.body.update.provenance.tag, "2026.4.24-new");
     assert.equal(all.status, 200);
     assert.equal(all.body.services[0].serviceId, "update-fixture");
+    assert.equal(all.body.services[0].update.provenance.current.comparison, "different");
   } finally {
     await apiServer.stop();
     await releaseServer.stop();

--- a/tests/cli-updates.test.js
+++ b/tests/cli-updates.test.js
@@ -204,6 +204,9 @@ test("CLI updates check returns JSON with recommended action", async () => {
     assert.equal(payload.action, "check");
     assert.equal(payload.services[0].serviceId, "update-fixture");
     assert.equal(payload.services[0].result.status, "update_available");
+    assert.equal(payload.services[0].result.provenance.sourceRepo, "service-lasso/update-fixture");
+    assert.equal(payload.services[0].result.provenance.tag, "2026.4.24-new");
+    assert.equal(payload.services[0].update.provenance.current.comparison, "different");
     assert.equal(payload.services[0].recommendedAction, "download");
   } finally {
     await releaseServer.stop();

--- a/tests/update-discovery.test.js
+++ b/tests/update-discovery.test.js
@@ -78,6 +78,7 @@ async function startFakeGitHubReleaseServer(options = {}) {
   const latestStatus = options.latestStatus ?? 200;
   const releaseTag = options.releaseTag ?? "2026.4.24-new";
   const assetName = options.assetName ?? "update-fixture.zip";
+  const extraAssets = options.extraAssets ?? [];
   const server = createServer((request, response) => {
     if (!request.url) {
       response.statusCode = 404;
@@ -109,6 +110,10 @@ async function startFakeGitHubReleaseServer(options = {}) {
             name: assetName,
             browser_download_url: `${baseUrl}/downloads/${assetName}`,
           },
+          ...extraAssets.map((asset) => ({
+            name: asset.name,
+            browser_download_url: asset.browser_download_url ?? `${baseUrl}/downloads/${asset.name}`,
+          })),
         ],
       }));
       return;
@@ -243,6 +248,11 @@ test("update discovery reports pinned manifests without calling the release API"
     assert.equal(result.status, "pinned");
     assert.equal(result.current.manifestTag, "2026.4.20-old");
     assert.equal(result.available, null);
+    assert.equal(result.provenance.sourceRepo, "service-lasso/update-fixture");
+    assert.equal(result.provenance.tag, "2026.4.20-old");
+    assert.equal(result.provenance.assetName, "update-fixture.zip");
+    assert.equal(result.provenance.checksum.available, false);
+    assert.equal(result.provenance.current.comparison, "same");
     assert.equal(releaseServer.getReleaseRequests(), 0);
   } finally {
     await releaseServer.stop();
@@ -252,15 +262,22 @@ test("update discovery reports pinned manifests without calling the release API"
 
 test("update discovery reports update_available for a newer tracked release", async () => {
   const servicesRoot = await makeTempServicesRoot();
-  const releaseServer = await startFakeGitHubReleaseServer();
+  const releaseServer = await startFakeGitHubReleaseServer({
+    extraAssets: [{ name: "SHA256SUMS.txt" }],
+  });
 
   try {
-    const serviceRoot = await writeManifest(servicesRoot, "update-fixture", createUpdateManifest(releaseServer, {
+    const manifest = createUpdateManifest(releaseServer, {
       updates: {
         mode: "notify",
         track: "latest",
       },
-    }));
+    });
+    manifest.artifact.platforms.default.checksum = {
+      algorithm: "sha256",
+      assetName: "SHA256SUMS.txt",
+    };
+    const serviceRoot = await writeManifest(servicesRoot, "update-fixture", manifest);
     await writeInstalledArtifact(serviceRoot, {
       sourceType: "github-release",
       repo: "service-lasso/update-fixture",
@@ -275,8 +292,16 @@ test("update discovery reports update_available for a newer tracked release", as
     assert.equal(result.current.installedTag, "2026.4.20-old");
     assert.equal(result.available.tag, "2026.4.24-new");
     assert.equal(result.available.releaseUrl.endsWith("/releases/2026.4.24-new"), true);
-    assert.deepEqual(result.available.assetNames, ["update-fixture.zip"]);
+    assert.deepEqual(result.available.assetNames, ["update-fixture.zip", "SHA256SUMS.txt"]);
     assert.equal(result.available.matchedAssetName, "update-fixture.zip");
+    assert.equal(result.provenance.sourceRepo, "service-lasso/update-fixture");
+    assert.equal(result.provenance.tag, "2026.4.24-new");
+    assert.equal(result.provenance.assetName, "update-fixture.zip");
+    assert.equal(result.provenance.releaseUrl.endsWith("/releases/2026.4.24-new"), true);
+    assert.equal(result.provenance.checksum.available, true);
+    assert.equal(result.provenance.checksum.source, "release-asset");
+    assert.equal(result.provenance.checksum.assetName, "SHA256SUMS.txt");
+    assert.equal(result.provenance.current.comparison, "different");
   } finally {
     await releaseServer.stop();
     await rm(servicesRoot, { recursive: true, force: true });
@@ -330,6 +355,11 @@ test("update discovery reports unavailable when the tracked release is missing t
     assert.equal(result.status, "unavailable");
     assert.match(result.reason, /did not contain expected asset "update-fixture\.zip"/);
     assert.deepEqual(result.available.assetNames, ["other.zip"]);
+    assert.equal(result.provenance.sourceRepo, "service-lasso/update-fixture");
+    assert.equal(result.provenance.tag, "2026.4.24-new");
+    assert.equal(result.provenance.assetName, "update-fixture.zip");
+    assert.equal(result.provenance.checksum.available, false);
+    assert.equal(result.provenance.current.comparison, "different");
   } finally {
     await releaseServer.stop();
     await rm(servicesRoot, { recursive: true, force: true });
@@ -395,8 +425,12 @@ test("update check results persist durable operator state", async () => {
     assert.equal(persisted.lastCheck.status, "update_available");
     assert.equal(persisted.lastCheck.sourceRepo, "service-lasso/update-fixture");
     assert.equal(persisted.lastCheck.installedTag, "2026.4.20-old");
+    assert.equal(persisted.provenance.sourceRepo, "service-lasso/update-fixture");
+    assert.equal(persisted.provenance.tag, "2026.4.24-new");
+    assert.equal(persisted.provenance.current.comparison, "different");
     assert.equal(persisted.available.tag, "2026.4.24-new");
     assert.equal(stored.updates.state, "available");
+    assert.equal(stored.updates.provenance.sourceRepo, "service-lasso/update-fixture");
     assert.equal(JSON.parse(await readFile(path.join(serviceRoot, ".state", "updates.json"), "utf8")).available.tag, "2026.4.24-new");
   } finally {
     await releaseServer.stop();


### PR DESCRIPTION
## Summary
- adds an operator-safe update candidate provenance summary to update check results and persisted update state
- exposes source repo, tag, asset, checksum availability, release URL, discovery time, and current-vs-candidate comparison through existing API/CLI JSON surfaces
- updates the update-management plan and tests pinned, available, unavailable, API, and CLI paths

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/update-discovery.test.js tests/cli-updates.test.js tests/api-updates.test.js`
- `npm test` (338 passed)

Closes #519