### PR TITLE
ISS-528 add readiness gate CLI

### DIFF
--- a/docs/reference/readiness-gate.md
+++ b/docs/reference/readiness-gate.md
@@ -1,0 +1,25 @@
+# Readiness Gate CLI
+
+`service-lasso readiness gate --json` emits a non-mutating readiness report for local automation.
+
+The report includes:
+
+- baseline start possibility for the selected `servicesRoot`
+- required provider manifests and any missing providers
+- unresolved blockers and warning-only partial states
+- current git branch/status hints
+- one recommended next action
+
+The command does not render secret values, provider credentials, tokens, private keys, cookies, passwords, raw environment values, or recovery material. Paths, service ids, provider ids, manifest metadata, and git status counts are safe to include in logs and support bundles.
+
+Example:
+
+```bash
+service-lasso readiness gate --services-root ./services --workspace-root ./workspace --json
+```
+
+Top-level statuses:
+
+- `ready`: no blockers or warnings were found.
+- `partial`: baseline start is possible, but the workspace has warning-only conditions such as disabled service manifests or a dirty git tree.
+- `blocked`: baseline start cannot proceed until reported blockers are fixed.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -128,6 +128,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/readiness-gate",
+          label: "Readiness Gate CLI",
+        },
+        {
+          type: "doc",
           id: "reference/dependency-graph-api",
           label: "Dependency Graph API",
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,12 +17,14 @@ import { runConfigSnapshotCliAction, type ConfigSnapshotCliAction, type ConfigSn
 import { runDiagnosticsCliAction, type DiagnosticsCliAction, type DiagnosticsCliResult } from "./runtime/cli/diagnostics.js";
 import { readRuntimeInstanceForCli } from "./runtime/cli/instance.js";
 import { runRuntimePlanCliAction, type RuntimePlanCliAction, type RuntimePlanCliResult } from "./runtime/cli/plan.js";
+import { runReadinessGateCliAction, type ReadinessGateCliResult } from "./runtime/cli/readiness.js";
 import type { ServiceUpdateState } from "./runtime/updates/state.js";
 import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "readiness" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "help" | "version";
+  readinessAction?: "gate";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
   updateAction?: UpdateCliAction;
@@ -81,6 +83,7 @@ function usageText(): string {
     "  service-lasso recovery restart-preflight <serviceId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso health history [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso instance [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso readiness gate [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso lockfile generate [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso lockfile verify [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-drift [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -108,8 +111,8 @@ function usageText(): string {
     "  - The plan command previews start, stop, update-install, and app-owned service import actions without writing state.",
     "  - The recovery command reads persisted recovery history or runs doctor/preflight checks.",
     "  - The instance command reads local runtime identity and recent instance registry state.",
+    "  - The readiness command emits a machine-readable gate for baseline automation.",
     "  - The lockfile command generates or verifies the servicesRoot service-lasso.lock.json.",
-    "  - The instance command reads local runtime identity and recent instance registry state.",
   ].join("\n");
 }
 
@@ -148,6 +151,7 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "plan" ||
       commandToken === "lockfile" ||
       commandToken === "instance" ||
+      commandToken === "readiness" ||
       commandToken === "config-drift" ||
       commandToken === "config-apply" ||
       commandToken === "config-snapshot" ||
@@ -253,6 +257,15 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     }
 
     parsed.lockfileAction = action;
+  }
+
+  if (command === "readiness") {
+    const action = remaining.shift();
+    if (action !== "gate") {
+      throw new Error('The "readiness" command requires: gate.');
+    }
+
+    parsed.readinessAction = action;
   }
 
   if (command === "plan") {
@@ -423,8 +436,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, and services commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "readiness" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, readiness, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, and services commands.");
         }
         parsed.json = true;
         break;
@@ -948,6 +961,27 @@ function printInstanceResult(result: RuntimeInstanceResponse, asJson: boolean): 
   console.log("- stale: " + result.registry.staleCount);
 }
 
+function printReadinessGateResult(result: ReadinessGateCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log("[service-lasso] readiness gate");
+  console.log("- status: " + result.status);
+  console.log("- baselineStartPossible: " + result.baseline.startPossible);
+  console.log("- services: enabled=" + result.baseline.enabledServices + " total=" + result.baseline.totalServices);
+  console.log("- providers: required=" + result.providers.required.length + " missing=" + result.providers.missing.length);
+  console.log("- git: " + (result.workspace.git.branch ?? "unknown") + " clean=" + result.workspace.git.clean);
+  for (const blocker of result.blockers) {
+    console.log("- blocked: " + blocker.message);
+  }
+  for (const warning of result.warnings) {
+    console.log("- warning: " + warning.message);
+  }
+  console.log("- nextAction: " + result.nextAction);
+}
+
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
   const parsed = parseCliArgs(argv);
   const runtimeVersion = resolveRuntimeVersion();
@@ -1059,6 +1093,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       version: runtimeVersion,
     });
     printInstanceResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "readiness") {
+    const result = await runReadinessGateCliAction({
+      servicesRoot: parsed.servicesRoot,
+      workspaceRoot: parsed.workspaceRoot,
+      version: runtimeVersion,
+    });
+    printReadinessGateResult(result, parsed.json);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/runtime/cli/readiness.ts
+++ b/src/runtime/cli/readiness.ts
@@ -1,0 +1,282 @@
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { promisify } from "node:util";
+import { discoverServices } from "../discovery/discoverServices.js";
+import { createServiceRegistry } from "../manager/DependencyGraph.js";
+import { resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
+import type { DiscoveredService } from "../../contracts/service.js";
+
+const execFileAsync = promisify(execFile);
+
+export type ReadinessGateStatus = "ready" | "partial" | "blocked";
+
+export interface ReadinessGateBlocker {
+  gate: "runtime.servicesRoot" | "runtime.manifests" | "baseline.services" | "providers";
+  id: string;
+  serviceId?: string;
+  message: string;
+  nextAction: string;
+}
+
+export interface ReadinessGateWarning {
+  gate: "workspace.git" | "baseline.services";
+  id: string;
+  message: string;
+  nextAction: string;
+}
+
+export interface ReadinessGateGitHints {
+  available: boolean;
+  root: string | null;
+  branch: string | null;
+  upstream: string | null;
+  head: string | null;
+  clean: boolean | null;
+  statusEntries: number;
+  hints: string[];
+}
+
+export interface ReadinessGateCliResult {
+  action: "gate";
+  generatedAt: string;
+  ok: boolean;
+  status: ReadinessGateStatus;
+  servicesRoot: string;
+  workspaceRoot: string;
+  baseline: {
+    startPossible: boolean;
+    status: Exclude<ReadinessGateStatus, "partial"> | "partial";
+    totalServices: number;
+    enabledServices: number;
+    disabledServices: number;
+    blockers: ReadinessGateBlocker[];
+  };
+  providers: {
+    status: Exclude<ReadinessGateStatus, "partial">;
+    required: string[];
+    present: string[];
+    missing: string[];
+  };
+  workspace: {
+    git: ReadinessGateGitHints;
+  };
+  blockers: ReadinessGateBlocker[];
+  warnings: ReadinessGateWarning[];
+  nextAction: string;
+}
+
+export interface ReadinessGateCliOptions extends RuntimeConfigOptions {
+  cwd?: string;
+}
+
+async function directoryExists(targetPath: string): Promise<boolean> {
+  try {
+    return (await stat(targetPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function gitOutput(args: string[], cwd: string): Promise<string | null> {
+  try {
+    const result = await execFileAsync("git", args, {
+      cwd,
+      windowsHide: true,
+      timeout: 5_000,
+    });
+    return String(result.stdout).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function readGitHints(cwd: string): Promise<ReadinessGateGitHints> {
+  const root = await gitOutput(["rev-parse", "--show-toplevel"], cwd);
+  if (!root) {
+    return {
+      available: false,
+      root: null,
+      branch: null,
+      upstream: null,
+      head: null,
+      clean: null,
+      statusEntries: 0,
+      hints: ["No git workspace was detected from the current directory."],
+    };
+  }
+
+  const branch = await gitOutput(["branch", "--show-current"], root);
+  const upstream = await gitOutput(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], root);
+  const head = await gitOutput(["rev-parse", "--short", "HEAD"], root);
+  const porcelain = await gitOutput(["status", "--porcelain"], root);
+  const statusEntries = porcelain ? porcelain.split(/\r?\n/).filter(Boolean).length : 0;
+  const hints: string[] = [];
+
+  if (statusEntries > 0) {
+    hints.push("Git workspace has uncommitted or untracked changes.");
+  }
+  if (!upstream) {
+    hints.push("Current branch has no upstream tracking branch.");
+  }
+
+  return {
+    available: true,
+    root,
+    branch: branch || null,
+    upstream: upstream || null,
+    head: head || null,
+    clean: statusEntries === 0,
+    statusEntries,
+    hints,
+  };
+}
+
+function requiredProviderIds(services: DiscoveredService[]): string[] {
+  const byId = new Map(services.map((service) => [service.manifest.id, service]));
+  const required = new Set<string>();
+
+  for (const service of services) {
+    if (service.manifest.enabled === false) {
+      continue;
+    }
+
+    for (const dependencyId of service.manifest.depend_on ?? []) {
+      const dependency = byId.get(dependencyId);
+      if (!dependency || dependency.manifest.role === "provider") {
+        required.add(dependencyId);
+      }
+    }
+  }
+
+  return [...required].sort((left, right) => left.localeCompare(right));
+}
+
+function createNextAction(blockers: ReadinessGateBlocker[], warnings: ReadinessGateWarning[]): string {
+  const firstBlocker = blockers[0];
+  if (firstBlocker) {
+    return firstBlocker.nextAction;
+  }
+
+  const firstWarning = warnings[0];
+  if (firstWarning) {
+    return firstWarning.nextAction;
+  }
+
+  return "Run `service-lasso start --json` or continue with the next automation step.";
+}
+
+export async function runReadinessGateCliAction(options: ReadinessGateCliOptions = {}): Promise<ReadinessGateCliResult> {
+  const runtimeConfig = resolveRuntimeConfig({
+    servicesRoot: options.servicesRoot,
+    workspaceRoot: options.workspaceRoot,
+    version: options.version,
+  });
+  const blockers: ReadinessGateBlocker[] = [];
+  const warnings: ReadinessGateWarning[] = [];
+  const git = await readGitHints(options.cwd ?? process.cwd());
+
+  if (git.clean === false) {
+    warnings.push({
+      gate: "workspace.git",
+      id: "git_dirty",
+      message: "Git workspace has uncommitted or untracked changes.",
+      nextAction: "Commit, stash, or intentionally ignore the local changes before release automation.",
+    });
+  }
+
+  let services: DiscoveredService[] = [];
+
+  if (!(await directoryExists(runtimeConfig.servicesRoot))) {
+    blockers.push({
+      gate: "runtime.servicesRoot",
+      id: "services_root_missing",
+      message: "Configured servicesRoot does not exist: " + runtimeConfig.servicesRoot,
+      nextAction: "Create the services root or pass --services-root to the intended Service Lasso services directory.",
+    });
+  } else {
+    try {
+      services = await discoverServices(runtimeConfig.servicesRoot);
+    } catch (error) {
+      blockers.push({
+        gate: "runtime.manifests",
+        id: "manifest_discovery_failed",
+        message: error instanceof Error ? error.message : String(error),
+        nextAction: "Fix the service manifest error and rerun the readiness gate.",
+      });
+    }
+  }
+
+  const registry = createServiceRegistry(services);
+  const enabledServices = services.filter((service) => service.manifest.enabled !== false);
+  const disabledServices = services.length - enabledServices.length;
+  if (
+    enabledServices.length === 0 &&
+    blockers.every((blocker) => blocker.gate !== "runtime.servicesRoot" && blocker.gate !== "runtime.manifests")
+  ) {
+    blockers.push({
+      gate: "baseline.services",
+      id: "no_enabled_services",
+      message: "No enabled services were discovered for baseline start.",
+      nextAction: "Enable at least one baseline service or point --services-root at a populated service directory.",
+    });
+  }
+  if (disabledServices > 0) {
+    warnings.push({
+      gate: "baseline.services",
+      id: "disabled_services_present",
+      message: `${disabledServices} disabled service(s) were discovered and will not be included in baseline start.`,
+      nextAction: "Review disabled service manifests if baseline coverage looks incomplete.",
+    });
+  }
+
+  const requiredProviders = requiredProviderIds(services);
+  const presentProviders = services
+    .filter((service) => service.manifest.role === "provider")
+    .map((service) => service.manifest.id)
+    .sort((left, right) => left.localeCompare(right));
+  const missingProviders = requiredProviders.filter((providerId) => !registry.getById(providerId));
+
+  for (const providerId of missingProviders) {
+    blockers.push({
+      gate: "providers",
+      id: "required_provider_missing",
+      serviceId: providerId,
+      message: "Required provider manifest is missing: " + providerId,
+      nextAction: "Restore or import the missing provider manifest before baseline start.",
+    });
+  }
+
+  const baselineBlockers = blockers;
+  const baselineStatus: ReadinessGateCliResult["baseline"]["status"] =
+    baselineBlockers.length > 0 ? "blocked" : warnings.some((warning) => warning.gate === "baseline.services") ? "partial" : "ready";
+  const status: ReadinessGateStatus = blockers.length > 0 ? "blocked" : warnings.length > 0 ? "partial" : "ready";
+
+  return {
+    action: "gate",
+    generatedAt: new Date().toISOString(),
+    ok: blockers.length === 0,
+    status,
+    servicesRoot: runtimeConfig.servicesRoot,
+    workspaceRoot: runtimeConfig.workspaceRoot,
+    baseline: {
+      startPossible: baselineBlockers.length === 0,
+      status: baselineStatus,
+      totalServices: services.length,
+      enabledServices: enabledServices.length,
+      disabledServices,
+      blockers: baselineBlockers,
+    },
+    providers: {
+      status: missingProviders.length > 0 ? "blocked" : "ready",
+      required: requiredProviders,
+      present: presentProviders,
+      missing: missingProviders,
+    },
+    workspace: {
+      git,
+    },
+    blockers,
+    warnings,
+    nextAction: createNextAction(blockers, warnings),
+  };
+}

--- a/tests/cli-readiness-gate.test.js
+++ b/tests/cli-readiness-gate.test.js
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { writeFile, rm } from "node:fs/promises";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+const execFileAsync = promisify(execFile);
+const cliPath = path.resolve("dist", "cli.js");
+
+async function run(command, args, options = {}) {
+  return execFileAsync(command, args, {
+    ...options,
+    windowsHide: true,
+  });
+}
+
+async function initCleanGitWorkspace(root) {
+  await run("git", ["init"], { cwd: root });
+  await run("git", ["config", "user.email", "agent@example.test"], { cwd: root });
+  await run("git", ["config", "user.name", "Service Lasso Agent"], { cwd: root });
+  await run("git", ["add", "."], { cwd: root });
+  await run("git", ["commit", "-m", "fixture"], { cwd: root });
+}
+
+async function runReadinessGate(fixture) {
+  const result = await execFileAsync(
+    process.execPath,
+    [
+      cliPath,
+      "readiness",
+      "gate",
+      "--services-root",
+      fixture.servicesRoot,
+      "--workspace-root",
+      fixture.workspaceRoot,
+      "--json",
+    ],
+    {
+      cwd: fixture.tempRoot,
+      windowsHide: true,
+    },
+  );
+  return JSON.parse(result.stdout);
+}
+
+test("CLI readiness gate reports ready baseline and provider state", async () => {
+  const fixture = await makeTempServicesRoot("service-lasso-readiness-ready-");
+
+  try {
+    await writeExecutableFixtureService(fixture.servicesRoot, "@node", { role: "provider" });
+    await writeExecutableFixtureService(fixture.servicesRoot, "app-service", { depend_on: ["@node"] });
+    await initCleanGitWorkspace(fixture.tempRoot);
+
+    const body = await runReadinessGate(fixture);
+
+    assert.equal(body.action, "gate");
+    assert.equal(body.ok, true);
+    assert.equal(body.status, "ready");
+    assert.equal(body.baseline.startPossible, true);
+    assert.equal(body.baseline.enabledServices, 2);
+    assert.deepEqual(body.providers.required, ["@node"]);
+    assert.deepEqual(body.providers.missing, []);
+    assert.equal(body.workspace.git.clean, true);
+    assert.match(body.nextAction, /service-lasso start --json/);
+  } finally {
+    await rm(fixture.tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI readiness gate blocks when a required provider manifest is missing", async () => {
+  const fixture = await makeTempServicesRoot("service-lasso-readiness-blocked-");
+
+  try {
+    await writeExecutableFixtureService(fixture.servicesRoot, "app-service", { depend_on: ["@missing"] });
+    await initCleanGitWorkspace(fixture.tempRoot);
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          cliPath,
+          "readiness",
+          "gate",
+          "--services-root",
+          fixture.servicesRoot,
+          "--workspace-root",
+          fixture.workspaceRoot,
+          "--json",
+        ],
+        {
+          cwd: fixture.tempRoot,
+          windowsHide: true,
+        },
+      ),
+      (error) => {
+        const body = JSON.parse(error.stdout);
+        assert.equal(body.ok, false);
+        assert.equal(body.status, "blocked");
+        assert.equal(body.baseline.startPossible, false);
+        assert.deepEqual(body.providers.missing, ["@missing"]);
+        assert.equal(body.blockers[0].id, "required_provider_missing");
+        return true;
+      },
+    );
+  } finally {
+    await rm(fixture.tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI readiness gate reports partial state for warning-only workspace conditions", async () => {
+  const fixture = await makeTempServicesRoot("service-lasso-readiness-partial-");
+
+  try {
+    await writeExecutableFixtureService(fixture.servicesRoot, "@node", { role: "provider" });
+    await writeExecutableFixtureService(fixture.servicesRoot, "app-service", { depend_on: ["@node"] });
+    await writeExecutableFixtureService(fixture.servicesRoot, "disabled-service", { enabled: false });
+    await initCleanGitWorkspace(fixture.tempRoot);
+    await writeFile(path.join(fixture.tempRoot, "local-note.txt"), "untracked");
+
+    const body = await runReadinessGate(fixture);
+
+    assert.equal(body.ok, true);
+    assert.equal(body.status, "partial");
+    assert.equal(body.baseline.startPossible, true);
+    assert.equal(body.baseline.status, "partial");
+    assert.equal(body.baseline.disabledServices, 1);
+    assert.equal(body.workspace.git.clean, false);
+    assert.ok(body.warnings.some((warning) => warning.id === "disabled_services_present"));
+    assert.ok(body.warnings.some((warning) => warning.id === "git_dirty"));
+  } finally {
+    await rm(fixture.tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add `service-lasso readiness gate` with JSON and human output for automation-safe baseline readiness checks.
- Report baseline start possibility, required provider manifest presence, blockers/warnings, git branch/status hints, and a recommended next action.
- Document the CLI contract and add ready/blocked/partial fixture tests.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/cli-readiness-gate.test.js`
- `git diff --check`

Closes #528