### PR TITLE
ISS-560 execute confirmed operator commands

### DIFF
--- a/docs/reference/operator-command-facade.md
+++ b/docs/reference/operator-command-facade.md
@@ -105,3 +105,27 @@ Confirmation fails closed when the actor changes, the phrase does not match, the
 ```
 
 Confirmation audit records are metadata-only and include the event kind, result status, stable error code when denied, actor id, chat metadata, command, target service id, and plan id.
+
+After confirmation, the same trusted actor can execute the confirmed mutation through the guarded handoff endpoint:
+
+```http
+POST /api/operator/confirmations/{confirmationId}/execute
+```
+
+```json
+{
+  "actor": {
+    "source": "chat-bridge",
+    "channel": "telegram",
+    "chatId": "-5128051597",
+    "senderId": "42",
+    "sourceMessageId": "1001"
+  },
+  "plan": {
+    "dryRun": true,
+    "serviceId": "@serviceadmin"
+  }
+}
+```
+
+Execution requires a confirmed, unexpired, unused record for the same actor and the same plan fingerprint. Service capability/lifecycle state is checked again immediately before the lifecycle action runs. A successful handoff marks the confirmation `executed`, appends an `executed` confirmation audit event, and returns the lifecycle action response. Reuse, actor mismatch, plan drift, expiry, or capability drift fail closed.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -354,6 +354,11 @@ export interface OperatorCommandConfirmationConfirmRequest {
   confirmationPhrase?: string;
 }
 
+export interface OperatorCommandConfirmationExecuteRequest {
+  actor?: OperatorCommandActorEnvelope;
+  plan?: unknown;
+}
+
 export interface OperatorCommandConfirmationRecord {
   contractVersion: "operator-command-confirmation.v1";
   id: string;
@@ -397,6 +402,14 @@ export interface OperatorCommandConfirmationResponse {
   confirmation: OperatorCommandConfirmationRecord;
   confirmationPhrase?: string;
   audit: OperatorCommandConfirmationAuditEvent;
+}
+
+export interface OperatorCommandConfirmationExecutionResponse {
+  contractVersion: "operator-command-confirmation-execution-response.v1";
+  ok: boolean;
+  confirmation: OperatorCommandConfirmationRecord;
+  audit: OperatorCommandConfirmationAuditEvent;
+  action: LifecycleActionResponse;
 }
 
 export interface DashboardLinkResponse {

--- a/src/runtime/operator/command-confirmations.ts
+++ b/src/runtime/operator/command-confirmations.ts
@@ -6,9 +6,12 @@ import type {
   OperatorCommandActorEnvelope,
   OperatorCommandConfirmationAuditEvent,
   OperatorCommandConfirmationConfirmRequest,
+  OperatorCommandConfirmationExecuteRequest,
+  OperatorCommandConfirmationExecutionResponse,
   OperatorCommandConfirmationIssueRequest,
   OperatorCommandConfirmationRecord,
   OperatorCommandConfirmationResponse,
+  LifecycleActionResponse,
 } from "../../contracts/api.js";
 import { getLifecycleState } from "../lifecycle/store.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
@@ -172,6 +175,91 @@ export async function confirmOperatorCommandConfirmation(
   };
 }
 
+export async function executeOperatorCommandConfirmation(
+  confirmationId: string,
+  request: OperatorCommandConfirmationExecuteRequest,
+  model: ConfirmationModel,
+  executor: (record: OperatorCommandConfirmationRecord) => Promise<LifecycleActionResponse>,
+): Promise<OperatorCommandConfirmationExecutionResponse> {
+  const actor = normalizeTrustedActor(request.actor, model.trustedChatBridge);
+  const store = await readConfirmationStore(model.workspaceRoot);
+  const index = store.records.findIndex((entry) => entry.id === confirmationId);
+  if (index < 0) {
+    throw new OperatorCommandConfirmationError("confirmation_not_found", 404, "Confirmation record was not found.");
+  }
+
+  const record = store.records[index];
+  const deny = async (code: string, statusCode: number, message: string, status: "denied" | "expired" = "denied"): Promise<never> => {
+    const now = new Date().toISOString();
+    record.status = status;
+    record.deniedAt = status === "denied" ? now : record.deniedAt;
+    record.denialReason = code;
+    store.records[index] = record;
+    await writeConfirmationStore(model.workspaceRoot, store);
+    await appendConfirmationAuditEvent(model.workspaceRoot, record, status, actor, code);
+    throw new OperatorCommandConfirmationError(code, statusCode, message);
+  };
+
+  if (record.status === "executed") {
+    throw new OperatorCommandConfirmationError("confirmation_already_executed", 409, "Confirmation has already been executed.");
+  }
+  if (record.status !== "confirmed") {
+    throw new OperatorCommandConfirmationError("confirmation_not_confirmed", 409, `Confirmation is ${record.status}.`);
+  }
+  if (Date.parse(record.expiresAt) <= Date.now()) {
+    await deny("confirmation_expired", 409, "Confirmation expired before it was executed.", "expired");
+  }
+  if (!sameActor(record.actor, actor)) {
+    await deny("actor_mismatch", 403, "Confirmation must be executed by the same authorized actor.");
+  }
+  if (fingerprintPlan(request.plan) !== record.planFingerprint) {
+    await deny("plan_changed", 409, "Dry-run plan changed before execution.");
+  }
+  if (fingerprintCapabilities(record.targetServiceId, model.registry) !== record.capabilityFingerprint) {
+    await deny("capability_drift", 409, "Runtime service state changed before execution.");
+  }
+
+  let action: LifecycleActionResponse;
+  try {
+    action = await executor(publicRecord(record));
+  } catch (error) {
+    record.status = "executed";
+    record.executedAt = new Date().toISOString();
+    store.records[index] = record;
+    await writeConfirmationStore(model.workspaceRoot, store);
+    await appendConfirmationAuditEvent(
+      model.workspaceRoot,
+      record,
+      "executed",
+      actor,
+      "lifecycle_action_failed",
+      "failed",
+    );
+    throw error;
+  }
+
+  record.status = "executed";
+  record.executedAt = new Date().toISOString();
+  store.records[index] = record;
+  await writeConfirmationStore(model.workspaceRoot, store);
+  const audit = await appendConfirmationAuditEvent(
+    model.workspaceRoot,
+    record,
+    "executed",
+    actor,
+    action.ok ? null : "lifecycle_action_failed",
+    action.ok ? "success" : "failed",
+  );
+
+  return {
+    contractVersion: "operator-command-confirmation-execution-response.v1",
+    ok: action.ok,
+    confirmation: publicRecord(record),
+    audit,
+    action,
+  };
+}
+
 function normalizeTrustedActor(input: OperatorCommandActorEnvelope | undefined, trustedChatBridge: boolean | undefined): NormalizedOperatorCommandActorEnvelope {
   const actor = normalizeOperatorCommandActor(input);
   if (actor.source === "chat-bridge" && trustedChatBridge !== true) {
@@ -296,6 +384,7 @@ async function appendConfirmationAuditEvent(
   event: OperatorCommandConfirmationAuditEvent["event"],
   actor: NormalizedOperatorCommandActorEnvelope,
   errorCode: string | null,
+  resultStatus: OperatorCommandConfirmationAuditEvent["resultStatus"] = errorCode ? "denied" : "success",
 ): Promise<OperatorCommandConfirmationAuditEvent> {
   const audit: OperatorCommandConfirmationAuditEvent = {
     contractVersion: "operator-command-confirmation-audit.v1",
@@ -303,7 +392,7 @@ async function appendConfirmationAuditEvent(
     at: new Date().toISOString(),
     confirmationId: record.id,
     event,
-    resultStatus: errorCode ? "denied" : "success",
+    resultStatus,
     errorCode,
     actorId: actor.actorId,
     channel: actor.channel ?? null,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,6 +58,7 @@ import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { executeOperatorCommandFacade } from "../runtime/operator/command-facade.js";
 import {
   confirmOperatorCommandConfirmation,
+  executeOperatorCommandConfirmation,
   issueOperatorCommandConfirmation,
 } from "../runtime/operator/command-confirmations.js";
 import { buildRestartSafetyPreflightReport } from "../runtime/operator/restart-safety-preflight.js";
@@ -137,6 +138,7 @@ import { ApiError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
   LifecycleActionResponse,
+  OperatorCommandConfirmationExecuteRequest,
   OperatorCommandConfirmationConfirmRequest,
   OperatorCommandConfirmationIssueRequest,
   RuntimeOrchestrationResponse,
@@ -1038,20 +1040,39 @@ async function routeRequest(
 
   if (request.method === "POST" && url.pathname.startsWith("/api/operator/confirmations/")) {
     const pathParts = url.pathname.split("/").filter(Boolean);
-    if (pathParts.length !== 5 || pathParts[4] !== "confirm") {
+    if (pathParts.length !== 5 || (pathParts[4] !== "confirm" && pathParts[4] !== "execute")) {
       throw new ApiError("invalid_action", 400, "Unknown operator confirmation route.");
     }
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    const confirmationResponse = await confirmOperatorCommandConfirmation(
-      decodeURIComponent(pathParts[3] ?? ""),
-      await readJsonBody(request) as OperatorCommandConfirmationConfirmRequest,
-      {
-        workspaceRoot: config.workspaceRoot,
-        registry: runtimeModel.registry,
-        trustedChatBridge: isTrustedChatBridgeRequest(request),
+    const confirmationId = decodeURIComponent(pathParts[3] ?? "");
+    const confirmationModel = {
+      workspaceRoot: config.workspaceRoot,
+      registry: runtimeModel.registry,
+      trustedChatBridge: isTrustedChatBridgeRequest(request),
+    };
+    if (pathParts[4] === "confirm") {
+      const confirmationResponse = await confirmOperatorCommandConfirmation(
+        confirmationId,
+        await readJsonBody(request) as OperatorCommandConfirmationConfirmRequest,
+        confirmationModel,
+      );
+      writeJson(response, 200, confirmationResponse);
+      return;
+    }
+
+    const executionResponse = await executeOperatorCommandConfirmation(
+      confirmationId,
+      await readJsonBody(request) as OperatorCommandConfirmationExecuteRequest,
+      confirmationModel,
+      async (record) => {
+        const service = runtimeModel.registry.getById(record.targetServiceId);
+        if (!service) {
+          throw new ApiError("service_not_found", 404, `Unknown service id: ${record.targetServiceId}.`);
+        }
+        return await executeLifecycleAction(record.command, service, runtimeModel.registry, config.workspaceRoot);
       },
     );
-    writeJson(response, 200, confirmationResponse);
+    writeJson(response, executionResponse.action.ok ? 200 : 409, executionResponse);
     return;
   }
 

--- a/tests/operator-command-confirmations.test.js
+++ b/tests/operator-command-confirmations.test.js
@@ -34,16 +34,16 @@ function chatActor(senderId = "42") {
   };
 }
 
-function safePlan() {
+function safePlan(action = "restart") {
   return {
     dryRun: true,
-    action: "restart",
+    action,
     serviceId: "alpha-service",
     generatedAt: "2026-05-29T00:00:00.000Z",
     steps: [
       {
         serviceId: "alpha-service",
-        action: "restart",
+        action,
         status: "would_run",
       },
     ],
@@ -119,6 +119,193 @@ test("operator command confirmations issue and confirm with the same trusted cha
     assert.deepEqual(events.map((event) => event.event), ["issued", "confirmed"]);
     assert.equal(events.every((event) => event.actorId === "telegram:42"), true);
     assert.equal(JSON.stringify({ issued, confirmed, events }).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+  });
+});
+
+test("operator command confirmations execute a confirmed mutation once", async () => {
+  await withApiServer("service-lasso-command-confirmation-execute-", async ({ apiServer, workspaceRoot }) => {
+    const headers = { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" };
+    setLifecycleState("alpha-service", {
+      ...getLifecycleState("alpha-service"),
+      running: true,
+    });
+    const issued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "stop alpha-service",
+        actor: chatActor(),
+        planId: "stop-plan-1",
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+    const confirmed = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+        confirmationPhrase: issued.body.confirmationPhrase,
+      },
+      headers,
+    );
+    assert.equal(confirmed.status, 200);
+
+    const executed = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/execute`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+
+    assert.equal(executed.status, 200);
+    assert.equal(executed.body.ok, true);
+    assert.equal(executed.body.contractVersion, "operator-command-confirmation-execution-response.v1");
+    assert.equal(executed.body.confirmation.status, "executed");
+    assert.equal(executed.body.confirmation.executedAt !== null, true);
+    assert.equal(executed.body.action.action, "stop");
+    assert.equal(executed.body.action.serviceId, "alpha-service");
+    assert.equal(executed.body.audit.event, "executed");
+    assert.equal(executed.body.audit.resultStatus, "success");
+
+    const reused = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/execute`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+    assert.equal(reused.status, 409);
+    assert.equal(reused.body.error, "confirmation_already_executed");
+
+    const store = JSON.parse(await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmations.json"), "utf8"));
+    assert.equal(store.records[0].status, "executed");
+
+    const auditLog = await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl"), "utf8");
+    const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(events.map((event) => event.event), ["issued", "confirmed", "executed"]);
+    assert.equal(JSON.stringify({ executed, events }).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+  });
+});
+
+test("operator command confirmations reject execution when the confirmed plan changes", async () => {
+  await withApiServer("service-lasso-command-confirmation-execute-plan-drift-", async ({ apiServer, workspaceRoot }) => {
+    const headers = { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" };
+    const issued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "stop alpha-service",
+        actor: chatActor(),
+        planId: "stop-plan-2",
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+    await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+        confirmationPhrase: issued.body.confirmationPhrase,
+      },
+      headers,
+    );
+
+    const rejected = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(issued.body.confirmation.id)}/execute`,
+      {
+        actor: chatActor(),
+        plan: { ...safePlan("stop"), generatedAt: "2026-05-29T00:01:00.000Z" },
+      },
+      headers,
+    );
+
+    assert.equal(rejected.status, 409);
+    assert.equal(rejected.body.error, "plan_changed");
+
+    const store = JSON.parse(await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmations.json"), "utf8"));
+    assert.equal(store.records[0].status, "denied");
+    assert.equal(store.records[0].denialReason, "plan_changed");
+  });
+});
+
+test("operator command confirmations reject execution when actor or capability state changes", async () => {
+  await withApiServer("service-lasso-command-confirmation-execute-drift-", async ({ apiServer, workspaceRoot }) => {
+    const headers = { "x-service-lasso-chat-bridge-token": "SERVICE_LASSO_TEST_BRIDGE_TOKEN" };
+
+    const actorMismatchIssued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "stop alpha-service",
+        actor: chatActor(),
+        planId: "stop-plan-actor-drift",
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+    await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(actorMismatchIssued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+        confirmationPhrase: actorMismatchIssued.body.confirmationPhrase,
+      },
+      headers,
+    );
+
+    const actorMismatch = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(actorMismatchIssued.body.confirmation.id)}/execute`,
+      {
+        actor: chatActor("99"),
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+
+    assert.equal(actorMismatch.status, 403);
+    assert.equal(actorMismatch.body.error, "actor_mismatch");
+
+    const capabilityDriftIssued = await postJson(
+      apiServer.url + "/api/operator/confirmations",
+      {
+        command: "stop alpha-service",
+        actor: chatActor(),
+        planId: "stop-plan-capability-drift",
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+    await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(capabilityDriftIssued.body.confirmation.id)}/confirm`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+        confirmationPhrase: capabilityDriftIssued.body.confirmationPhrase,
+      },
+      headers,
+    );
+    setLifecycleState("alpha-service", {
+      ...getLifecycleState("alpha-service"),
+      installed: true,
+    });
+
+    const capabilityDrift = await postJson(
+      apiServer.url + `/api/operator/confirmations/${encodeURIComponent(capabilityDriftIssued.body.confirmation.id)}/execute`,
+      {
+        actor: chatActor(),
+        plan: safePlan("stop"),
+      },
+      headers,
+    );
+
+    assert.equal(capabilityDrift.status, 409);
+    assert.equal(capabilityDrift.body.error, "capability_drift");
+
+    const store = JSON.parse(await readFile(path.join(workspaceRoot, ".state", "operator-command-confirmations.json"), "utf8"));
+    assert.equal(store.records.some((record) => record.denialReason === "actor_mismatch"), true);
+    assert.equal(store.records.some((record) => record.denialReason === "capability_drift"), true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add guarded execution endpoint for confirmed operator command confirmations
- revalidate actor, plan fingerprint, and service capability/lifecycle fingerprint before lifecycle handoff
- persist metadata-only executed audit records and document the execution contract

## Validation
- npm run build
- node --test --test-concurrency=1 tests/operator-command-confirmations.test.js tests/operator-command-facade.test.js
- git diff --check

Closes part of #560.