### PR TITLE
chore #132 update serviceadmin demo artifact pin

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.6-10a9643"
+      "tag": "2026.6.6-6715d14"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.6-10a9643");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.6-6715d14");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Summary
- Pin the canonical demo `@serviceadmin` manifest to the latest Service Admin release `2026.6.6-6715d14` produced by service-lasso/lasso-serviceadmin#152.
- Update the manifest discovery expectation for the new demo artifact tag.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/manifest-discovery.test.js` (23 passed)
- `npm test` attempted locally but blocked by the active canonical demo locking `services/*/.state/extracted/current/*.exe`; hosted CI should provide clean full-suite evidence.

Related: service-lasso/lasso-serviceadmin#132