### PR TITLE
fix(test): keep dry-run plan workspace-free

### DIFF
--- a/tests/cli-dry-run-plan.test.js
+++ b/tests/cli-dry-run-plan.test.js
@@ -35,6 +35,7 @@ test("CLI plan start returns structured dry-run without creating workspace state
   const workspaceRoot = path.join(tempRoot, "workspace");
 
   try {
+    await rm(workspaceRoot, { recursive: true, force: true });
     await writeExecutableFixtureService(servicesRoot, "alpha-service");
 
     const stdout = await runCli([


### PR DESCRIPTION
## Summary
- Preserve the CLI plan start dry-run assertion by removing the helper-created temp workspace before invoking the command.
- Confirms #484 registry/runtime-state expectations now match the checked-in 11-service inventory.

## Validation
- npm run build
- node --test --test-concurrency=1 tests/cli-dry-run-plan.test.js
- node --test --test-concurrency=1 tests/registry-runtime-state.test.js
- npm test (377/377 passing on rerun)

Fixes #484