### PR TITLE
ISS-518 add restart safety preflight

### DIFF
--- a/docs/development/service-recovery-doctor-upgrade-hooks-plan.md
+++ b/docs/development/service-recovery-doctor-upgrade-hooks-plan.md
@@ -56,9 +56,11 @@ The sixth implemented slice adds operator and app-host surfaces:
 
 - `service-lasso recovery status [serviceId]` reads bounded recovery history with human or JSON output
 - `service-lasso recovery doctor <serviceId>` runs configured doctor/preflight steps without restarting the service and persists the result
+- `service-lasso recovery restart-preflight <serviceId>` computes a read-only restart safety report for dependency/provider-ref changes, including dependent services, restart-order risk, doctor requirements, and lifecycle/provider blockers
 - `GET /api/recovery` lists persisted recovery history for all services
 - `GET /api/services/:id/recovery` returns persisted recovery history for one service
 - `POST /api/services/:id/recovery/doctor` runs manual doctor/preflight checks and returns the updated recovery history
+- `GET /api/services/:id/recovery/restart-preflight` returns the same non-mutating restart safety preflight report for operator/API callers
 
 The seventh implemented slice adds Service Admin visibility:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,7 @@ function usageText(): string {
     "  service-lasso plan import <manifestPath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso recovery status [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso recovery doctor <serviceId> [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso recovery restart-preflight <serviceId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso health history [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso instance [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso lockfile generate [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -217,15 +218,15 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
 
   if (command === "recovery") {
     const action = remaining.shift();
-    if (action !== "status" && action !== "doctor") {
-      throw new Error('The "recovery" command requires one of: status, doctor.');
+    if (action !== "status" && action !== "doctor" && action !== "restart-preflight") {
+      throw new Error('The "recovery" command requires one of: status, doctor, restart-preflight.');
     }
 
     parsed.recoveryAction = action;
-    if (action === "doctor") {
+    if (action === "doctor" || action === "restart-preflight") {
       const serviceId = remaining.shift();
       if (!serviceId || serviceId.startsWith("-")) {
-        throw new Error('The "recovery doctor" command requires a <serviceId> argument.');
+        throw new Error(`The "recovery ${action}" command requires a <serviceId> argument.`);
       }
       parsed.serviceId = serviceId;
     } else if (remaining[0] && !remaining[0].startsWith("-")) {
@@ -607,6 +608,18 @@ function printRecoveryResult(result: RecoveryCliResult, asJson: boolean): void {
     for (const service of result.services) {
       console.log(`- ${formatRecoveryLine(service)}`);
     }
+    return;
+  }
+
+  if (result.action === "restart-preflight") {
+    console.log("[service-lasso] restart preflight");
+    console.log(`- service: ${result.serviceId}`);
+    console.log(`- ok: ${result.preflight.ok}`);
+    console.log(`- status: ${result.preflight.status}`);
+    console.log(`- blockers: ${result.preflight.blockers.length}`);
+    console.log(`- warnings: ${result.preflight.warnings.length}`);
+    console.log(`- dependents: ${result.preflight.dependencyGraph.dependents.length}`);
+    console.log(`- restartOrderRisk: ${result.preflight.restartOrderRisk.level}`);
     return;
   }
 

--- a/src/runtime/cli/recovery.ts
+++ b/src/runtime/cli/recovery.ts
@@ -3,9 +3,13 @@ import { createServiceRegistry } from "../manager/DependencyGraph.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
 import { runAndRecordDoctorPreflight, type DoctorRunResult } from "../recovery/doctor.js";
 import { readServiceRecoveryHistory, type ServiceRecoveryHistoryState } from "../recovery/history.js";
+import {
+  buildRestartSafetyPreflightReport,
+  type RestartSafetyPreflightReport,
+} from "../operator/restart-safety-preflight.js";
 import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
 
-export type RecoveryCliAction = "status" | "doctor";
+export type RecoveryCliAction = "status" | "doctor" | "restart-preflight";
 
 export interface RecoveryCliOptions extends RuntimeConfigOptions {
   action: RecoveryCliAction;
@@ -29,6 +33,13 @@ export type RecoveryCliResult =
       serviceId: string;
       doctor: DoctorRunResult;
       recovery: ServiceRecoveryHistoryState;
+    }
+  | {
+      action: "restart-preflight";
+      servicesRoot: string;
+      workspaceRoot: string;
+      serviceId: string;
+      preflight: RestartSafetyPreflightReport;
     };
 
 export async function runRecoveryCliAction(options: RecoveryCliOptions): Promise<RecoveryCliResult> {
@@ -64,12 +75,22 @@ export async function runRecoveryCliAction(options: RecoveryCliOptions): Promise
   }
 
   if (!options.serviceId) {
-    throw new Error('The "recovery doctor" command requires a <serviceId> argument.');
+    throw new Error(`The "recovery ${options.action}" command requires a <serviceId> argument.`);
   }
 
   const service = registry.getById(options.serviceId);
   if (!service) {
     throw new Error(`Unknown service id: ${options.serviceId}.`);
+  }
+
+  if (options.action === "restart-preflight") {
+    return {
+      action: "restart-preflight",
+      servicesRoot: runtimeConfig.servicesRoot,
+      workspaceRoot: runtimeConfig.workspaceRoot,
+      serviceId: service.manifest.id,
+      preflight: buildRestartSafetyPreflightReport(service, registry),
+    };
   }
 
   const doctor = await runAndRecordDoctorPreflight(service);

--- a/src/runtime/operator/restart-safety-preflight.ts
+++ b/src/runtime/operator/restart-safety-preflight.ts
@@ -1,0 +1,361 @@
+import type { DiscoveredService, ServiceHookFailurePolicy } from "../../contracts/service.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import { DependencyGraph } from "../manager/DependencyGraph.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+
+export type RestartSafetyPreflightStatus = "allowed" | "warning" | "blocked";
+
+export type RestartSafetyBlockerCode =
+  | "service_not_installed"
+  | "service_not_configured"
+  | "dependency_missing"
+  | "dependency_cycle"
+  | "provider_missing"
+  | "provider_not_installed"
+  | "provider_not_configured";
+
+export interface RestartSafetyPreflightIssue {
+  code: RestartSafetyBlockerCode | "running_dependents" | "doctor_required";
+  serviceId: string;
+  reason: string;
+}
+
+export interface RestartSafetyDependent {
+  serviceId: string;
+  relationship: "direct" | "transitive";
+  via: string[];
+  running: boolean;
+  configured: boolean;
+}
+
+export interface RestartSafetyProviderRef {
+  serviceId: string;
+  status: "none" | "available" | "missing" | "not_ready";
+  installed: boolean | null;
+  configured: boolean | null;
+}
+
+export interface RestartSafetyDoctorRequirement {
+  required: boolean;
+  enabled: boolean;
+  stepCount: number;
+  failurePolicy: ServiceHookFailurePolicy;
+  status: "disabled" | "will_run_before_restart";
+}
+
+export interface RestartSafetyPreflightReport {
+  action: "restart-preflight";
+  ok: boolean;
+  dryRun: true;
+  mutated: false;
+  generatedAt: string;
+  serviceId: string;
+  status: RestartSafetyPreflightStatus;
+  lifecycle: {
+    installed: boolean;
+    configured: boolean;
+    running: boolean;
+  };
+  dependencyGraph: {
+    dependencies: string[];
+    startupOrder: string[];
+    missingDependencies: string[];
+    dependents: RestartSafetyDependent[];
+  };
+  providerRef: RestartSafetyProviderRef;
+  doctorRequirement: RestartSafetyDoctorRequirement;
+  restartOrderRisk: {
+    level: "none" | "dependent_restart_recommended" | "blocked";
+    reason: string;
+    stopBeforeTarget: string[];
+    startAfterTarget: string[];
+  };
+  blockers: RestartSafetyPreflightIssue[];
+  warnings: RestartSafetyPreflightIssue[];
+  expectedOperatorImpact: string[];
+}
+
+function addUnique(values: string[], value: string): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function collectDirectDependents(registry: ServiceRegistry, serviceId: string): string[] {
+  return registry
+    .list()
+    .filter((service) =>
+      (service.manifest.depend_on ?? []).includes(serviceId) ||
+      service.manifest.execservice === serviceId,
+    )
+    .map((service) => service.manifest.id)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function collectDependents(registry: ServiceRegistry, serviceId: string): RestartSafetyDependent[] {
+  const queue: Array<{
+    dependentId: string;
+    via: string[];
+    relationship: RestartSafetyDependent["relationship"];
+  }> = collectDirectDependents(registry, serviceId).map((dependentId) => ({
+    dependentId,
+    via: [serviceId],
+    relationship: "direct" as const,
+  }));
+  const visited = new Set<string>();
+  const dependents: RestartSafetyDependent[] = [];
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index];
+    if (!current || current.dependentId === serviceId || visited.has(current.dependentId)) {
+      continue;
+    }
+    visited.add(current.dependentId);
+
+    const service = registry.getById(current.dependentId);
+    if (!service) {
+      continue;
+    }
+
+    const lifecycle = getLifecycleState(current.dependentId);
+    dependents.push({
+      serviceId: current.dependentId,
+      relationship: current.relationship,
+      via: current.via,
+      running: lifecycle.running,
+      configured: lifecycle.configured,
+    });
+
+    for (const nextDependentId of collectDirectDependents(registry, current.dependentId)) {
+      if (nextDependentId === serviceId) {
+        continue;
+      }
+      queue.push({
+        dependentId: nextDependentId,
+        via: [...current.via, current.dependentId],
+        relationship: "transitive",
+      });
+    }
+  }
+
+  return dependents.sort((left, right) => left.serviceId.localeCompare(right.serviceId));
+}
+
+function buildProviderRef(service: DiscoveredService, registry: ServiceRegistry): RestartSafetyProviderRef {
+  const providerServiceId = service.manifest.execservice;
+  if (!providerServiceId) {
+    return {
+      serviceId: "",
+      status: "none",
+      installed: null,
+      configured: null,
+    };
+  }
+
+  const provider = registry.getById(providerServiceId);
+  if (!provider) {
+    return {
+      serviceId: providerServiceId,
+      status: "missing",
+      installed: null,
+      configured: null,
+    };
+  }
+
+  const lifecycle = getLifecycleState(providerServiceId);
+  return {
+    serviceId: providerServiceId,
+    status: lifecycle.installed && lifecycle.configured ? "available" : "not_ready",
+    installed: lifecycle.installed,
+    configured: lifecycle.configured,
+  };
+}
+
+function buildDoctorRequirement(service: DiscoveredService): RestartSafetyDoctorRequirement {
+  const doctor = service.manifest.doctor;
+  const enabled = doctor?.enabled === true;
+  const stepCount = doctor?.steps?.length ?? 0;
+  const failurePolicy = doctor?.failurePolicy ?? "block";
+  return {
+    required: enabled && stepCount > 0,
+    enabled,
+    stepCount,
+    failurePolicy,
+    status: enabled && stepCount > 0 ? "will_run_before_restart" : "disabled",
+  };
+}
+
+function worstStatus(blockers: RestartSafetyPreflightIssue[], warnings: RestartSafetyPreflightIssue[]): RestartSafetyPreflightStatus {
+  if (blockers.length > 0) {
+    return "blocked";
+  }
+  if (warnings.length > 0) {
+    return "warning";
+  }
+  return "allowed";
+}
+
+function buildImpact(
+  status: RestartSafetyPreflightStatus,
+  dependents: RestartSafetyDependent[],
+  doctorRequirement: RestartSafetyDoctorRequirement,
+  providerRef: RestartSafetyProviderRef,
+): string[] {
+  const impact: string[] = [
+    "Restart preflight is read-only and does not mutate lifecycle state.",
+  ];
+  if (providerRef.status === "available") {
+    impact.push(`Provider ${providerRef.serviceId} is installed and configured.`);
+  } else if (providerRef.status === "missing" || providerRef.status === "not_ready") {
+    impact.push(`Provider ${providerRef.serviceId} must be ready before restart.`);
+  }
+  if (dependents.length > 0) {
+    impact.push(`${dependents.length} dependent service(s) may need coordinated restart after dependency/provider changes.`);
+  }
+  if (doctorRequirement.required) {
+    impact.push(`Doctor preflight will run ${doctorRequirement.stepCount} step(s) before restart.`);
+  }
+  if (status === "blocked") {
+    impact.push("Restart should not proceed until blockers are resolved.");
+  }
+  impact.push("No raw secret values, provider credentials, env values, tokens, cookies, or recovery material are included.");
+  return impact;
+}
+
+export function buildRestartSafetyPreflightReport(
+  service: DiscoveredService,
+  registry: ServiceRegistry,
+): RestartSafetyPreflightReport {
+  const serviceId = service.manifest.id;
+  const lifecycle = getLifecycleState(serviceId);
+  const graph = new DependencyGraph(registry);
+  const dependencies = [...(service.manifest.depend_on ?? [])].sort((left, right) => left.localeCompare(right));
+  const missingDependencies = dependencies.filter((dependencyId) => !registry.getById(dependencyId));
+  const blockers: RestartSafetyPreflightIssue[] = [];
+  const warnings: RestartSafetyPreflightIssue[] = [];
+  let startupOrder: string[] = [];
+
+  if (!lifecycle.installed) {
+    blockers.push({
+      code: "service_not_installed",
+      serviceId,
+      reason: "Restart requires the service to be installed first.",
+    });
+  }
+  if (!lifecycle.configured) {
+    blockers.push({
+      code: "service_not_configured",
+      serviceId,
+      reason: "Restart requires the service to be configured first.",
+    });
+  }
+  for (const dependencyId of missingDependencies) {
+    blockers.push({
+      code: "dependency_missing",
+      serviceId: dependencyId,
+      reason: `Declared dependency "${dependencyId}" is not present in the service registry.`,
+    });
+  }
+
+  try {
+    startupOrder = graph.getStartupOrder(serviceId);
+  } catch (error) {
+    blockers.push({
+      code: "dependency_cycle",
+      serviceId,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const providerRef = buildProviderRef(service, registry);
+  if (providerRef.status === "missing") {
+    blockers.push({
+      code: "provider_missing",
+      serviceId: providerRef.serviceId,
+      reason: `Provider service "${providerRef.serviceId}" is not present in the service registry.`,
+    });
+  } else if (providerRef.status === "not_ready") {
+    if (providerRef.installed === false) {
+      blockers.push({
+        code: "provider_not_installed",
+        serviceId: providerRef.serviceId,
+        reason: `Provider service "${providerRef.serviceId}" is not installed.`,
+      });
+    }
+    if (providerRef.configured === false) {
+      blockers.push({
+        code: "provider_not_configured",
+        serviceId: providerRef.serviceId,
+        reason: `Provider service "${providerRef.serviceId}" is not configured.`,
+      });
+    }
+  }
+
+  const dependents = collectDependents(registry, serviceId);
+  const runningDependents = dependents.filter((dependent) => dependent.running);
+  if (runningDependents.length > 0) {
+    warnings.push({
+      code: "running_dependents",
+      serviceId,
+      reason: "Running dependent services may need to be stopped before the target restart and started after it.",
+    });
+  }
+
+  const doctorRequirement = buildDoctorRequirement(service);
+  if (doctorRequirement.required) {
+    warnings.push({
+      code: "doctor_required",
+      serviceId,
+      reason: "Configured doctor preflight will run before restart and may block based on its failure policy.",
+    });
+  }
+
+  const status = worstStatus(blockers, warnings);
+  const stopBeforeTarget: string[] = [];
+  const startAfterTarget: string[] = [];
+  for (const dependent of runningDependents) {
+    addUnique(stopBeforeTarget, dependent.serviceId);
+    addUnique(startAfterTarget, dependent.serviceId);
+  }
+  const restartOrderRisk = {
+    level: blockers.length > 0
+      ? "blocked" as const
+      : runningDependents.length > 0
+        ? "dependent_restart_recommended" as const
+        : "none" as const,
+    reason: blockers.length > 0
+      ? "Dependency/provider/lifecycle blockers must be resolved before restart."
+      : runningDependents.length > 0
+        ? "The target has running dependents that may observe dependency/provider changes."
+        : "No running dependent services were detected.",
+    stopBeforeTarget: stopBeforeTarget.sort((left, right) => left.localeCompare(right)),
+    startAfterTarget: startAfterTarget.sort((left, right) => left.localeCompare(right)),
+  };
+
+  return {
+    action: "restart-preflight",
+    ok: blockers.length === 0,
+    dryRun: true,
+    mutated: false,
+    generatedAt: new Date().toISOString(),
+    serviceId,
+    status,
+    lifecycle: {
+      installed: lifecycle.installed,
+      configured: lifecycle.configured,
+      running: lifecycle.running,
+    },
+    dependencyGraph: {
+      dependencies,
+      startupOrder,
+      missingDependencies,
+      dependents,
+    },
+    providerRef,
+    doctorRequirement,
+    restartOrderRisk,
+    blockers,
+    warnings,
+    expectedOperatorImpact: buildImpact(status, dependents, doctorRequirement, providerRef),
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -54,6 +54,7 @@ import { buildOperatorNotifications } from "../runtime/operator/notifications.js
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
+import { buildRestartSafetyPreflightReport } from "../runtime/operator/restart-safety-preflight.js";
 import { buildServiceCompatibilityReport } from "../runtime/operator/catalog-compatibility.js";
 import { buildServiceConfigDriftReport } from "../runtime/operator/config-drift.js";
 import {
@@ -1315,6 +1316,14 @@ async function routeRequest(
       writeJson(response, 200, {
         serviceId,
         recovery: await readServiceRecoveryHistory(service),
+      });
+      return;
+    }
+
+    if (request.method === "GET" && pathParts.length === 5 && pathParts[3] === "recovery" && pathParts[4] === "restart-preflight") {
+      writeJson(response, 200, {
+        serviceId,
+        preflight: buildRestartSafetyPreflightReport(service, runtimeModel.registry),
       });
       return;
     }

--- a/tests/api-recovery.test.js
+++ b/tests/api-recovery.test.js
@@ -67,3 +67,29 @@ test("recovery API exposes status and manual doctor execution", async () => {
   }
 });
 
+test("recovery API exposes read-only restart safety preflight", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-api-restart-preflight-");
+  await writeExecutableFixtureService(servicesRoot, "api", {
+    depend_on: ["missing-database"],
+    execservice: "missing-provider",
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const preflight = await getJson(`${apiServer.url}/api/services/api/recovery/restart-preflight`);
+
+    assert.equal(preflight.status, 200);
+    assert.equal(preflight.body.serviceId, "api");
+    assert.equal(preflight.body.preflight.action, "restart-preflight");
+    assert.equal(preflight.body.preflight.ok, false);
+    assert.equal(preflight.body.preflight.dryRun, true);
+    assert.equal(preflight.body.preflight.mutated, false);
+    assert.deepEqual(preflight.body.preflight.dependencyGraph.missingDependencies, ["missing-database"]);
+    assert.ok(preflight.body.preflight.blockers.some((blocker) => blocker.code === "provider_missing"));
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/cli-recovery.test.js
+++ b/tests/cli-recovery.test.js
@@ -88,3 +88,48 @@ test("CLI recovery doctor records history readable by recovery status", async ()
   }
 });
 
+test("CLI recovery restart-preflight emits machine-readable blocked restart safety report", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-cli-restart-preflight-");
+  await writeExecutableFixtureService(servicesRoot, "api", {
+    depend_on: ["missing-database"],
+    execservice: "missing-provider",
+  });
+
+  try {
+    const out = await runCli([
+      "recovery",
+      "restart-preflight",
+      "api",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const result = JSON.parse(out);
+
+    assert.equal(result.action, "restart-preflight");
+    assert.equal(result.serviceId, "api");
+    assert.equal(result.preflight.ok, false);
+    assert.equal(result.preflight.status, "blocked");
+    assert.equal(result.preflight.dryRun, true);
+    assert.equal(result.preflight.mutated, false);
+    assert.deepEqual(result.preflight.dependencyGraph.missingDependencies, ["missing-database"]);
+    assert.ok(result.preflight.blockers.some((blocker) => blocker.code === "provider_missing"));
+
+    const humanOut = await runCli([
+      "recovery",
+      "restart-preflight",
+      "api",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+    ]);
+
+    assert.match(humanOut, /\[service-lasso\] restart preflight/);
+    assert.match(humanOut, /status: blocked/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/restart-safety-preflight.test.js
+++ b/tests/restart-safety-preflight.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { configService, installService } from "../dist/runtime/lifecycle/actions.js";
+import { getLifecycleState, setLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
+import { buildRestartSafetyPreflightReport } from "../dist/runtime/operator/restart-safety-preflight.js";
+import { rehydrateDiscoveredServices } from "../dist/runtime/state/rehydrate.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function installAndConfig(registry, serviceId) {
+  const service = registry.getById(serviceId);
+  assert.ok(service);
+  const install = await installService(service, registry);
+  setLifecycleState(serviceId, install.state);
+  const config = await configService(service, registry);
+  setLifecycleState(serviceId, config.state);
+  return service;
+}
+
+test("restart safety preflight reports ready dependencies, provider ref, doctor requirement, and dependent restart risk", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-restart-preflight-ready-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "@node", { role: "provider" });
+    await writeExecutableFixtureService(servicesRoot, "database");
+    await writeExecutableFixtureService(servicesRoot, "api", {
+      depend_on: ["database"],
+      execservice: "@node",
+      doctor: {
+        enabled: true,
+        failurePolicy: "block",
+        steps: [
+          {
+            name: "dependency-change-check",
+            command: process.execPath,
+            args: ["-e", "process.exit(0)"],
+          },
+        ],
+      },
+    });
+    await writeExecutableFixtureService(servicesRoot, "web", {
+      depend_on: ["api"],
+    });
+
+    const discovered = await discoverServices(servicesRoot);
+    await rehydrateDiscoveredServices(discovered);
+    const registry = createServiceRegistry(discovered);
+
+    await installAndConfig(registry, "@node");
+    await installAndConfig(registry, "database");
+    const api = await installAndConfig(registry, "api");
+    await installAndConfig(registry, "web");
+    setLifecycleState("web", {
+      ...getLifecycleState("web"),
+      running: true,
+      runtime: {
+        ...getLifecycleState("web").runtime,
+        pid: 12345,
+      },
+    });
+
+    const report = buildRestartSafetyPreflightReport(api, registry);
+
+    assert.equal(report.action, "restart-preflight");
+    assert.equal(report.ok, true);
+    assert.equal(report.status, "warning");
+    assert.equal(report.dryRun, true);
+    assert.equal(report.mutated, false);
+    assert.deepEqual(report.dependencyGraph.dependencies, ["database"]);
+    assert.deepEqual(report.dependencyGraph.startupOrder, ["database"]);
+    assert.equal(report.providerRef.serviceId, "@node");
+    assert.equal(report.providerRef.status, "available");
+    assert.equal(report.doctorRequirement.required, true);
+    assert.equal(report.doctorRequirement.stepCount, 1);
+    assert.equal(report.restartOrderRisk.level, "dependent_restart_recommended");
+    assert.deepEqual(report.restartOrderRisk.stopBeforeTarget, ["web"]);
+    assert.equal(report.dependencyGraph.dependents[0].serviceId, "web");
+    assert.equal(report.dependencyGraph.dependents[0].running, true);
+    assert.doesNotMatch(JSON.stringify(report), /BEGIN PRIVATE KEY|Bearer\s+\S+|ACTUAL_SECRET|client_secret[:=]|password[:=]/i);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("restart safety preflight blocks missing dependencies and provider refs", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-restart-preflight-blocked-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "blocked-api", {
+      depend_on: ["missing-database"],
+      execservice: "missing-provider",
+    });
+    const discovered = await discoverServices(servicesRoot);
+    await rehydrateDiscoveredServices(discovered);
+    const registry = createServiceRegistry(discovered);
+    const api = registry.getById("blocked-api");
+    assert.ok(api);
+
+    const report = buildRestartSafetyPreflightReport(api, registry);
+    const blockerCodes = report.blockers.map((blocker) => blocker.code).sort();
+
+    assert.equal(report.ok, false);
+    assert.equal(report.status, "blocked");
+    assert.equal(report.restartOrderRisk.level, "blocked");
+    assert.deepEqual(report.dependencyGraph.missingDependencies, ["missing-database"]);
+    assert.ok(blockerCodes.includes("dependency_missing"));
+    assert.ok(blockerCodes.includes("provider_missing"));
+    assert.ok(blockerCodes.includes("service_not_installed"));
+    assert.ok(blockerCodes.includes("service_not_configured"));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -37,8 +37,10 @@ export async function clearPersistedFixtureState(servicesRoot) {
 export async function makeTempServicesRoot(prefix = "service-lasso-fixture-") {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), prefix));
   const servicesRoot = path.join(tempRoot, "services");
+  const workspaceRoot = path.join(tempRoot, "workspace");
   await mkdir(servicesRoot, { recursive: true });
-  return { tempRoot, servicesRoot };
+  await mkdir(workspaceRoot, { recursive: true });
+  return { tempRoot, servicesRoot, workspaceRoot };
 }
 
 export async function writeManifest(servicesRoot, serviceId, body) {
@@ -71,6 +73,7 @@ export async function writeExecutableFixtureService(
     doctor = undefined,
     ports = undefined,
     depend_on = undefined,
+    execservice = undefined,
     urls = undefined,
     install = undefined,
     config = undefined,
@@ -196,6 +199,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     doctor,
     ports,
     depend_on,
+    execservice,
     urls,
     install,
     config,


### PR DESCRIPTION
## Summary\n- Add a read-only restart safety preflight report for dependency/provider-ref changes.\n- Expose it through service-lasso recovery restart-preflight <serviceId> and GET /api/services/:id/recovery/restart-preflight.\n- Report lifecycle/provider/dependency blockers, running dependent restart-order risk, and doctor requirements without raw secret/provider/env values.\n\n## Validation\n- 
pm run build\n- 
ode --test --test-concurrency=1 tests/restart-safety-preflight.test.js tests/cli-recovery.test.js tests/api-recovery.test.js (6/6 pass)\n- git diff --check\n\nCloses #518