### PR TITLE
chore(#49): pin demo Secrets Broker release

### DIFF
--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -2,7 +2,7 @@
   "id": "@secretsbroker",
   "name": "Service Lasso Secrets Broker",
   "description": "Release-backed local-first secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
-  "version": "2026.6.7-cef6f31",
+  "version": "2026.6.7-6dd6d3d",
   "enabled": true,
   "ports": {
     "service": 17890
@@ -27,7 +27,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-secretsbroker",
-      "tag": "2026.6.7-cef6f31"
+      "tag": "2026.6.7-6dd6d3d"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Summary\n- pins the canonical @secretsbroker service manifest to lasso-secretsbroker release 2026.6.7-6dd6d3d\n- keeps the core demo aligned with the merged lasso-secretsbroker#49 1Password CLI adapter slice\n\n## Validation\n- npm run build\n- git diff --check\n\nFollows service-lasso/lasso-secretsbroker#49 and PR service-lasso/lasso-secretsbroker#89.