### PR TITLE
ISS-134 pin Service Admin demo release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.5-030ff1f"
+      "tag": "2026.6.6-10a9643"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.5-030ff1f");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.6-10a9643");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Summary
- pins the canonical @serviceadmin demo manifest to the merged Service Admin release 2026.6.6-10a9643
- updates the baseline inventory test expectation to match the release pin

## Validation
- 
pm run build — passed
- 
ode --test --test-concurrency=1 tests/manifest-discovery.test.js — 23 passed
- 
pm test — attempted, but blocked by the live canonical demo holding extracted service binaries open during reset (EPERM unlink on running demo artifacts); one expected-tag assertion was fixed by this PR and the targeted manifest test now passes.

Related to service-lasso/lasso-serviceadmin#134