### PR TITLE
chore(#53): pin demo secrets broker release

### DIFF
--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -2,7 +2,7 @@
   "id": "@secretsbroker",
   "name": "Service Lasso Secrets Broker",
   "description": "Release-backed local-first secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
-  "version": "2026.6.6-4456ca1",
+  "version": "2026.6.7-5266561",
   "enabled": true,
   "ports": {
     "service": 17890
@@ -27,7 +27,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-secretsbroker",
-      "tag": "2026.6.6-4456ca1"
+      "tag": "2026.6.7-5266561"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.6-4456ca1");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.7-5266561");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);


### PR DESCRIPTION
## Summary
- update the canonical `@secretsbroker` service manifest to release `2026.6.7-5266561`
- update the clean-clone baseline manifest assertion to match the new pin

## Validation
- `npm run build`
- `node --test tests/manifest-discovery.test.js`
- `npm test` was attempted locally but live canonical demo processes held extracted `.exe` files open, causing EPERM unlink failures; hosted CI is the clean full-run gate.

Related to service-lasso/lasso-secretsbroker#53 and service-lasso/lasso-secretsbroker#82.