### PR TITLE
fix(demo): add canonical watchdog recovery

### DIFF
--- a/docs/reference/canonical-demo-watchdog.md
+++ b/docs/reference/canonical-demo-watchdog.md
@@ -1,0 +1,45 @@
+# Canonical demo watchdog
+
+The canonical Service Lasso LAN demo is:
+
+| Surface | URL |
+| --- | --- |
+| Service Admin | `http://192.168.1.53:17700/` |
+| Runtime API health | `http://192.168.1.53:17883/api/health` |
+
+Use the repo-owned watchdog when the canonical demo must be kept online:
+
+```powershell
+npm run demo:watchdog
+```
+
+The watchdog checks both LAN URLs before it attempts recovery. If either URL is
+unreachable, it acquires `.demo-logs/demo-watchdog.lock.json` before launching
+recovery so repeated scheduler runs cannot overlap. Recovery runs:
+
+```powershell
+npm run demo:recycle -- --port=17883
+```
+
+The command also sets `SERVICE_LASSO_PORT=17883` in the recovery process. This
+keeps the runtime on the canonical port instead of falling back to the generic
+development default.
+
+Logs are appended under `.demo-logs/`, including
+`.demo-logs/demo-watchdog-recovery.log` for recovery output and the existing
+`demo-recycle.*.log` files for detached demo runtime output.
+
+Useful overrides:
+
+| Setting | Purpose |
+| --- | --- |
+| `--host=<host>` / `SERVICE_LASSO_DEMO_HOST` | LAN host for both default checks. |
+| `--runtime-port=<port>` / `SERVICE_LASSO_PORT` | Runtime port used for health and recovery. |
+| `--service-admin-url=<url>` | Explicit Service Admin check URL. |
+| `--runtime-health-url=<url>` | Explicit runtime health check URL. |
+| `--lock-path=<path>` | Alternate lock file for validation. |
+| `--dry-run` | Check health and report that recovery would be needed without recycling. |
+
+Every final demo handoff should include the branch, commit, `npm run demo:watchdog`
+or `npm run demo:recycle -- --port=17883` result, and live LAN proof for both
+canonical URLs.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "demo:reset": "npm run build && node scripts/demo-reset.mjs",
     "demo:recycle": "npm run build && node scripts/demo-recycle.mjs",
     "demo:smoke": "npm run build && node scripts/demo-smoke.mjs",
+    "demo:watchdog": "node scripts/demo-watchdog.mjs",
     "docs:start": "docusaurus start docs",
     "docs:build": "docusaurus build docs",
     "docs:serve": "docusaurus serve docs",

--- a/scripts/demo-watchdog.mjs
+++ b/scripts/demo-watchdog.mjs
@@ -1,0 +1,263 @@
+import { spawn } from "node:child_process";
+import { mkdir, open, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { repoRoot } from "./demo-instance-lib.mjs";
+
+const defaultRuntimePort = 17883;
+const defaultDemoHost = "192.168.1.53";
+const defaultLockTtlMs = 30 * 60 * 1000;
+const defaultRecoveryTimeoutMs = 15 * 60 * 1000;
+
+function parseFlag(args, name) {
+  const prefix = `--${name}=`;
+  const value = args.find((entry) => entry.startsWith(prefix));
+  return value ? value.slice(prefix.length) : undefined;
+}
+
+function parseNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveWatchdogOptions(args = process.argv.slice(2), env = process.env) {
+  const runtimePort = parseNumber(
+    parseFlag(args, "runtime-port") ?? parseFlag(args, "port") ?? env.SERVICE_LASSO_PORT,
+    defaultRuntimePort,
+  );
+  const demoHost = parseFlag(args, "host") ?? env.SERVICE_LASSO_DEMO_HOST ?? defaultDemoHost;
+  const serviceAdminUrl =
+    parseFlag(args, "service-admin-url")
+    ?? env.SERVICE_LASSO_DEMO_SERVICEADMIN_URL
+    ?? `http://${demoHost}:17700/`;
+  const runtimeHealthUrl =
+    parseFlag(args, "runtime-health-url")
+    ?? env.SERVICE_LASSO_DEMO_RUNTIME_HEALTH_URL
+    ?? `http://${demoHost}:${runtimePort}/api/health`;
+  const lockPath =
+    parseFlag(args, "lock-path")
+    ?? env.SERVICE_LASSO_DEMO_WATCHDOG_LOCK
+    ?? path.join(repoRoot, ".demo-logs", "demo-watchdog.lock.json");
+
+  return {
+    runtimePort,
+    serviceAdminUrl,
+    runtimeHealthUrl,
+    lockPath,
+    lockTtlMs: parseNumber(parseFlag(args, "lock-ttl-ms") ?? env.SERVICE_LASSO_DEMO_WATCHDOG_LOCK_TTL_MS, defaultLockTtlMs),
+    recoveryTimeoutMs: parseNumber(
+      parseFlag(args, "recovery-timeout-ms") ?? env.SERVICE_LASSO_DEMO_RECOVERY_TIMEOUT_MS,
+      defaultRecoveryTimeoutMs,
+    ),
+    dryRun: args.includes("--dry-run"),
+  };
+}
+
+export async function checkEndpoint(url, { expectRuntimeHealth = false, timeoutMs = 10_000 } = {}) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const status = response.status;
+    if (status < 200 || status >= 300) {
+      return { ok: false, status, reason: `HTTP ${status}` };
+    }
+
+    if (expectRuntimeHealth) {
+      const body = await response.json();
+      if (body?.status !== "ok") {
+        return { ok: false, status, reason: `runtime status ${JSON.stringify(body?.status ?? null)}` };
+      }
+    }
+
+    return { ok: true, status };
+  } catch (error) {
+    return { ok: false, reason: error.message };
+  }
+}
+
+async function processExists(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readLock(lockPath) {
+  try {
+    return JSON.parse(await readFile(lockPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export async function acquireWatchdogLock(lockPath, { ttlMs = defaultLockTtlMs, now = () => new Date() } = {}) {
+  await mkdir(path.dirname(lockPath), { recursive: true });
+  const existing = await readLock(lockPath);
+  const nowDate = now();
+
+  if (existing) {
+    const startedAt = Date.parse(existing.startedAt ?? "");
+    const ageMs = Number.isFinite(startedAt) ? nowDate.getTime() - startedAt : Number.POSITIVE_INFINITY;
+    const stillRunning = await processExists(existing.pid);
+
+    if (stillRunning && ageMs < ttlMs) {
+      return {
+        acquired: false,
+        reason: "recovery_already_running",
+        lock: existing,
+      };
+    }
+
+    await rm(lockPath, { force: true });
+  }
+
+  const lock = {
+    pid: process.pid,
+    startedAt: nowDate.toISOString(),
+    ttlMs,
+  };
+
+  try {
+    const handle = await open(lockPath, "wx");
+    await handle.writeFile(`${JSON.stringify(lock, null, 2)}\n`);
+    await handle.close();
+    return { acquired: true, lock };
+  } catch {
+    return {
+      acquired: false,
+      reason: "lock_race_lost",
+      lock: await readLock(lockPath),
+    };
+  }
+}
+
+export async function releaseWatchdogLock(lockPath) {
+  const existing = await readLock(lockPath);
+  if (existing?.pid === process.pid) {
+    await rm(lockPath, { force: true });
+  }
+}
+
+export function buildRecoveryCommand(options) {
+  return {
+    command: process.platform === "win32" ? "npm.cmd" : "npm",
+    args: ["run", "demo:recycle", "--", `--port=${options.runtimePort}`],
+    env: {
+      SERVICE_LASSO_PORT: String(options.runtimePort),
+    },
+  };
+}
+
+async function runRecovery(options) {
+  const recovery = buildRecoveryCommand(options);
+  const logRoot = path.join(repoRoot, ".demo-logs");
+  await mkdir(logRoot, { recursive: true });
+  const logPath = path.join(logRoot, "demo-watchdog-recovery.log");
+  const startedAt = new Date().toISOString();
+  await writeFile(logPath, `[${startedAt}] starting recovery: ${recovery.command} ${recovery.args.join(" ")}\n`, { flag: "a" });
+
+  return await new Promise((resolve) => {
+    const child = spawn(recovery.command, recovery.args, {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      env: {
+        ...process.env,
+        ...recovery.env,
+      },
+    });
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill("SIGTERM");
+      resolve({ code: 124, logPath, timedOut: true });
+    }, options.recoveryTimeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      void writeFile(logPath, chunk, { flag: "a" });
+    });
+    child.stderr.on("data", (chunk) => {
+      void writeFile(logPath, chunk, { flag: "a" });
+    });
+    child.once("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ code, logPath, timedOut: false });
+    });
+    child.once("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      void writeFile(logPath, `\n${error.message}\n`, { flag: "a" });
+      resolve({ code: 1, logPath, timedOut: false });
+    });
+  });
+}
+
+export async function runWatchdog(options = resolveWatchdogOptions()) {
+  const serviceAdmin = await checkEndpoint(options.serviceAdminUrl);
+  const runtimeHealth = await checkEndpoint(options.runtimeHealthUrl, { expectRuntimeHealth: true });
+  const healthy = serviceAdmin.ok && runtimeHealth.ok;
+
+  if (healthy) {
+    return { ok: true, recovered: false, serviceAdmin, runtimeHealth };
+  }
+
+  if (options.dryRun) {
+    return { ok: false, recovered: false, dryRun: true, serviceAdmin, runtimeHealth };
+  }
+
+  const lock = await acquireWatchdogLock(options.lockPath, { ttlMs: options.lockTtlMs });
+  if (!lock.acquired) {
+    return { ok: false, recovered: false, blockedByLock: true, lock, serviceAdmin, runtimeHealth };
+  }
+
+  try {
+    const recovery = await runRecovery(options);
+    const recoveredServiceAdmin = await checkEndpoint(options.serviceAdminUrl);
+    const recoveredRuntimeHealth = await checkEndpoint(options.runtimeHealthUrl, { expectRuntimeHealth: true });
+    return {
+      ok: recovery.code === 0 && recoveredServiceAdmin.ok && recoveredRuntimeHealth.ok,
+      recovered: recovery.code === 0,
+      recovery,
+      serviceAdmin: recoveredServiceAdmin,
+      runtimeHealth: recoveredRuntimeHealth,
+    };
+  } finally {
+    await releaseWatchdogLock(options.lockPath);
+  }
+}
+
+function printResult(result, options) {
+  console.log("[service-lasso demo] watchdog result");
+  console.log(`- runtimePort: ${options.runtimePort}`);
+  console.log(`- serviceAdmin: ${result.serviceAdmin.ok ? "ok" : "down"} ${options.serviceAdminUrl} ${result.serviceAdmin.status ?? result.serviceAdmin.reason}`);
+  console.log(`- runtimeHealth: ${result.runtimeHealth.ok ? "ok" : "down"} ${options.runtimeHealthUrl} ${result.runtimeHealth.status ?? result.runtimeHealth.reason}`);
+  console.log(`- recovered: ${result.recovered === true}`);
+  if (result.blockedByLock) {
+    console.log(`- blocked: ${result.lock.reason}`);
+  }
+  if (result.recovery?.logPath) {
+    console.log(`- recoveryLog: ${result.recovery.logPath}`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const options = resolveWatchdogOptions();
+  const result = await runWatchdog(options);
+  printResult(result, options);
+  process.exitCode = result.ok ? 0 : 1;
+}

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -2,9 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import os from "node:os";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { DEFAULT_BASELINE_SERVICE_IDS } from "../dist/runtime/cli/bootstrap.js";
 import { assertDemoPortsAvailable, demoProviderServiceIds, demoRequiredServiceIds } from "../scripts/demo-instance-lib.mjs";
+import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
 
 async function listenOnLoopback() {
   const server = net.createServer();
@@ -48,6 +51,51 @@ test("demo recycle uses the canonical baseline service set", () => {
   assert.equal(demoProviderServiceIds.has("@archive"), true);
   assert.equal(demoProviderServiceIds.has("@node"), true);
   assert.equal(demoProviderServiceIds.has("@serviceadmin"), false);
+});
+
+test("demo watchdog defaults to the canonical LAN endpoints and runtime port", () => {
+  const options = resolveWatchdogOptions([], {});
+  assert.equal(options.runtimePort, 17883);
+  assert.equal(options.serviceAdminUrl, "http://192.168.1.53:17700/");
+  assert.equal(options.runtimeHealthUrl, "http://192.168.1.53:17883/api/health");
+
+  const recovery = buildRecoveryCommand(options);
+  assert.deepEqual(recovery.args, ["run", "demo:recycle", "--", "--port=17883"]);
+  assert.equal(recovery.env.SERVICE_LASSO_PORT, "17883");
+});
+
+test("demo watchdog refuses to overlap an active recovery lock", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-watchdog-"));
+  const lockPath = path.join(tempDir, "watchdog.lock.json");
+
+  try {
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString(), ttlMs: 60_000 })}\n`,
+    );
+
+    const lock = await acquireWatchdogLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(lock.acquired, false);
+    assert.equal(lock.reason, "recovery_already_running");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("demo watchdog lock is released only by the owning process", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-watchdog-"));
+  const lockPath = path.join(tempDir, "watchdog.lock.json");
+
+  try {
+    const lock = await acquireWatchdogLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(lock.acquired, true);
+    await releaseWatchdogLock(lockPath);
+    const reacquired = await acquireWatchdogLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(reacquired.acquired, true);
+    await releaseWatchdogLock(lockPath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("demo smoke script validates the bounded demo instance end to end", async () => {


### PR DESCRIPTION
## Summary
- Add a repo-owned `demo:watchdog` script for the canonical LAN demo.
- Default checks target Service Admin `http://192.168.1.53:17700/` and runtime health `http://192.168.1.53:17883/api/health`.
- Recovery passes `--port=17883` and `SERVICE_LASSO_PORT=17883`, records logs under `.demo-logs/`, and uses a lock to avoid overlapping recovery runs.
- Document the watchdog/runbook and add focused regression coverage for canonical defaults and lock behavior.

## Validation
- `npm run build` passed.
- `node --test --test-concurrency=1 --test-name-pattern "demo watchdog" tests/demo-instance.test.js` passed, 3/3.
- Full `tests/demo-instance.test.js` was attempted and the pre-existing smoke case failed because the live demo had a locked `services/@traefik/.state/extracted/current/traefik.exe`; log: `.work-agent/logs/593/demo-instance-test.log`.
- Clean canonical demo recycle succeeded while holding the existing local watchdog lock: `SERVICE_LASSO_PORT=17883 npm run demo:recycle`, log: `.work-agent/logs/593/canonical-demo-clean-recycle.log`.
- Live demo evidence after recycle: branch `fix/593-canonical-demo-watchdog`, commit `1daa06982298`, runtime `http://192.168.1.53:17883/api/health` HTTP 200 status ok, Service Admin `http://192.168.1.53:17700/` HTTP 200.
- `node scripts/demo-watchdog.mjs --dry-run` passed against the canonical LAN URLs; log: `.work-agent/logs/593/watchdog-dry-run-final.log`.

Closes #593