### PR TITLE
ISS-560 add operator command confirmations

### DIFF
--- a/docs/reference/operator-command-facade.md
+++ b/docs/reference/operator-command-facade.md
@@ -62,3 +62,46 @@ Audit records include the normalized actor, command, read/plan/blocked class, ta
 Unsupported commands, unknown services, mutating commands without `--plan`, and invalid or unbounded log tails fail closed with a 4xx response. The facade does not handle Telegram SDK details, allowlists, or confirmation tokens; those stay in the OpenClaw bridge and later confirmation-token work.
 
 The facade must not return raw environment values, secrets, provider credentials, tokens, cookies, private keys, or diagnostic payload contents. Log output is bounded, redacted, and marked when redaction or truncation occurred.
+
+## Mutating Command Confirmations
+
+Chat or automation bridges can issue a short-lived confirmation record after they have shown a fresh dry-run plan to the operator:
+
+```http
+POST /api/operator/confirmations
+```
+
+```json
+{
+  "command": "restart @serviceadmin",
+  "actor": {
+    "source": "chat-bridge",
+    "channel": "telegram",
+    "chatId": "-5128051597",
+    "senderId": "42",
+    "sourceMessageId": "1001"
+  },
+  "planId": "restart-plan-2026-05-29T00:00:00Z",
+  "plan": {
+    "dryRun": true,
+    "serviceId": "@serviceadmin"
+  },
+  "expiresInSeconds": 300
+}
+```
+
+The response returns `operator-command-confirmation-response.v1`, the pending confirmation metadata, and a short confirmation phrase such as `confirm restart @serviceadmin`. The persisted public record stores only metadata and plan/capability fingerprints; it does not store the raw plan or the bridge credential.
+
+To confirm, the bridge must send the same actor, the same dry-run plan, and the exact phrase before expiry:
+
+```http
+POST /api/operator/confirmations/{confirmationId}/confirm
+```
+
+Confirmation fails closed when the actor changes, the phrase does not match, the plan changes, the record expires, the record is no longer pending, or the target service capability/lifecycle fingerprint changes. Audit events are appended to:
+
+```text
+<workspaceRoot>/.state/operator-command-confirmation-audit.jsonl
+```
+
+Confirmation audit records are metadata-only and include the event kind, result status, stable error code when denied, actor id, chat metadata, command, target service id, and plan id.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -335,6 +335,70 @@ export interface OperatorCommandResponse {
   audit: OperatorCommandAuditEvent;
 }
 
+export type OperatorCommandConfirmationStatus = "pending" | "confirmed" | "expired" | "denied" | "executed";
+export type OperatorCommandConfirmationEventKind = "issued" | "confirmed" | "expired" | "denied" | "executed";
+
+export interface OperatorCommandConfirmationIssueRequest {
+  command?: string;
+  args?: string[];
+  serviceId?: string;
+  actor?: OperatorCommandActorEnvelope;
+  planId?: string;
+  plan?: unknown;
+  expiresInSeconds?: number;
+}
+
+export interface OperatorCommandConfirmationConfirmRequest {
+  actor?: OperatorCommandActorEnvelope;
+  plan?: unknown;
+  confirmationPhrase?: string;
+}
+
+export interface OperatorCommandConfirmationRecord {
+  contractVersion: "operator-command-confirmation.v1";
+  id: string;
+  status: OperatorCommandConfirmationStatus;
+  command: "restart" | "start" | "stop";
+  canonicalCommand: string;
+  targetServiceId: string;
+  planId: string;
+  planFingerprint: string;
+  capabilityFingerprint: string;
+  actor: NormalizedOperatorCommandActorEnvelope;
+  issuedAt: string;
+  expiresAt: string;
+  confirmedAt: string | null;
+  deniedAt: string | null;
+  denialReason: string | null;
+  executedAt: string | null;
+}
+
+export interface OperatorCommandConfirmationAuditEvent {
+  contractVersion: "operator-command-confirmation-audit.v1";
+  id: string;
+  at: string;
+  confirmationId: string;
+  event: OperatorCommandConfirmationEventKind;
+  resultStatus: "success" | "denied" | "failed";
+  errorCode: string | null;
+  actorId: string;
+  channel: OperatorCommandChatChannel | null;
+  chatId: string | null;
+  senderId: string | null;
+  sourceMessageId: string | null;
+  command: OperatorCommandConfirmationRecord["command"];
+  targetServiceId: string;
+  planId: string;
+}
+
+export interface OperatorCommandConfirmationResponse {
+  contractVersion: "operator-command-confirmation-response.v1";
+  ok: boolean;
+  confirmation: OperatorCommandConfirmationRecord;
+  confirmationPhrase?: string;
+  audit: OperatorCommandConfirmationAuditEvent;
+}
+
 export interface DashboardLinkResponse {
   label: string;
   url: string;

--- a/src/runtime/operator/command-confirmations.ts
+++ b/src/runtime/operator/command-confirmations.ts
@@ -1,0 +1,340 @@
+import { createHash, randomUUID } from "node:crypto";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  NormalizedOperatorCommandActorEnvelope,
+  OperatorCommandActorEnvelope,
+  OperatorCommandConfirmationAuditEvent,
+  OperatorCommandConfirmationConfirmRequest,
+  OperatorCommandConfirmationIssueRequest,
+  OperatorCommandConfirmationRecord,
+  OperatorCommandConfirmationResponse,
+} from "../../contracts/api.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import {
+  normalizeOperatorCommandActor,
+  OperatorActorValidationError,
+} from "./command-audit.js";
+
+const DEFAULT_CONFIRMATION_TTL_SECONDS = 300;
+const MIN_CONFIRMATION_TTL_SECONDS = 30;
+const MAX_CONFIRMATION_TTL_SECONDS = 900;
+const CONFIRMATION_STORE_VERSION = 1;
+const secretLikeValuePattern =
+  /((password|passwd|secret|token|credential|cookie|private[_-]?key)\s*[:=]\s*[^\s,;]+)|(bearer\s+[A-Za-z0-9._~+/=-]+)|(gh[pousr]_[A-Za-z0-9_]+)/i;
+
+type ConfirmationCommand = OperatorCommandConfirmationRecord["command"];
+
+interface ConfirmationModel {
+  workspaceRoot: string;
+  registry: ServiceRegistry;
+  trustedChatBridge?: boolean;
+}
+
+interface ParsedMutatingCommand {
+  command: ConfirmationCommand;
+  canonicalCommand: string;
+  targetServiceId: string;
+}
+
+interface StoredConfirmationRecord extends OperatorCommandConfirmationRecord {
+  confirmationPhrase: string;
+}
+
+interface ConfirmationStore {
+  version: number;
+  records: StoredConfirmationRecord[];
+}
+
+export class OperatorCommandConfirmationError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+
+  constructor(code: string, statusCode: number, message: string) {
+    super(message);
+    this.name = "OperatorCommandConfirmationError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export function operatorCommandConfirmationStorePath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".state", "operator-command-confirmations.json");
+}
+
+export function operatorCommandConfirmationAuditPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl");
+}
+
+export async function issueOperatorCommandConfirmation(
+  request: OperatorCommandConfirmationIssueRequest,
+  model: ConfirmationModel,
+): Promise<OperatorCommandConfirmationResponse> {
+  const actor = normalizeTrustedActor(request.actor, model.trustedChatBridge);
+  const parsed = parseMutatingCommand(request);
+  if (!model.registry.getById(parsed.targetServiceId)) {
+    throw new OperatorCommandConfirmationError("service_not_found", 404, `Unknown service id: ${parsed.targetServiceId}.`);
+  }
+
+  const planId = normalizeRequiredText(request.planId, "planId");
+  const planFingerprint = fingerprintPlan(request.plan);
+  const issuedAt = new Date();
+  const expiresAt = new Date(issuedAt.getTime() + normalizeTtlSeconds(request.expiresInSeconds) * 1000);
+  const record: StoredConfirmationRecord = {
+    contractVersion: "operator-command-confirmation.v1",
+    id: `operator-confirmation-${randomUUID()}`,
+    status: "pending",
+    command: parsed.command,
+    canonicalCommand: parsed.canonicalCommand,
+    targetServiceId: parsed.targetServiceId,
+    planId,
+    planFingerprint,
+    capabilityFingerprint: fingerprintCapabilities(parsed.targetServiceId, model.registry),
+    actor,
+    issuedAt: issuedAt.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    confirmedAt: null,
+    deniedAt: null,
+    denialReason: null,
+    executedAt: null,
+    confirmationPhrase: createConfirmationPhrase(parsed.command, parsed.targetServiceId),
+  };
+
+  const store = await readConfirmationStore(model.workspaceRoot);
+  store.records = [record, ...store.records.filter((entry) => entry.id !== record.id)].slice(0, 200);
+  await writeConfirmationStore(model.workspaceRoot, store);
+  const audit = await appendConfirmationAuditEvent(model.workspaceRoot, record, "issued", actor, null);
+
+  return {
+    contractVersion: "operator-command-confirmation-response.v1",
+    ok: true,
+    confirmation: publicRecord(record),
+    confirmationPhrase: record.confirmationPhrase,
+    audit,
+  };
+}
+
+export async function confirmOperatorCommandConfirmation(
+  confirmationId: string,
+  request: OperatorCommandConfirmationConfirmRequest,
+  model: ConfirmationModel,
+): Promise<OperatorCommandConfirmationResponse> {
+  const actor = normalizeTrustedActor(request.actor, model.trustedChatBridge);
+  const store = await readConfirmationStore(model.workspaceRoot);
+  const index = store.records.findIndex((entry) => entry.id === confirmationId);
+  if (index < 0) {
+    throw new OperatorCommandConfirmationError("confirmation_not_found", 404, "Confirmation record was not found.");
+  }
+
+  const record = store.records[index];
+  const deny = async (code: string, statusCode: number, message: string, status: "denied" | "expired" = "denied"): Promise<never> => {
+    const now = new Date().toISOString();
+    record.status = status;
+    record.deniedAt = status === "denied" ? now : record.deniedAt;
+    record.denialReason = code;
+    store.records[index] = record;
+    await writeConfirmationStore(model.workspaceRoot, store);
+    await appendConfirmationAuditEvent(model.workspaceRoot, record, status, actor, code);
+    throw new OperatorCommandConfirmationError(code, statusCode, message);
+  };
+
+  if (record.status !== "pending") {
+    throw new OperatorCommandConfirmationError("confirmation_not_pending", 409, `Confirmation is ${record.status}.`);
+  }
+  if (Date.parse(record.expiresAt) <= Date.now()) {
+    await deny("confirmation_expired", 409, "Confirmation expired before it was confirmed.", "expired");
+  }
+  if (!sameActor(record.actor, actor)) {
+    await deny("actor_mismatch", 403, "Confirmation must be completed by the same authorized actor.");
+  }
+  if (request.confirmationPhrase !== record.confirmationPhrase) {
+    await deny("confirmation_phrase_mismatch", 403, "Confirmation phrase did not match.");
+  }
+  if (fingerprintPlan(request.plan) !== record.planFingerprint) {
+    await deny("plan_changed", 409, "Dry-run plan changed before confirmation.");
+  }
+  if (fingerprintCapabilities(record.targetServiceId, model.registry) !== record.capabilityFingerprint) {
+    await deny("capability_drift", 409, "Runtime service state changed before confirmation.");
+  }
+
+  record.status = "confirmed";
+  record.confirmedAt = new Date().toISOString();
+  store.records[index] = record;
+  await writeConfirmationStore(model.workspaceRoot, store);
+  const audit = await appendConfirmationAuditEvent(model.workspaceRoot, record, "confirmed", actor, null);
+
+  return {
+    contractVersion: "operator-command-confirmation-response.v1",
+    ok: true,
+    confirmation: publicRecord(record),
+    audit,
+  };
+}
+
+function normalizeTrustedActor(input: OperatorCommandActorEnvelope | undefined, trustedChatBridge: boolean | undefined): NormalizedOperatorCommandActorEnvelope {
+  const actor = normalizeOperatorCommandActor(input);
+  if (actor.source === "chat-bridge" && trustedChatBridge !== true) {
+    throw new OperatorActorValidationError(
+      "untrusted_chat_bridge",
+      403,
+      "Chat bridge actor metadata requires trusted local bridge authentication.",
+    );
+  }
+  return actor;
+}
+
+function parseMutatingCommand(request: OperatorCommandConfirmationIssueRequest): ParsedMutatingCommand {
+  const tokens = [...(request.command ?? "").trim().split(/\s+/).filter(Boolean), ...(request.args ?? [])];
+  const command = tokens[0];
+  const targetServiceId = request.serviceId ?? tokens[1];
+  if ((command === "restart" || command === "start" || command === "stop") && targetServiceId) {
+    if (tokens.includes("--plan")) {
+      throw new OperatorCommandConfirmationError("plan_command_not_mutating", 400, "Confirmation records must target the mutating command, not the dry-run plan command.");
+    }
+    return {
+      command,
+      canonicalCommand: `${command} ${targetServiceId}`,
+      targetServiceId,
+    };
+  }
+
+  throw new OperatorCommandConfirmationError("unsupported_mutating_command", 400, "Only start, stop, and restart confirmations are supported in this slice.");
+}
+
+function normalizeRequiredText(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new OperatorCommandConfirmationError("invalid_confirmation_request", 400, `"${field}" must be a non-empty string.`);
+  }
+  const normalized = value.trim().replace(/\s+/g, " ").slice(0, 160);
+  if (secretLikeValuePattern.test(normalized)) {
+    throw new OperatorCommandConfirmationError("invalid_confirmation_request", 400, `"${field}" must not contain secret-like material.`);
+  }
+  return normalized;
+}
+
+function normalizeTtlSeconds(value: unknown): number {
+  if (value === undefined || value === null) {
+    return DEFAULT_CONFIRMATION_TTL_SECONDS;
+  }
+  if (!Number.isFinite(value) || typeof value !== "number") {
+    throw new OperatorCommandConfirmationError("invalid_confirmation_request", 400, '"expiresInSeconds" must be a number when present.');
+  }
+  return Math.min(MAX_CONFIRMATION_TTL_SECONDS, Math.max(MIN_CONFIRMATION_TTL_SECONDS, Math.trunc(value)));
+}
+
+function createConfirmationPhrase(command: ConfirmationCommand, serviceId: string): string {
+  return `confirm ${command} ${serviceId}`;
+}
+
+function fingerprintPlan(plan: unknown): string {
+  if (plan === undefined || plan === null) {
+    throw new OperatorCommandConfirmationError("invalid_plan", 400, '"plan" must be supplied for confirmation.');
+  }
+  const serialized = stableJson(plan);
+  if (secretLikeValuePattern.test(serialized)) {
+    throw new OperatorCommandConfirmationError("invalid_plan", 400, "Confirmation plans must not include secret-like material.");
+  }
+  return sha256(serialized);
+}
+
+function fingerprintCapabilities(serviceId: string, registry: ServiceRegistry): string {
+  const service = registry.getById(serviceId);
+  if (!service) {
+    throw new OperatorCommandConfirmationError("service_not_found", 404, `Unknown service id: ${serviceId}.`);
+  }
+  const lifecycle = getLifecycleState(serviceId);
+  return sha256(stableJson({
+    serviceId,
+    enabled: service.manifest.enabled !== false,
+    version: service.manifest.version ?? null,
+    dependencies: service.manifest.depend_on ?? [],
+    installed: lifecycle.installed,
+    configured: lifecycle.configured,
+    running: lifecycle.running,
+  }));
+}
+
+function sameActor(expected: NormalizedOperatorCommandActorEnvelope, actual: NormalizedOperatorCommandActorEnvelope): boolean {
+  return expected.source === actual.source
+    && expected.actorId === actual.actorId
+    && (expected.channel ?? null) === (actual.channel ?? null)
+    && (expected.chatId ?? null) === (actual.chatId ?? null)
+    && (expected.senderId ?? null) === (actual.senderId ?? null);
+}
+
+function publicRecord(record: StoredConfirmationRecord): OperatorCommandConfirmationRecord {
+  const { confirmationPhrase: _confirmationPhrase, ...rest } = record;
+  return rest;
+}
+
+async function readConfirmationStore(workspaceRoot: string): Promise<ConfirmationStore> {
+  try {
+    const raw = await readFile(operatorCommandConfirmationStorePath(workspaceRoot), "utf8");
+    const parsed = JSON.parse(raw) as Partial<ConfirmationStore>;
+    return {
+      version: CONFIRMATION_STORE_VERSION,
+      records: Array.isArray(parsed.records) ? parsed.records as StoredConfirmationRecord[] : [],
+    };
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return { version: CONFIRMATION_STORE_VERSION, records: [] };
+    }
+    throw error;
+  }
+}
+
+async function writeConfirmationStore(workspaceRoot: string, store: ConfirmationStore): Promise<void> {
+  const targetPath = operatorCommandConfirmationStorePath(workspaceRoot);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, JSON.stringify({ version: CONFIRMATION_STORE_VERSION, records: store.records }, null, 2) + "\n", "utf8");
+}
+
+async function appendConfirmationAuditEvent(
+  workspaceRoot: string,
+  record: StoredConfirmationRecord,
+  event: OperatorCommandConfirmationAuditEvent["event"],
+  actor: NormalizedOperatorCommandActorEnvelope,
+  errorCode: string | null,
+): Promise<OperatorCommandConfirmationAuditEvent> {
+  const audit: OperatorCommandConfirmationAuditEvent = {
+    contractVersion: "operator-command-confirmation-audit.v1",
+    id: `operator-confirmation-audit-${Date.now()}-${randomUUID()}`,
+    at: new Date().toISOString(),
+    confirmationId: record.id,
+    event,
+    resultStatus: errorCode ? "denied" : "success",
+    errorCode,
+    actorId: actor.actorId,
+    channel: actor.channel ?? null,
+    chatId: actor.chatId ?? null,
+    senderId: actor.senderId ?? null,
+    sourceMessageId: actor.sourceMessageId ?? null,
+    command: record.command,
+    targetServiceId: record.targetServiceId,
+    planId: record.planId,
+  };
+  if (secretLikeValuePattern.test(JSON.stringify(audit))) {
+    throw new Error("Operator command confirmation audit metadata must not include raw tokens, cookies, secrets, credentials, or private keys");
+  }
+  const auditPath = operatorCommandConfirmationAuditPath(workspaceRoot);
+  await mkdir(path.dirname(auditPath), { recursive: true });
+  await appendFile(auditPath, JSON.stringify(audit) + "\n", "utf8");
+  return audit;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "undefined";
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map((entry) => stableJson(entry)).join(",") + "]";
+  }
+  return "{" + Object.keys(value as Record<string, unknown>).sort()
+    .map((key) => JSON.stringify(key) + ":" + stableJson((value as Record<string, unknown>)[key]))
+    .join(",") + "}";
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -56,6 +56,10 @@ import { buildServiceMetrics } from "../runtime/operator/metrics.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { executeOperatorCommandFacade } from "../runtime/operator/command-facade.js";
+import {
+  confirmOperatorCommandConfirmation,
+  issueOperatorCommandConfirmation,
+} from "../runtime/operator/command-confirmations.js";
 import { buildRestartSafetyPreflightReport } from "../runtime/operator/restart-safety-preflight.js";
 import { buildServiceCompatibilityReport } from "../runtime/operator/catalog-compatibility.js";
 import { buildServiceConfigDriftReport } from "../runtime/operator/config-drift.js";
@@ -133,6 +137,8 @@ import { ApiError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
   LifecycleActionResponse,
+  OperatorCommandConfirmationConfirmRequest,
+  OperatorCommandConfirmationIssueRequest,
   RuntimeOrchestrationResponse,
   OperatorCommandRequest,
   ServiceDetailResponse,
@@ -1013,6 +1019,39 @@ async function routeRequest(
     });
 
     writeJson(response, commandResponse.statusCode, commandResponse);
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/operator/confirmations") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(
+      response,
+      201,
+      await issueOperatorCommandConfirmation(await readJsonBody(request) as OperatorCommandConfirmationIssueRequest, {
+        workspaceRoot: config.workspaceRoot,
+        registry: runtimeModel.registry,
+        trustedChatBridge: isTrustedChatBridgeRequest(request),
+      }),
+    );
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname.startsWith("/api/operator/confirmations/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    if (pathParts.length !== 5 || pathParts[4] !== "confirm") {
+      throw new ApiError("invalid_action", 400, "Unknown operator confirmation route.");
+    }
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const confirmationResponse = await confirmOperatorCommandConfirmation(
+      decodeURIComponent(pathParts[3] ?? ""),
+      await readJsonBody(request) as OperatorCommandConfirmationConfirmRequest,
+      {
+        workspaceRoot: config.workspaceRoot,
+        registry: runtimeModel.registry,
+        trustedChatBridge: isTrustedChatBridgeRequest(request),
+      },
+    );
+    writeJson(response, 200, confirmationResponse);
     return;
   }
 

--- a/tests/operator-command-confirmations.test.js
+++ b/tests/operator-command-confirmations.test.js
@@ -1,0 +1,204 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { getLifecycleState, resetLifecycleState, setLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function postJson(url, body, headers = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function chatActor(senderId = "42") {
+  return {
+    source: "chat-bridge",
+    channel: "telegram",
+    chatId: "-5128051597",
+    senderId,
+    senderDisplay: "Operator",
+    sourceMessageId: "2001",
+    roles: ["operator"],
+  };
+}
+
+function safePlan() {
+  return {
+    dryRun: true,
+    action: "restart",
+    serviceId: "alpha-service",
+    generatedAt: "2026-05-29T00:00:00.000Z",
+    steps: [
+      {
+        serviceId: "alpha-service",
+        action: "restart",
+        status: "would_run",
+      },
+    ],
+  };
+}
+
+async function withApiServer(prefix, fn) {
+  resetLifecycleState();
+  const previousToken = process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+  process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = "SERVICE_LASSO_TEST_BRIDGE_TOKEN";
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot(prefix);
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    await fn({ apiServer, workspaceRoot });
+  } finally {
+    await apiServer.stop();
+    if (previousToken === undefined) {
+      delete process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_CHAT_BRIDGE_TOKEN = previousToken;
+    }
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test("operator command confirmations issue and confirm with the same trusted chat actor", async () => {
+  await withApiServer("service-lasso-command-confirmation-success-", async ({ apiServer, workspaceRoot }) => {
+    const issued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "restart alpha-service",
+        actor: chatActor(),
+        planId: "restart-plan-1",
+        plan: safePlan(),
+      },
+      { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" },
+    );
+
+    assert.equal(issued.status, 201);
+    assert.equal(issued.body.ok, true);
+    assert.equal(issued.body.confirmation.status, "pending");
+    assert.equal(issued.body.confirmation.command, "restart");
+    assert.equal(issued.body.confirmation.targetServiceId, "alpha-service");
+    assert.equal(issued.body.confirmationPhrase, "confirm restart alpha-service");
+    assert.equal("confirmationPhrase" in issued.body.confirmation, false);
+
+    const confirmed = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan(),
+        confirmationPhrase: issued.body.confirmationPhrase,
+      },
+      { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" },
+    );
+
+    assert.equal(confirmed.status, 200);
+    assert.equal(confirmed.body.ok, true);
+    assert.equal(confirmed.body.confirmation.status, "confirmed");
+    assert.equal(confirmed.body.confirmation.confirmedAt !== null, true);
+    assert.equal("confirmationPhrase" in confirmed.body.confirmation, false);
+
+    const store = JSON.parse(await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmations.json"), "utf8"));
+    assert.equal(store.records.length, 1);
+    assert.equal(store.records[0].confirmationPhrase, "confirm restart alpha-service");
+    assert.equal(store.records[0].status, "confirmed");
+
+    const auditLog = await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl"), "utf8");
+    const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(events.map((event) => event.event), ["issued", "confirmed"]);
+    assert.equal(events.every((event) => event.actorId === "telegram:42"), true);
+    assert.equal(JSON.stringify({ issued, confirmed, events }).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+  });
+});
+
+test("operator command confirmations deny actor mismatch and capability drift", async () => {
+  await withApiServer("service-lasso-command-confirmation-deny-", async ({ apiServer, workspaceRoot }) => {
+    const issueBody = {
+      command: "restart alpha-service",
+      actor: chatActor(),
+      planId: "restart-plan-2",
+      plan: safePlan(),
+    };
+    const headers = { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" };
+
+    const actorMismatchIssued = await postJson(apiServer.url + "/api/operator/confirmations", issueBody, headers);
+    const actorMismatch = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(actorMismatchIssued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor("99"),
+        plan: safePlan(),
+        confirmationPhrase: actorMismatchIssued.body.confirmationPhrase,
+      },
+      headers,
+    );
+
+    assert.equal(actorMismatch.status, 403);
+    assert.equal(actorMismatch.body.error, "actor_mismatch");
+
+    const driftIssued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      { ...issueBody, planId: "restart-plan-3" },
+      headers,
+    );
+    const current = getLifecycleState("alpha-service");
+    setLifecycleState("alpha-service", {
+      ...current,
+      installed: true,
+    });
+
+    const drift = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(driftIssued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan(),
+        confirmationPhrase: driftIssued.body.confirmationPhrase,
+      },
+      headers,
+    );
+
+    assert.equal(drift.status, 409);
+    assert.equal(drift.body.error, "capability_drift");
+
+    const auditLog = await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl"), "utf8");
+    const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(events.some((event) => event.event === "denied" && event.errorCode === "actor_mismatch"), true);
+    assert.equal(events.some((event) => event.event === "denied" && event.errorCode === "capability_drift"), true);
+  });
+});
+
+test("operator command confirmations reject unsafe plans before audit persistence", async () => {
+  await withApiServer("service-lasso-command-confirmation-unsafe-", async ({ apiServer, workspaceRoot }) => {
+    const response = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "restart alpha-service",
+        actor: chatActor(),
+        planId: "restart-plan-unsafe",
+        plan: {
+          dryRun: true,
+          detail: "token=SERVICE_LASSO_FAKE_SECRET_SENTINEL_CONFIRMATION_DO_NOT_USE",
+        },
+      },
+      { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, "invalid_plan");
+    assert.equal(JSON.stringify(response.body).includes("SERVICE_LASSO_FAKE_SECRET_SENTINEL_CONFIRMATION_DO_NOT_USE"), false);
+    await assert.rejects(
+      readFile(path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl"), "utf8"),
+      /ENOENT/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add operator command confirmation contracts and API endpoints for issuing and confirming short-lived chat-origin mutation confirmations.
- Persist metadata-only confirmation records and confirmation audit events under workspace `.state`.
- Fail closed on untrusted chat bridge metadata, actor mismatch, phrase mismatch, stale/changed plans, capability/lifecycle drift, unsupported commands, and secret-like plan/request content.
- Document the confirmation API alongside the operator command facade.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/operator-command-confirmations.test.js tests/operator-command-facade.test.js`
- `git diff --check`

## Notes
This is a bounded #560 slice for confirmation issuance/validation/audit. The actual bridge execution handoff for confirmed mutating commands remains the next #560 slice.

Refs #560