### PR TITLE
ISS-530 add secret rotation readiness report

### DIFF
--- a/docs/reference/secret-reference-audit.md
+++ b/docs/reference/secret-reference-audit.md
@@ -6,6 +6,8 @@ Service Lasso exposes a read-only secret reference audit so operators and API co
 
 - GET /api/secrets/audit
 - GET /api/services/SERVICE_ID/secrets/audit
+- GET /api/secrets/rotation-readiness
+- GET /api/services/SERVICE_ID/secrets/rotation-readiness
 
 The response includes service id, manifest path, reference metadata, location, status, and aggregate counts. It never includes resolved values, raw env values, provider credentials, tokens, passwords, or private-key material.
 
@@ -21,9 +23,31 @@ Commands:
 
 - service-lasso secrets audit --json
 - service-lasso secrets audit SERVICE_ID --json
+- service-lasso secrets rotation-readiness --json
+- service-lasso secrets rotation-readiness SERVICE_ID --json
 
 Human output prints aggregate counts only. JSON output returns the same safe metadata as the API.
 
+## Rotation Readiness Report
+
+The rotation-readiness report groups secret refs and classifies the next blocker before a rotate campaign can safely proceed.
+
+Per ref, the report includes:
+
+- policy status: declared, missing, or malformed.
+- provider capability for the rotate operation: supported, unsupported, unknown, or blocked.
+- provider auth requirement: unknown or blocked in the core runtime because live provider auth state belongs to the Secrets Broker.
+- last-used manifest metadata: source sections, manifest locations, reference count, and whether any use is required.
+- machine-readable blockers such as missing_broker_policy, malformed_ref, rotation_capability_unknown, rotation_capability_not_declared, and provider_auth_requirement_unknown.
+
+Readiness statuses:
+
+- ready: policy is declared, rotate capability is supported, and no provider auth check is required.
+- needs_policy: the ref is used but is not declared in broker policy.
+- needs_capability: policy is declared but rotate capability is unsupported or unknown.
+- needs_auth_check: rotate capability is declared but the Secrets Broker must confirm live provider auth state before rotation.
+- blocked: the ref is malformed or cannot be evaluated safely.
+
 ## Scope
 
-This audit is intentionally diagnostic. It does not resolve secrets, contact a provider, create a new broker, or validate runtime authorization. Broker enforcement remains the responsibility of the Secrets Broker integration and runtime execution path.
+This audit is intentionally diagnostic. It does not resolve secrets, contact a provider, create a new broker, or validate runtime authorization. The rotation-readiness report only classifies static manifest policy and declared rotate capability. Broker enforcement and live provider auth checks remain the responsibility of the Secrets Broker integration and runtime execution path.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,7 @@ function usageText(): string {
     "  service-lasso config-snapshot export [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso config-snapshot import <snapshotPath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso secrets audit [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso secrets rotation-readiness [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup create [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup restore-plan <archivePath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso diagnostics bundle [serviceId|baseline] --preview [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -329,8 +330,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
 
   if (command === "secrets") {
     const action = remaining.shift();
-    if (action !== "audit") {
-      throw new Error('The "secrets" command requires: audit.');
+    if (action !== "audit" && action !== "rotation-readiness") {
+      throw new Error('The "secrets" command requires one of: audit, rotation-readiness.');
     }
 
     parsed.secretsAction = action;
@@ -751,6 +752,48 @@ function printConfigSnapshotResult(result: ConfigSnapshotCliResult, asJson: bool
 function printSecretsResult(result: SecretsCliResult, asJson: boolean): void {
   if (asJson) {
     console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (result.action === "rotation-readiness") {
+    console.log("[service-lasso] secret rotation readiness");
+    if ("services" in result) {
+      console.log("- services: " + result.summary.services);
+      console.log("- references: " + result.summary.references);
+      console.log("- ready: " + result.summary.ready);
+      console.log("- needsPolicy: " + result.summary.needsPolicy);
+      console.log("- needsCapability: " + result.summary.needsCapability);
+      console.log("- needsAuthCheck: " + result.summary.needsAuthCheck);
+      console.log("- blocked: " + result.summary.blocked);
+      for (const service of result.services) {
+        console.log(
+          "- " +
+            service.serviceId +
+            ": ready=" +
+            service.summary.ready +
+            " needsPolicy=" +
+            service.summary.needsPolicy +
+            " needsCapability=" +
+            service.summary.needsCapability +
+            " needsAuthCheck=" +
+            service.summary.needsAuthCheck +
+            " blocked=" +
+            service.summary.blocked,
+        );
+      }
+      return;
+    }
+
+    console.log("- service: " + result.serviceId);
+    console.log("- ready: " + result.summary.ready);
+    console.log("- needsPolicy: " + result.summary.needsPolicy);
+    console.log("- needsCapability: " + result.summary.needsCapability);
+    console.log("- needsAuthCheck: " + result.summary.needsAuthCheck);
+    console.log("- blocked: " + result.summary.blocked);
+    for (const ref of result.refs) {
+      const suffix = ref.blockers.length > 0 ? " [" + ref.blockers.join(", ") + "]" : "";
+      console.log("- " + ref.status + ": " + ref.ref + suffix);
+    }
     return;
   }
 

--- a/src/runtime/cli/secrets.ts
+++ b/src/runtime/cli/secrets.ts
@@ -3,12 +3,16 @@ import { createServiceRegistry } from "../manager/DependencyGraph.js";
 import { resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
 import {
   buildSecretReferenceAudit,
+  buildSecretRotationReadinessReport,
   buildServiceSecretReferenceAudit,
+  buildServiceSecretRotationReadinessReport,
   type SecretReferenceAudit,
+  type SecretRotationReadinessReport,
   type ServiceSecretReferenceAudit,
+  type ServiceSecretRotationReadinessReport,
 } from "../operator/secret-audit.js";
 
-export type SecretsCliAction = "audit";
+export type SecretsCliAction = "audit" | "rotation-readiness";
 
 export interface SecretsCliOptions extends RuntimeConfigOptions {
   action: SecretsCliAction;
@@ -25,6 +29,16 @@ export type SecretsCliResult =
       action: "audit";
       servicesRoot: string;
       workspaceRoot: string;
+    })
+  | (SecretRotationReadinessReport & {
+      action: "rotation-readiness";
+      servicesRoot: string;
+      workspaceRoot: string;
+    })
+  | (ServiceSecretRotationReadinessReport & {
+      action: "rotation-readiness";
+      servicesRoot: string;
+      workspaceRoot: string;
     });
 
 export async function runSecretsCliAction(options: SecretsCliOptions): Promise<SecretsCliResult> {
@@ -35,12 +49,21 @@ export async function runSecretsCliAction(options: SecretsCliOptions): Promise<S
   });
   const discovered = await discoverServices(runtimeConfig.servicesRoot);
 
-  if (!options.serviceId) {
+  if (!options.serviceId && options.action === "audit") {
     return {
       action: "audit",
       servicesRoot: runtimeConfig.servicesRoot,
       workspaceRoot: runtimeConfig.workspaceRoot,
       ...buildSecretReferenceAudit(discovered),
+    };
+  }
+
+  if (!options.serviceId) {
+    return {
+      action: "rotation-readiness",
+      servicesRoot: runtimeConfig.servicesRoot,
+      workspaceRoot: runtimeConfig.workspaceRoot,
+      ...buildSecretRotationReadinessReport(discovered),
     };
   }
 
@@ -52,10 +75,19 @@ export async function runSecretsCliAction(options: SecretsCliOptions): Promise<S
     throw new Error("Unknown service id: " + options.serviceId + "." + hint);
   }
 
+  if (options.action === "audit") {
+    return {
+      action: "audit",
+      servicesRoot: runtimeConfig.servicesRoot,
+      workspaceRoot: runtimeConfig.workspaceRoot,
+      ...buildServiceSecretReferenceAudit(service),
+    };
+  }
+
   return {
-    action: "audit",
+    action: "rotation-readiness",
     servicesRoot: runtimeConfig.servicesRoot,
     workspaceRoot: runtimeConfig.workspaceRoot,
-    ...buildServiceSecretReferenceAudit(service),
+    ...buildServiceSecretRotationReadinessReport(service),
   };
 }

--- a/src/runtime/operator/secret-audit.ts
+++ b/src/runtime/operator/secret-audit.ts
@@ -44,6 +44,61 @@ export interface SecretReferenceAudit {
   };
 }
 
+export type SecretRotationReadinessStatus = "ready" | "needs_policy" | "needs_capability" | "needs_auth_check" | "blocked";
+export type SecretRotationPolicyStatus = "declared" | "missing" | "malformed";
+export type SecretRotationCapabilityStatus = "supported" | "unsupported" | "unknown" | "blocked";
+export type SecretRotationAuthRequirementStatus = "not_required" | "required" | "unknown" | "blocked";
+
+export interface SecretRotationReadinessRef {
+  serviceId: string;
+  ref: string;
+  namespace?: string;
+  key?: string;
+  status: SecretRotationReadinessStatus;
+  policy: {
+    status: SecretRotationPolicyStatus;
+    reason: string;
+  };
+  providerCapability: {
+    operation: "rotate";
+    status: SecretRotationCapabilityStatus;
+    reason: string;
+  };
+  authRequirement: {
+    status: SecretRotationAuthRequirementStatus;
+    reason: string;
+  };
+  lastUsed: {
+    observedInManifest: boolean;
+    referenceCount: number;
+    sources: SecretReferenceAuditSource[];
+    locations: string[];
+    required: boolean;
+  };
+  blockers: string[];
+}
+
+export interface ServiceSecretRotationReadinessReport {
+  serviceId: string;
+  manifestPath: string;
+  refs: SecretRotationReadinessRef[];
+  summary: {
+    ready: number;
+    needsPolicy: number;
+    needsCapability: number;
+    needsAuthCheck: number;
+    blocked: number;
+  };
+}
+
+export interface SecretRotationReadinessReport {
+  services: ServiceSecretRotationReadinessReport[];
+  summary: ServiceSecretRotationReadinessReport["summary"] & {
+    services: number;
+    references: number;
+  };
+}
+
 interface CandidateRef {
   ref: string;
   source: SecretReferenceAuditSource;
@@ -255,6 +310,226 @@ export function buildSecretReferenceAudit(services: DiscoveredService[]): Secret
       present: serviceSummaries.reduce((total, summary) => total + summary.present, 0),
       missing: serviceSummaries.reduce((total, summary) => total + summary.missing, 0),
       malformed: serviceSummaries.reduce((total, summary) => total + summary.malformed, 0),
+    },
+  };
+}
+
+function uniqueSorted<T extends string>(values: T[]): T[] {
+  return [...new Set(values)].sort();
+}
+
+function mostSeverePolicyStatus(findings: SecretReferenceAuditFinding[]): SecretRotationPolicyStatus {
+  if (findings.some((finding) => finding.status === "malformed")) {
+    return "malformed";
+  }
+  if (findings.some((finding) => finding.status === "missing")) {
+    return "missing";
+  }
+  return "declared";
+}
+
+function hasRotationWritebackPolicy(service: DiscoveredService, ref: string, namespace?: string): boolean {
+  const writeback = service.manifest.broker?.writeback;
+  if (!writeback) {
+    return false;
+  }
+
+  if ((writeback.generatedSecrets ?? []).some((entry) => entry.ref === ref && entry.operation === "rotate")) {
+    return true;
+  }
+
+  const allowedOperations = writeback.allowedOperations ?? [];
+  if (!allowedOperations.includes("rotate")) {
+    return false;
+  }
+
+  const allowedRefs = writeback.allowedRefs ?? [];
+  if (allowedRefs.length > 0 && !allowedRefs.includes(ref)) {
+    return false;
+  }
+
+  const allowedNamespaces = writeback.allowedNamespaces ?? [];
+  if (namespace && allowedNamespaces.length > 0 && !allowedNamespaces.includes(namespace)) {
+    return false;
+  }
+
+  return true;
+}
+
+function classifyCapability(
+  service: DiscoveredService,
+  ref: string,
+  policyStatus: SecretRotationPolicyStatus,
+  namespace?: string,
+): SecretRotationReadinessRef["providerCapability"] {
+  if (policyStatus !== "declared") {
+    return {
+      operation: "rotate",
+      status: "blocked",
+      reason: "Rotation capability cannot be evaluated until the reference policy is valid.",
+    };
+  }
+
+  if (hasRotationWritebackPolicy(service, ref, namespace)) {
+    return {
+      operation: "rotate",
+      status: "supported",
+      reason: "The service manifest declares rotate writeback capability for this reference.",
+    };
+  }
+
+  if (service.manifest.broker?.writeback) {
+    return {
+      operation: "rotate",
+      status: "unsupported",
+      reason: "The service manifest has broker writeback policy but does not allow rotate for this reference.",
+    };
+  }
+
+  return {
+    operation: "rotate",
+    status: "unknown",
+    reason: "No provider rotation capability is declared in the service manifest.",
+  };
+}
+
+function classifyAuthRequirement(
+  policyStatus: SecretRotationPolicyStatus,
+  capabilityStatus: SecretRotationCapabilityStatus,
+): SecretRotationReadinessRef["authRequirement"] {
+  if (policyStatus !== "declared" || capabilityStatus === "blocked") {
+    return {
+      status: "blocked",
+      reason: "Provider auth requirement cannot be evaluated until policy and capability blockers are cleared.",
+    };
+  }
+
+  if (capabilityStatus === "supported") {
+    return {
+      status: "unknown",
+      reason: "Core manifests do not carry live provider auth state; the Secrets Broker must confirm reconnect requirements before rotation.",
+    };
+  }
+
+  return {
+    status: "unknown",
+    reason: "Provider auth requirement is unknown because rotation capability is not declared.",
+  };
+}
+
+function toRotationReadinessRef(
+  service: DiscoveredService,
+  ref: string,
+  findings: SecretReferenceAuditFinding[],
+): SecretRotationReadinessRef {
+  const parsed = parseBrokerRef(ref);
+  const policyStatus = mostSeverePolicyStatus(findings);
+  const capability = classifyCapability(service, ref, policyStatus, parsed?.namespace);
+  const authRequirement = classifyAuthRequirement(policyStatus, capability.status);
+  const blockers: string[] = [];
+
+  if (policyStatus === "malformed") {
+    blockers.push("malformed_ref");
+  }
+  if (policyStatus === "missing") {
+    blockers.push("missing_broker_policy");
+  }
+  if (capability.status === "unsupported") {
+    blockers.push("rotation_capability_not_declared");
+  }
+  if (capability.status === "unknown") {
+    blockers.push("rotation_capability_unknown");
+  }
+  if (capability.status === "supported" && authRequirement.status === "unknown") {
+    blockers.push("provider_auth_requirement_unknown");
+  }
+
+  const status: SecretRotationReadinessStatus =
+    policyStatus === "malformed"
+      ? "blocked"
+      : policyStatus === "missing"
+        ? "needs_policy"
+        : capability.status === "supported" && authRequirement.status === "not_required"
+          ? "ready"
+          : capability.status === "supported"
+            ? "needs_auth_check"
+            : "needs_capability";
+
+  return {
+    serviceId: service.manifest.id,
+    ref,
+    namespace: parsed?.namespace,
+    key: parsed?.key,
+    status,
+    policy: {
+      status: policyStatus,
+      reason:
+        policyStatus === "declared"
+          ? "Reference is declared in broker policy."
+          : policyStatus === "missing"
+            ? "Reference is used but not declared in broker policy."
+            : "Reference is not in supported namespace.key form.",
+    },
+    providerCapability: capability,
+    authRequirement,
+    lastUsed: {
+      observedInManifest: findings.length > 0,
+      referenceCount: findings.length,
+      sources: uniqueSorted(findings.map((finding) => finding.source)),
+      locations: uniqueSorted(findings.map((finding) => finding.location)),
+      required: findings.some((finding) => finding.required !== false),
+    },
+    blockers,
+  };
+}
+
+function summarizeRotationReadiness(refs: SecretRotationReadinessRef[]): ServiceSecretRotationReadinessReport["summary"] {
+  return {
+    ready: refs.filter((ref) => ref.status === "ready").length,
+    needsPolicy: refs.filter((ref) => ref.status === "needs_policy").length,
+    needsCapability: refs.filter((ref) => ref.status === "needs_capability").length,
+    needsAuthCheck: refs.filter((ref) => ref.status === "needs_auth_check").length,
+    blocked: refs.filter((ref) => ref.status === "blocked").length,
+  };
+}
+
+export function buildServiceSecretRotationReadinessReport(service: DiscoveredService): ServiceSecretRotationReadinessReport {
+  const audit = buildServiceSecretReferenceAudit(service);
+  const findingsByRef = new Map<string, SecretReferenceAuditFinding[]>();
+
+  for (const finding of audit.findings) {
+    findingsByRef.set(finding.ref, [...(findingsByRef.get(finding.ref) ?? []), finding]);
+  }
+
+  const refs = [...findingsByRef.entries()]
+    .map(([ref, findings]) => toRotationReadinessRef(service, ref, findings))
+    .sort((left, right) =>
+      left.status.localeCompare(right.status) ||
+      left.ref.localeCompare(right.ref),
+    );
+
+  return {
+    serviceId: service.manifest.id,
+    manifestPath: service.manifestPath,
+    refs,
+    summary: summarizeRotationReadiness(refs),
+  };
+}
+
+export function buildSecretRotationReadinessReport(services: DiscoveredService[]): SecretRotationReadinessReport {
+  const serviceReports = services.map((service) => buildServiceSecretRotationReadinessReport(service));
+  const summaries = serviceReports.map((service) => service.summary);
+
+  return {
+    services: serviceReports,
+    summary: {
+      services: serviceReports.length,
+      references: serviceReports.reduce((total, service) => total + service.refs.length, 0),
+      ready: summaries.reduce((total, summary) => total + summary.ready, 0),
+      needsPolicy: summaries.reduce((total, summary) => total + summary.needsPolicy, 0),
+      needsCapability: summaries.reduce((total, summary) => total + summary.needsCapability, 0),
+      needsAuthCheck: summaries.reduce((total, summary) => total + summary.needsAuthCheck, 0),
+      blocked: summaries.reduce((total, summary) => total + summary.blocked, 0),
     },
   };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,7 +59,9 @@ import { buildServiceCompatibilityReport } from "../runtime/operator/catalog-com
 import { buildServiceConfigDriftReport } from "../runtime/operator/config-drift.js";
 import {
   buildSecretReferenceAudit,
+  buildSecretRotationReadinessReport,
   buildServiceSecretReferenceAudit,
+  buildServiceSecretRotationReadinessReport,
 } from "../runtime/operator/secret-audit.js";
 import {
   mutateOperatorActionItem,
@@ -1304,6 +1306,11 @@ async function routeRequest(
       return;
     }
 
+    if (request.method === "GET" && pathParts.length === 5 && pathParts[3] === "secrets" && pathParts[4] === "rotation-readiness") {
+      writeJson(response, 200, buildServiceSecretRotationReadinessReport(service));
+      return;
+    }
+
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "updates") {
       writeJson(response, 200, {
         serviceId,
@@ -1559,6 +1566,12 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/secrets/audit") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, buildSecretReferenceAudit(runtimeModel.discovered));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/secrets/rotation-readiness") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, buildSecretRotationReadinessReport(runtimeModel.discovered));
     return;
   }
 

--- a/tests/secret-reference-audit.test.js
+++ b/tests/secret-reference-audit.test.js
@@ -51,6 +51,50 @@ async function writeSecretAuditFixture(servicesRoot) {
   });
 }
 
+async function writeRotationReadinessFixture(servicesRoot) {
+  await writeSecretAuditFixture(servicesRoot);
+  await writeManifest(servicesRoot, "rotation-consumer", {
+    id: "rotation-consumer",
+    name: "Rotation Consumer",
+    description: "Service with a declared rotate-capable secret reference.",
+    env: {
+      ROTATE_TOKEN: "\${secretsbroker.ROTATE_TOKEN}",
+      RAW_SENTINEL: rawSecretSentinel,
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "secretsbroker",
+          ref: "secretsbroker.ROTATE_TOKEN",
+          as: "ROTATE_TOKEN",
+          required: true,
+        },
+      ],
+      exports: [
+        {
+          namespace: "secretsbroker",
+          ref: "secretsbroker.ROTATE_TOKEN",
+          source: "env.ROTATE_TOKEN",
+          required: true,
+        },
+      ],
+      writeback: {
+        allowedNamespaces: ["secretsbroker"],
+        allowedOperations: ["rotate"],
+        allowedRefs: ["secretsbroker.ROTATE_TOKEN"],
+        generatedSecrets: [
+          {
+            ref: "secretsbroker.ROTATE_TOKEN",
+            source: "env.ROTATE_TOKEN",
+            operation: "rotate",
+            required: true,
+          },
+        ],
+      },
+    },
+  });
+}
+
 test("secret reference audit reports declared missing and malformed refs without raw values", async () => {
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-audit-");
   await writeSecretAuditFixture(servicesRoot);
@@ -74,6 +118,46 @@ test("secret reference audit reports declared missing and malformed refs without
     assert.equal(serviceResult.status, 200);
     assert.equal(serviceResult.body.serviceId, "audit-consumer");
     assert.deepEqual(serviceResult.body.summary, result.body.services[0].summary);
+    assertNoSecretMaterial(serviceResult.body);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("secret rotation readiness classifies policy capability and auth states without raw values", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-rotation-readiness-");
+  await writeRotationReadinessFixture(servicesRoot);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/secrets/rotation-readiness");
+    assert.equal(result.status, 200);
+    assert.equal(result.body.summary.services, 2);
+    assert.equal(result.body.summary.needsPolicy, 1);
+    assert.equal(result.body.summary.needsCapability, 1);
+    assert.equal(result.body.summary.needsAuthCheck, 1);
+    assert.equal(result.body.summary.blocked, 1);
+    assertNoSecretMaterial(result.body);
+
+    const auditConsumer = result.body.services.find((service) => service.serviceId === "audit-consumer");
+    assert.ok(auditConsumer.refs.some((ref) => ref.ref === "secretsbroker.API_TOKEN" && ref.status === "needs_capability"));
+    assert.ok(auditConsumer.refs.some((ref) => ref.ref === "secretsbroker.DB_PASSWORD" && ref.status === "needs_policy"));
+    assert.ok(auditConsumer.refs.some((ref) => ref.ref === "LOCAL_SECRET_TOKEN" && ref.status === "blocked"));
+
+    const rotationConsumer = result.body.services.find((service) => service.serviceId === "rotation-consumer");
+    const rotateRef = rotationConsumer.refs.find((ref) => ref.ref === "secretsbroker.ROTATE_TOKEN");
+    assert.equal(rotateRef.status, "needs_auth_check");
+    assert.equal(rotateRef.policy.status, "declared");
+    assert.equal(rotateRef.providerCapability.status, "supported");
+    assert.equal(rotateRef.authRequirement.status, "unknown");
+    assert.deepEqual(rotateRef.blockers, ["provider_auth_requirement_unknown"]);
+    assert.ok(rotateRef.lastUsed.locations.includes("broker.writeback.generatedSecrets[0].ref"));
+
+    const serviceResult = await getJson(apiServer.url + "/api/services/rotation-consumer/secrets/rotation-readiness");
+    assert.equal(serviceResult.status, 200);
+    assert.equal(serviceResult.body.serviceId, "rotation-consumer");
+    assert.equal(serviceResult.body.summary.needsAuthCheck, 1);
     assertNoSecretMaterial(serviceResult.body);
   } finally {
     await apiServer.stop();
@@ -113,6 +197,43 @@ test("CLI secrets audit returns the same safe reference metadata", async () => {
     assert.equal(result.summary.present, 3);
     assert.equal(result.summary.missing, 1);
     assert.equal(result.summary.malformed, 1);
+    assertNoSecretMaterial(result);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI secrets rotation-readiness returns the same safe classification metadata", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-secret-rotation-cli-");
+  await writeRotationReadinessFixture(servicesRoot);
+
+  try {
+    const stdout = await execFile(
+      process.execPath,
+      [
+        path.resolve("dist", "cli.js"),
+        "secrets",
+        "rotation-readiness",
+        "rotation-consumer",
+        "--services-root",
+        servicesRoot,
+        "--workspace-root",
+        workspaceRoot,
+        "--json",
+      ],
+      {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          npm_package_version: "0.1.0-test",
+        },
+      },
+    );
+    const result = JSON.parse(stdout.stdout);
+    assert.equal(result.action, "rotation-readiness");
+    assert.equal(result.serviceId, "rotation-consumer");
+    assert.equal(result.summary.needsAuthCheck, 1);
+    assert.equal(result.refs[0].providerCapability.status, "supported");
     assertNoSecretMaterial(result);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add read-only secret rotation readiness reports for all services and per service
- expose `GET /api/secrets/rotation-readiness`, `GET /api/services/:serviceId/secrets/rotation-readiness`, and `service-lasso secrets rotation-readiness [serviceId] --json`
- classify policy, rotate capability, provider auth-check requirements, last-used manifest metadata, and machine-readable blockers without exposing secret values

## Validation
- PASS `npm run build`
- PASS `node --test --test-concurrency=1 tests/secret-reference-audit.test.js`
- PASS `git diff --check`
- PASS `npm run docs:build`

Issue: #530