### PR TITLE
chore(#595): pin Secrets Broker demo release f7a35b1

### DIFF
--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -2,7 +2,7 @@
   "id": "@secretsbroker",
   "name": "Service Lasso Secrets Broker",
   "description": "Release-backed local-first secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
-  "version": "2026.6.8-c108d8c",
+  "version": "2026.6.8-f7a35b1",
   "enabled": true,
   "ports": {
     "service": 17890
@@ -27,7 +27,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-secretsbroker",
-      "tag": "2026.6.8-c108d8c"
+      "tag": "2026.6.8-f7a35b1"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Closes #595

## Summary
- Pin the canonical demo Secrets Broker manifest to release `2026.6.8-f7a35b1`.
- This release was published from lasso-secretsbroker#91 / lasso-secretsbroker#47.

## Validation
- `node -e` manifest tag/version check
- `gh release view 2026.6.8-f7a35b1 --repo service-lasso/lasso-secretsbroker`
- `git diff --check`
- `npm run build`
- Canonical demo recycle and LAN proof will be added after recycle completes.

## Logs
- `.work-agent/logs/issue-595-20260609-0429/`