### PR TITLE
ISS-534 add release manifest verifier

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Use this short list as the public documentation map:
 - [Quick Start](quick-start.md): clone the repo, install dependencies, start the baseline services, open the useful URLs, and stop cleanly.
 - [Service Authoring Overview](service-authoring/overview.md): ordered process for planning, manifesting, releasing, wiring, and validating a service.
 - [service.json Reference](reference/service-json-reference.md): canonical manifest fields, artifact metadata, health checks, actions, env, dependencies, and update policy.
+- [Release Manifest Verification](reference/release-manifest-verification.md): read-only checks for service release manifests, platform assets, release labels, and checksums.
 - [One-shot Jobs](reference/one-shot-jobs.md): setup-step contract for schema init, sample data loading, certificate generation, and other non-daemon workloads.
 - [Template Upgrade Compatibility](reference/template-upgrade-compatibility.md): read-only checker for app/template inventories against current core provider expectations.
 - [Reference Apps](reference-apps.md): choose the right host/template repo and understand the release output options.

--- a/docs/reference/release-manifest-verification.md
+++ b/docs/reference/release-manifest-verification.md
@@ -1,0 +1,22 @@
+# Release Manifest Verification
+
+`service-lasso release verify-manifest <manifestPath>` checks a local `service.json` and the release asset set beside it before a service release is published or consumed.
+
+Use `--assets-root <path>` when the archives and checksum files are staged outside the manifest directory. Use `--release-version <yyyy.m.d-shortsha>` to verify the expected release label explicitly.
+
+The verifier is read-only. It checks:
+
+- `service.json` parses against the Service Lasso manifest contract.
+- archive artifact metadata exists.
+- the release label is present, uses `yyyy.m.d-<shortsha>`, and matches `artifact.source.tag` when both are supplied.
+- runtime/service `version` metadata is present.
+- the asset set includes `service.json` and each platform archive named by `artifact.platforms`.
+- each archive has a verifiable SHA-256 checksum from `sha256`, `checksum.value`, `checksum.assetName`, or a local `SHA256SUMS.txt` / `SHA256SUMS` entry.
+
+JSON output is intended for automation:
+
+```powershell
+service-lasso release verify-manifest .\service.json --assets-root .\dist\release --release-version 2026.5.29-abcdef1 --json
+```
+
+The command exits non-zero when any `error` finding is emitted. Findings include machine-readable `code`, `severity`, and safe asset/platform metadata only.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { importServiceManifestFromCli, type ImportServiceManifestCliResult } fro
 import { runHealthCliAction, type HealthCliAction, type HealthCliResult } from "./runtime/cli/health.js";
 import { runLockfileCliAction, type LockfileCliAction, type LockfileCliResult } from "./runtime/cli/lockfile.js";
 import { runRecoveryCliAction, type RecoveryCliAction, type RecoveryCliResult } from "./runtime/cli/recovery.js";
+import { runReleaseCliAction, type ReleaseCliAction, type ReleaseCliResult } from "./runtime/cli/release.js";
 import type { ServiceRecoveryHistoryState } from "./runtime/recovery/history.js";
 import { runOperatorCliAction, type OperatorActionsCliAction, type OperatorCliResult } from "./runtime/cli/operator.js";
 import { runSecretsCliAction, type SecretsCliAction, type SecretsCliResult } from "./runtime/cli/secrets.js";
@@ -24,7 +25,7 @@ import { resolveRuntimeVersion } from "./runtime/version.js";
 import type { RuntimeInstanceResponse } from "./contracts/api.js";
 
 interface ParsedCliOptions {
-  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "readiness" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "template" | "help" | "version";
+  command: "serve" | "install" | "start" | "setup" | "updates" | "recovery" | "health" | "plan" | "lockfile" | "instance" | "readiness" | "config-drift" | "config-apply" | "config-snapshot" | "secrets" | "backup" | "diagnostics" | "operator" | "services" | "template" | "release" | "help" | "version";
   readinessAction?: "gate";
   serviceCommand?: "import";
   setupAction?: SetupCliAction;
@@ -40,6 +41,7 @@ interface ParsedCliOptions {
   diagnosticsAction?: DiagnosticsCliAction;
   operatorActionsAction?: OperatorActionsCliAction;
   templateAction?: TemplateCliAction;
+  releaseAction?: ReleaseCliAction;
   actionId?: string;
   deferredUntil?: string | null;
   serviceId?: string;
@@ -47,6 +49,8 @@ interface ParsedCliOptions {
   tag?: string;
   apiBaseUrl?: string;
   manifestPath?: string;
+  assetsRoot?: string;
+  releaseVersion?: string;
   stepId?: string;
   archivePath?: string;
   snapshotPath?: string;
@@ -106,6 +110,7 @@ function usageText(): string {
     "  service-lasso operator actions reopen <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso services import <owner/repo> [--tag <tag>] [--services-root <path>] [--dry-run] [--force] [--json]",
     "  service-lasso template check-upgrade <targetServicesRoot> [--core-services-root <path>] [--json]",
+    "  service-lasso release verify-manifest <manifestPath> [--assets-root <path>] [--release-version <version>] [--json]",
     "  service-lasso help",
     "  service-lasso --version",
     "",
@@ -121,6 +126,7 @@ function usageText(): string {
     "  - The readiness command emits a machine-readable gate for baseline automation.",
     "  - The lockfile command generates or verifies the servicesRoot service-lasso.lock.json.",
     "  - The template check-upgrade command compares an app/template service inventory to current core provider expectations.",
+    "  - The release verify-manifest command checks service.json, platform assets, release labels, and SHA-256 checksums.",
   ].join("\n");
 }
 
@@ -168,7 +174,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       commandToken === "diagnostics" ||
       commandToken === "operator" ||
       commandToken === "services" ||
-      commandToken === "template"
+      commandToken === "template" ||
+      commandToken === "release"
       ? commandToken
       : null;
   if (!command) {
@@ -426,6 +433,19 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
     parsed.targetServicesRoot = targetServicesRoot;
   }
 
+  if (command === "release") {
+    const action = remaining.shift();
+    if (action !== "verify-manifest") {
+      throw new Error('The "release" command requires one of: verify-manifest.');
+    }
+    parsed.releaseAction = action;
+    const manifestPath = remaining.shift();
+    if (!manifestPath || manifestPath.startsWith("-")) {
+      throw new Error('The "release verify-manifest" command requires a <manifestPath> argument.');
+    }
+    parsed.manifestPath = manifestPath;
+  }
+
   while (remaining.length > 0) {
     const token = remaining.shift();
 
@@ -458,8 +478,8 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
         break;
       }
       case "--json": {
-        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "readiness" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services" && command !== "template") {
-          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, readiness, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, services, and template commands.");
+        if (command !== "install" && command !== "start" && command !== "setup" && command !== "updates" && command !== "recovery" && command !== "health" && command !== "plan" && command !== "lockfile" && command !== "instance" && command !== "readiness" && command !== "config-drift" && command !== "config-apply" && command !== "config-snapshot" && command !== "secrets" && command !== "backup" && command !== "diagnostics" && command !== "operator" && command !== "services" && command !== "template" && command !== "release") {
+          throw new Error("--json is only supported for the install, start, setup, updates, recovery, health, plan, lockfile, instance, readiness, config-drift, config-apply, config-snapshot, secrets, backup, diagnostics, operator, services, template, and release commands.");
         }
         parsed.json = true;
         break;
@@ -523,6 +543,28 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
           throw new Error("Missing value for --core-services-root.");
         }
         parsed.coreServicesRoot = value;
+        break;
+      }
+      case "--assets-root": {
+        if (command !== "release" || parsed.releaseAction !== "verify-manifest") {
+          throw new Error("--assets-root is only supported for the release verify-manifest command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --assets-root.");
+        }
+        parsed.assetsRoot = value;
+        break;
+      }
+      case "--release-version": {
+        if (command !== "release" || parsed.releaseAction !== "verify-manifest") {
+          throw new Error("--release-version is only supported for the release verify-manifest command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --release-version.");
+        }
+        parsed.releaseVersion = value;
         break;
       }
       case "--force": {
@@ -730,6 +772,38 @@ function printTemplateResult(result: TemplateCliResult, asJson: boolean): void {
   }
   for (const finding of result.findings) {
     console.log("- " + finding.severity + " " + finding.serviceId + ": " + finding.kind + " - " + finding.hint);
+  }
+}
+
+function printReleaseResult(result: ReleaseCliResult, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(result.ok ? "[service-lasso] release manifest verified" : "[service-lasso] release manifest verification blocked");
+  console.log("- service: " + (result.service.id ?? "unknown"));
+  console.log("- version: " + (result.service.version ?? "unknown"));
+  console.log("- releaseVersion: " + (result.releaseVersion ?? "unknown"));
+  console.log("- assetsRoot: " + result.assetsRoot);
+  console.log("- assets: " + result.summary.presentAssets + "/" + result.summary.expectedAssets);
+  console.log("- checksumsVerified: " + result.summary.checksumsVerified);
+  console.log("- findings: errors=" + result.summary.errors + " warnings=" + result.summary.warnings);
+  for (const asset of result.assets) {
+    console.log(
+      "- " +
+        asset.platform +
+        ": " +
+        (asset.assetName ?? "unknown") +
+        " asset=" +
+        asset.status +
+        " checksum=" +
+        asset.checksum.status,
+    );
+  }
+  for (const finding of result.findings) {
+    const context = finding.platform ? " " + finding.platform : "";
+    console.log("- " + finding.severity + context + ": " + finding.code + " - " + finding.message);
   }
 }
 
@@ -1155,6 +1229,20 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       coreServicesRoot: parsed.coreServicesRoot,
     });
     printTemplateResult(result, parsed.json);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (parsed.command === "release") {
+    const result = await runReleaseCliAction({
+      action: parsed.releaseAction!,
+      manifestPath: parsed.manifestPath!,
+      assetsRoot: parsed.assetsRoot,
+      releaseVersion: parsed.releaseVersion,
+    });
+    printReleaseResult(result, parsed.json);
     if (!result.ok) {
       process.exitCode = 1;
     }

--- a/src/runtime/cli/release.ts
+++ b/src/runtime/cli/release.ts
@@ -1,0 +1,25 @@
+import { verifyReleaseManifest, type ReleaseManifestVerificationReport } from "../release/manifest-verification.js";
+
+export type ReleaseCliAction = "verify-manifest";
+
+export interface ReleaseCliOptions {
+  action: ReleaseCliAction;
+  manifestPath: string;
+  assetsRoot?: string;
+  releaseVersion?: string;
+}
+
+export type ReleaseCliResult = ReleaseManifestVerificationReport & {
+  action: ReleaseCliAction;
+};
+
+export async function runReleaseCliAction(options: ReleaseCliOptions): Promise<ReleaseCliResult> {
+  return {
+    action: options.action,
+    ...(await verifyReleaseManifest({
+      manifestPath: options.manifestPath,
+      assetsRoot: options.assetsRoot,
+      releaseVersion: options.releaseVersion,
+    })),
+  };
+}

--- a/src/runtime/release/manifest-verification.ts
+++ b/src/runtime/release/manifest-verification.ts
@@ -1,0 +1,463 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { access, readFile } from "node:fs/promises";
+import type { ServiceArchiveArtifact, ServiceArtifactPlatform, ServiceManifest } from "../../contracts/service.js";
+import { loadServiceManifest } from "../discovery/loadManifest.js";
+
+export type ReleaseManifestFindingSeverity = "error" | "warning";
+
+export type ReleaseManifestFindingCode =
+  | "invalid-service-manifest"
+  | "missing-release-artifact-metadata"
+  | "missing-runtime-version"
+  | "missing-release-version"
+  | "invalid-release-version"
+  | "release-version-mismatch"
+  | "missing-service-json-asset"
+  | "missing-asset-name"
+  | "missing-release-asset"
+  | "checksum-missing"
+  | "checksum-asset-missing"
+  | "checksum-entry-missing"
+  | "checksum-mismatch";
+
+export interface ReleaseManifestVerificationFinding {
+  severity: ReleaseManifestFindingSeverity;
+  code: ReleaseManifestFindingCode;
+  message: string;
+  platform?: string;
+  assetName?: string;
+}
+
+export type ReleaseAssetVerificationStatus = "present" | "missing";
+export type ReleaseAssetChecksumSource = "manifest-sha256" | "manifest-checksum" | "release-asset" | "none";
+export type ReleaseAssetChecksumStatus = "verified" | "mismatch" | "missing" | "not-declared";
+
+export interface ReleaseAssetVerification {
+  platform: string;
+  assetName: string | null;
+  archiveType: ServiceArtifactPlatform["archiveType"];
+  status: ReleaseAssetVerificationStatus;
+  checksum: {
+    source: ReleaseAssetChecksumSource;
+    status: ReleaseAssetChecksumStatus;
+    assetName: string | null;
+    expectedSha256: string | null;
+    actualSha256: string | null;
+  };
+}
+
+export interface ReleaseManifestVerificationReport {
+  ok: boolean;
+  status: "verified" | "blocked";
+  manifestPath: string;
+  assetsRoot: string;
+  releaseVersion: string | null;
+  service: {
+    id: string | null;
+    version: string | null;
+    sourceRepo: string | null;
+    releaseTag: string | null;
+  };
+  summary: {
+    errors: number;
+    warnings: number;
+    platforms: number;
+    expectedAssets: number;
+    presentAssets: number;
+    checksumsVerified: number;
+  };
+  assets: ReleaseAssetVerification[];
+  findings: ReleaseManifestVerificationFinding[];
+}
+
+export interface VerifyReleaseManifestOptions {
+  manifestPath: string;
+  assetsRoot?: string;
+  releaseVersion?: string;
+}
+
+const releaseVersionPattern = /^\d{4}\.\d{1,2}\.\d{1,2}-[0-9a-f]{7,40}$/i;
+const defaultChecksumAssetNames = ["SHA256SUMS.txt", "SHA256SUMS"];
+
+function normalizeSha256(value: string | undefined): string | null {
+  const candidate = value?.trim().toLowerCase();
+  return candidate && /^[a-f0-9]{64}$/.test(candidate) ? candidate : null;
+}
+
+function normalizeOptional(value: string | undefined): string | null {
+  const candidate = value?.trim();
+  return candidate ? candidate : null;
+}
+
+function assetNameFromPlatform(platform: ServiceArtifactPlatform): string | null {
+  if (platform.assetName?.trim()) {
+    return platform.assetName.trim();
+  }
+
+  if (!platform.assetUrl?.trim()) {
+    return null;
+  }
+
+  try {
+    return path.basename(new URL(platform.assetUrl).pathname);
+  } catch {
+    return path.basename(platform.assetUrl);
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
+}
+
+function findSha256InChecksumFile(content: string, artifactAssetName: string): string | null {
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const match = /^([a-fA-F0-9]{64})\s+\*?(.+)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const [, checksum, filename] = match;
+    if (path.basename(filename.trim()) === artifactAssetName) {
+      return checksum.toLowerCase();
+    }
+  }
+
+  return null;
+}
+
+async function readChecksumFromAsset(
+  assetsRoot: string,
+  checksumAssetName: string,
+  artifactAssetName: string,
+): Promise<{ status: "found"; checksum: string } | { status: "asset-missing" } | { status: "entry-missing" }> {
+  const checksumPath = path.join(assetsRoot, checksumAssetName);
+  if (!(await fileExists(checksumPath))) {
+    return { status: "asset-missing" };
+  }
+
+  const checksum = findSha256InChecksumFile(await readFile(checksumPath, "utf8"), artifactAssetName);
+  return checksum ? { status: "found", checksum } : { status: "entry-missing" };
+}
+
+async function resolveChecksum(
+  assetsRoot: string,
+  platform: ServiceArtifactPlatform,
+  assetName: string,
+): Promise<{
+  source: ReleaseAssetChecksumSource;
+  expectedSha256: string | null;
+  checksumAssetName: string | null;
+  finding: ReleaseManifestVerificationFinding | null;
+}> {
+  const directChecksum = normalizeSha256(platform.checksum?.value) ?? normalizeSha256(platform.sha256);
+  if (directChecksum) {
+    return {
+      source: platform.checksum?.value ? "manifest-checksum" : "manifest-sha256",
+      expectedSha256: directChecksum,
+      checksumAssetName: null,
+      finding: null,
+    };
+  }
+
+  const checksumAssetCandidates = [
+    ...(platform.checksum?.assetName ? [platform.checksum.assetName] : []),
+    ...defaultChecksumAssetNames,
+  ];
+
+  for (const checksumAssetName of checksumAssetCandidates) {
+    const result = await readChecksumFromAsset(assetsRoot, checksumAssetName, assetName);
+    if (result.status === "found") {
+      return {
+        source: "release-asset",
+        expectedSha256: result.checksum,
+        checksumAssetName,
+        finding: null,
+      };
+    }
+
+    if (platform.checksum?.assetName === checksumAssetName && result.status === "asset-missing") {
+      return {
+        source: "release-asset",
+        expectedSha256: null,
+        checksumAssetName,
+        finding: {
+          severity: "error",
+          code: "checksum-asset-missing",
+          message: `Checksum asset "${checksumAssetName}" is missing.`,
+          assetName,
+        },
+      };
+    }
+
+    if (platform.checksum?.assetName === checksumAssetName && result.status === "entry-missing") {
+      return {
+        source: "release-asset",
+        expectedSha256: null,
+        checksumAssetName,
+        finding: {
+          severity: "error",
+          code: "checksum-entry-missing",
+          message: `Checksum asset "${checksumAssetName}" does not contain an entry for "${assetName}".`,
+          assetName,
+        },
+      };
+    }
+  }
+
+  return {
+    source: "none",
+    expectedSha256: null,
+    checksumAssetName: null,
+    finding: {
+      severity: "error",
+      code: "checksum-missing",
+      message: `Release asset "${assetName}" has no verifiable SHA-256 checksum.`,
+      assetName,
+    },
+  };
+}
+
+function buildEmptyReport(
+  manifestPath: string,
+  assetsRoot: string,
+  releaseVersion: string | null,
+  finding: ReleaseManifestVerificationFinding,
+): ReleaseManifestVerificationReport {
+  return {
+    ok: false,
+    status: "blocked",
+    manifestPath,
+    assetsRoot,
+    releaseVersion,
+    service: {
+      id: null,
+      version: null,
+      sourceRepo: null,
+      releaseTag: null,
+    },
+    summary: {
+      errors: finding.severity === "error" ? 1 : 0,
+      warnings: finding.severity === "warning" ? 1 : 0,
+      platforms: 0,
+      expectedAssets: 0,
+      presentAssets: 0,
+      checksumsVerified: 0,
+    },
+    assets: [],
+    findings: [finding],
+  };
+}
+
+async function verifyPlatformAsset(
+  assetsRoot: string,
+  platformName: string,
+  platform: ServiceArtifactPlatform,
+): Promise<{ asset: ReleaseAssetVerification; findings: ReleaseManifestVerificationFinding[] }> {
+  const findings: ReleaseManifestVerificationFinding[] = [];
+  const assetName = assetNameFromPlatform(platform);
+
+  if (!assetName) {
+    const asset: ReleaseAssetVerification = {
+      platform: platformName,
+      assetName: null,
+      archiveType: platform.archiveType,
+      status: "missing",
+      checksum: {
+        source: "none",
+        status: "not-declared",
+        assetName: null,
+        expectedSha256: null,
+        actualSha256: null,
+      },
+    };
+    findings.push({
+      severity: "error",
+      code: "missing-asset-name",
+      message: `Platform "${platformName}" does not declare an asset name or asset URL.`,
+      platform: platformName,
+    });
+    return { asset, findings };
+  }
+
+  const assetPath = path.join(assetsRoot, assetName);
+  const exists = await fileExists(assetPath);
+  const checksum = await resolveChecksum(assetsRoot, platform, assetName);
+  if (checksum.finding) {
+    findings.push({ ...checksum.finding, platform: platformName });
+  }
+
+  let actualSha256: string | null = null;
+  let checksumStatus: ReleaseAssetChecksumStatus = checksum.expectedSha256 ? "missing" : "not-declared";
+  if (exists && checksum.expectedSha256) {
+    actualSha256 = await sha256File(assetPath);
+    checksumStatus = actualSha256 === checksum.expectedSha256 ? "verified" : "mismatch";
+    if (checksumStatus === "mismatch") {
+      findings.push({
+        severity: "error",
+        code: "checksum-mismatch",
+        message: `Release asset "${assetName}" checksum did not match expected SHA-256.`,
+        platform: platformName,
+        assetName,
+      });
+    }
+  }
+
+  if (!exists) {
+    findings.push({
+      severity: "error",
+      code: "missing-release-asset",
+      message: `Release asset "${assetName}" is missing.`,
+      platform: platformName,
+      assetName,
+    });
+  }
+
+  return {
+    asset: {
+      platform: platformName,
+      assetName,
+      archiveType: platform.archiveType,
+      status: exists ? "present" : "missing",
+      checksum: {
+        source: checksum.source,
+        status: checksumStatus,
+        assetName: checksum.checksumAssetName,
+        expectedSha256: checksum.expectedSha256,
+        actualSha256,
+      },
+    },
+    findings,
+  };
+}
+
+function validateReleaseMetadata(
+  manifest: ServiceManifest,
+  artifact: ServiceArchiveArtifact,
+  releaseVersion: string | null,
+): ReleaseManifestVerificationFinding[] {
+  const findings: ReleaseManifestVerificationFinding[] = [];
+  const manifestReleaseTag = normalizeOptional(artifact.source.tag);
+  const effectiveReleaseVersion = releaseVersion ?? manifestReleaseTag;
+
+  if (!normalizeOptional(manifest.version)) {
+    findings.push({
+      severity: "error",
+      code: "missing-runtime-version",
+      message: "service.json must include runtime/service version metadata.",
+    });
+  }
+
+  if (!effectiveReleaseVersion) {
+    findings.push({
+      severity: "error",
+      code: "missing-release-version",
+      message: "Release verification requires artifact.source.tag or --release-version.",
+    });
+  } else if (!releaseVersionPattern.test(effectiveReleaseVersion)) {
+    findings.push({
+      severity: "error",
+      code: "invalid-release-version",
+      message: `Release version "${effectiveReleaseVersion}" must use yyyy.m.d-<shortsha>.`,
+    });
+  }
+
+  if (releaseVersion && manifestReleaseTag && releaseVersion !== manifestReleaseTag) {
+    findings.push({
+      severity: "error",
+      code: "release-version-mismatch",
+      message: `--release-version "${releaseVersion}" does not match artifact.source.tag "${manifestReleaseTag}".`,
+    });
+  }
+
+  return findings;
+}
+
+export async function verifyReleaseManifest(
+  options: VerifyReleaseManifestOptions,
+): Promise<ReleaseManifestVerificationReport> {
+  const manifestPath = path.resolve(options.manifestPath);
+  const assetsRoot = path.resolve(options.assetsRoot ?? path.dirname(manifestPath));
+  const releaseVersion = normalizeOptional(options.releaseVersion);
+
+  let manifest: ServiceManifest;
+  try {
+    manifest = await loadServiceManifest(manifestPath);
+  } catch (error) {
+    return buildEmptyReport(manifestPath, assetsRoot, releaseVersion, {
+      severity: "error",
+      code: "invalid-service-manifest",
+      message: error instanceof Error ? error.message : "service.json could not be parsed or validated.",
+    });
+  }
+
+  if (!manifest.artifact) {
+    return buildEmptyReport(manifestPath, assetsRoot, releaseVersion, {
+      severity: "error",
+      code: "missing-release-artifact-metadata",
+      message: "service.json must include archive artifact metadata for release verification.",
+    });
+  }
+
+  const findings: ReleaseManifestVerificationFinding[] = [
+    ...validateReleaseMetadata(manifest, manifest.artifact, releaseVersion),
+  ];
+
+  if (!(await fileExists(path.join(assetsRoot, "service.json")))) {
+    findings.push({
+      severity: "error",
+      code: "missing-service-json-asset",
+      message: "Release asset set must include service.json.",
+      assetName: "service.json",
+    });
+  }
+
+  const assets: ReleaseAssetVerification[] = [];
+  for (const [platformName, platform] of Object.entries(manifest.artifact.platforms)) {
+    const result = await verifyPlatformAsset(assetsRoot, platformName, platform);
+    assets.push(result.asset);
+    findings.push(...result.findings);
+  }
+
+  const errors = findings.filter((finding) => finding.severity === "error").length;
+  const warnings = findings.filter((finding) => finding.severity === "warning").length;
+  const checksumsVerified = assets.filter((asset) => asset.checksum.status === "verified").length;
+
+  return {
+    ok: errors === 0,
+    status: errors === 0 ? "verified" : "blocked",
+    manifestPath,
+    assetsRoot,
+    releaseVersion: releaseVersion ?? normalizeOptional(manifest.artifact.source.tag),
+    service: {
+      id: manifest.id,
+      version: normalizeOptional(manifest.version),
+      sourceRepo: manifest.artifact.source.repo,
+      releaseTag: normalizeOptional(manifest.artifact.source.tag),
+    },
+    summary: {
+      errors,
+      warnings,
+      platforms: Object.keys(manifest.artifact.platforms).length,
+      expectedAssets: assets.length,
+      presentAssets: assets.filter((asset) => asset.status === "present").length,
+      checksumsVerified,
+    },
+    assets,
+    findings,
+  };
+}

--- a/tests/cli-release-manifest.test.js
+++ b/tests/cli-release-manifest.test.js
@@ -1,0 +1,186 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { runReleaseCliAction } from "../dist/runtime/cli/release.js";
+
+const execFile = promisify(execFileCallback);
+const repoRoot = path.resolve(".");
+const releaseVersion = "2026.5.29-abcdef1";
+
+async function makeReleaseFixture(prefix = "service-lasso-release-manifest-") {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  await mkdir(root, { recursive: true });
+
+  const archiveName = "lasso-fixture-linux.tar.gz";
+  const archiveContent = "fixture archive payload\n";
+  const archiveSha256 = createHash("sha256").update(archiveContent).digest("hex");
+  const manifest = {
+    id: "fixture-service",
+    name: "Fixture Service",
+    description: "Release verification fixture.",
+    version: releaseVersion,
+    artifact: {
+      kind: "archive",
+      source: {
+        type: "github-release",
+        repo: "service-lasso/lasso-fixture",
+        tag: releaseVersion,
+      },
+      platforms: {
+        linux: {
+          assetName: archiveName,
+          archiveType: "tar.gz",
+          checksum: {
+            algorithm: "sha256",
+            assetName: "SHA256SUMS.txt",
+          },
+        },
+      },
+    },
+  };
+
+  await writeFile(path.join(root, archiveName), archiveContent);
+  await writeFile(path.join(root, "SHA256SUMS.txt"), `${archiveSha256}  ${archiveName}\n`);
+  await writeFile(path.join(root, "service.json"), JSON.stringify(manifest, null, 2));
+
+  return { root, archiveName, manifestPath: path.join(root, "service.json"), manifest, archiveSha256 };
+}
+
+async function writeManifest(root, manifest) {
+  await writeFile(path.join(root, "service.json"), JSON.stringify(manifest, null, 2));
+}
+
+async function runCli(args) {
+  const cliPath = path.join(repoRoot, "dist", "cli.js");
+  const result = await execFile(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      npm_package_version: "0.1.0-test",
+    },
+  });
+
+  return result.stdout.trim();
+}
+
+test("release verify-manifest accepts a complete manifest and asset set", async () => {
+  const { root, manifestPath } = await makeReleaseFixture("service-lasso-release-manifest-ok-");
+
+  try {
+    const output = await runCli(["release", "verify-manifest", manifestPath, "--assets-root", root, "--json"]);
+    const report = JSON.parse(output);
+
+    assert.equal(report.action, "verify-manifest");
+    assert.equal(report.ok, true);
+    assert.equal(report.status, "verified");
+    assert.equal(report.summary.errors, 0);
+    assert.equal(report.summary.platforms, 1);
+    assert.equal(report.summary.presentAssets, 1);
+    assert.equal(report.summary.checksumsVerified, 1);
+    assert.deepEqual(report.findings, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("release verify-manifest reports a missing platform asset", async () => {
+  const { root, archiveName, manifestPath } = await makeReleaseFixture("service-lasso-release-manifest-missing-");
+
+  try {
+    await rm(path.join(root, archiveName), { force: true });
+
+    const report = await runReleaseCliAction({
+      action: "verify-manifest",
+      manifestPath,
+      assetsRoot: root,
+    });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.status, "blocked");
+    assert.equal(report.summary.errors, 1);
+    assert.equal(report.assets[0].status, "missing");
+    assert.ok(report.findings.some((finding) =>
+      finding.code === "missing-release-asset" &&
+      finding.platform === "linux" &&
+      finding.assetName === archiveName
+    ));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("release verify-manifest blocks bad release version labels", async () => {
+  const { root, manifestPath, manifest } = await makeReleaseFixture("service-lasso-release-manifest-version-");
+
+  try {
+    const badVersionManifest = {
+      ...manifest,
+      version: "latest",
+      artifact: {
+        ...manifest.artifact,
+        source: {
+          ...manifest.artifact.source,
+          tag: "latest",
+        },
+      },
+    };
+    await writeManifest(root, badVersionManifest);
+
+    const report = await runReleaseCliAction({
+      action: "verify-manifest",
+      manifestPath,
+      assetsRoot: root,
+    });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.status, "blocked");
+    assert.ok(report.findings.some((finding) => finding.code === "invalid-release-version"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("release verify-manifest blocks checksum mismatches", async () => {
+  const { root, archiveName, manifestPath, manifest } = await makeReleaseFixture("service-lasso-release-manifest-checksum-");
+
+  try {
+    const mismatchManifest = {
+      ...manifest,
+      artifact: {
+        ...manifest.artifact,
+        platforms: {
+          linux: {
+            ...manifest.artifact.platforms.linux,
+            checksum: {
+              algorithm: "sha256",
+              value: "0".repeat(64),
+            },
+          },
+        },
+      },
+    };
+    await writeManifest(root, mismatchManifest);
+
+    const report = await runReleaseCliAction({
+      action: "verify-manifest",
+      manifestPath,
+      assetsRoot: root,
+    });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.status, "blocked");
+    assert.equal(report.assets[0].checksum.status, "mismatch");
+    assert.ok(report.findings.some((finding) =>
+      finding.code === "checksum-mismatch" &&
+      finding.platform === "linux" &&
+      finding.assetName === archiveName
+    ));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add `service-lasso release verify-manifest <manifestPath>` with JSON/human output.
- Verify `service.json`, archive artifact metadata, release version labels, platform assets, and SHA-256 checksums.
- Add release manifest verification docs and command coverage for valid, missing asset, bad version, and checksum mismatch cases.

## Validation
- PASS `npm run build`
- PASS `node --test --test-concurrency=1 tests/cli-release-manifest.test.js`
- PASS `git diff --check`
- PASS `npm run verify:baseline-start`
- PASS `npm run verify:real-app-e2e`
- PASS `npm run verify:multi-instance-ports`
- NOTE `npm test` currently has one unrelated failure in `tests/cli-dry-run-plan.test.js` (`CLI plan start returns structured dry-run without creating workspace state`, assertion at line 57: workspace path exists). The new release manifest tests pass inside the same run.

Closes #534