### PR TITLE
ISS-531 add provider auth-required summary

### DIFF
--- a/docs/reference/secret-reference-audit.md
+++ b/docs/reference/secret-reference-audit.md
@@ -8,6 +8,8 @@ Service Lasso exposes a read-only secret reference audit so operators and API co
 - GET /api/services/SERVICE_ID/secrets/audit
 - GET /api/secrets/rotation-readiness
 - GET /api/services/SERVICE_ID/secrets/rotation-readiness
+- GET /api/secrets/provider-auth-required
+- GET /api/services/SERVICE_ID/secrets/provider-auth-required
 
 The response includes service id, manifest path, reference metadata, location, status, and aggregate counts. It never includes resolved values, raw env values, provider credentials, tokens, passwords, or private-key material.
 
@@ -25,6 +27,8 @@ Commands:
 - service-lasso secrets audit SERVICE_ID --json
 - service-lasso secrets rotation-readiness --json
 - service-lasso secrets rotation-readiness SERVICE_ID --json
+- service-lasso secrets provider-auth-required --json
+- service-lasso secrets provider-auth-required SERVICE_ID --json
 
 Human output prints aggregate counts only. JSON output returns the same safe metadata as the API.
 
@@ -47,6 +51,17 @@ Readiness statuses:
 - needs_capability: policy is declared but rotate capability is unsupported or unknown.
 - needs_auth_check: rotate capability is declared but the Secrets Broker must confirm live provider auth state before rotation.
 - blocked: the ref is malformed or cannot be evaluated safely.
+
+## Provider Auth-Required Summary
+
+The provider-auth-required summary is a narrow operator view for reconnect planning before rotation or migration workflows. It reports safe metadata only:
+
+- service id, ref, namespace/key, provider name, and manifest locations.
+- per-ref status: auth_required, not_required, or blocked.
+- provider aggregates for refs that need broker auth/reconnect confirmation.
+- counts for affected services, providers, references, auth-required refs, not-required refs, and blocked refs.
+
+Core does not return provider credentials, raw secret values, OAuth tokens, provider response bodies, cookies, private keys, passwords, or raw env values. An `auth_required` status means the Secrets Broker must confirm provider reconnect/auth state before the ref is used by rotate or migration workflows; it is not a raw secret reveal path.
 
 ## Scope
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ function usageText(): string {
     "  service-lasso config-snapshot import <snapshotPath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso secrets audit [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso secrets rotation-readiness [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
+    "  service-lasso secrets provider-auth-required [serviceId] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup create [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso backup restore-plan <archivePath> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso diagnostics bundle [serviceId|baseline] --preview [--services-root <path>] [--workspace-root <path>] [--json]",
@@ -330,8 +331,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
 
   if (command === "secrets") {
     const action = remaining.shift();
-    if (action !== "audit" && action !== "rotation-readiness") {
-      throw new Error('The "secrets" command requires one of: audit, rotation-readiness.');
+    if (action !== "audit" && action !== "rotation-readiness" && action !== "provider-auth-required") {
+      throw new Error('The "secrets" command requires one of: audit, rotation-readiness, provider-auth-required.');
     }
 
     parsed.secretsAction = action;
@@ -789,6 +790,39 @@ function printSecretsResult(result: SecretsCliResult, asJson: boolean): void {
     console.log("- needsPolicy: " + result.summary.needsPolicy);
     console.log("- needsCapability: " + result.summary.needsCapability);
     console.log("- needsAuthCheck: " + result.summary.needsAuthCheck);
+    console.log("- blocked: " + result.summary.blocked);
+    for (const ref of result.refs) {
+      const suffix = ref.blockers.length > 0 ? " [" + ref.blockers.join(", ") + "]" : "";
+      console.log("- " + ref.status + ": " + ref.ref + suffix);
+    }
+    return;
+  }
+
+  if (result.action === "provider-auth-required") {
+    console.log("[service-lasso] secret provider auth-required summary");
+    if ("services" in result) {
+      console.log("- services: " + result.summary.services);
+      console.log("- providers: " + result.summary.providers);
+      console.log("- references: " + result.summary.references);
+      console.log("- authRequired: " + result.summary.authRequired);
+      console.log("- notRequired: " + result.summary.notRequired);
+      console.log("- blocked: " + result.summary.blocked);
+      for (const provider of result.providers) {
+        console.log(
+          "- provider " +
+            provider.provider +
+            ": authRequiredRefs=" +
+            provider.authRequiredRefs +
+            " services=" +
+            provider.services.join(", "),
+        );
+      }
+      return;
+    }
+
+    console.log("- service: " + result.serviceId);
+    console.log("- authRequired: " + result.summary.authRequired);
+    console.log("- notRequired: " + result.summary.notRequired);
     console.log("- blocked: " + result.summary.blocked);
     for (const ref of result.refs) {
       const suffix = ref.blockers.length > 0 ? " [" + ref.blockers.join(", ") + "]" : "";

--- a/src/runtime/cli/secrets.ts
+++ b/src/runtime/cli/secrets.ts
@@ -2,17 +2,21 @@ import { discoverServices } from "../discovery/discoverServices.js";
 import { createServiceRegistry } from "../manager/DependencyGraph.js";
 import { resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
 import {
+  buildSecretProviderAuthRequiredSummary,
   buildSecretReferenceAudit,
   buildSecretRotationReadinessReport,
+  buildServiceSecretProviderAuthRequiredSummary,
   buildServiceSecretReferenceAudit,
   buildServiceSecretRotationReadinessReport,
+  type SecretProviderAuthRequiredSummary,
   type SecretReferenceAudit,
   type SecretRotationReadinessReport,
+  type ServiceSecretProviderAuthRequiredSummary,
   type ServiceSecretReferenceAudit,
   type ServiceSecretRotationReadinessReport,
 } from "../operator/secret-audit.js";
 
-export type SecretsCliAction = "audit" | "rotation-readiness";
+export type SecretsCliAction = "audit" | "rotation-readiness" | "provider-auth-required";
 
 export interface SecretsCliOptions extends RuntimeConfigOptions {
   action: SecretsCliAction;
@@ -39,6 +43,16 @@ export type SecretsCliResult =
       action: "rotation-readiness";
       servicesRoot: string;
       workspaceRoot: string;
+    })
+  | (SecretProviderAuthRequiredSummary & {
+      action: "provider-auth-required";
+      servicesRoot: string;
+      workspaceRoot: string;
+    })
+  | (ServiceSecretProviderAuthRequiredSummary & {
+      action: "provider-auth-required";
+      servicesRoot: string;
+      workspaceRoot: string;
     });
 
 export async function runSecretsCliAction(options: SecretsCliOptions): Promise<SecretsCliResult> {
@@ -58,12 +72,21 @@ export async function runSecretsCliAction(options: SecretsCliOptions): Promise<S
     };
   }
 
-  if (!options.serviceId) {
+  if (!options.serviceId && options.action === "rotation-readiness") {
     return {
       action: "rotation-readiness",
       servicesRoot: runtimeConfig.servicesRoot,
       workspaceRoot: runtimeConfig.workspaceRoot,
       ...buildSecretRotationReadinessReport(discovered),
+    };
+  }
+
+  if (!options.serviceId) {
+    return {
+      action: "provider-auth-required",
+      servicesRoot: runtimeConfig.servicesRoot,
+      workspaceRoot: runtimeConfig.workspaceRoot,
+      ...buildSecretProviderAuthRequiredSummary(discovered),
     };
   }
 
@@ -84,10 +107,19 @@ export async function runSecretsCliAction(options: SecretsCliOptions): Promise<S
     };
   }
 
+  if (options.action === "rotation-readiness") {
+    return {
+      action: "rotation-readiness",
+      servicesRoot: runtimeConfig.servicesRoot,
+      workspaceRoot: runtimeConfig.workspaceRoot,
+      ...buildServiceSecretRotationReadinessReport(service),
+    };
+  }
+
   return {
-    action: "rotation-readiness",
+    action: "provider-auth-required",
     servicesRoot: runtimeConfig.servicesRoot,
     workspaceRoot: runtimeConfig.workspaceRoot,
-    ...buildServiceSecretRotationReadinessReport(service),
+    ...buildServiceSecretProviderAuthRequiredSummary(service),
   };
 }

--- a/src/runtime/operator/secret-audit.ts
+++ b/src/runtime/operator/secret-audit.ts
@@ -99,6 +99,50 @@ export interface SecretRotationReadinessReport {
   };
 }
 
+export type SecretProviderAuthRequiredStatus = "auth_required" | "not_required" | "blocked";
+
+export interface SecretProviderAuthRequiredRef {
+  serviceId: string;
+  ref: string;
+  namespace?: string;
+  key?: string;
+  provider: string;
+  status: SecretProviderAuthRequiredStatus;
+  required: boolean;
+  reason: string;
+  sources: SecretReferenceAuditSource[];
+  locations: string[];
+  blockers: string[];
+}
+
+export interface SecretProviderAuthRequiredProviderSummary {
+  provider: string;
+  authRequiredRefs: number;
+  services: string[];
+  refs: string[];
+}
+
+export interface ServiceSecretProviderAuthRequiredSummary {
+  serviceId: string;
+  manifestPath: string;
+  refs: SecretProviderAuthRequiredRef[];
+  summary: {
+    authRequired: number;
+    notRequired: number;
+    blocked: number;
+  };
+}
+
+export interface SecretProviderAuthRequiredSummary {
+  services: ServiceSecretProviderAuthRequiredSummary[];
+  providers: SecretProviderAuthRequiredProviderSummary[];
+  summary: ServiceSecretProviderAuthRequiredSummary["summary"] & {
+    services: number;
+    providers: number;
+    references: number;
+  };
+}
+
 interface CandidateRef {
   ref: string;
   source: SecretReferenceAuditSource;
@@ -529,6 +573,137 @@ export function buildSecretRotationReadinessReport(services: DiscoveredService[]
       needsPolicy: summaries.reduce((total, summary) => total + summary.needsPolicy, 0),
       needsCapability: summaries.reduce((total, summary) => total + summary.needsCapability, 0),
       needsAuthCheck: summaries.reduce((total, summary) => total + summary.needsAuthCheck, 0),
+      blocked: summaries.reduce((total, summary) => total + summary.blocked, 0),
+    },
+  };
+}
+
+function providerFromRef(ref: SecretRotationReadinessRef): string {
+  if (ref.namespace) {
+    return ref.namespace;
+  }
+  const dotIndex = ref.ref.indexOf(".");
+  return dotIndex > 0 ? ref.ref.slice(0, dotIndex) : "unknown";
+}
+
+function toProviderAuthRequiredRef(ref: SecretRotationReadinessRef): SecretProviderAuthRequiredRef {
+  if (ref.policy.status !== "declared" || ref.providerCapability.status === "blocked") {
+    return {
+      serviceId: ref.serviceId,
+      ref: ref.ref,
+      namespace: ref.namespace,
+      key: ref.key,
+      provider: providerFromRef(ref),
+      status: "blocked",
+      required: ref.lastUsed.required,
+      reason: "Provider auth state cannot be evaluated until broker policy and capability blockers are cleared.",
+      sources: ref.lastUsed.sources,
+      locations: ref.lastUsed.locations,
+      blockers: ref.blockers,
+    };
+  }
+
+  if (ref.providerCapability.status === "supported" && ref.authRequirement.status === "unknown") {
+    return {
+      serviceId: ref.serviceId,
+      ref: ref.ref,
+      namespace: ref.namespace,
+      key: ref.key,
+      provider: providerFromRef(ref),
+      status: "auth_required",
+      required: ref.lastUsed.required,
+      reason: "The Secrets Broker must confirm provider reconnect/auth state before rotate or migration workflows use this ref.",
+      sources: ref.lastUsed.sources,
+      locations: ref.lastUsed.locations,
+      blockers: ["provider_auth_required"],
+    };
+  }
+
+  return {
+    serviceId: ref.serviceId,
+    ref: ref.ref,
+    namespace: ref.namespace,
+    key: ref.key,
+    provider: providerFromRef(ref),
+    status: "not_required",
+    required: ref.lastUsed.required,
+    reason: "No provider auth-required state is surfaced for this ref by the current manifest contract.",
+    sources: ref.lastUsed.sources,
+    locations: ref.lastUsed.locations,
+    blockers: [],
+  };
+}
+
+function summarizeProviderAuthRequiredRefs(
+  refs: SecretProviderAuthRequiredRef[],
+): ServiceSecretProviderAuthRequiredSummary["summary"] {
+  return {
+    authRequired: refs.filter((ref) => ref.status === "auth_required").length,
+    notRequired: refs.filter((ref) => ref.status === "not_required").length,
+    blocked: refs.filter((ref) => ref.status === "blocked").length,
+  };
+}
+
+export function buildServiceSecretProviderAuthRequiredSummary(
+  service: DiscoveredService,
+): ServiceSecretProviderAuthRequiredSummary {
+  const readiness = buildServiceSecretRotationReadinessReport(service);
+  const refs = readiness.refs
+    .map(toProviderAuthRequiredRef)
+    .sort((left, right) =>
+      left.status.localeCompare(right.status) ||
+      left.provider.localeCompare(right.provider) ||
+      left.ref.localeCompare(right.ref),
+    );
+
+  return {
+    serviceId: service.manifest.id,
+    manifestPath: service.manifestPath,
+    refs,
+    summary: summarizeProviderAuthRequiredRefs(refs),
+  };
+}
+
+function summarizeProviders(services: ServiceSecretProviderAuthRequiredSummary[]): SecretProviderAuthRequiredProviderSummary[] {
+  const byProvider = new Map<string, { services: Set<string>; refs: Set<string>; count: number }>();
+
+  for (const service of services) {
+    for (const ref of service.refs) {
+      if (ref.status !== "auth_required") {
+        continue;
+      }
+      const entry = byProvider.get(ref.provider) ?? { services: new Set<string>(), refs: new Set<string>(), count: 0 };
+      entry.services.add(service.serviceId);
+      entry.refs.add(ref.ref);
+      entry.count += 1;
+      byProvider.set(ref.provider, entry);
+    }
+  }
+
+  return [...byProvider.entries()]
+    .map(([provider, entry]) => ({
+      provider,
+      authRequiredRefs: entry.count,
+      services: [...entry.services].sort(),
+      refs: [...entry.refs].sort(),
+    }))
+    .sort((left, right) => left.provider.localeCompare(right.provider));
+}
+
+export function buildSecretProviderAuthRequiredSummary(services: DiscoveredService[]): SecretProviderAuthRequiredSummary {
+  const serviceSummaries = services.map((service) => buildServiceSecretProviderAuthRequiredSummary(service));
+  const summaries = serviceSummaries.map((service) => service.summary);
+  const providers = summarizeProviders(serviceSummaries);
+
+  return {
+    services: serviceSummaries,
+    providers,
+    summary: {
+      services: serviceSummaries.length,
+      providers: providers.length,
+      references: serviceSummaries.reduce((total, service) => total + service.refs.length, 0),
+      authRequired: summaries.reduce((total, summary) => total + summary.authRequired, 0),
+      notRequired: summaries.reduce((total, summary) => total + summary.notRequired, 0),
       blocked: summaries.reduce((total, summary) => total + summary.blocked, 0),
     },
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,8 +58,10 @@ import { buildRestartSafetyPreflightReport } from "../runtime/operator/restart-s
 import { buildServiceCompatibilityReport } from "../runtime/operator/catalog-compatibility.js";
 import { buildServiceConfigDriftReport } from "../runtime/operator/config-drift.js";
 import {
+  buildSecretProviderAuthRequiredSummary,
   buildSecretReferenceAudit,
   buildSecretRotationReadinessReport,
+  buildServiceSecretProviderAuthRequiredSummary,
   buildServiceSecretReferenceAudit,
   buildServiceSecretRotationReadinessReport,
 } from "../runtime/operator/secret-audit.js";
@@ -1311,6 +1313,11 @@ async function routeRequest(
       return;
     }
 
+    if (request.method === "GET" && pathParts.length === 5 && pathParts[3] === "secrets" && pathParts[4] === "provider-auth-required") {
+      writeJson(response, 200, buildServiceSecretProviderAuthRequiredSummary(service));
+      return;
+    }
+
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "updates") {
       writeJson(response, 200, {
         serviceId,
@@ -1572,6 +1579,12 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/secrets/rotation-readiness") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, buildSecretRotationReadinessReport(runtimeModel.discovered));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/secrets/provider-auth-required") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, buildSecretProviderAuthRequiredSummary(runtimeModel.discovered));
     return;
   }
 

--- a/tests/secret-reference-audit.test.js
+++ b/tests/secret-reference-audit.test.js
@@ -95,6 +95,71 @@ async function writeRotationReadinessFixture(servicesRoot) {
   });
 }
 
+async function writeProviderAuthNotRequiredFixture(servicesRoot) {
+  await writeManifest(servicesRoot, "no-auth-consumer", {
+    id: "no-auth-consumer",
+    name: "No Auth Consumer",
+    description: "Service with a declared broker ref and no rotate-capable writeback.",
+    env: {
+      API_TOKEN: "\${secretsbroker.API_TOKEN}",
+      RAW_SENTINEL: rawSecretSentinel,
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "secretsbroker",
+          ref: "secretsbroker.API_TOKEN",
+          as: "API_TOKEN",
+          required: true,
+        },
+      ],
+    },
+  });
+}
+
+async function writeProviderAuthRequiredFixture(servicesRoot) {
+  await writeManifest(servicesRoot, "auth-required-consumer", {
+    id: "auth-required-consumer",
+    name: "Auth Required Consumer",
+    description: "Service with a rotate-capable ref that needs broker auth confirmation.",
+    env: {
+      ROTATE_TOKEN: "\${secretsbroker.ROTATE_TOKEN}",
+      RAW_SENTINEL: rawSecretSentinel,
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "secretsbroker",
+          ref: "secretsbroker.ROTATE_TOKEN",
+          as: "ROTATE_TOKEN",
+          required: true,
+        },
+      ],
+      exports: [
+        {
+          namespace: "secretsbroker",
+          ref: "secretsbroker.ROTATE_TOKEN",
+          source: "env.ROTATE_TOKEN",
+          required: true,
+        },
+      ],
+      writeback: {
+        allowedNamespaces: ["secretsbroker"],
+        allowedOperations: ["rotate"],
+        allowedRefs: ["secretsbroker.ROTATE_TOKEN"],
+        generatedSecrets: [
+          {
+            ref: "secretsbroker.ROTATE_TOKEN",
+            source: "env.ROTATE_TOKEN",
+            operation: "rotate",
+            required: true,
+          },
+        ],
+      },
+    },
+  });
+}
+
 test("secret reference audit reports declared missing and malformed refs without raw values", async () => {
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-audit-");
   await writeSecretAuditFixture(servicesRoot);
@@ -159,6 +224,93 @@ test("secret rotation readiness classifies policy capability and auth states wit
     assert.equal(serviceResult.body.serviceId, "rotation-consumer");
     assert.equal(serviceResult.body.summary.needsAuthCheck, 1);
     assertNoSecretMaterial(serviceResult.body);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider auth-required summary reports no auth-required refs without raw values", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-auth-none-");
+  await writeProviderAuthNotRequiredFixture(servicesRoot);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/secrets/provider-auth-required");
+    assert.equal(result.status, 200);
+    assert.equal(result.body.summary.services, 1);
+    assert.equal(result.body.summary.references, 1);
+    assert.equal(result.body.summary.authRequired, 0);
+    assert.equal(result.body.summary.notRequired, 1);
+    assert.equal(result.body.summary.blocked, 0);
+    assert.deepEqual(result.body.providers, []);
+    assertNoSecretMaterial(result.body);
+
+    const serviceResult = await getJson(apiServer.url + "/api/services/no-auth-consumer/secrets/provider-auth-required");
+    assert.equal(serviceResult.status, 200);
+    assert.equal(serviceResult.body.serviceId, "no-auth-consumer");
+    assert.equal(serviceResult.body.refs[0].ref, "secretsbroker.API_TOKEN");
+    assert.equal(serviceResult.body.refs[0].status, "not_required");
+    assertNoSecretMaterial(serviceResult.body);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider auth-required summary identifies provider refs that need broker auth confirmation", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-auth-required-");
+  await writeProviderAuthRequiredFixture(servicesRoot);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/secrets/provider-auth-required");
+    assert.equal(result.status, 200);
+    assert.equal(result.body.summary.authRequired, 1);
+    assert.equal(result.body.summary.notRequired, 0);
+    assert.equal(result.body.summary.blocked, 0);
+    assert.deepEqual(result.body.providers, [
+      {
+        provider: "secretsbroker",
+        authRequiredRefs: 1,
+        services: ["auth-required-consumer"],
+        refs: ["secretsbroker.ROTATE_TOKEN"],
+      },
+    ]);
+    assertNoSecretMaterial(result.body);
+
+    const serviceResult = await getJson(apiServer.url + "/api/services/auth-required-consumer/secrets/provider-auth-required");
+    assert.equal(serviceResult.status, 200);
+    assert.equal(serviceResult.body.refs[0].status, "auth_required");
+    assert.deepEqual(serviceResult.body.refs[0].blockers, ["provider_auth_required"]);
+    assertNoSecretMaterial(serviceResult.body);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("provider auth-required summary handles mixed provider states", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-auth-mixed-");
+  await writeProviderAuthNotRequiredFixture(servicesRoot);
+  await writeProviderAuthRequiredFixture(servicesRoot);
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/secrets/provider-auth-required");
+    assert.equal(result.status, 200);
+    assert.equal(result.body.summary.services, 2);
+    assert.equal(result.body.summary.references, 2);
+    assert.equal(result.body.summary.authRequired, 1);
+    assert.equal(result.body.summary.notRequired, 1);
+    assert.equal(result.body.summary.blocked, 0);
+
+    const byService = Object.fromEntries(result.body.services.map((service) => [service.serviceId, service]));
+    assert.equal(byService["no-auth-consumer"].summary.notRequired, 1);
+    assert.equal(byService["auth-required-consumer"].summary.authRequired, 1);
+    assert.equal(result.body.providers[0].provider, "secretsbroker");
+    assert.equal(result.body.providers[0].authRequiredRefs, 1);
+    assertNoSecretMaterial(result.body);
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });
@@ -234,6 +386,43 @@ test("CLI secrets rotation-readiness returns the same safe classification metada
     assert.equal(result.serviceId, "rotation-consumer");
     assert.equal(result.summary.needsAuthCheck, 1);
     assert.equal(result.refs[0].providerCapability.status, "supported");
+    assertNoSecretMaterial(result);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI secrets provider-auth-required returns the same safe summary metadata", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-secret-auth-cli-");
+  await writeProviderAuthRequiredFixture(servicesRoot);
+
+  try {
+    const stdout = await execFile(
+      process.execPath,
+      [
+        path.resolve("dist", "cli.js"),
+        "secrets",
+        "provider-auth-required",
+        "auth-required-consumer",
+        "--services-root",
+        servicesRoot,
+        "--workspace-root",
+        workspaceRoot,
+        "--json",
+      ],
+      {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          npm_package_version: "0.1.0-test",
+        },
+      },
+    );
+    const result = JSON.parse(stdout.stdout);
+    assert.equal(result.action, "provider-auth-required");
+    assert.equal(result.serviceId, "auth-required-consumer");
+    assert.equal(result.summary.authRequired, 1);
+    assert.equal(result.refs[0].status, "auth_required");
     assertNoSecretMaterial(result);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary\n- Add safe provider auth-required summary builders for secret refs.\n- Expose global and per-service API endpoints: /api/secrets/provider-auth-required and /api/services/{serviceId}/secrets/provider-auth-required.\n- Add matching CLI command: service-lasso secrets provider-auth-required [serviceId] --json.\n- Document the safe response contract and add API/CLI tests for no-auth, auth-required, and mixed states.\n\n## Validation\n- npm run build\n- node --test --test-concurrency=1 tests/secret-reference-audit.test.js\n- git diff --check\n\nCloses #531