### PR TITLE
fix(demo): pin routes table Service Admin release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@node` | release-backed Node runtime provider | acquired from [`service-lasso/lasso-node`](https://github.com/service-lasso/lasso-node) release `2026.4.27-eca215a`; installed/configured but not launched as a daemon |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.5.9-c7dca55`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.5-785447f` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.5-351750c` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` is part of that baseline so archive-capable services are present in proper instances instead of relying on fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.5-785447f"
+      "tag": "2026.6.5-351750c"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.5-785447f");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.5-351750c");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
Refs #572. Supports service-lasso/lasso-serviceadmin#139.

## Summary
- pins core `@serviceadmin` to lasso-serviceadmin release `2026.6.5-351750c`
- updates README/catalog documentation for the new release tag
- updates manifest discovery coverage for the core baseline pin

## Validation
- `npm run verify:service-catalog` -> passed
- `node --test tests/manifest-discovery.test.js tests/demo-instance.test.js` -> 26 passed
- `git diff --check` -> passed

## Release source
- Service Admin release: https://github.com/service-lasso/lasso-serviceadmin/releases/tag/2026.6.5-351750c
- Service Admin PR: https://github.com/service-lasso/lasso-serviceadmin/pull/140