### PR TITLE
ISS-532 add runtime instance lease heartbeat

### DIFF
--- a/docs/reference/runtime-instance-registry.md
+++ b/docs/reference/runtime-instance-registry.md
@@ -12,10 +12,17 @@ The current instance includes:
 - pid: API process id.
 - apiPort, apiUrl, and advertisedUrls.
 - servicesRoot and workspaceRoot.
-- startedAt and updatedAt.
-- status: active or stale.
+- startedAt, updatedAt, heartbeatAt, leaseExpiresAt, and leaseTtlMs.
+- status: active, stale, or unknown.
+- statusReason / staleReason when the runtime can classify why a record is not active.
 
-The registry includes active and stale recent entries from the local host registry file. Stale entries are retained for troubleshooting instead of being trusted as live runtimes.
+The registry includes active, stale, and unknown recent entries from the local host registry file. A running API process refreshes its lease heartbeat while it is serving requests. Records are classified as:
+
+- active: the process exists and its lease has not expired.
+- stale: the process is explicitly stopped or no longer exists.
+- unknown: the process id exists, but the lease expired or cannot be trusted.
+
+Stale and unknown entries are retained for troubleshooting instead of being trusted as live runtimes.
 
 ## CLI
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1036,6 +1036,7 @@ function printInstanceResult(result: RuntimeInstanceResponse, asJson: boolean): 
   console.log("- registry: " + result.registry.path);
   console.log("- active: " + result.registry.activeCount);
   console.log("- stale: " + result.registry.staleCount);
+  console.log("- unknown: " + result.registry.unknownCount);
 }
 
 function printReadinessGateResult(result: ReadinessGateCliResult, asJson: boolean): void {

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -135,7 +135,7 @@ export interface RuntimeSummaryResponse {
   };
 }
 
-export type RuntimeInstanceStatus = "active" | "stale";
+export type RuntimeInstanceStatus = "active" | "stale" | "unknown";
 
 export interface RuntimeInstanceRecord {
   instanceId: string;
@@ -147,8 +147,12 @@ export interface RuntimeInstanceRecord {
   advertisedUrls: string[];
   startedAt: string;
   updatedAt: string;
+  heartbeatAt: string;
+  leaseExpiresAt: string;
+  leaseTtlMs: number;
   version: string;
   status: RuntimeInstanceStatus;
+  statusReason?: string;
   staleReason?: string;
 }
 
@@ -156,6 +160,7 @@ export interface RuntimeInstanceRegistrySnapshot {
   path: string;
   activeCount: number;
   staleCount: number;
+  unknownCount: number;
   instances: RuntimeInstanceRecord[];
 }
 

--- a/src/runtime/instance/registry.ts
+++ b/src/runtime/instance/registry.ts
@@ -11,11 +11,17 @@ import type {
 
 const INSTANCE_FILE_NAME = "runtime-instance.json";
 const INSTANCE_REGISTRY_FILE_NAME = "instances.json";
+export const DEFAULT_RUNTIME_INSTANCE_LEASE_TTL_MS = 45_000;
+export const DEFAULT_RUNTIME_INSTANCE_HEARTBEAT_INTERVAL_MS = 15_000;
 
 export interface RuntimeInstanceRegistrationOptions {
   apiPort: number;
   apiUrl: string;
   startedAt?: string;
+}
+
+export interface RuntimeInstanceLeaseRefreshOptions {
+  now?: Date;
 }
 
 export function resolveRuntimeInstanceId(config: RuntimeConfig): string {
@@ -61,6 +67,20 @@ function normalizeStringArray(value: unknown): string[] {
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function parseIsoTime(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function addMilliseconds(value: string, milliseconds: number): string {
+  const parsed = parseIsoTime(value) ?? Date.now();
+  return new Date(parsed + milliseconds).toISOString();
+}
+
 function normalizeInstanceRecord(input: unknown): RuntimeInstanceRecord | null {
   if (!isRecord(input)) {
     return null;
@@ -72,13 +92,25 @@ function normalizeInstanceRecord(input: unknown): RuntimeInstanceRecord | null {
   const apiUrl = typeof input.apiUrl === "string" ? input.apiUrl : null;
   const startedAt = typeof input.startedAt === "string" ? input.startedAt : null;
   const updatedAt = typeof input.updatedAt === "string" ? input.updatedAt : null;
+  const heartbeatAt = typeof input.heartbeatAt === "string" ? input.heartbeatAt : updatedAt;
   const version = typeof input.version === "string" ? input.version : null;
   const apiPort = typeof input.apiPort === "number" && Number.isInteger(input.apiPort) ? input.apiPort : null;
   const pid = typeof input.pid === "number" && Number.isInteger(input.pid) ? input.pid : null;
 
-  if (!instanceId || !servicesRoot || !workspaceRoot || !apiUrl || !startedAt || !updatedAt || !apiPort || !pid) {
+  if (!instanceId || !servicesRoot || !workspaceRoot || !apiUrl || !startedAt || !updatedAt || !heartbeatAt || !apiPort || !pid) {
     return null;
   }
+
+  const leaseTtlMs = normalizePositiveInteger(input.leaseTtlMs, DEFAULT_RUNTIME_INSTANCE_LEASE_TTL_MS);
+  const leaseExpiresAt = typeof input.leaseExpiresAt === "string"
+    ? input.leaseExpiresAt
+    : addMilliseconds(heartbeatAt, leaseTtlMs);
+  const status = input.status === "stale" || input.status === "unknown" ? input.status : "active";
+  const statusReason = typeof input.statusReason === "string"
+    ? input.statusReason
+    : typeof input.staleReason === "string"
+      ? input.staleReason
+      : undefined;
 
   return {
     instanceId,
@@ -90,8 +122,12 @@ function normalizeInstanceRecord(input: unknown): RuntimeInstanceRecord | null {
     advertisedUrls: normalizeStringArray(input.advertisedUrls),
     startedAt,
     updatedAt,
+    heartbeatAt,
+    leaseExpiresAt,
+    leaseTtlMs,
     version: version ?? "unknown",
-    status: input.status === "stale" ? "stale" : "active",
+    status,
+    statusReason,
     staleReason: typeof input.staleReason === "string" ? input.staleReason : undefined,
   };
 }
@@ -119,22 +155,37 @@ function processExists(pid: number): boolean {
   }
 }
 
-function classifyRecord(record: RuntimeInstanceRecord): RuntimeInstanceRecord {
+function classifyRecord(record: RuntimeInstanceRecord, now: Date = new Date()): RuntimeInstanceRecord {
   if (record.status === "stale" && record.staleReason) {
-    return record;
+    return {
+      ...record,
+      statusReason: record.statusReason ?? record.staleReason,
+    };
   }
 
   if (!processExists(record.pid)) {
     return {
       ...record,
       status: "stale",
+      statusReason: "process_not_running",
       staleReason: "process_not_running",
+    };
+  }
+
+  const leaseExpiresAt = parseIsoTime(record.leaseExpiresAt);
+  if (leaseExpiresAt === null || leaseExpiresAt <= now.getTime()) {
+    return {
+      ...record,
+      status: "unknown",
+      statusReason: "lease_expired",
+      staleReason: undefined,
     };
   }
 
   return {
     ...record,
     status: "active",
+    statusReason: undefined,
     staleReason: undefined,
   };
 }
@@ -147,6 +198,8 @@ function createInstanceRecord(
 ): RuntimeInstanceRecord {
   const now = new Date().toISOString();
   const startedAt = options.startedAt ?? now;
+  const leaseTtlMs = DEFAULT_RUNTIME_INSTANCE_LEASE_TTL_MS;
+  const statusReason = staleReason;
 
   return {
     instanceId: resolveRuntimeInstanceId(config),
@@ -158,9 +211,29 @@ function createInstanceRecord(
     advertisedUrls: [options.apiUrl],
     startedAt,
     updatedAt: now,
+    heartbeatAt: now,
+    leaseExpiresAt: addMilliseconds(now, leaseTtlMs),
+    leaseTtlMs,
     version: config.version,
     status,
+    statusReason,
     staleReason,
+  };
+}
+
+function refreshInstanceRecord(record: RuntimeInstanceRecord, options: RuntimeInstanceLeaseRefreshOptions = {}): RuntimeInstanceRecord {
+  const now = options.now ?? new Date();
+  const heartbeatAt = now.toISOString();
+
+  return {
+    ...record,
+    pid: process.pid,
+    updatedAt: heartbeatAt,
+    heartbeatAt,
+    leaseExpiresAt: new Date(now.getTime() + record.leaseTtlMs).toISOString(),
+    status: "active",
+    statusReason: undefined,
+    staleReason: undefined,
   };
 }
 
@@ -171,12 +244,13 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 
 export async function readRuntimeInstanceRegistry(): Promise<RuntimeInstanceRegistrySnapshot> {
   const registryPath = getRuntimeInstanceRegistryPath();
-  const records = normalizeRegistry(await readJsonIfPresent(registryPath)).map(classifyRecord);
+  const records = normalizeRegistry(await readJsonIfPresent(registryPath)).map((record) => classifyRecord(record));
 
   return {
     path: registryPath,
     activeCount: records.filter((record) => record.status === "active").length,
     staleCount: records.filter((record) => record.status === "stale").length,
+    unknownCount: records.filter((record) => record.status === "unknown").length,
     instances: records,
   };
 }
@@ -203,6 +277,28 @@ export async function registerRuntimeInstance(
   return record;
 }
 
+export async function refreshRuntimeInstanceLease(
+  config: RuntimeConfig,
+  options: RuntimeInstanceLeaseRefreshOptions = {},
+): Promise<RuntimeInstanceRecord | null> {
+  const current = normalizeInstanceRecord(await readJsonIfPresent(getRuntimeInstanceStatePath(config.workspaceRoot)));
+  if (!current) {
+    return null;
+  }
+
+  const refreshed = refreshInstanceRecord(current, options);
+  const registry = await readRuntimeInstanceRegistry();
+  const records = registry.instances.filter((entry) => entry.instanceId !== refreshed.instanceId);
+  records.push(refreshed);
+
+  await Promise.all([
+    writeJson(getRuntimeInstanceStatePath(config.workspaceRoot), refreshed),
+    writeJson(registry.path, { version: 1, updatedAt: refreshed.updatedAt, instances: records }),
+  ]);
+
+  return refreshed;
+}
+
 export async function markRuntimeInstanceStopped(config: RuntimeConfig): Promise<void> {
   const current = await readRuntimeInstanceState(config);
   if (!current) {
@@ -212,6 +308,7 @@ export async function markRuntimeInstanceStopped(config: RuntimeConfig): Promise
   const stopped: RuntimeInstanceRecord = {
     ...current,
     status: "stale",
+    statusReason: "stopped",
     staleReason: "stopped",
     updatedAt: new Date().toISOString(),
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -87,8 +87,10 @@ import { createRuntimeServiceMonitor, type RuntimeServiceMonitor } from "../runt
 import { readServiceUpdateState } from "../runtime/updates/state.js";
 import { createRuntimeUpdateScheduler, type RuntimeUpdateScheduler } from "../runtime/updates/scheduler.js";
 import {
+  DEFAULT_RUNTIME_INSTANCE_HEARTBEAT_INTERVAL_MS,
   createRuntimeInstanceSnapshot,
   markRuntimeInstanceStopped,
+  refreshRuntimeInstanceLease,
   registerRuntimeInstance,
 } from "../runtime/instance/registry.js";
 import {
@@ -1714,6 +1716,10 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
     apiPort: resolvedPort,
     apiUrl: "http://" + publicHost + ":" + resolvedPort,
   });
+  const leaseHeartbeat = setInterval(() => {
+    void refreshRuntimeInstanceLease(config).catch(() => undefined);
+  }, DEFAULT_RUNTIME_INSTANCE_HEARTBEAT_INTERVAL_MS);
+  leaseHeartbeat.unref?.();
   if (requestedPort === 0) {
     await reservePorts(config.workspaceRoot, [toApiPortReservation(resolvedPort, bindHost)]);
   }
@@ -1725,6 +1731,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
     monitor,
     updateScheduler,
     stop: async () => {
+      clearInterval(leaseHeartbeat);
       await monitor?.stop();
       await updateScheduler?.stop();
       await stopAllManagedProcesses();

--- a/tests/registry-runtime-state.test.js
+++ b/tests/registry-runtime-state.test.js
@@ -8,7 +8,12 @@ import { discoverServices } from "../dist/runtime/discovery/discoverServices.js"
 import { DependencyGraph, createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
-import { getRuntimeInstanceStatePath } from "../dist/runtime/instance/registry.js";
+import {
+  getRuntimeInstanceStatePath,
+  readRuntimeInstanceRegistry,
+  refreshRuntimeInstanceLease,
+  registerRuntimeInstance,
+} from "../dist/runtime/instance/registry.js";
 import { clearPersistedFixtureState, makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
 
 const servicesRoot = path.resolve("services");
@@ -207,7 +212,12 @@ test("runtime instance API and CLI expose distinct local instance records", asyn
     assert.equal(secondBody.instance.workspaceRoot, secondWorkspaceRoot);
     assert.equal(secondBody.registry.path, registryPath);
     assert.equal(secondBody.registry.activeCount, 2);
+    assert.equal(secondBody.registry.staleCount, 0);
+    assert.equal(secondBody.registry.unknownCount, 0);
     assert.equal(secondBody.registry.instances.length, 2);
+    assert.equal(typeof firstBody.instance.heartbeatAt, "string");
+    assert.equal(typeof firstBody.instance.leaseExpiresAt, "string");
+    assert.ok(firstBody.instance.leaseTtlMs > 0);
 
     const instanceFile = JSON.parse(await readFile(getRuntimeInstanceStatePath(firstWorkspaceRoot), "utf8"));
     assert.equal(instanceFile.instanceId, firstBody.instance.instanceId);
@@ -234,6 +244,7 @@ test("runtime instance API and CLI expose distinct local instance records", asyn
     const cliBody = JSON.parse(cli.stdout);
     assert.equal(cliBody.instance.instanceId, firstBody.instance.instanceId);
     assert.equal(cliBody.registry.activeCount, 2);
+    assert.equal(cliBody.registry.unknownCount, 0);
   } finally {
     if (firstServer) await firstServer.stop();
     if (secondServer) await secondServer.stop();
@@ -295,10 +306,109 @@ test("runtime instance registry classifies old process entries as stale", async 
     assert.equal(response.status, 200);
     assert.equal(body.registry.activeCount, 1);
     assert.equal(body.registry.staleCount, 1);
+    assert.equal(body.registry.unknownCount, 0);
     assert.equal(oldEntry.status, "stale");
+    assert.equal(oldEntry.statusReason, "process_not_running");
     assert.equal(oldEntry.staleReason, "process_not_running");
   } finally {
     if (apiServer) await apiServer.stop();
+    if (previousRegistryPath === undefined) {
+      delete process.env.SERVICE_LASSO_INSTANCE_REGISTRY_PATH;
+    } else {
+      process.env.SERVICE_LASSO_INSTANCE_REGISTRY_PATH = previousRegistryPath;
+    }
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("runtime instance leases classify active, expired, and refreshed records", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-instance-lease-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const registryPath = path.join(tempRoot, "registry", "instances.json");
+  const previousRegistryPath = process.env.SERVICE_LASSO_INSTANCE_REGISTRY_PATH;
+  process.env.SERVICE_LASSO_INSTANCE_REGISTRY_PATH = registryPath;
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "lease-service");
+    await mkdir(path.dirname(registryPath), { recursive: true });
+    const now = new Date();
+    const expiredHeartbeat = new Date(now.getTime() - 120_000).toISOString();
+    const expiredLease = new Date(now.getTime() - 60_000).toISOString();
+    const activeLease = new Date(now.getTime() + 60_000).toISOString();
+
+    await writeFile(
+      registryPath,
+      JSON.stringify(
+        {
+          version: 1,
+          updatedAt: now.toISOString(),
+          instances: [
+            {
+              instanceId: "sl_active",
+              servicesRoot,
+              workspaceRoot: path.join(tempRoot, "active-workspace"),
+              pid: process.pid,
+              apiPort: 19001,
+              apiUrl: "http://127.0.0.1:19001",
+              advertisedUrls: ["http://127.0.0.1:19001"],
+              startedAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+              heartbeatAt: now.toISOString(),
+              leaseExpiresAt: activeLease,
+              leaseTtlMs: 45_000,
+              version: "0.0.0-test",
+              status: "active",
+            },
+            {
+              instanceId: "sl_expired",
+              servicesRoot,
+              workspaceRoot: path.join(tempRoot, "expired-workspace"),
+              pid: process.pid,
+              apiPort: 19002,
+              apiUrl: "http://127.0.0.1:19002",
+              advertisedUrls: ["http://127.0.0.1:19002"],
+              startedAt: expiredHeartbeat,
+              updatedAt: expiredHeartbeat,
+              heartbeatAt: expiredHeartbeat,
+              leaseExpiresAt: expiredLease,
+              leaseTtlMs: 45_000,
+              version: "0.0.0-test",
+              status: "active",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const registry = await readRuntimeInstanceRegistry();
+    const activeEntry = registry.instances.find((entry) => entry.instanceId === "sl_active");
+    const expiredEntry = registry.instances.find((entry) => entry.instanceId === "sl_expired");
+
+    assert.equal(registry.activeCount, 1);
+    assert.equal(registry.unknownCount, 1);
+    assert.equal(registry.staleCount, 0);
+    assert.equal(activeEntry.status, "active");
+    assert.equal(expiredEntry.status, "unknown");
+    assert.equal(expiredEntry.statusReason, "lease_expired");
+
+    const config = { servicesRoot, workspaceRoot, version: "0.0.0-test" };
+    const registered = await registerRuntimeInstance(config, {
+      apiPort: 19003,
+      apiUrl: "http://127.0.0.1:19003",
+      startedAt: expiredHeartbeat,
+    });
+    const refreshed = await refreshRuntimeInstanceLease(config, { now: new Date(now.getTime() + 10_000) });
+
+    assert.equal(refreshed.instanceId, registered.instanceId);
+    assert.equal(refreshed.status, "active");
+    assert.equal(refreshed.statusReason, undefined);
+    assert.ok(Date.parse(refreshed.heartbeatAt) > Date.parse(registered.heartbeatAt));
+    assert.ok(Date.parse(refreshed.leaseExpiresAt) > Date.parse(refreshed.heartbeatAt));
+  } finally {
     if (previousRegistryPath === undefined) {
       delete process.env.SERVICE_LASSO_INSTANCE_REGISTRY_PATH;
     } else {


### PR DESCRIPTION
## Summary
- add lease heartbeat fields to runtime instance records and registry snapshots
- refresh the current API instance lease on a bounded interval while the server is running
- classify records as active, stale, or unknown when a PID exists but the lease has expired
- update CLI/docs and focused registry tests

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/registry-runtime-state.test.js` (11 passed)
- `git diff --check`

Evidence logs:
- `.work-agent/logs/issue-532-20260528-2325/01-build.txt`
- `.work-agent/logs/issue-532-20260528-2325/02-registry-runtime-state-test.txt`
- `.work-agent/logs/issue-532-20260528-2325/03-git-diff-check.txt`

Closes #532