### PR TITLE
ISS-570 pin Service Admin baseline release

### DIFF
--- a/.governance/project/BACKLOG.md
+++ b/.governance/project/BACKLOG.md
@@ -132,6 +132,8 @@ This backlog tracks active product delivery for the `service-lasso` core runtime
 | `ISS-341` | `done` | Migrate TypeRefinery Keycloak service or document Zitadel replacement decision | `SPEC-002`, `AC-4Y`, `AC-4Z`, `AC-4AK` | GitHub issue: `#341`. Implemented as `service-lasso/lasso-keycloak`; release `2026.5.2-9801925` publishes Keycloak `23.0.4` Windows/Linux/macOS archives, released `service.json`, and `SHA256SUMS.txt`. The manifest depends on `@java` and `postgres`, declares HTTP/HTTPS ports, health/metrics URLs, env/globalenv, and setup steps for keystore/database/build preparation. |
 | `ISS-342` | `done` | Classify disabled TypeRefinery WebSocket examples for migration | `SPEC-002`, `AC-4Y`, `AC-4Z`, `AC-6` | GitHub issue: `#342`. `wsecho` and `messageservice-client` are deprecated/superseded and are not active Service Catalog entries. Use `service-lasso/lasso-echoservice` for echo/lifecycle harness coverage and `service-lasso/lasso-totaljs-messageservice` plus `service-lasso/lasso-totaljs-flow` for maintained messaging/flow examples. Decision recorded in `docs/development/deprecated-service-decisions.md`; no migration repo is required. |
 
+| `ISS-570` | `in_progress` | Pin Service Admin baseline to current release for demo freshness | `SPEC-002`, `AC-4Y`, `AC-4Z` | GitHub issue: `#570`. The local demo proved the core `@serviceadmin` manifest was still pinned to `2026.5.15-c66d8ce` while the current Service Admin release is `2026.6.4-de50799`; update the release pin and verify canonical LAN demo URLs serve the current artifact. |
+
 ## Task Queue
 | ID | Status | Linked Issue | Title | Spec References | Exit Evidence |
 | --- | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@nginx` | release-backed NGINX Open Source service for Traefik routing dependencies | acquired from [`service-lasso/lasso-nginx`](https://github.com/service-lasso/lasso-nginx) release `2026.4.27-712c75f`; started as a managed daemon with HTTP `/health` |
 | `@traefik` | local edge/router service depending on `@localcert` and `@nginx` | acquired from [`service-lasso/lasso-traefik`](https://github.com/service-lasso/lasso-traefik) release `2026.5.9-9511770` |
 | `@node` | release-backed Node runtime provider | acquired from [`service-lasso/lasso-node`](https://github.com/service-lasso/lasso-node) release `2026.4.27-eca215a`; installed/configured but not launched as a daemon |
-| `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c`; installed/configured as a provider and skipped for daemon launch |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.5.9-c7dca55`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.5.14-0821754` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.4-de50799` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage. `@archive` is optional because Service Lasso already extracts normal `zip`, `tar.gz`, and `tgz` release artifacts without an external archive provider; keep it disabled unless a service needs external 7-Zip tooling for formats such as `.7z`, `.rar`, `.xz`, split archives, or legacy install flows.
 

--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -247,7 +247,6 @@ Default baseline services currently are:
 - `@nginx`
 - `@traefik`
 - `@node`
-- `@python`
 - `@secretsbroker`
 - `echo-service`
 - `@serviceadmin`

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.5.15-c66d8ce"
+      "tag": "2026.6.4-de50799"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Summary
- pins core `@serviceadmin` to Service Admin release `2026.6.4-de50799`
- updates README and service-authoring guide catalog docs to match the runtime default baseline and release pin
- records governed backlog traceability for #570

## Validation
- `npm run demo:recycle -- --port=17883`
- `npm run verify:service-catalog`
- `git diff --check`
- LAN checks after recycle:
  - `http://192.168.1.53:17700/` -> 200, hash `50E196F354B18E0E1636EA22FACBFCCACB85836EC8270FDBA41060D8D0A354F9`
  - `http://192.168.1.53:17700/secrets-broker#secret-sources` -> 200, same updated hash
  - `http://192.168.1.53:17700/secrets-broker/sources` -> 200, same updated hash
  - `http://192.168.1.53:17883/api/health` -> 200

Fixes #570