### PR TITLE
fix(demo): keep recycled demo stack reachable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 dist/
 .tmp/
 artifacts/
+.demo-logs/
 docs/.docusaurus/
 docs/build/
 workspace/

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -33,6 +33,7 @@ export function resolveDemoOptions(args = process.argv.slice(2)) {
     workspaceRoot: path.resolve(parseOption(args, "workspace-root", "SERVICE_LASSO_WORKSPACE_ROOT") ?? defaultDemoWorkspaceRoot),
     port: Number(parseOption(args, "port", "SERVICE_LASSO_PORT") ?? 18080),
     preserve: args.includes("--preserve"),
+    foreground: args.includes("--foreground"),
   };
 }
 
@@ -367,6 +368,7 @@ export async function runDemoRecycle(options = {}) {
   const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
   const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
   const preserve = options.preserve === true;
+  const keepAlive = options.keepAlive === true;
   const stopped = await stopDemoManagedProcesses({ servicesRoot, workspaceRoot });
 
   await assertDemoPortsAvailable({ port, workspaceRoot });
@@ -374,6 +376,7 @@ export async function runDemoRecycle(options = {}) {
 
   const runtime = await startDemoRuntime({ servicesRoot, workspaceRoot, port });
   let servicesStopped = false;
+  let runtimeKeptAlive = false;
 
   try {
     const apiUrl = runtime.apiServer.url;
@@ -410,7 +413,7 @@ export async function runDemoRecycle(options = {}) {
 
     const git = await getGitSummary();
 
-    return {
+    const result = {
       apiUrl,
       serviceAdminUrl,
       servicesRoot,
@@ -431,6 +434,12 @@ export async function runDemoRecycle(options = {}) {
         healthy: service.health?.healthy === true,
       })),
     };
+
+    if (keepAlive) {
+      runtimeKeptAlive = true;
+    }
+
+    return result;
   } catch (error) {
     try {
       await getJson(`${runtime.apiServer.url}/api/runtime/actions/stopAll`, "POST");
@@ -438,7 +447,7 @@ export async function runDemoRecycle(options = {}) {
     } catch {}
     throw error;
   } finally {
-    if (!preserve) {
+    if (!preserve && !runtimeKeptAlive) {
       if (!servicesStopped) {
         try {
           await getJson(`${runtime.apiServer.url}/api/runtime/actions/stopAll`, "POST");
@@ -446,7 +455,9 @@ export async function runDemoRecycle(options = {}) {
       }
       await resetDemoInstance({ servicesRoot, workspaceRoot });
     }
-    await runtime.apiServer.stop();
+    if (!runtimeKeptAlive) {
+      await runtime.apiServer.stop();
+    }
   }
 }
 

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -1,16 +1,186 @@
+import { spawn } from "node:child_process";
+import { mkdir, open } from "node:fs/promises";
+import path from "node:path";
 import { resolveDemoOptions, runDemoRecycle } from "./demo-instance-lib.mjs";
 
 const options = resolveDemoOptions();
-const result = await runDemoRecycle(options);
 
-console.log("[service-lasso demo] recycle passed");
-console.log(`- api: ${result.apiUrl}`);
-console.log(`- serviceAdmin: ${result.serviceAdminUrl}`);
-console.log(`- servicesRoot: ${result.servicesRoot}`);
-console.log(`- workspaceRoot: ${result.workspaceRoot}`);
-console.log(`- git: ${result.git.branch}@${result.git.commit}`);
-console.log(`- services: ${result.services.map((service) => `${service.id}:running=${service.running}:healthy=${service.healthy}`).join(", ")}`);
-console.log("- endpoints:");
-for (const [name, endpoint] of Object.entries(result.endpoints)) {
-  console.log(`  - ${name}: ${endpoint.status} ${endpoint.url}`);
+async function commandOutput(command, args) {
+  return await new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.once("close", (code) => resolve(code === 0 ? stdout.trim() : ""));
+    child.once("error", () => resolve(""));
+  });
+}
+
+const endpointsFor = (apiUrl = `http://127.0.0.1:${options.port}`) => ({
+  runtimeApiHealth: `${apiUrl}/api/health`,
+  serviceAdminRoot: "http://127.0.0.1:17700/",
+  serviceAdminHealth: "http://127.0.0.1:17700/health",
+  secretsBrokerHealth: "http://127.0.0.1:17890/health",
+  echoHealth: "http://127.0.0.1:4011/health",
+  runtimeServices: `${apiUrl}/api/services`,
+});
+
+async function waitForEndpoint(url, timeoutMs = 300_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+      if (response.status >= 200 && response.status < 300) {
+        return response.status;
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`${url} did not become reachable: ${lastError || "timeout"}`);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function getGitSummary() {
+  const [branch, commit] = await Promise.all([
+    commandOutput("git", ["branch", "--show-current"]),
+    commandOutput("git", ["rev-parse", "--short=12", "HEAD"]),
+  ]);
+
+  return {
+    branch: branch || "unknown",
+    commit: commit || "unknown",
+  };
+}
+
+async function waitForLiveDemo() {
+  const endpoints = endpointsFor();
+  const statuses = {};
+
+  for (const [name, url] of Object.entries(endpoints)) {
+    statuses[name] = {
+      url,
+      status: await waitForEndpoint(url),
+    };
+  }
+
+  return statuses;
+}
+
+async function getLiveServiceSummary(apiUrl) {
+  const result = await fetchJson(`${apiUrl}/api/services`);
+  if (result.status !== 200 || !Array.isArray(result.body.services)) {
+    return [];
+  }
+
+  return result.body.services
+    .filter((service) => ["@serviceadmin", "@secretsbroker", "echo-service", "@node", "node-sample-service"].includes(service.id))
+    .map((service) => ({
+      id: service.id,
+      running: service.lifecycle?.running === true,
+      healthy: service.health?.healthy === true,
+    }));
+}
+
+function printResult(result) {
+  console.log("[service-lasso demo] recycle passed");
+  console.log(`- api: ${result.apiUrl}`);
+  console.log(`- serviceAdmin: ${result.serviceAdminUrl}`);
+  console.log(`- servicesRoot: ${result.servicesRoot}`);
+  console.log(`- workspaceRoot: ${result.workspaceRoot}`);
+  console.log(`- git: ${result.git.branch}@${result.git.commit}`);
+  console.log(`- services: ${result.services.map((service) => `${service.id}:running=${service.running}:healthy=${service.healthy}`).join(", ")}`);
+  console.log("- endpoints:");
+  for (const [name, endpoint] of Object.entries(result.endpoints)) {
+    console.log(`  - ${name}: ${endpoint.status} ${endpoint.url}`);
+  }
+}
+
+async function runForegroundWorker() {
+  const result = await runDemoRecycle({ ...options, preserve: true, keepAlive: true });
+  printResult(result);
+
+  await new Promise((resolve) => {
+    const shutdown = () => resolve();
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}
+
+async function runDetachedRecycle() {
+  const logsRoot = path.join(process.cwd(), ".demo-logs");
+  await mkdir(logsRoot, { recursive: true });
+
+  const stdout = await open(path.join(logsRoot, "demo-recycle.out.log"), "a");
+  const stderr = await open(path.join(logsRoot, "demo-recycle.err.log"), "a");
+  const args = [
+    path.resolve("scripts", "demo-recycle.mjs"),
+    "--foreground",
+    "--preserve",
+    `--services-root=${options.servicesRoot}`,
+    `--workspace-root=${options.workspaceRoot}`,
+    `--port=${options.port}`,
+  ];
+
+  const child = spawn(process.execPath, args, {
+    cwd: process.cwd(),
+    detached: true,
+    stdio: ["ignore", stdout.fd, stderr.fd],
+    windowsHide: true,
+    env: {
+      ...process.env,
+      SERVICE_LASSO_PORT: String(options.port),
+    },
+  });
+
+  child.unref();
+
+  try {
+    const apiUrl = `http://127.0.0.1:${options.port}`;
+    const endpoints = await waitForLiveDemo();
+    const [git, services] = await Promise.all([
+      getGitSummary(),
+      getLiveServiceSummary(apiUrl),
+    ]);
+    console.log("[service-lasso demo] recycle passed");
+    console.log(`- api: ${apiUrl}`);
+    console.log("- serviceAdmin: http://127.0.0.1:17700");
+    console.log(`- servicesRoot: ${options.servicesRoot}`);
+    console.log(`- workspaceRoot: ${options.workspaceRoot}`);
+    console.log(`- git: ${git.branch}@${git.commit}`);
+    console.log("- mode: detached live demo");
+    console.log(`- pid: ${child.pid}`);
+    console.log(`- logs: ${logsRoot}`);
+    console.log(`- services: ${services.map((service) => `${service.id}:running=${service.running}:healthy=${service.healthy}`).join(", ")}`);
+    console.log("- endpoints:");
+    for (const [name, endpoint] of Object.entries(endpoints)) {
+      console.log(`  - ${name}: ${endpoint.status} ${endpoint.url}`);
+    }
+  } finally {
+    await stdout.close();
+    await stderr.close();
+  }
+}
+
+if (options.foreground) {
+  await runForegroundWorker();
+} else {
+  await runDetachedRecycle();
 }


### PR DESCRIPTION
## Summary

Fixes the #567 post-validation gap where `npm run demo:recycle` proved endpoints during the command run but left nothing reachable after the command exited.

Changes:
- Adds a foreground/keep-alive path for demo recycle.
- Makes the default `demo:recycle` spawn a detached live demo worker and wait for endpoints after parent exit semantics.
- Keeps generated recycle logs under `.demo-logs/` outside the resettable demo workspace.
- Keeps final command output evidence for API URL, Service Admin URL, services/workspace roots, branch/commit, service states, endpoint statuses, worker PID, and logs path.

## Validation

Local gates:
- PASS `npm run build`
- PASS `node --test --test-concurrency=1 tests/demo-instance.test.js`
- PASS `npm test` — 378 tests passed
- PASS `git diff --check`

Live demo deployment from this branch:
- PASS `npm run demo:recycle -- --port=17884`
- Deployed branch/commit: `issue-567-demo-recycle-detached@3a10cd6847aa`
- Runtime API: `http://127.0.0.1:17884`
- Service Admin: `http://127.0.0.1:17700`
- Detached worker PID: `59120`
- Logs: `C:\projects\service-lasso\service-lasso\.demo-logs`

Independent post-exit reachability check:
- PASS `http://127.0.0.1:17884/api/health` -> 200
- PASS `http://127.0.0.1:17700/` -> 200
- PASS `http://127.0.0.1:17700/health` -> 200
- PASS `http://127.0.0.1:17890/health` -> 200
- PASS `http://127.0.0.1:4011/health` -> 200
- PASS `http://127.0.0.1:17884/api/services` -> 200

Note: npm currently emits warnings for `npm run demo:recycle -- --port=17884` because the script supports npm config/env arg forwarding. The command still exits 0 and deploys the requested port.
