### PR TITLE
feat(backup): add restore dry-run validation report

### DIFF
--- a/docs/reference/workspace-backup-restore.md
+++ b/docs/reference/workspace-backup-restore.md
@@ -18,7 +18,7 @@ Preview a restore:
 service-lasso backup restore-plan ./workspace/backups/service-lasso-backup-2026-05-21T00-00-00-000Z.zip --services-root ./services --workspace-root ./workspace --json
 ~~~
 
-The restore-plan command is read-only. It reports what would be restored or created, version mismatches, root mismatches, service count differences, and unsupported backup schemas. It does not write service state, launch services, or overwrite files.
+The restore-plan command is read-only. It reports what would be overwritten or created, archive structure findings, redacted manifest compatibility, version mismatches, root mismatches, service count differences, target path conflicts, and unsupported backup schemas. It does not write service state, launch services, or overwrite files.
 
 ## Backup Archive Contract
 
@@ -47,6 +47,19 @@ Each service has:
 - manifest.redacted.json
 - redacted .state/*.json files when present
 - logs.metadata.json with log paths and file sizes only
+
+## Restore Dry-Run Report
+
+`backup restore-plan --json` emits a machine-readable report with:
+
+- `archive.manifestEntry`, `archive.structureOk`, and `archive.issues`
+- per-service `operation` of `create` or `overwrite`
+- per-service `targetPath`, `targetExists`, and `targetKind`
+- per-service archive entry counts for redacted manifests, logs metadata, and expected state files
+- per-service `manifestCompatibility` based on the redacted service manifest
+- `blocked` reason codes such as `backup_manifest_missing`, `unsupported_backup_schema`, `<serviceId>:target_path_conflict`, `<serviceId>:redacted_manifest_missing`, and `<serviceId>:state_file_missing`
+
+The report remains non-mutating even when `ok` is `false`.
 
 ## Secret-Safety Rules
 

--- a/src/runtime/cli/backup.ts
+++ b/src/runtime/cli/backup.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
-import { mkdir, readdir, stat } from "node:fs/promises";
+import { lstat, mkdir, readdir, stat } from "node:fs/promises";
 import AdmZip from "adm-zip";
 import type { ServiceManifest } from "../../contracts/service.js";
 import { discoverServices } from "../discovery/discoverServices.js";
+import { validateServiceManifest } from "../discovery/validateManifest.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig } from "../config.js";
 import { readStoredState, type StoredStateSnapshot } from "../state/readState.js";
 
@@ -63,9 +64,25 @@ export interface BackupCreateResult {
 export interface RestorePlanServiceChange {
   serviceId: string;
   action: "restore" | "create";
+  operation: "overwrite" | "create";
   reasons: string[];
+  blocked: string[];
   currentVersion: string | null;
   backupVersion: string | null;
+  targetPath: string;
+  targetExists: boolean;
+  targetKind: "directory" | "file" | "other" | "missing";
+  archiveEntries: {
+    redactedManifest: boolean;
+    logsMetadata: boolean;
+    stateFilesExpected: number;
+    stateFilesPresent: number;
+    missingStateFiles: string[];
+  };
+  manifestCompatibility: {
+    compatible: boolean;
+    issues: string[];
+  };
 }
 
 export interface BackupRestorePlanResult {
@@ -92,6 +109,11 @@ export interface BackupRestorePlanResult {
   };
   services: RestorePlanServiceChange[];
   blocked: string[];
+  archive: {
+    manifestEntry: boolean;
+    structureOk: boolean;
+    issues: string[];
+  };
   mutated: false;
 }
 
@@ -200,14 +222,25 @@ function addJson(zip: AdmZip, entryPath: string, value: unknown): void {
   zip.addFile(entryPath, Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8"));
 }
 
-async function readArchiveManifest(archivePath: string): Promise<WorkspaceBackupManifest | null> {
+function readArchive(archivePath: string): { zip: AdmZip; manifest: WorkspaceBackupManifest | null; issues: string[] } {
   const zip = new AdmZip(archivePath);
+  const issues: string[] = [];
   const manifestEntry = zip.getEntry("backup-manifest.json");
+
   if (!manifestEntry) {
-    return null;
+    return { zip, manifest: null, issues };
   }
 
-  return JSON.parse(manifestEntry.getData().toString("utf8")) as WorkspaceBackupManifest;
+  try {
+    return {
+      zip,
+      manifest: JSON.parse(manifestEntry.getData().toString("utf8")) as WorkspaceBackupManifest,
+      issues,
+    };
+  } catch {
+    issues.push("backup_manifest_invalid_json");
+    return { zip, manifest: null, issues };
+  }
 }
 
 export async function createWorkspaceBackup(options: Omit<BackupCliOptions, "action" | "archivePath">): Promise<BackupCreateResult> {
@@ -273,21 +306,145 @@ export async function createWorkspaceBackup(options: Omit<BackupCliOptions, "act
   };
 }
 
-function buildServicePlan(backup: WorkspaceBackupManifest, current: Awaited<ReturnType<typeof discoverServices>>): RestorePlanServiceChange[] {
-  const currentById = new Map(current.map((service) => [service.manifest.id, service]));
+function parseArchiveJson(zip: AdmZip, entryPath: string): { ok: true; value: unknown } | { ok: false; issue: string } {
+  const entry = zip.getEntry(entryPath);
+  if (!entry) {
+    return { ok: false, issue: "missing" };
+  }
 
-  return backup.services.map((backupService) => {
+  try {
+    return { ok: true, value: JSON.parse(entry.getData().toString("utf8")) as unknown };
+  } catch {
+    return { ok: false, issue: "invalid_json" };
+  }
+}
+
+function pathIsInside(root: string, candidate: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+function resolveServiceTargetPath(servicesRoot: string, backupService: BackupServiceEntry): { targetPath: string; escapesRoot: boolean } {
+  const serviceRootSegment = backupService.serviceRoot || safeSegment(backupService.serviceId);
+  const targetPath = path.resolve(servicesRoot, serviceRootSegment);
+
+  return {
+    targetPath,
+    escapesRoot: !pathIsInside(path.resolve(servicesRoot), targetPath),
+  };
+}
+
+async function inspectTargetPath(targetPath: string): Promise<{ exists: boolean; kind: "directory" | "file" | "other" | "missing" }> {
+  try {
+    const stats = await lstat(targetPath);
+    return {
+      exists: true,
+      kind: stats.isDirectory() ? "directory" : stats.isFile() ? "file" : "other",
+    };
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return { exists: false, kind: "missing" };
+    }
+    throw error;
+  }
+}
+
+function validateBackupServiceManifest(zip: AdmZip, backupService: BackupServiceEntry): RestorePlanServiceChange["manifestCompatibility"] {
+  const serviceArchiveRoot = toArchivePath("services", safeSegment(backupService.serviceId));
+  const manifestEntryPath = toArchivePath(serviceArchiveRoot, "manifest.redacted.json");
+  const parsed = parseArchiveJson(zip, manifestEntryPath);
+  const issues: string[] = [];
+
+  if (!parsed.ok) {
+    issues.push(parsed.issue === "missing" ? "redacted_manifest_missing" : "redacted_manifest_invalid_json");
+    return { compatible: false, issues };
+  }
+
+  try {
+    const manifest = validateServiceManifest(parsed.value, manifestEntryPath);
+    if (manifest.id !== backupService.serviceId) {
+      issues.push("manifest_service_id_mismatch");
+    }
+    if ((manifest.version ?? null) !== backupService.version) {
+      issues.push("manifest_version_mismatch");
+    }
+  } catch {
+    issues.push("redacted_manifest_incompatible");
+  }
+
+  return {
+    compatible: issues.length === 0,
+    issues,
+  };
+}
+
+async function buildServicePlan(
+  backup: WorkspaceBackupManifest,
+  current: Awaited<ReturnType<typeof discoverServices>>,
+  zip: AdmZip,
+  servicesRoot: string,
+): Promise<RestorePlanServiceChange[]> {
+  const currentById = new Map(current.map((service) => [service.manifest.id, service]));
+  const seenServiceIds = new Set<string>();
+
+  return await Promise.all(backup.services.map(async (backupService) => {
     const currentService = currentById.get(backupService.serviceId);
     const reasons: string[] = [];
+    const blocked: string[] = [];
+    const serviceArchiveRoot = toArchivePath("services", safeSegment(backupService.serviceId));
+    const manifestEntryPath = toArchivePath(serviceArchiveRoot, "manifest.redacted.json");
+    const logsEntryPath = toArchivePath(serviceArchiveRoot, "logs.metadata.json");
+    const missingStateFiles = backupService.stateFiles.filter((stateFile) => !zip.getEntry(toArchivePath(serviceArchiveRoot, "state", stateFile)));
+    const manifestCompatibility = validateBackupServiceManifest(zip, backupService);
+    const target = resolveServiceTargetPath(servicesRoot, backupService);
+    const targetState = await inspectTargetPath(target.targetPath);
+
+    if (!backupService.serviceId || backupService.serviceId.trim().length === 0) {
+      blocked.push("service_id_missing");
+    }
+    if (seenServiceIds.has(backupService.serviceId)) {
+      blocked.push("duplicate_service_id");
+    }
+    seenServiceIds.add(backupService.serviceId);
+
+    if (target.escapesRoot) {
+      blocked.push("target_path_escapes_services_root");
+    }
+    if (targetState.exists && targetState.kind !== "directory") {
+      blocked.push("target_path_conflict");
+    }
+    if (!zip.getEntry(manifestEntryPath)) {
+      blocked.push("redacted_manifest_missing");
+    }
+    if (!zip.getEntry(logsEntryPath)) {
+      blocked.push("logs_metadata_missing");
+    }
+    if (missingStateFiles.length > 0) {
+      blocked.push("state_file_missing");
+    }
+    blocked.push(...manifestCompatibility.issues);
 
     if (!currentService) {
       reasons.push("service_missing_currently");
       return {
         serviceId: backupService.serviceId,
         action: "create",
+        operation: "create",
         reasons,
+        blocked: Array.from(new Set(blocked)).sort(),
         currentVersion: null,
         backupVersion: backupService.version,
+        targetPath: target.targetPath,
+        targetExists: targetState.exists,
+        targetKind: targetState.kind,
+        archiveEntries: {
+          redactedManifest: Boolean(zip.getEntry(manifestEntryPath)),
+          logsMetadata: Boolean(zip.getEntry(logsEntryPath)),
+          stateFilesExpected: backupService.stateFiles.length,
+          stateFilesPresent: backupService.stateFiles.length - missingStateFiles.length,
+          missingStateFiles,
+        },
+        manifestCompatibility,
       };
     }
 
@@ -307,24 +464,45 @@ function buildServicePlan(backup: WorkspaceBackupManifest, current: Awaited<Retu
     return {
       serviceId: backupService.serviceId,
       action: "restore",
+      operation: "overwrite",
       reasons,
+      blocked: Array.from(new Set(blocked)).sort(),
       currentVersion,
       backupVersion: backupService.version,
+      targetPath: target.targetPath,
+      targetExists: targetState.exists,
+      targetKind: targetState.kind,
+      archiveEntries: {
+        redactedManifest: Boolean(zip.getEntry(manifestEntryPath)),
+        logsMetadata: Boolean(zip.getEntry(logsEntryPath)),
+        stateFilesExpected: backupService.stateFiles.length,
+        stateFilesPresent: backupService.stateFiles.length - missingStateFiles.length,
+        missingStateFiles,
+      },
+      manifestCompatibility,
     };
-  });
+  }));
 }
 
 export async function planWorkspaceRestore(options: Omit<BackupCliOptions, "action"> & { archivePath: string }): Promise<BackupRestorePlanResult> {
   const config = await ensureRuntimeConfig(resolveRuntimeConfig(options));
-  const backup = await readArchiveManifest(options.archivePath);
+  const archive = readArchive(options.archivePath);
+  const backup = archive.manifest;
   const currentServices = await discoverServices(config.servicesRoot);
-  const blocked: string[] = [];
+  const blocked: string[] = [...archive.issues];
 
   if (!backup) {
     blocked.push("backup_manifest_missing");
   } else if (backup.schemaVersion !== BACKUP_SCHEMA_VERSION) {
     blocked.push("unsupported_backup_schema");
   }
+
+  const servicePlans = backup
+    ? await buildServicePlan(backup, currentServices, archive.zip, config.servicesRoot)
+    : [];
+  const serviceBlocked = servicePlans.flatMap((service) => service.blocked.map((entry) => `${service.serviceId}:${entry}`));
+  const archiveIssues = Array.from(new Set([...blocked, ...serviceBlocked])).sort();
+  blocked.push(...serviceBlocked);
 
   return {
     action: "restore-plan",
@@ -348,8 +526,13 @@ export async function planWorkspaceRestore(options: Omit<BackupCliOptions, "acti
       current: currentServices.length,
       backup: backup?.serviceCount ?? 0,
     },
-    services: backup ? buildServicePlan(backup, currentServices) : [],
-    blocked,
+    services: servicePlans,
+    blocked: Array.from(new Set(blocked)).sort(),
+    archive: {
+      manifestEntry: Boolean(archive.zip.getEntry("backup-manifest.json")),
+      structureOk: archiveIssues.length === 0,
+      issues: archiveIssues,
+    },
     mutated: false,
   };
 }

--- a/tests/cli-backup.test.js
+++ b/tests/cli-backup.test.js
@@ -173,3 +173,137 @@ test("CLI backup restore-plan reports version mismatches without mutating state"
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("CLI backup restore-plan reports valid overwrite operations and archive structure", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempRuntime("service-lasso-cli-restore-valid-");
+  const serviceRoot = await writeManifest(servicesRoot, "restore-valid", {
+    id: "restore-valid",
+    name: "Restore Valid",
+    description: "Fixture used for valid restore plan checks.",
+    version: "1.0.0",
+  });
+  await writeRuntimeState(serviceRoot);
+
+  try {
+    const createOut = await runCli([
+      "backup",
+      "create",
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const backup = JSON.parse(createOut);
+
+    const planOut = await runCli([
+      "backup",
+      "restore-plan",
+      backup.archivePath,
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const plan = JSON.parse(planOut);
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.archive.manifestEntry, true);
+    assert.equal(plan.archive.structureOk, true);
+    assert.deepEqual(plan.archive.issues, []);
+    assert.equal(plan.services[0].serviceId, "restore-valid");
+    assert.equal(plan.services[0].action, "restore");
+    assert.equal(plan.services[0].operation, "overwrite");
+    assert.deepEqual(plan.services[0].blocked, []);
+    assert.equal(plan.services[0].targetExists, true);
+    assert.equal(plan.services[0].targetKind, "directory");
+    assert.equal(plan.services[0].archiveEntries.redactedManifest, true);
+    assert.equal(plan.services[0].archiveEntries.logsMetadata, true);
+    assert.equal(plan.services[0].archiveEntries.stateFilesExpected, 2);
+    assert.equal(plan.services[0].archiveEntries.stateFilesPresent, 2);
+    assert.equal(plan.services[0].manifestCompatibility.compatible, true);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI backup restore-plan blocks archives missing the top-level manifest", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempRuntime("service-lasso-cli-restore-missing-manifest-");
+  const archivePath = path.join(workspaceRoot, "missing-manifest.zip");
+  const zip = new AdmZip();
+  zip.addFile("not-the-manifest.json", Buffer.from("{}\n", "utf8"));
+  zip.writeZip(archivePath);
+
+  try {
+    const planOut = await runCli([
+      "backup",
+      "restore-plan",
+      archivePath,
+      "--services-root",
+      servicesRoot,
+      "--workspace-root",
+      workspaceRoot,
+      "--json",
+    ]);
+    const plan = JSON.parse(planOut);
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.archive.manifestEntry, false);
+    assert.equal(plan.archive.structureOk, false);
+    assert.deepEqual(plan.blocked, ["backup_manifest_missing"]);
+    assert.deepEqual(plan.services, []);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI backup restore-plan reports create target path conflicts", async () => {
+  const source = await makeTempRuntime("service-lasso-cli-restore-source-");
+  const target = await makeTempRuntime("service-lasso-cli-restore-target-");
+  const sourceServiceRoot = await writeManifest(source.servicesRoot, "path-conflict", {
+    id: "path-conflict",
+    name: "Path Conflict",
+    description: "Fixture used for restore path conflict checks.",
+    version: "1.0.0",
+  });
+  await writeRuntimeState(sourceServiceRoot);
+  await writeFile(path.join(target.servicesRoot, "path-conflict"), "occupied by a file");
+
+  try {
+    const createOut = await runCli([
+      "backup",
+      "create",
+      "--services-root",
+      source.servicesRoot,
+      "--workspace-root",
+      source.workspaceRoot,
+      "--json",
+    ]);
+    const backup = JSON.parse(createOut);
+
+    const planOut = await runCli([
+      "backup",
+      "restore-plan",
+      backup.archivePath,
+      "--services-root",
+      target.servicesRoot,
+      "--workspace-root",
+      target.workspaceRoot,
+      "--json",
+    ]);
+    const plan = JSON.parse(planOut);
+
+    assert.equal(plan.ok, false);
+    assert.equal(plan.archive.structureOk, false);
+    assert.deepEqual(plan.blocked, ["path-conflict:target_path_conflict"]);
+    assert.equal(plan.services[0].action, "create");
+    assert.equal(plan.services[0].operation, "create");
+    assert.equal(plan.services[0].targetExists, true);
+    assert.equal(plan.services[0].targetKind, "file");
+    assert.deepEqual(plan.services[0].blocked, ["target_path_conflict"]);
+  } finally {
+    await rm(source.tempRoot, { recursive: true, force: true });
+    await rm(target.tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- hardens `backup restore-plan` with archive structure findings, per-service create/overwrite operations, manifest compatibility, target path state, and path conflict blockers
- keeps restore planning non-mutating and reports machine-readable blocker codes
- documents the restore dry-run JSON report contract

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/cli-backup.test.js` (5 passed)
- `git diff --check`

Closes #525.