### PR TITLE
ISS-527 add dependency reverse lookup API

### DIFF
--- a/docs/reference/dependency-graph-api.md
+++ b/docs/reference/dependency-graph-api.md
@@ -1,0 +1,42 @@
+# Dependency Graph API
+
+Service Lasso exposes read-only dependency graph endpoints for operator UIs,
+automation, and support evidence. These payloads contain service ids, names,
+declared dependency links, and machine-readable relationship metadata only. They
+do not include environment values, provider credentials, tokens, passwords,
+cookies, private keys, raw logs, broker secret material, or recovery material.
+
+## Full Graph
+
+```http
+GET /api/dependencies
+```
+
+Returns the discovered service graph:
+
+- `nodes`: discovered services by `id` and `name`.
+- `edges`: declared dependency links where `from` is the dependency service id
+  and `to` is the consuming service id.
+
+## Reverse Lookup
+
+```http
+GET /api/dependencies/{serviceId}/dependents
+```
+
+Returns services that depend on `{serviceId}`.
+
+- `target.id`: requested service or provider id.
+- `target.name`: discovered service name, or `null` when the id is only known
+  from another service's missing dependency declaration.
+- `target.exists`: whether the target manifest is currently discovered.
+- `dependents[].relation`: `direct` when the dependent declares `{serviceId}`
+  directly, otherwise `transitive`.
+- `dependents[].depth`: number of graph hops from target to dependent.
+- `dependents[].path`: dependency path from target to dependent.
+- `dependents[].blockedBy`: dependency ids on that path that can block the
+  dependent; missing manifests are marked with `missing: true`.
+- `summary`: total, direct, transitive, and missing-target counts.
+
+The traversal is cycle-protected. A cyclic graph is reported once per reachable
+dependent and does not include the target as its own dependent.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -128,6 +128,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/dependency-graph-api",
+          label: "Dependency Graph API",
+        },
+        {
+          type: "doc",
           id: "reference/runtime-port-reservations",
           label: "Runtime Port Reservations",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -397,6 +397,34 @@ export interface DependenciesResponse {
   };
 }
 
+export interface DependencyReverseLookupResponse {
+  dependencies: {
+    target: {
+      id: string;
+      name: string | null;
+      exists: boolean;
+    };
+    dependents: Array<{
+      id: string;
+      name: string;
+      relation: "direct" | "transitive";
+      depth: number;
+      path: string[];
+      blockedBy: Array<{
+        id: string;
+        name: string | null;
+        missing: boolean;
+      }>;
+    }>;
+    summary: {
+      total: number;
+      direct: number;
+      transitive: number;
+      missingTarget: boolean;
+    };
+  };
+}
+
 export type BaselineDependencyDiagnosticStatus = "startable" | "blocked" | "degraded" | "running";
 
 export type ServiceDependencyReadiness = "ready" | "blocked" | "degraded" | "running" | "disabled";

--- a/src/runtime/manager/DependencyGraph.ts
+++ b/src/runtime/manager/DependencyGraph.ts
@@ -16,6 +16,36 @@ export interface ServiceDependencySummary {
   dependents: string[];
 }
 
+export interface ReverseDependencyBlockedBy {
+  id: string;
+  name: string | null;
+  missing: boolean;
+}
+
+export interface ReverseDependencyDependent {
+  id: string;
+  name: string;
+  relation: "direct" | "transitive";
+  depth: number;
+  path: string[];
+  blockedBy: ReverseDependencyBlockedBy[];
+}
+
+export interface ReverseDependencyLookup {
+  target: {
+    id: string;
+    name: string | null;
+    exists: boolean;
+  };
+  dependents: ReverseDependencyDependent[];
+  summary: {
+    total: number;
+    direct: number;
+    transitive: number;
+    missingTarget: boolean;
+  };
+}
+
 export class DependencyGraph {
   readonly #registry: ServiceRegistry;
 
@@ -57,6 +87,78 @@ export class DependencyGraph {
     return {
       dependencies,
       dependents,
+    };
+  }
+
+  getReverseDependencies(serviceId: string): ReverseDependencyLookup {
+    const target = this.#registry.getById(serviceId);
+    const services = this.#registry.list();
+    const visited = new Set<string>();
+    const dependents: ReverseDependencyDependent[] = [];
+    const queue: Array<{ id: string; path: string[] }> = services
+      .filter((candidate) => (candidate.manifest.depend_on ?? []).includes(serviceId))
+      .map((candidate) => ({ id: candidate.manifest.id, path: [serviceId, candidate.manifest.id] }))
+      .sort((left, right) => left.id.localeCompare(right.id));
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || current.id === serviceId || visited.has(current.id)) {
+        continue;
+      }
+
+      const service = this.#registry.getById(current.id);
+      if (!service) {
+        continue;
+      }
+
+      visited.add(current.id);
+      const depth = current.path.length - 1;
+      const blockedBy = current.path.slice(0, -1).map((dependencyId) => {
+        const dependency = this.#registry.getById(dependencyId);
+        return {
+          id: dependencyId,
+          name: dependency?.manifest.name ?? null,
+          missing: dependency === undefined,
+        };
+      });
+
+      dependents.push({
+        id: service.manifest.id,
+        name: service.manifest.name,
+        relation: depth === 1 ? "direct" : "transitive",
+        depth,
+        path: current.path,
+        blockedBy,
+      });
+
+      const nextDependents = services
+        .filter((candidate) => (candidate.manifest.depend_on ?? []).includes(current.id))
+        .map((candidate) => candidate.manifest.id)
+        .sort((left, right) => left.localeCompare(right));
+
+      for (const nextId of nextDependents) {
+        if (nextId !== serviceId && !visited.has(nextId)) {
+          queue.push({ id: nextId, path: [...current.path, nextId] });
+        }
+      }
+    }
+
+    dependents.sort((left, right) => left.depth - right.depth || left.id.localeCompare(right.id));
+    const direct = dependents.filter((dependent) => dependent.relation === "direct").length;
+
+    return {
+      target: {
+        id: serviceId,
+        name: target?.manifest.name ?? null,
+        exists: target !== undefined,
+      },
+      dependents,
+      summary: {
+        total: dependents.length,
+        direct,
+        transitive: dependents.length - direct,
+        missingTarget: target === undefined,
+      },
     };
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHealthResponse } from "./routes/health.js";
 import { createServicesResponse } from "./routes/services.js";
-import { createDependenciesResponse } from "./routes/dependencies.js";
+import { createDependenciesResponse, createDependencyReverseLookupResponse } from "./routes/dependencies.js";
 import { createRuntimeCapabilitiesResponse, createRuntimeSummaryResponse } from "./routes/runtime.js";
 import { createServiceHealthHistoryResponse, createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
@@ -1518,6 +1518,17 @@ async function routeRequest(
       }),
     );
     return;
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/api/dependencies/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const serviceId = decodeURIComponent(pathParts[2] ?? "");
+
+    if (pathParts.length === 4 && pathParts[3] === "dependents") {
+      const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+      writeJson(response, 200, createDependencyReverseLookupResponse(runtimeModel.graph.getReverseDependencies(serviceId)));
+      return;
+    }
   }
 
   if (request.method === "GET" && url.pathname === "/api/diagnostics/dependencies") {

--- a/src/server/routes/dependencies.ts
+++ b/src/server/routes/dependencies.ts
@@ -1,8 +1,17 @@
-import type { DependenciesResponse } from "../../contracts/api.js";
+import type { DependenciesResponse, DependencyReverseLookupResponse } from "../../contracts/api.js";
+import type { ReverseDependencyLookup } from "../../runtime/manager/DependencyGraph.js";
 
 export function createDependenciesResponse(
   input: DependenciesResponse["dependencies"],
 ): DependenciesResponse {
+  return {
+    dependencies: input,
+  };
+}
+
+export function createDependencyReverseLookupResponse(
+  input: ReverseDependencyLookup,
+): DependencyReverseLookupResponse {
   return {
     dependencies: input,
   };

--- a/tests/registry-runtime-state.test.js
+++ b/tests/registry-runtime-state.test.js
@@ -83,6 +83,49 @@ test("ServiceRegistry and DependencyGraph model dependencies and dependents", as
   assert.deepEqual(graph.getStartupOrder("@serviceadmin"), ["@node"]);
 });
 
+test("DependencyGraph reverse lookup classifies direct, transitive, cyclic, and missing targets", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-reverse-deps-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "base-service");
+    await writeExecutableFixtureService(servicesRoot, "direct-a", { depend_on: ["base-service"] });
+    await writeExecutableFixtureService(servicesRoot, "direct-b", { depend_on: ["base-service"] });
+    await writeExecutableFixtureService(servicesRoot, "transitive-c", { depend_on: ["direct-a", "cycle-d"] });
+    await writeExecutableFixtureService(servicesRoot, "cycle-d", { depend_on: ["transitive-c"] });
+    await writeExecutableFixtureService(servicesRoot, "missing-consumer", { depend_on: ["missing-provider"] });
+
+    const registry = createServiceRegistry(await discoverServices(servicesRoot));
+    const graph = new DependencyGraph(registry);
+    const reverse = graph.getReverseDependencies("base-service");
+    const byId = new Map(reverse.dependents.map((dependent) => [dependent.id, dependent]));
+
+    assert.deepEqual(reverse.target, { id: "base-service", name: "base-service", exists: true });
+    assert.deepEqual(reverse.summary, { total: 4, direct: 2, transitive: 2, missingTarget: false });
+    assert.equal(byId.get("direct-a")?.relation, "direct");
+    assert.equal(byId.get("direct-a")?.depth, 1);
+    assert.deepEqual(byId.get("direct-a")?.path, ["base-service", "direct-a"]);
+    assert.deepEqual(byId.get("direct-a")?.blockedBy, [
+      { id: "base-service", name: "base-service", missing: false },
+    ]);
+    assert.equal(byId.get("transitive-c")?.relation, "transitive");
+    assert.equal(byId.get("transitive-c")?.depth, 2);
+    assert.deepEqual(byId.get("transitive-c")?.path, ["base-service", "direct-a", "transitive-c"]);
+    assert.equal(byId.get("cycle-d")?.relation, "transitive");
+    assert.deepEqual(byId.get("cycle-d")?.path, ["base-service", "direct-a", "transitive-c", "cycle-d"]);
+
+    const missingReverse = graph.getReverseDependencies("missing-provider");
+    assert.deepEqual(missingReverse.target, { id: "missing-provider", name: null, exists: false });
+    assert.deepEqual(missingReverse.summary, { total: 1, direct: 1, transitive: 0, missingTarget: true });
+    assert.deepEqual(missingReverse.dependents[0]?.blockedBy, [
+      { id: "missing-provider", name: null, missing: true },
+    ]);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/services/:id returns discovered service detail with dependency context", async () => {
   resetLifecycleState();
   await clearPersistedFixtureState(servicesRoot);
@@ -288,6 +331,50 @@ test("GET /api/dependencies returns graph nodes and edges", async () => {
     await apiServer.stop();
     resetLifecycleState();
     await clearPersistedFixtureState(servicesRoot);
+  }
+});
+
+test("GET /api/dependencies/:id/dependents returns reverse dependency lookup", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-reverse-deps-api-");
+  let apiServer = null;
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "base-service");
+    await writeExecutableFixtureService(servicesRoot, "direct-a", { depend_on: ["base-service"] });
+    await writeExecutableFixtureService(servicesRoot, "transitive-b", { depend_on: ["direct-a"] });
+    await writeExecutableFixtureService(servicesRoot, "missing-consumer", { depend_on: ["missing-provider"] });
+
+    apiServer = await startApiServer({ port: 0, servicesRoot });
+
+    const response = await fetch(`${apiServer.url}/api/dependencies/base-service/dependents`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.dependencies.target, { id: "base-service", name: "base-service", exists: true });
+    assert.deepEqual(body.dependencies.summary, { total: 2, direct: 1, transitive: 1, missingTarget: false });
+    assert.deepEqual(
+      body.dependencies.dependents.map((dependent) => ({
+        id: dependent.id,
+        relation: dependent.relation,
+        path: dependent.path,
+      })),
+      [
+        { id: "direct-a", relation: "direct", path: ["base-service", "direct-a"] },
+        { id: "transitive-b", relation: "transitive", path: ["base-service", "direct-a", "transitive-b"] },
+      ],
+    );
+
+    const missingResponse = await fetch(`${apiServer.url}/api/dependencies/missing-provider/dependents`);
+    const missingBody = await missingResponse.json();
+
+    assert.equal(missingResponse.status, 200);
+    assert.deepEqual(missingBody.dependencies.target, { id: "missing-provider", name: null, exists: false });
+    assert.deepEqual(missingBody.dependencies.summary, { total: 1, direct: 1, transitive: 0, missingTarget: true });
+  } finally {
+    if (apiServer) await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Add cycle-protected reverse dependency traversal to `DependencyGraph`.
- Expose `GET /api/dependencies/{serviceId}/dependents` with direct/transitive classification, dependency path, and missing-target/blocked-by metadata.
- Document the dependency graph API and add targeted graph/API tests.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/registry-runtime-state.test.js`
- `git diff --check`

## Issue
Closes #527