### PR TITLE
chore(#51): pin demo secrets broker release

### DIFF
--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -2,7 +2,7 @@
   "id": "@secretsbroker",
   "name": "Service Lasso Secrets Broker",
   "description": "Release-backed local-first secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
-  "version": "2026.6.7-5266561",
+  "version": "2026.6.7-eecdb39",
   "enabled": true,
   "ports": {
     "service": 17890
@@ -27,7 +27,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-secretsbroker",
-      "tag": "2026.6.7-5266561"
+      "tag": "2026.6.7-eecdb39"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.7-5266561");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.7-eecdb39");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);


### PR DESCRIPTION
## Summary
- pin the canonical demo `@secretsbroker` manifest to lasso-secretsbroker release `2026.6.7-eecdb39`
- update manifest discovery coverage for the new release tag

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/manifest-discovery.test.js`
- `git diff --check`

Related to service-lasso/lasso-secretsbroker#51 and service-lasso/lasso-secretsbroker#83.