### PR TITLE
feat(telegram): add chat-origin actor audit contract

### DIFF
--- a/docs/development/telegram-group-control-plan.md
+++ b/docs/development/telegram-group-control-plan.md
@@ -50,16 +50,18 @@ OpenClaw should map the Telegram sender to a Service Lasso actor envelope before
 
 ~~~json
 {
+  "source": "chat-bridge",
   "channel": "telegram",
   "chatId": "-5128051597",
   "senderId": "123456789",
   "senderDisplay": "operator",
-  "serviceLassoActor": "telegram:123456789",
+  "actorId": "telegram:123456789",
+  "sourceMessageId": "1001",
   "roles": ["operator"]
 }
 ~~~
 
-Service Lasso should trust only a locally configured OpenClaw bridge or explicit local token, not arbitrary remote Telegram metadata. Runtime API calls should include safe actor headers or a local bridge credential so audit records can distinguish shell, web UI, and chat-originated activity.
+Service Lasso should trust only a locally configured OpenClaw bridge or explicit local token, not arbitrary remote Telegram metadata. Runtime API calls should include the actor envelope in the operator command body and a local bridge credential, such as `X-Service-Lasso-Chat-Bridge-Token`, so audit records can distinguish shell, web UI, and chat-originated activity without storing the credential.
 
 ## Confirmation Model
 

--- a/docs/reference/operator-command-facade.md
+++ b/docs/reference/operator-command-facade.md
@@ -13,7 +13,16 @@ The endpoint accepts a small command request:
   "command": "service @serviceadmin logs --tail 20",
   "args": [],
   "serviceId": "@serviceadmin",
-  "tail": 20
+  "tail": 20,
+  "actor": {
+    "source": "chat-bridge",
+    "channel": "telegram",
+    "chatId": "-5128051597",
+    "senderId": "42",
+    "senderDisplay": "Operator",
+    "sourceMessageId": "1001",
+    "roles": ["operator"]
+  }
 }
 ```
 
@@ -36,6 +45,19 @@ Responses use contract version `operator-command.v1` and include:
 - `summary`: compact operator-facing text.
 - `data`: structured payload for OpenClaw or another bridge to render.
 - `safety`: redaction/truncation flags and omitted sensitive field classes.
+- `audit`: the persisted audit metadata for the command.
+
+Actor metadata is optional for local API/shell callers. When omitted, Service Lasso records `source: "api"` and `actorId: "api:local"`. Chat bridge callers must send `actor.source: "chat-bridge"` with `channel`, `chatId`, and `senderId`.
+
+Chat-originated actor metadata is accepted only from a trusted local bridge request. Configure the local runtime with `SERVICE_LASSO_CHAT_BRIDGE_TOKEN` and send the matching value in the `X-Service-Lasso-Chat-Bridge-Token` header. The token itself is not included in command responses or audit records.
+
+Audit events are appended to:
+
+```text
+<workspaceRoot>/.state/operator-command-audit.jsonl
+```
+
+Audit records include the normalized actor, command, read/plan/blocked class, target service id when present, status code, stable error code, redaction/truncation flags, and future `planId`/`confirmationId` fields. Audit records must stay metadata-only.
 
 Unsupported commands, unknown services, mutating commands without `--plan`, and invalid or unbounded log tails fail closed with a 4xx response. The facade does not handle Telegram SDK details, allowlists, or confirmation tokens; those stay in the OpenClaw bridge and later confirmation-token work.
 

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -257,6 +257,60 @@ export interface OperatorCommandRequest {
   args?: string[];
   serviceId?: string;
   tail?: number;
+  actor?: OperatorCommandActorEnvelope;
+}
+
+export type OperatorCommandActorSource = "api" | "shell" | "web" | "chat-bridge";
+export type OperatorCommandChatChannel = "telegram" | "custom";
+
+export interface OperatorCommandActorEnvelope {
+  source?: OperatorCommandActorSource;
+  actorId?: string;
+  roles?: string[];
+  channel?: OperatorCommandChatChannel;
+  chatId?: string;
+  senderId?: string;
+  senderDisplay?: string | null;
+  sourceMessageId?: string | null;
+  planId?: string | null;
+  confirmationId?: string | null;
+}
+
+export interface NormalizedOperatorCommandActorEnvelope {
+  source: OperatorCommandActorSource;
+  actorId: string;
+  roles: string[];
+  channel?: OperatorCommandChatChannel;
+  chatId?: string;
+  senderId?: string;
+  senderDisplay?: string | null;
+  sourceMessageId?: string | null;
+  planId?: string | null;
+  confirmationId?: string | null;
+}
+
+export interface OperatorCommandAuditEvent {
+  contractVersion: "operator-command-audit.v1";
+  id: string;
+  at: string;
+  source: OperatorCommandActorSource;
+  actorId: string;
+  roles: string[];
+  channel: OperatorCommandChatChannel | null;
+  chatId: string | null;
+  senderId: string | null;
+  senderDisplay: string | null;
+  sourceMessageId: string | null;
+  command: OperatorCommandKind | "unsupported";
+  commandClass: "read" | "plan" | "blocked";
+  targetServiceId: string | null;
+  resultStatus: "success" | "denied" | "failed";
+  statusCode: number;
+  errorCode: OperatorCommandErrorCode | null;
+  redacted: boolean;
+  truncated: boolean;
+  planId: string | null;
+  confirmationId: string | null;
 }
 
 export interface OperatorCommandResponse {
@@ -278,6 +332,7 @@ export interface OperatorCommandResponse {
     truncated: boolean;
     omittedSensitiveFields: string[];
   };
+  audit: OperatorCommandAuditEvent;
 }
 
 export interface DashboardLinkResponse {

--- a/src/runtime/operator/command-audit.ts
+++ b/src/runtime/operator/command-audit.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, appendFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  NormalizedOperatorCommandActorEnvelope,
+  OperatorCommandActorSource,
+  OperatorCommandAuditEvent,
+  OperatorCommandChatChannel,
+  OperatorCommandResponse,
+} from "../../contracts/api.js";
+
+const MAX_SAFE_TEXT_LENGTH = 160;
+const secretLikeValuePattern =
+  /((password|passwd|secret|token|credential|cookie|private[_-]?key)\s*[:=]\s*[^\s,;]+)|(bearer\s+[A-Za-z0-9._~+/=-]+)|(gh[pousr]_[A-Za-z0-9_]+)/i;
+
+export class OperatorActorValidationError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+
+  constructor(code: string, statusCode: number, message: string) {
+    super(message);
+    this.name = "OperatorActorValidationError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export function operatorCommandAuditPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".state", "operator-command-audit.jsonl");
+}
+
+export function normalizeOperatorCommandActor(input: unknown): NormalizedOperatorCommandActorEnvelope {
+  if (input === undefined || input === null) {
+    return {
+      source: "api",
+      actorId: "api:local",
+      roles: [],
+    };
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new OperatorActorValidationError("invalid_actor", 400, '"actor" must be an object when present.');
+  }
+
+  const candidate = input as Record<string, unknown>;
+  const source = expectSource(candidate.source);
+  const channel = candidate.channel === undefined || candidate.channel === null ? undefined : expectChannel(candidate.channel);
+  if (source === "chat-bridge" && !channel) {
+    throw new OperatorActorValidationError("invalid_actor", 400, 'Chat bridge actor metadata requires "channel".');
+  }
+
+  const actorId = normalizeSafeText(
+    candidate.actorId,
+    source === "chat-bridge" && channel && typeof candidate.senderId === "string"
+      ? `${channel}:${candidate.senderId}`
+      : `${source}:local`,
+    "actor.actorId",
+  );
+  const roles = normalizeRoles(candidate.roles);
+  const actor: NormalizedOperatorCommandActorEnvelope = {
+    source,
+    actorId,
+    roles,
+    channel,
+    chatId: optionalSafeText(candidate.chatId, "actor.chatId"),
+    senderId: optionalSafeText(candidate.senderId, "actor.senderId"),
+    senderDisplay: optionalSafeText(candidate.senderDisplay, "actor.senderDisplay"),
+    sourceMessageId: optionalSafeText(candidate.sourceMessageId, "actor.sourceMessageId"),
+    planId: optionalSafeText(candidate.planId, "actor.planId"),
+    confirmationId: optionalSafeText(candidate.confirmationId, "actor.confirmationId"),
+  };
+
+  if (actor.source === "chat-bridge" && (!actor.chatId || !actor.senderId)) {
+    throw new OperatorActorValidationError("invalid_actor", 400, "Chat bridge actor metadata requires chatId and senderId.");
+  }
+  if (operatorActorIncludesSecretMaterial(actor)) {
+    throw new OperatorActorValidationError("invalid_actor", 400, "Actor metadata must not include tokens, cookies, secrets, credentials, or private keys.");
+  }
+  return actor;
+}
+
+export function buildOperatorCommandAuditEvent(input: {
+  actor: NormalizedOperatorCommandActorEnvelope;
+  response: Omit<OperatorCommandResponse, "audit">;
+  targetServiceId?: string | null;
+}): OperatorCommandAuditEvent {
+  const at = input.response.generatedAt;
+  const event: OperatorCommandAuditEvent = {
+    contractVersion: "operator-command-audit.v1",
+    id: `operator-command-${Date.parse(at)}-${randomUUID()}`,
+    at,
+    source: input.actor.source,
+    actorId: input.actor.actorId,
+    roles: [...input.actor.roles],
+    channel: input.actor.channel ?? null,
+    chatId: input.actor.chatId ?? null,
+    senderId: input.actor.senderId ?? null,
+    senderDisplay: input.actor.senderDisplay ?? null,
+    sourceMessageId: input.actor.sourceMessageId ?? null,
+    command: input.response.command,
+    commandClass: input.response.commandClass,
+    targetServiceId: input.targetServiceId ?? null,
+    resultStatus: input.response.ok ? "success" : input.response.error?.code === "mutating_command_blocked" ? "denied" : "failed",
+    statusCode: input.response.statusCode,
+    errorCode: input.response.error?.code ?? null,
+    redacted: input.response.safety.redacted,
+    truncated: input.response.safety.truncated,
+    planId: input.actor.planId ?? null,
+    confirmationId: input.actor.confirmationId ?? null,
+  };
+  if (operatorCommandAuditIncludesSecretMaterial(event)) {
+    throw new Error("Operator command audit metadata must not include raw tokens, cookies, secrets, credentials, or private keys");
+  }
+  return event;
+}
+
+export async function appendOperatorCommandAuditEvent(workspaceRoot: string, event: OperatorCommandAuditEvent): Promise<void> {
+  const auditPath = operatorCommandAuditPath(workspaceRoot);
+  await mkdir(path.dirname(auditPath), { recursive: true });
+  await appendFile(auditPath, JSON.stringify(event) + "\n", "utf8");
+}
+
+export function operatorCommandAuditIncludesSecretMaterial(event: OperatorCommandAuditEvent): boolean {
+  return secretLikeValuePattern.test(JSON.stringify(event));
+}
+
+function expectSource(value: unknown): OperatorCommandActorSource {
+  if (value === "api" || value === "shell" || value === "web" || value === "chat-bridge") {
+    return value;
+  }
+  throw new OperatorActorValidationError("invalid_actor", 400, '"actor.source" must be api, shell, web, or chat-bridge.');
+}
+
+function expectChannel(value: unknown): OperatorCommandChatChannel {
+  if (value === "telegram" || value === "custom") {
+    return value;
+  }
+  throw new OperatorActorValidationError("invalid_actor", 400, '"actor.channel" must be telegram or custom.');
+}
+
+function normalizeRoles(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new OperatorActorValidationError("invalid_actor", 400, '"actor.roles" must be an array of strings when present.');
+  }
+  return value.map((entry) => normalizeSafeText(entry, "", "actor.roles")).filter(Boolean).slice(0, 20);
+}
+
+function optionalSafeText(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return normalizeSafeText(value, "", field);
+}
+
+function normalizeSafeText(value: unknown, fallback: string, field: string): string {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (typeof value !== "string") {
+    throw new OperatorActorValidationError("invalid_actor", 400, `"${field}" must be a string when present.`);
+  }
+  const normalized = value.trim().replace(/\s+/g, " ").slice(0, MAX_SAFE_TEXT_LENGTH);
+  if (secretLikeValuePattern.test(normalized)) {
+    throw new OperatorActorValidationError("invalid_actor", 400, "Actor metadata must not include tokens, cookies, secrets, credentials, or private keys.");
+  }
+  return normalized || fallback;
+}
+
+function operatorActorIncludesSecretMaterial(actor: NormalizedOperatorCommandActorEnvelope): boolean {
+  return secretLikeValuePattern.test(JSON.stringify(actor));
+}

--- a/src/runtime/operator/command-facade.ts
+++ b/src/runtime/operator/command-facade.ts
@@ -10,6 +10,12 @@ import { readServiceLogChunk } from "./logs.js";
 import { buildOperatorNotifications } from "./notifications.js";
 import { buildRestartSafetyPreflightReport } from "./restart-safety-preflight.js";
 import { listServiceUpdateStates } from "../updates/actions.js";
+import {
+  appendOperatorCommandAuditEvent,
+  buildOperatorCommandAuditEvent,
+  normalizeOperatorCommandActor,
+  OperatorActorValidationError,
+} from "./command-audit.js";
 
 const DEFAULT_LOG_TAIL_LINES = 20;
 const MAX_COMMAND_LOG_TAIL_LINES = 80;
@@ -22,6 +28,7 @@ export interface OperatorCommandFacadeModel {
   workspaceRoot: string;
   version: string;
   sharedGlobalEnv: Record<string, string>;
+  trustedChatBridge?: boolean;
 }
 
 type NormalizedOperatorCommand =
@@ -29,6 +36,8 @@ type NormalizedOperatorCommand =
   | { kind: "blocked"; reason: "invalid_log_tail"; attempted: string }
   | { kind: "blocked"; reason: "mutating_command_blocked"; attempted: string }
   | { kind: "unsupported"; attempted: string };
+
+type OperatorCommandResponseDraft = Omit<OperatorCommandResponse, "audit">;
 
 function createResponse(input: {
   ok: boolean;
@@ -40,7 +49,7 @@ function createResponse(input: {
   error?: OperatorCommandResponse["error"];
   redacted?: boolean;
   truncated?: boolean;
-}): OperatorCommandResponse {
+}): OperatorCommandResponseDraft {
   return {
     contractVersion: "operator-command.v1",
     ok: input.ok,
@@ -159,7 +168,7 @@ function redactOperatorText(value: string): string {
   );
 }
 
-function getServiceOrError(model: OperatorCommandFacadeModel, serviceId: string | undefined): DiscoveredService | OperatorCommandResponse {
+function getServiceOrError(model: OperatorCommandFacadeModel, serviceId: string | undefined): DiscoveredService | OperatorCommandResponseDraft {
   if (!serviceId) {
     return createResponse({
       ok: false,
@@ -185,12 +194,10 @@ function getServiceOrError(model: OperatorCommandFacadeModel, serviceId: string 
   return service;
 }
 
-export async function executeOperatorCommandFacade(
-  request: OperatorCommandRequest,
+async function executeNormalizedOperatorCommand(
+  normalized: NormalizedOperatorCommand,
   model: OperatorCommandFacadeModel,
-): Promise<OperatorCommandResponse> {
-  const normalized = normalizeOperatorCommand(request);
-
+): Promise<OperatorCommandResponseDraft> {
   if (normalized.kind === "blocked") {
     if (normalized.reason === "invalid_log_tail") {
       return createResponse({
@@ -331,7 +338,10 @@ export async function executeOperatorCommandFacade(
       normalized.serviceId ? [model.registry.getById(normalized.serviceId)].filter((service): service is DiscoveredService => Boolean(service)) : model.registry.list(),
     );
     if (normalized.serviceId && updateStates.length === 0) {
-      return getServiceOrError(model, normalized.serviceId) as OperatorCommandResponse;
+      const service = getServiceOrError(model, normalized.serviceId);
+      if ("contractVersion" in service) {
+        return service;
+      }
     }
     return createResponse({
       ok: true,
@@ -359,7 +369,10 @@ export async function executeOperatorCommandFacade(
 
   if (normalized.kind === "diagnostics.bundle.preview") {
     if (normalized.serviceId && !model.registry.getById(normalized.serviceId)) {
-      return getServiceOrError(model, normalized.serviceId) as OperatorCommandResponse;
+      const service = getServiceOrError(model, normalized.serviceId);
+      if ("contractVersion" in service) {
+        return service;
+      }
     }
     const preview = buildDiagnosticsBundlePreview(await buildDiagnosticsBundle({
       servicesRoot: model.servicesRoot,
@@ -407,4 +420,31 @@ export async function executeOperatorCommandFacade(
     summary: "Unsupported operator command.",
     error: { code: "unsupported_command", message: "Unsupported operator command." },
   });
+}
+
+export async function executeOperatorCommandFacade(
+  request: OperatorCommandRequest,
+  model: OperatorCommandFacadeModel,
+): Promise<OperatorCommandResponse> {
+  const actor = normalizeOperatorCommandActor(request.actor);
+  if (actor.source === "chat-bridge" && model.trustedChatBridge !== true) {
+    throw new OperatorActorValidationError(
+      "untrusted_chat_bridge",
+      403,
+      "Chat bridge actor metadata requires trusted local bridge authentication.",
+    );
+  }
+
+  const normalized = normalizeOperatorCommand(request);
+  const response = await executeNormalizedOperatorCommand(normalized, model);
+  const audit = buildOperatorCommandAuditEvent({
+    actor,
+    response,
+    targetServiceId: "serviceId" in normalized ? normalized.serviceId ?? null : null,
+  });
+  await appendOperatorCommandAuditEvent(model.workspaceRoot, audit);
+  return {
+    ...response,
+    audit,
+  };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { once } from "node:events";
+import { timingSafeEqual } from "node:crypto";
 import { cp } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -275,6 +276,7 @@ function parseOperatorCommandBody(input: unknown): OperatorCommandRequest {
     args: Array.isArray(candidate.args) ? candidate.args : undefined,
     serviceId: typeof candidate.serviceId === "string" ? candidate.serviceId : undefined,
     tail: typeof candidate.tail === "number" ? candidate.tail : undefined,
+    actor: candidate.actor as OperatorCommandRequest["actor"],
   };
 }
 
@@ -464,6 +466,18 @@ function countWorkflowPackageSources(packages: Array<{ source: WorkflowPackageSo
 function firstHeader(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) return value[0];
   return value;
+}
+
+function isTrustedChatBridgeRequest(request: IncomingMessage): boolean {
+  const expected = process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  const provided = firstHeader(request.headers["x-service-lasso-chat-bridge-token"]);
+  if (!expected || !provided) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  return expectedBuffer.length === providedBuffer.length && timingSafeEqual(expectedBuffer, providedBuffer);
 }
 
 function parseEntitlements(request: IncomingMessage): PlatformEntitlement[] {
@@ -995,6 +1009,7 @@ async function routeRequest(
       workspaceRoot: config.workspaceRoot,
       version: config.version,
       sharedGlobalEnv,
+      trustedChatBridge: isTrustedChatBridgeRequest(request),
     });
 
     writeJson(response, commandResponse.statusCode, commandResponse);

--- a/tests/operator-command-facade.test.js
+++ b/tests/operator-command-facade.test.js
@@ -1,16 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
 
-async function postJson(url, body) {
+async function postJson(url, body, headers = {}) {
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
+      ...headers,
     },
     body: JSON.stringify(body),
   });
@@ -44,12 +45,144 @@ test("operator command facade lists services without leaking environment values"
     assert.equal(response.body.ok, true);
     assert.equal(response.body.command, "services");
     assert.equal(response.body.commandClass, "read");
+    assert.equal(response.body.audit.source, "api");
+    assert.equal(response.body.audit.command, "services");
     assert.equal(response.body.data.services.length, 1);
     assert.equal(response.body.data.services[0].id, "alpha-service");
     assert.ok(response.body.data.services[0].envKeyCount >= 1);
     assert.equal(JSON.stringify(response.body).includes("SERVICE_LASSO_FAKE_SECRET_SENTINEL_OPERATOR_COMMAND_DO_NOT_USE"), false);
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("operator command facade records trusted chat actor audit metadata", async () => {
+  resetLifecycleState();
+  const previousToken = process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = "SERVICE_LASSO_TEST_BRIDGE_TOKEN";
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-operator-command-audit-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const response = await postJson(
+      apiServer.url + "/api/operator/commands",
+      {
+        command: "service alpha-service status",
+        actor: {
+          source: "chat-bridge",
+          channel: "telegram",
+          chatId: "-5128051597",
+          senderId: "42",
+          senderDisplay: "Operator",
+          sourceMessageId: "1001",
+          roles: ["operator"],
+        },
+      },
+      { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" },
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.audit.source, "chat-bridge");
+    assert.equal(response.body.audit.channel, "telegram");
+    assert.equal(response.body.audit.chatId, "-5128051597");
+    assert.equal(response.body.audit.senderId, "42");
+    assert.equal(response.body.audit.actorId, "telegram:42");
+    assert.equal(response.body.audit.command, "service.status");
+    assert.equal(response.body.audit.targetServiceId, "alpha-service");
+
+    const auditLog = await readFile(path.join(workspaceRoot, ".state", "operator-command-audit.jsonl"), "utf8");
+    const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], response.body.audit);
+    assert.equal(JSON.stringify(events[0]).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+  } finally {
+    await apiServer.stop();
+    if (previousToken === undefined) {
+      delete process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = previousToken;
+    }
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("operator command facade rejects untrusted chat bridge actor metadata", async () => {
+  resetLifecycleState();
+  const previousToken = process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  delete process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-operator-command-untrusted-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const response = await postJson(apiServer.url + "/api/operator/commands", {
+      command: "services",
+      actor: {
+        source: "chat-bridge",
+        channel: "telegram",
+        chatId: "-5128051597",
+        senderId: "42",
+        roles: ["operator"],
+      },
+    });
+
+    assert.equal(response.status, 403);
+    assert.equal(response.body.error, "untrusted_chat_bridge");
+  } finally {
+    await apiServer.stop();
+    if (previousToken === undefined) {
+      delete process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = previousToken;
+    }
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("operator command facade rejects secret-like actor metadata without auditing it", async () => {
+  resetLifecycleState();
+  const previousToken = process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = "SERVICE_LASSO_TEST_BRIDGE_TOKEN";
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-operator-command-actor-secret-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const response = await postJson(
+      apiServer.url + "/api/operator/commands",
+      {
+        command: "services",
+        actor: {
+          source: "chat-bridge",
+          channel: "telegram",
+          chatId: "-5128051597",
+          senderId: "42",
+          senderDisplay: "token=SERVICE_LASSO_FAKE_SECRET_SENTINEL_ACTOR_DO_NOT_USE",
+          roles: ["operator"],
+        },
+      },
+      { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, "invalid_actor");
+    assert.equal(JSON.stringify(response.body).includes("SERVICE_LASSO_FAKE_SECRET_SENTINEL_ACTOR_DO_NOT_USE"), false);
+    await assert.rejects(
+      readFile(path.join(workspaceRoot, ".state", "operator-command-audit.jsonl"), "utf8"),
+      /ENOENT/,
+    );
+  } finally {
+    await apiServer.stop();
+    if (previousToken === undefined) {
+      delete process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = previousToken;
+    }
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `operator-command-audit.v1` metadata and JSONL persistence for operator command facade calls
- normalize API/shell/web/chat actor envelopes, requiring trusted local bridge token for chat-origin metadata
- document OpenClaw bridge calling shape and audit storage contract

## Validation
- PASS `npm run build`
- PASS `node --test --test-concurrency=1 tests/operator-command-facade.test.js`
- PASS `npm run docs:build`
- PASS `git diff --check`

Closes #559