### PR TITLE
ISS-533 add template upgrade compatibility checker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Use this short list as the public documentation map:
 - [Service Authoring Overview](service-authoring/overview.md): ordered process for planning, manifesting, releasing, wiring, and validating a service.
 - [service.json Reference](reference/service-json-reference.md): canonical manifest fields, artifact metadata, health checks, actions, env, dependencies, and update policy.
 - [One-shot Jobs](reference/one-shot-jobs.md): setup-step contract for schema init, sample data loading, certificate generation, and other non-daemon workloads.
+- [Template Upgrade Compatibility](reference/template-upgrade-compatibility.md): read-only checker for app/template inventories against current core provider expectations.
 - [Reference Apps](reference-apps.md): choose the right host/template repo and understand the release output options.
 
 ## Source of truth for `service.json`

--- a/docs/reference/template-upgrade-compatibility.md
+++ b/docs/reference/template-upgrade-compatibility.md
@@ -1,0 +1,34 @@
+# Template Upgrade Compatibility
+
+`service-lasso template check-upgrade <targetServicesRoot>` compares an app or
+template service inventory with the current core provider inventory.
+
+The check is read-only. It does not write manifests, runtime state, logs,
+lockfiles, or provider artifacts. The report includes service ids, provider
+source repos, release tags, versions, platform keys, and upgrade hints only; it
+does not include environment values, provider credentials, tokens, passwords,
+cookies, private keys, or broker secret material.
+
+Use JSON output for automation:
+
+```powershell
+service-lasso template check-upgrade C:\path\to\app\services --json
+```
+
+Use `--core-services-root <path>` when comparing against a checked-out core
+inventory other than `./services`:
+
+```powershell
+service-lasso template check-upgrade C:\path\to\app\services --core-services-root C:\projects\service-lasso\service-lasso\services --json
+```
+
+The top-level status is:
+
+- `compatible`: no findings.
+- `upgrade-advised`: warnings only, such as missing optional providers or stale
+  provider pins.
+- `blocked`: at least one error, such as a required provider that is missing or
+  a provider manifest that no longer matches the core provider role/source
+  contract.
+
+Findings are machine-readable by `kind`, `severity`, and `serviceId`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import type { ServiceRecoveryHistoryState } from "./runtime/recovery/history.js"
 import { runOperatorCliAction, type OperatorActionsCliAction, type OperatorCliResult } from "./runtime/cli/operator.js";
 import { runSecretsCliAction, type SecretsCliAction, type SecretsCliResult } from "./runtime/cli/secrets.js";
 import { runSetupCliAction, type SetupCliAction, type SetupCliResult } from "./runtime/cli/setup.js";
+import { runTemplateCliAction, type TemplateCliAction, type TemplateCliResult } from "./runtime/cli/template.js";
 import { runUpdatesCliAction, type UpdateCliAction, type UpdatesCliResult } from "./runtime/cli/updates.js";
 import { runConfigDriftCliAction, type ConfigDriftCliResult } from "./runtime/cli/config-drift.js";
 import { runConfigApplyCliAction, type ConfigApplyCliAction, type ConfigApplyCliResult } from "./runtime/cli/config-apply.js";
@@ -23,7 +24,7 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "readiness" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "readiness" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "template" | "help" | "version";
   readinessAction?: "gate";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
@@ -38,6 +39,7 @@ interface ParsedCliOptions {
   backupAction?: BackupCliAction;
   diagnosticsAction?: DiagnosticsCliAction;
   operatorActionsAction?: OperatorActionsCliAction;
+  templateAction?: TemplateCliAction;
   actionId?: string;
   deferredUntil?: string | null;
   serviceId?: string;
@@ -50,6 +52,8 @@ interface ParsedCliOptions {
   snapshotPath?: string;
   port?: number;
   servicesRoot?: string;
+  targetServicesRoot?: string;
+  coreServicesRoot?: string;
   workspaceRoot?: string;
   json: boolean;
   force: boolean;
@@ -101,6 +105,7 @@ function usageText(): string {
     "  service-lasso operator actions defer <actionId> [--until <iso>] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions reopen <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso services import <owner/repo> [--tag <tag>] [--services-root <path>] [--dry-run] [--force] [--json]",
+    "  service-lasso template check-upgrade <targetServicesRoot> [--core-services-root <path>] [--json]",
     "  service-lasso help",
     "  service-lasso --version",
     "",
@@ -115,6 +120,7 @@ function usageText(): string {
     "  - The instance command reads local runtime identity and recent instance registry state.",
     "  - The readiness command emits a machine-readable gate for baseline automation.",
     "  - The lockfile command generates or verifies the servicesRoot service-lasso.lock.json.",
+    "  - The template check-upgrade command compares an app/template service inventory to current core provider expectations.",
   ].join("\n");
 }
 
@@ -161,7 +167,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "backup" ||
       commandToken === "diagnostics" ||
       commandToken === "operator" ||
-      commandToken === "services"
+      commandToken === "services" ||
+      commandToken === "template"
       ? commandToken
       : null;
   if (!command) {
@@ -406,6 +413,19 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     parsed.repo = repo;
   }
 
+  if (command === "template") {
+    const action = remaining.shift();
+    if (action !== "check-upgrade") {
+      throw new Error('The "template" command requires one of: check-upgrade.');
+    }
+    parsed.templateAction = action;
+    const targetServicesRoot = remaining.shift();
+    if (!targetServicesRoot || targetServicesRoot.startsWith("-")) {
+      throw new Error('The "template check-upgrade" command requires a <targetServicesRoot> argument.');
+    }
+    parsed.targetServicesRoot = targetServicesRoot;
+  }
+
   while (remaining.length > 0) {
     const token = remaining.shift();
 
@@ -438,8 +458,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "readiness" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, readiness, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, and services commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "readiness" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services" && command !== "template") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, readiness, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, services, and template commands.");
         }
         parsed.json = true;
         break;
@@ -492,6 +512,17 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
           throw new Error("Missing value for --api-base-url.");
         }
         parsed.apiBaseUrl = value;
+        break;
+      }
+      case "--core-services-root": {
+        if (command !== "template" || parsed.templateAction !== "check-upgrade") {
+          throw new Error("--core-services-root is only supported for the template check-upgrade command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --core-services-root.");
+        }
+        parsed.coreServicesRoot = value;
         break;
       }
       case "--force": {
@@ -680,6 +711,25 @@ function printLockfileResult(result: LockfileCliResult, asJson: boolean): void {
   console.log("- checkedServices: " + result.checkedServices);
   for (const issue of result.issues) {
     console.log("- " + issue.serviceId + ": " + issue.status + " (" + issue.message + ")");
+  }
+}
+
+function printTemplateResult(result: TemplateCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(result.ok ? "[service-lasso] template upgrade compatibility checked" : "[service-lasso] template upgrade compatibility blocked");
+  console.log("- status: " + result.status);
+  console.log("- targetServicesRoot: " + result.targetServicesRoot);
+  console.log("- checkedProviders: " + result.checkedProviders);
+  console.log("- findings: errors=" + result.summary.errors + " warnings=" + result.summary.warnings);
+  for (const provider of result.providers) {
+    console.log("- " + provider.serviceId + ": " + provider.status);
+  }
+  for (const finding of result.findings) {
+    console.log("- " + finding.severity + " " + finding.serviceId + ": " + finding.kind + " - " + finding.hint);
   }
 }
 
@@ -1095,6 +1145,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       dryRun: parsed.dryRun,
     });
     printImportServiceResult(result, parsed.json);
+    return;
+  }
+
+  if (parsed.command === "template") {
+    const result = await runTemplateCliAction({
+      action: parsed.templateAction!,
+      targetServicesRoot: parsed.targetServicesRoot!,
+      coreServicesRoot: parsed.coreServicesRoot,
+    });
+    printTemplateResult(result, parsed.json);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/runtime/cli/template.ts
+++ b/src/runtime/cli/template.ts
@@ -1,0 +1,32 @@
+import { discoverServices } from "../discovery/discoverServices.js";
+import { buildTemplateUpgradeCompatibilityReport, type TemplateUpgradeCompatibilityReport } from "../template/upgrade-compatibility.js";
+
+export type TemplateCliAction = "check-upgrade";
+
+export interface TemplateCliOptions {
+  action: TemplateCliAction;
+  targetServicesRoot: string;
+  coreServicesRoot?: string;
+}
+
+export type TemplateCliResult = TemplateUpgradeCompatibilityReport & {
+  action: "check-upgrade";
+};
+
+export async function runTemplateCliAction(options: TemplateCliOptions): Promise<TemplateCliResult> {
+  const coreServicesRoot = options.coreServicesRoot ?? "./services";
+  const [currentServices, targetServices] = await Promise.all([
+    discoverServices(coreServicesRoot),
+    discoverServices(options.targetServicesRoot),
+  ]);
+
+  return {
+    action: options.action,
+    ...buildTemplateUpgradeCompatibilityReport({
+      currentCoreRoot: coreServicesRoot,
+      targetServicesRoot: options.targetServicesRoot,
+      currentServices,
+      targetServices,
+    }),
+  };
+}

--- a/src/runtime/template/upgrade-compatibility.ts
+++ b/src/runtime/template/upgrade-compatibility.ts
@@ -1,0 +1,324 @@
+import path from "node:path";
+import type { DiscoveredService, ServiceManifest } from "../../contracts/service.js";
+import { compareTimestampedReleaseTags } from "../updates/check.js";
+
+export type TemplateUpgradeFindingKind =
+  | "missing-optional-provider"
+  | "missing-required-provider"
+  | "provider-role-mismatch"
+  | "provider-source-mismatch"
+  | "provider-release-stale"
+  | "provider-release-drift"
+  | "provider-version-drift"
+  | "provider-platform-gap"
+  | "provider-artifact-missing"
+  | "unknown-provider-reference";
+
+export type TemplateUpgradeFindingSeverity = "info" | "warning" | "error";
+
+export interface TemplateUpgradeFinding {
+  kind: TemplateUpgradeFindingKind;
+  severity: TemplateUpgradeFindingSeverity;
+  serviceId: string;
+  message: string;
+  current?: {
+    sourceRepo?: string;
+    releaseTag?: string;
+    version?: string;
+    platforms?: string[];
+  };
+  target?: {
+    sourceRepo?: string;
+    releaseTag?: string;
+    version?: string;
+    platforms?: string[];
+  };
+  hint: string;
+}
+
+export interface TemplateUpgradeProviderSummary {
+  serviceId: string;
+  currentReleaseTag: string | null;
+  targetReleaseTag: string | null;
+  status: "current" | "missing" | "stale" | "drifted" | "incompatible";
+}
+
+export interface TemplateUpgradeCompatibilityReport {
+  ok: boolean;
+  status: "compatible" | "upgrade-advised" | "blocked";
+  currentCoreRoot: string;
+  targetServicesRoot: string;
+  checkedProviders: number;
+  targetServices: number;
+  providers: TemplateUpgradeProviderSummary[];
+  findings: TemplateUpgradeFinding[];
+  summary: {
+    errors: number;
+    warnings: number;
+    info: number;
+    missingOptionalProviders: number;
+    stalePins: number;
+    incompatibleProviders: number;
+  };
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter((value) => value.trim().length > 0))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function releaseTag(manifest: ServiceManifest): string | undefined {
+  return manifest.artifact?.source.tag?.trim() || manifest.artifact?.source.channel?.trim() || undefined;
+}
+
+function sourceRepo(manifest: ServiceManifest): string | undefined {
+  return manifest.artifact?.source.repo?.trim() || undefined;
+}
+
+function platforms(manifest: ServiceManifest): string[] {
+  return uniqueSorted(Object.keys(manifest.artifact?.platforms ?? {}));
+}
+
+function collectSetupProviders(manifest: ServiceManifest): string[] {
+  return Object.values(manifest.setup?.steps ?? {}).flatMap((step) => (step.execservice ? [step.execservice] : []));
+}
+
+function collectProviderReferences(services: DiscoveredService[]): Set<string> {
+  const refs = new Set<string>();
+  for (const service of services) {
+    for (const providerId of [service.manifest.execservice, ...collectSetupProviders(service.manifest)]) {
+      if (providerId) {
+        refs.add(providerId);
+      }
+    }
+  }
+  return refs;
+}
+
+function describeCurrent(manifest: ServiceManifest): TemplateUpgradeFinding["current"] {
+  return {
+    sourceRepo: sourceRepo(manifest),
+    releaseTag: releaseTag(manifest),
+    version: manifest.version,
+    platforms: platforms(manifest),
+  };
+}
+
+function describeTarget(manifest: ServiceManifest): TemplateUpgradeFinding["target"] {
+  return {
+    sourceRepo: sourceRepo(manifest),
+    releaseTag: releaseTag(manifest),
+    version: manifest.version,
+    platforms: platforms(manifest),
+  };
+}
+
+function makeFinding(
+  finding: Omit<TemplateUpgradeFinding, "message"> & { message?: string },
+): TemplateUpgradeFinding {
+  return {
+    ...finding,
+    message: finding.message ?? finding.hint,
+  };
+}
+
+function severityRank(severity: TemplateUpgradeFindingSeverity): number {
+  if (severity === "error") return 3;
+  if (severity === "warning") return 2;
+  return 1;
+}
+
+function providerStatus(
+  serviceId: string,
+  findings: TemplateUpgradeFinding[],
+): TemplateUpgradeProviderSummary["status"] {
+  const providerFindings = findings.filter((finding) => finding.serviceId === serviceId);
+  if (providerFindings.some((finding) => finding.kind === "missing-optional-provider" || finding.kind === "missing-required-provider")) {
+    return "missing";
+  }
+  if (providerFindings.some((finding) => finding.severity === "error")) {
+    return "incompatible";
+  }
+  if (providerFindings.some((finding) => finding.kind === "provider-release-stale")) {
+    return "stale";
+  }
+  if (providerFindings.length > 0) {
+    return "drifted";
+  }
+  return "current";
+}
+
+function compareProviderPins(
+  current: DiscoveredService,
+  target: DiscoveredService,
+): TemplateUpgradeFinding[] {
+  const findings: TemplateUpgradeFinding[] = [];
+  const serviceId = current.manifest.id;
+  const currentDescription = describeCurrent(current.manifest);
+  const targetDescription = describeTarget(target.manifest);
+  const currentRepo = sourceRepo(current.manifest);
+  const targetRepo = sourceRepo(target.manifest);
+  const currentTag = releaseTag(current.manifest);
+  const targetTag = releaseTag(target.manifest);
+
+  if (target.manifest.role !== "provider") {
+    findings.push(makeFinding({
+      kind: "provider-role-mismatch",
+      severity: "error",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: `Keep ${serviceId} as a provider-role manifest when adopting current core provider expectations.`,
+    }));
+  }
+
+  if (current.manifest.artifact && !target.manifest.artifact) {
+    findings.push(makeFinding({
+      kind: "provider-artifact-missing",
+      severity: "error",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: `Copy the current ${serviceId} release artifact block before relying on this inventory for upgrades.`,
+    }));
+  }
+
+  if (currentRepo && targetRepo && currentRepo !== targetRepo) {
+    findings.push(makeFinding({
+      kind: "provider-source-mismatch",
+      severity: "error",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: `Review ${serviceId}; the target manifest points at ${targetRepo} instead of ${currentRepo}.`,
+    }));
+  }
+
+  if (currentTag && targetTag && currentTag !== targetTag) {
+    const comparison = compareTimestampedReleaseTags(targetTag, currentTag);
+    findings.push(makeFinding({
+      kind: comparison === 1 ? "provider-release-stale" : "provider-release-drift",
+      severity: "warning",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: comparison === 1
+        ? `Update ${serviceId} from ${targetTag} to the current core pin ${currentTag}.`
+        : `Review ${serviceId}; the target pin ${targetTag} differs from the current core pin ${currentTag}.`,
+    }));
+  }
+
+  if (current.manifest.version && target.manifest.version && current.manifest.version !== target.manifest.version) {
+    findings.push(makeFinding({
+      kind: "provider-version-drift",
+      severity: "warning",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: `Review ${serviceId} runtime version drift: target ${target.manifest.version}, current ${current.manifest.version}.`,
+    }));
+  }
+
+  const targetPlatforms = new Set(platforms(target.manifest));
+  const missingPlatforms = platforms(current.manifest).filter((platform) => !targetPlatforms.has(platform));
+  if (missingPlatforms.length > 0) {
+    findings.push(makeFinding({
+      kind: "provider-platform-gap",
+      severity: "warning",
+      serviceId,
+      current: currentDescription,
+      target: targetDescription,
+      hint: `Add ${serviceId} platform entries missing from the target inventory: ${missingPlatforms.join(", ")}.`,
+    }));
+  }
+
+  return findings;
+}
+
+export function buildTemplateUpgradeCompatibilityReport(options: {
+  currentCoreRoot: string;
+  targetServicesRoot: string;
+  currentServices: DiscoveredService[];
+  targetServices: DiscoveredService[];
+}): TemplateUpgradeCompatibilityReport {
+  const currentProviders = options.currentServices
+    .filter((service) => service.manifest.role === "provider")
+    .sort((left, right) => left.manifest.id.localeCompare(right.manifest.id));
+  const targetById = new Map(options.targetServices.map((service) => [service.manifest.id, service]));
+  const expectedProviderIds = new Set(currentProviders.map((service) => service.manifest.id));
+  const targetProviderRefs = collectProviderReferences(options.targetServices);
+  const findings: TemplateUpgradeFinding[] = [];
+
+  for (const provider of currentProviders) {
+    const target = targetById.get(provider.manifest.id);
+    if (!target) {
+      const required = targetProviderRefs.has(provider.manifest.id);
+      findings.push(makeFinding({
+        kind: required ? "missing-required-provider" : "missing-optional-provider",
+        severity: required ? "error" : "warning",
+        serviceId: provider.manifest.id,
+        current: describeCurrent(provider.manifest),
+        hint: required
+          ? `Add ${provider.manifest.id}; at least one target service references it as an execution provider.`
+          : `Consider adding current optional provider ${provider.manifest.id} so the inventory can adopt newer Service Lasso provider capabilities.`,
+      }));
+      continue;
+    }
+
+    findings.push(...compareProviderPins(provider, target));
+  }
+
+  for (const providerId of targetProviderRefs) {
+    if (!targetById.has(providerId) && !expectedProviderIds.has(providerId)) {
+      findings.push(makeFinding({
+        kind: "unknown-provider-reference",
+        severity: "warning",
+        serviceId: providerId,
+        hint: `Target inventory references provider ${providerId}, but no matching provider manifest was discovered in the target or current core inventory.`,
+      }));
+    }
+  }
+
+  findings.sort((left, right) => {
+    const severity = severityRank(right.severity) - severityRank(left.severity);
+    if (severity !== 0) return severity;
+    const service = left.serviceId.localeCompare(right.serviceId);
+    if (service !== 0) return service;
+    return left.kind.localeCompare(right.kind);
+  });
+
+  const providers = currentProviders.map((provider) => {
+    const target = targetById.get(provider.manifest.id);
+    return {
+      serviceId: provider.manifest.id,
+      currentReleaseTag: releaseTag(provider.manifest) ?? null,
+      targetReleaseTag: target ? releaseTag(target.manifest) ?? null : null,
+      status: providerStatus(provider.manifest.id, findings),
+    };
+  });
+
+  const errors = findings.filter((finding) => finding.severity === "error").length;
+  const warnings = findings.filter((finding) => finding.severity === "warning").length;
+  const info = findings.filter((finding) => finding.severity === "info").length;
+  const status = errors > 0 ? "blocked" : warnings > 0 ? "upgrade-advised" : "compatible";
+
+  return {
+    ok: errors === 0,
+    status,
+    currentCoreRoot: path.resolve(options.currentCoreRoot),
+    targetServicesRoot: path.resolve(options.targetServicesRoot),
+    checkedProviders: currentProviders.length,
+    targetServices: options.targetServices.length,
+    providers,
+    findings,
+    summary: {
+      errors,
+      warnings,
+      info,
+      missingOptionalProviders: findings.filter((finding) => finding.kind === "missing-optional-provider").length,
+      stalePins: findings.filter((finding) => finding.kind === "provider-release-stale").length,
+      incompatibleProviders: findings.filter((finding) => finding.severity === "error").length,
+    },
+  };
+}

--- a/tests/template-upgrade-compatibility.test.js
+++ b/tests/template-upgrade-compatibility.test.js
@@ -1,0 +1,260 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { runTemplateCliAction } from "../dist/runtime/cli/template.js";
+import { buildTemplateUpgradeCompatibilityReport } from "../dist/runtime/template/upgrade-compatibility.js";
+
+const execFile = promisify(execFileCallback);
+
+async function makeTempInventory(prefix = "service-lasso-template-upgrade-") {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const currentRoot = path.join(root, "core-services");
+  const targetRoot = path.join(root, "target-services");
+  await mkdir(currentRoot, { recursive: true });
+  await mkdir(targetRoot, { recursive: true });
+  return { root, currentRoot, targetRoot };
+}
+
+async function writeManifest(servicesRoot, serviceId, body) {
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  await mkdir(serviceRoot, { recursive: true });
+  await writeFile(path.join(serviceRoot, "service.json"), JSON.stringify(body, null, 2));
+}
+
+function providerManifest(serviceId, tag, overrides = {}) {
+  return {
+    id: serviceId,
+    name: serviceId + " Provider",
+    description: "Provider fixture.",
+    role: "provider",
+    version: "1.0.0",
+    artifact: {
+      kind: "archive",
+      source: {
+        type: "github-release",
+        repo: "service-lasso/" + serviceId.replace(/^@/, "lasso-"),
+        tag,
+      },
+      platforms: {
+        default: {
+          assetName: serviceId.replace(/^@/, "") + ".zip",
+          archiveType: "zip",
+        },
+        linux: {
+          assetName: serviceId.replace(/^@/, "") + "-linux.zip",
+          archiveType: "zip",
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+async function buildReport(currentRoot, targetRoot) {
+  const [currentServices, targetServices] = await Promise.all([
+    discoverServices(currentRoot),
+    discoverServices(targetRoot),
+  ]);
+
+  return buildTemplateUpgradeCompatibilityReport({
+    currentCoreRoot: currentRoot,
+    targetServicesRoot: targetRoot,
+    currentServices,
+    targetServices,
+  });
+}
+
+async function runCli(args, cwd = path.resolve(".")) {
+  const cliPath = path.join(cwd, "dist", "cli.js");
+  const result = await execFile(process.execPath, [cliPath, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      npm_package_version: "0.1.0-test",
+    },
+  });
+
+  return result.stdout.trim();
+}
+
+test("template upgrade report accepts matching provider inventory", async () => {
+  const { root, currentRoot, targetRoot } = await makeTempInventory("service-lasso-template-upgrade-ok-");
+
+  try {
+    await writeManifest(currentRoot, "@node", providerManifest("@node", "2026.5.20-current"));
+    await writeManifest(targetRoot, "@node", providerManifest("@node", "2026.5.20-current"));
+    await writeManifest(targetRoot, "reference-app", {
+      id: "reference-app",
+      name: "Reference App",
+      description: "Template-style app using the node provider.",
+      execservice: "@node",
+    });
+
+    const report = await buildReport(currentRoot, targetRoot);
+
+    assert.equal(report.ok, true);
+    assert.equal(report.status, "compatible");
+    assert.equal(report.checkedProviders, 1);
+    assert.deepEqual(report.findings, []);
+    assert.deepEqual(report.providers, [{
+      serviceId: "@node",
+      currentReleaseTag: "2026.5.20-current",
+      targetReleaseTag: "2026.5.20-current",
+      status: "current",
+    }]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("template upgrade report warns for missing optional providers and stale pins", async () => {
+  const { root, currentRoot, targetRoot } = await makeTempInventory("service-lasso-template-upgrade-warn-");
+
+  try {
+    await writeManifest(currentRoot, "@node", providerManifest("@node", "2026.5.20-current"));
+    await writeManifest(currentRoot, "@python", providerManifest("@python", "2026.5.20-current"));
+    await writeManifest(targetRoot, "@node", providerManifest("@node", "2026.5.10-old"));
+    await writeManifest(targetRoot, "reference-app", {
+      id: "reference-app",
+      name: "Reference App",
+      description: "Template-style app using the node provider.",
+      execservice: "@node",
+    });
+
+    const report = await buildReport(currentRoot, targetRoot);
+
+    assert.equal(report.ok, true);
+    assert.equal(report.status, "upgrade-advised");
+    assert.equal(report.summary.errors, 0);
+    assert.equal(report.summary.missingOptionalProviders, 1);
+    assert.equal(report.summary.stalePins, 1);
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "missing-optional-provider" &&
+      finding.serviceId === "@python" &&
+      finding.severity === "warning"
+    ));
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "provider-release-stale" &&
+      finding.serviceId === "@node" &&
+      finding.target.releaseTag === "2026.5.10-old" &&
+      finding.current.releaseTag === "2026.5.20-current"
+    ));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("template upgrade report blocks when referenced provider is missing or incompatible", async () => {
+  const { root, currentRoot, targetRoot } = await makeTempInventory("service-lasso-template-upgrade-block-");
+
+  try {
+    await writeManifest(currentRoot, "@node", providerManifest("@node", "2026.5.20-current"));
+    await writeManifest(currentRoot, "@python", providerManifest("@python", "2026.5.20-current"));
+    await writeManifest(targetRoot, "@node", providerManifest("@node", "2026.5.20-current", {
+      role: "service",
+      artifact: {
+        kind: "archive",
+        source: {
+          type: "github-release",
+          repo: "service-lasso/forked-node",
+          tag: "2026.5.20-current",
+        },
+        platforms: {
+          win32: {
+            assetName: "node-win32.zip",
+            archiveType: "zip",
+          },
+        },
+      },
+    }));
+    await writeManifest(targetRoot, "reference-app", {
+      id: "reference-app",
+      name: "Reference App",
+      description: "Template-style app using missing provider.",
+      execservice: "@python",
+      setup: {
+        steps: {
+          seed: {
+            execservice: "@unknown",
+            args: ["seed.js"],
+          },
+        },
+      },
+      env: {
+        API_TOKEN: "should-not-appear",
+      },
+    });
+
+    const report = await buildReport(currentRoot, targetRoot);
+    const serialized = JSON.stringify(report);
+
+    assert.equal(report.ok, false);
+    assert.equal(report.status, "blocked");
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "missing-required-provider" &&
+      finding.serviceId === "@python" &&
+      finding.severity === "error"
+    ));
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "provider-role-mismatch" &&
+      finding.serviceId === "@node" &&
+      finding.severity === "error"
+    ));
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "provider-source-mismatch" &&
+      finding.serviceId === "@node" &&
+      finding.severity === "error"
+    ));
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "provider-platform-gap" &&
+      finding.serviceId === "@node" &&
+      finding.severity === "warning"
+    ));
+    assert.ok(report.findings.some((finding) =>
+      finding.kind === "unknown-provider-reference" &&
+      finding.serviceId === "@unknown" &&
+      finding.severity === "warning"
+    ));
+    assert.equal(serialized.includes("should-not-appear"), false);
+    assert.equal(serialized.includes("API_TOKEN"), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("template check-upgrade CLI emits machine-readable compatibility report", async () => {
+  const { root, currentRoot, targetRoot } = await makeTempInventory("service-lasso-template-upgrade-cli-");
+
+  try {
+    await writeManifest(currentRoot, "@node", providerManifest("@node", "2026.5.20-current"));
+    await writeManifest(targetRoot, "@node", providerManifest("@node", "2026.5.10-old"));
+
+    const direct = await runTemplateCliAction({
+      action: "check-upgrade",
+      coreServicesRoot: currentRoot,
+      targetServicesRoot: targetRoot,
+    });
+    const cli = JSON.parse(await runCli([
+      "template",
+      "check-upgrade",
+      targetRoot,
+      "--core-services-root",
+      currentRoot,
+      "--json",
+    ]));
+
+    assert.equal(direct.action, "check-upgrade");
+    assert.equal(cli.action, "check-upgrade");
+    assert.equal(cli.status, "upgrade-advised");
+    assert.equal(cli.summary.stalePins, 1);
+    assert.equal(cli.currentCoreRoot, path.resolve(currentRoot));
+    assert.equal(cli.targetServicesRoot, path.resolve(targetRoot));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `service-lasso template check-upgrade <targetServicesRoot>` for read-only app/template inventory compatibility checks.
- Compares target provider manifests against the current core provider inventory for missing optional/required providers, stale pins, role/source drift, platform gaps, and unknown provider refs.
- Documents the checker contract and adds fixture coverage for compatible, warning, blocked, safe-output, and CLI JSON paths.

## Validation
- PASS: `npm run build`
- PASS: `node --test --test-concurrency=1 tests/template-upgrade-compatibility.test.js`
- PASS: `git diff --check`
- NOTE: `npm test` currently fails in `tests/cli-dry-run-plan.test.js` at `CLI plan start returns structured dry-run without creating workspace state` because `workspaceRoot` exists after the dry-run. The failed file is outside this PR's diff; the other 360 tests passed locally.

Fixes #533