### PR TITLE
#594 fix(demo): add canonical demo verifier

### DIFF
--- a/docs/reference/canonical-demo-watchdog.md
+++ b/docs/reference/canonical-demo-watchdog.md
@@ -25,6 +25,19 @@ The command also sets `SERVICE_LASSO_PORT=17883` in the recovery process. This
 keeps the runtime on the canonical port instead of falling back to the generic
 development default.
 
+Before claiming a demo deploy or recycle succeeded, run the canonical verifier:
+
+```powershell
+npm run demo:verify-canonical
+```
+
+The verifier checks the canonical LAN ports, runtime health, Service Admin
+reachability, runtime `servicesRoot` / `workspaceRoot`, and the live
+`@serviceadmin` / `@secretsbroker` release metadata against the checked-in
+`services/` manifests. It reports separate failure codes for wrong runtime port,
+wrong lane, missing service, unhealthy service, stale release pin, stale
+installed artifact, wrong service port, and unreachable LAN endpoints.
+
 Logs are appended under `.demo-logs/`, including
 `.demo-logs/demo-watchdog-recovery.log` for recovery output and the existing
 `demo-recycle.*.log` files for detached demo runtime output.
@@ -41,5 +54,5 @@ Useful overrides:
 | `--dry-run` | Check health and report that recovery would be needed without recycling. |
 
 Every final demo handoff should include the branch, commit, `npm run demo:watchdog`
-or `npm run demo:recycle -- --port=17883` result, and live LAN proof for both
-canonical URLs.
+or `npm run demo:recycle -- --port=17883` result, `npm run demo:verify-canonical`
+output, and live LAN proof for both canonical URLs.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "demo:recycle": "npm run build && node scripts/demo-recycle.mjs",
     "demo:smoke": "npm run build && node scripts/demo-smoke.mjs",
     "demo:watchdog": "node scripts/demo-watchdog.mjs",
+    "demo:verify-canonical": "node scripts/demo-verify-canonical.mjs",
     "docs:start": "docusaurus start docs",
     "docs:build": "docusaurus build docs",
     "docs:serve": "docusaurus serve docs",

--- a/scripts/demo-verify-canonical.mjs
+++ b/scripts/demo-verify-canonical.mjs
@@ -1,0 +1,321 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  defaultDemoServicesRoot,
+  defaultDemoWorkspaceRoot,
+} from "./demo-instance-lib.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+export const canonicalDemoHost = "192.168.1.53";
+export const canonicalRuntimePort = 17883;
+export const canonicalServiceAdminPort = 17700;
+export const canonicalServiceIds = ["@serviceadmin", "@secretsbroker"];
+
+function parseFlag(args, name) {
+  const prefix = `--${name}=`;
+  const value = args.find((entry) => entry.startsWith(prefix));
+  return value ? value.slice(prefix.length) : undefined;
+}
+
+function parseNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeUrlBase(url) {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function urlPort(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) {
+      return Number(parsed.port);
+    }
+    return parsed.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
+}
+
+function normalizePathForCompare(value) {
+  const resolved = path.resolve(String(value ?? ""));
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function check(checks, name, ok, code, detail = "") {
+  checks.push({ name, ok, code: ok ? null : code, detail });
+}
+
+function checkEqual(checks, name, actual, expected, code, detailPrefix = "") {
+  const ok = actual === expected;
+  const detail = ok
+    ? `${actual}`
+    : `${detailPrefix}${detailPrefix ? ": " : ""}expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`;
+  check(checks, name, ok, code, detail);
+}
+
+async function fetchJson(url, fetchImpl, timeoutMs) {
+  try {
+    const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const body = await response.json();
+    return { ok: response.status >= 200 && response.status < 300, status: response.status, body };
+  } catch (error) {
+    return { ok: false, status: null, error: error.message, body: null };
+  }
+}
+
+async function fetchText(url, fetchImpl, timeoutMs) {
+  try {
+    const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const body = await response.text();
+    return { ok: response.status >= 200 && response.status < 300, status: response.status, body };
+  } catch (error) {
+    return { ok: false, status: null, error: error.message, body: "" };
+  }
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+export function resolveCanonicalVerifierOptions(args = process.argv.slice(2), env = process.env) {
+  const host = parseFlag(args, "host") ?? env.SERVICE_LASSO_DEMO_HOST ?? canonicalDemoHost;
+  const runtimePort = parseNumber(
+    parseFlag(args, "runtime-port") ?? parseFlag(args, "port") ?? env.SERVICE_LASSO_PORT,
+    canonicalRuntimePort,
+  );
+  const serviceAdminPort = parseNumber(
+    parseFlag(args, "service-admin-port") ?? env.SERVICE_LASSO_DEMO_SERVICEADMIN_PORT,
+    canonicalServiceAdminPort,
+  );
+
+  const runtimeUrl = normalizeUrlBase(
+    parseFlag(args, "runtime-url")
+      ?? env.SERVICE_LASSO_DEMO_RUNTIME_URL
+      ?? `http://${host}:${runtimePort}`,
+  );
+  const serviceAdminUrl =
+    parseFlag(args, "service-admin-url")
+    ?? env.SERVICE_LASSO_DEMO_SERVICEADMIN_URL
+    ?? `http://${host}:${serviceAdminPort}/`;
+
+  return {
+    host,
+    runtimePort,
+    serviceAdminPort,
+    runtimeUrl,
+    serviceAdminUrl,
+    runtimeHealthUrl: `${runtimeUrl}/api/health`,
+    runtimeSummaryUrl: `${runtimeUrl}/api/runtime`,
+    runtimeServicesUrl: `${runtimeUrl}/api/services`,
+    servicesRoot: path.resolve(parseFlag(args, "services-root") ?? env.SERVICE_LASSO_SERVICES_ROOT ?? defaultDemoServicesRoot),
+    workspaceRoot: path.resolve(parseFlag(args, "workspace-root") ?? env.SERVICE_LASSO_WORKSPACE_ROOT ?? defaultDemoWorkspaceRoot),
+    timeoutMs: parseNumber(parseFlag(args, "timeout-ms") ?? env.SERVICE_LASSO_DEMO_VERIFY_TIMEOUT_MS, 10_000),
+    serviceIds: canonicalServiceIds,
+  };
+}
+
+export async function readExpectedDemoServices(servicesRoot, serviceIds = canonicalServiceIds) {
+  const expected = new Map();
+
+  for (const serviceId of serviceIds) {
+    const manifest = await readJson(path.join(servicesRoot, serviceId, "service.json"));
+    const platform = manifest.artifact?.platforms?.[process.platform];
+    expected.set(serviceId, {
+      id: serviceId,
+      repo: manifest.artifact?.source?.repo ?? null,
+      tag: manifest.artifact?.source?.tag ?? null,
+      assetName: platform?.assetName ?? null,
+      ports: manifest.ports ?? {},
+      serviceRoot: path.join(servicesRoot, serviceId),
+    });
+  }
+
+  return expected;
+}
+
+function serviceSummary(service, expected) {
+  return {
+    id: service.id,
+    running: service.lifecycle?.running === true,
+    healthy: service.health?.healthy === true,
+    catalogTag: service.catalogProvenance?.releaseTag ?? null,
+    installedTag: service.lifecycle?.installArtifacts?.artifact?.tag ?? null,
+    expectedTag: expected.tag,
+  };
+}
+
+export async function verifyCanonicalDemo(options = {}, deps = {}) {
+  const resolved = {
+    ...resolveCanonicalVerifierOptions([], {}),
+    ...options,
+  };
+  const fetchImpl = deps.fetch ?? fetch;
+  const checks = [];
+  const expectedServices = await readExpectedDemoServices(resolved.servicesRoot, resolved.serviceIds);
+
+  checkEqual(
+    checks,
+    "runtime port is canonical",
+    urlPort(resolved.runtimeUrl),
+    resolved.runtimePort,
+    "wrong_runtime_port",
+  );
+  checkEqual(
+    checks,
+    "Service Admin port is canonical",
+    urlPort(resolved.serviceAdminUrl),
+    resolved.serviceAdminPort,
+    "wrong_serviceadmin_port",
+  );
+
+  const [serviceAdmin, runtimeHealth, runtimeSummary, runtimeServices] = await Promise.all([
+    fetchText(resolved.serviceAdminUrl, fetchImpl, resolved.timeoutMs),
+    fetchJson(resolved.runtimeHealthUrl, fetchImpl, resolved.timeoutMs),
+    fetchJson(resolved.runtimeSummaryUrl, fetchImpl, resolved.timeoutMs),
+    fetchJson(resolved.runtimeServicesUrl, fetchImpl, resolved.timeoutMs),
+  ]);
+
+  check(
+    checks,
+    "Service Admin LAN reachable",
+    serviceAdmin.ok,
+    "unreachable_lan",
+    serviceAdmin.ok ? `HTTP ${serviceAdmin.status}` : `${resolved.serviceAdminUrl}: ${serviceAdmin.error ?? `HTTP ${serviceAdmin.status}`}`,
+  );
+  check(
+    checks,
+    "runtime health LAN reachable",
+    runtimeHealth.ok && runtimeHealth.body?.status === "ok",
+    "unreachable_lan",
+    runtimeHealth.ok
+      ? `HTTP ${runtimeHealth.status}, status=${JSON.stringify(runtimeHealth.body?.status ?? null)}`
+      : `${resolved.runtimeHealthUrl}: ${runtimeHealth.error ?? `HTTP ${runtimeHealth.status}`}`,
+  );
+  check(
+    checks,
+    "runtime summary reachable",
+    Boolean(runtimeSummary.ok && runtimeSummary.body?.runtime),
+    "missing_runtime_metadata",
+    runtimeSummary.ok ? `HTTP ${runtimeSummary.status}` : `${resolved.runtimeSummaryUrl}: ${runtimeSummary.error ?? `HTTP ${runtimeSummary.status}`}`,
+  );
+  check(
+    checks,
+    "runtime services reachable",
+    Boolean(runtimeServices.ok && Array.isArray(runtimeServices.body?.services)),
+    "missing_runtime_services",
+    runtimeServices.ok ? `HTTP ${runtimeServices.status}` : `${resolved.runtimeServicesUrl}: ${runtimeServices.error ?? `HTTP ${runtimeServices.status}`}`,
+  );
+
+  const runtime = runtimeSummary.body?.runtime;
+  if (runtime) {
+    checkEqual(
+      checks,
+      "runtime services root matches canonical repo",
+      normalizePathForCompare(runtime.servicesRoot),
+      normalizePathForCompare(resolved.servicesRoot),
+      "wrong_lane",
+    );
+    checkEqual(
+      checks,
+      "runtime workspace root matches canonical demo",
+      normalizePathForCompare(runtime.workspaceRoot),
+      normalizePathForCompare(resolved.workspaceRoot),
+      "wrong_lane",
+    );
+  }
+
+  const liveServices = new Map((runtimeServices.body?.services ?? []).map((service) => [service.id, service]));
+  const serviceSummaries = [];
+
+  for (const [serviceId, expected] of expectedServices.entries()) {
+    const live = liveServices.get(serviceId);
+    check(checks, `${serviceId} is present`, Boolean(live), "missing_service", serviceId);
+    if (!live) {
+      continue;
+    }
+
+    serviceSummaries.push(serviceSummary(live, expected));
+    check(checks, `${serviceId} is running`, live.lifecycle?.running === true, "unhealthy_service", `running=${live.lifecycle?.running === true}`);
+    check(checks, `${serviceId} is healthy`, live.health?.healthy === true, "unhealthy_service", `healthy=${live.health?.healthy === true}`);
+    checkEqual(
+      checks,
+      `${serviceId} service root matches canonical services root`,
+      normalizePathForCompare(live.serviceRoot),
+      normalizePathForCompare(expected.serviceRoot),
+      "wrong_lane",
+    );
+    checkEqual(checks, `${serviceId} catalog repo matches manifest`, live.catalogProvenance?.repo ?? null, expected.repo, "stale_release_pin");
+    checkEqual(checks, `${serviceId} catalog release tag matches manifest`, live.catalogProvenance?.releaseTag ?? null, expected.tag, "stale_release_pin");
+    checkEqual(checks, `${serviceId} installed artifact repo matches manifest`, live.lifecycle?.installArtifacts?.artifact?.repo ?? null, expected.repo, "stale_installed_artifact");
+    checkEqual(checks, `${serviceId} installed artifact tag matches manifest`, live.lifecycle?.installArtifacts?.artifact?.tag ?? null, expected.tag, "stale_installed_artifact");
+    if (expected.assetName) {
+      checkEqual(
+        checks,
+        `${serviceId} installed artifact asset matches platform`,
+        live.lifecycle?.installArtifacts?.artifact?.assetName ?? null,
+        expected.assetName,
+        "stale_installed_artifact",
+      );
+    }
+
+    for (const [portName, port] of Object.entries(expected.ports)) {
+      checkEqual(
+        checks,
+        `${serviceId} runtime port ${portName} matches manifest`,
+        live.lifecycle?.runtime?.ports?.[portName] ?? null,
+        port,
+        "wrong_service_port",
+      );
+    }
+  }
+
+  return {
+    ok: checks.every((entry) => entry.ok),
+    checks,
+    failures: checks.filter((entry) => !entry.ok),
+    summary: {
+      runtimeUrl: resolved.runtimeUrl,
+      serviceAdminUrl: resolved.serviceAdminUrl,
+      servicesRoot: resolved.servicesRoot,
+      workspaceRoot: resolved.workspaceRoot,
+      services: serviceSummaries,
+    },
+  };
+}
+
+export function formatCanonicalVerifierResult(result) {
+  const lines = [
+    `[service-lasso demo] canonical verifier ${result.ok ? "passed" : "failed"}`,
+    `- runtime: ${result.summary.runtimeUrl}`,
+    `- serviceAdmin: ${result.summary.serviceAdminUrl}`,
+    `- servicesRoot: ${result.summary.servicesRoot}`,
+    `- workspaceRoot: ${result.summary.workspaceRoot}`,
+  ];
+
+  if (result.summary.services.length > 0) {
+    lines.push("- release pins:");
+    for (const service of result.summary.services) {
+      lines.push(
+        `  - ${service.id}: expected=${service.expectedTag} catalog=${service.catalogTag} installed=${service.installedTag} running=${service.running} healthy=${service.healthy}`,
+      );
+    }
+  }
+
+  lines.push("- checks:");
+  for (const checkResult of result.checks) {
+    lines.push(
+      `  - ${checkResult.ok ? "ok" : "FAIL"} ${checkResult.name}${checkResult.ok ? "" : ` [${checkResult.code}]`}: ${checkResult.detail}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  const result = await verifyCanonicalDemo(resolveCanonicalVerifierOptions());
+  console.log(formatCanonicalVerifierResult(result));
+  process.exitCode = result.ok ? 0 : 1;
+}

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -3,11 +3,17 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import os from "node:os";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { DEFAULT_BASELINE_SERVICE_IDS } from "../dist/runtime/cli/bootstrap.js";
 import { assertDemoPortsAvailable, demoProviderServiceIds, demoRequiredServiceIds } from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
+import {
+  canonicalRuntimePort,
+  canonicalServiceAdminPort,
+  resolveCanonicalVerifierOptions,
+  verifyCanonicalDemo,
+} from "../scripts/demo-verify-canonical.mjs";
 
 async function listenOnLoopback() {
   const server = net.createServer();
@@ -26,6 +32,102 @@ async function listenOnLoopback() {
     close: async () => {
       await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
     },
+  };
+}
+
+async function writeCanonicalManifest(servicesRoot, serviceId, { repo, tag, assetName, ports }) {
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  await mkdir(serviceRoot, { recursive: true });
+  await writeFile(
+    path.join(serviceRoot, "service.json"),
+    `${JSON.stringify({
+      id: serviceId,
+      artifact: {
+        source: { repo, tag },
+        platforms: {
+          [process.platform]: { assetName },
+        },
+      },
+      ports,
+    }, null, 2)}\n`,
+  );
+}
+
+function jsonResponse(status, body) {
+  return {
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function textResponse(status, body) {
+  return {
+    status,
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  };
+}
+
+function canonicalFetch({ servicesRoot, workspaceRoot, serviceAdminTag = "2026.6.6-good", secretsBrokerTag = "2026.6.8-good" }) {
+  const services = [
+    {
+      id: "@serviceadmin",
+      serviceRoot: path.join(servicesRoot, "@serviceadmin"),
+      lifecycle: {
+        running: true,
+        installArtifacts: {
+          artifact: {
+            repo: "service-lasso/lasso-serviceadmin",
+            tag: serviceAdminTag,
+            assetName: "@serviceadmin-win32.zip",
+          },
+        },
+        runtime: { ports: { ui: 17700 } },
+      },
+      health: { healthy: true },
+      catalogProvenance: {
+        repo: "service-lasso/lasso-serviceadmin",
+        releaseTag: serviceAdminTag,
+      },
+    },
+    {
+      id: "@secretsbroker",
+      serviceRoot: path.join(servicesRoot, "@secretsbroker"),
+      lifecycle: {
+        running: true,
+        installArtifacts: {
+          artifact: {
+            repo: "service-lasso/lasso-secretsbroker",
+            tag: secretsBrokerTag,
+            assetName: "secretsbroker-win32.zip",
+          },
+        },
+        runtime: { ports: { service: 17890 } },
+      },
+      health: { healthy: true },
+      catalogProvenance: {
+        repo: "service-lasso/lasso-secretsbroker",
+        releaseTag: secretsBrokerTag,
+      },
+    },
+  ];
+
+  return async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === "/") {
+      return textResponse(200, "<html>Service Admin</html>");
+    }
+    if (parsed.pathname === "/api/health") {
+      return jsonResponse(200, { status: "ok" });
+    }
+    if (parsed.pathname === "/api/runtime") {
+      return jsonResponse(200, { runtime: { servicesRoot, workspaceRoot } });
+    }
+    if (parsed.pathname === "/api/services") {
+      return jsonResponse(200, { services });
+    }
+    return jsonResponse(404, { error: "not_found" });
   };
 }
 
@@ -62,6 +164,96 @@ test("demo watchdog defaults to the canonical LAN endpoints and runtime port", (
   const recovery = buildRecoveryCommand(options);
   assert.deepEqual(recovery.args, ["run", "demo:recycle", "--", "--port=17883"]);
   assert.equal(recovery.env.SERVICE_LASSO_PORT, "17883");
+});
+
+test("canonical demo verifier defaults to canonical LAN URLs", () => {
+  const options = resolveCanonicalVerifierOptions([], {});
+  assert.equal(options.runtimePort, canonicalRuntimePort);
+  assert.equal(options.serviceAdminPort, canonicalServiceAdminPort);
+  assert.equal(options.runtimeUrl, "http://192.168.1.53:17883");
+  assert.equal(options.serviceAdminUrl, "http://192.168.1.53:17700/");
+  assert.equal(options.runtimeHealthUrl, "http://192.168.1.53:17883/api/health");
+});
+
+test("canonical demo verifier accepts live metadata matching checked-in release pins", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-canonical-demo-"));
+  const servicesRoot = path.join(tempDir, "services");
+  const workspaceRoot = path.join(tempDir, "workspace", "demo-instance");
+
+  try {
+    await writeCanonicalManifest(servicesRoot, "@serviceadmin", {
+      repo: "service-lasso/lasso-serviceadmin",
+      tag: "2026.6.6-good",
+      assetName: "@serviceadmin-win32.zip",
+      ports: { ui: 17700 },
+    });
+    await writeCanonicalManifest(servicesRoot, "@secretsbroker", {
+      repo: "service-lasso/lasso-secretsbroker",
+      tag: "2026.6.8-good",
+      assetName: "secretsbroker-win32.zip",
+      ports: { service: 17890 },
+    });
+
+    const result = await verifyCanonicalDemo(
+      {
+        servicesRoot,
+        workspaceRoot,
+        runtimeUrl: "http://192.168.1.53:17883",
+        serviceAdminUrl: "http://192.168.1.53:17700/",
+      },
+      { fetch: canonicalFetch({ servicesRoot, workspaceRoot }) },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.failures.length, 0);
+    assert.equal(result.summary.services.length, 2);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("canonical demo verifier reports wrong runtime lane and stale release pins", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-canonical-demo-"));
+  const servicesRoot = path.join(tempDir, "services");
+  const workspaceRoot = path.join(tempDir, "workspace", "demo-instance");
+
+  try {
+    await writeCanonicalManifest(servicesRoot, "@serviceadmin", {
+      repo: "service-lasso/lasso-serviceadmin",
+      tag: "2026.6.6-good",
+      assetName: "@serviceadmin-win32.zip",
+      ports: { ui: 17700 },
+    });
+    await writeCanonicalManifest(servicesRoot, "@secretsbroker", {
+      repo: "service-lasso/lasso-secretsbroker",
+      tag: "2026.6.8-good",
+      assetName: "secretsbroker-win32.zip",
+      ports: { service: 17890 },
+    });
+
+    const result = await verifyCanonicalDemo(
+      {
+        servicesRoot,
+        workspaceRoot,
+        runtimeUrl: "http://192.168.1.53:18080",
+        serviceAdminUrl: "http://192.168.1.53:17700/",
+      },
+      {
+        fetch: canonicalFetch({
+          servicesRoot,
+          workspaceRoot,
+          serviceAdminTag: "2026.5.15-stale",
+        }),
+      },
+    );
+
+    assert.equal(result.ok, false);
+    assert.ok(result.failures.some((failure) => failure.code === "wrong_runtime_port"));
+    assert.ok(result.failures.some((failure) => failure.code === "stale_release_pin"));
+    assert.ok(result.failures.some((failure) => failure.code === "stale_installed_artifact"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("demo watchdog refuses to overlap an active recovery lock", async () => {


### PR DESCRIPTION
## Summary
- Adds `npm run demo:verify-canonical` to validate the canonical LAN demo on runtime port 17883 and Service Admin port 17700.
- Compares live runtime roots, service presence/health, runtime service ports, catalog release tags, installed artifact tags, repos, and platform assets for `@serviceadmin` and `@secretsbroker` against checked-in manifests.
- Updates the canonical demo watchdog handoff docs to require verifier output before claiming demo deployment success.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 --test-name-pattern="canonical demo verifier" tests/demo-instance.test.js`
- `git diff --check`
- `npm run demo:recycle -- --port=17883`
- `npm run demo:watchdog`
- `npm run demo:verify-canonical`

## Demo evidence
- Deployed branch/commit: `fix/594-canonical-demo-verifier@ab55933704e8`
- Runtime health LAN: `http://192.168.1.53:17883/api/health` -> 200 / `status="ok"`
- Service Admin LAN: `http://192.168.1.53:17700/` -> 200
- Verifier release pins: `@serviceadmin` expected/catalog/installed `2026.6.6-6715d14`; `@secretsbroker` expected/catalog/installed `2026.6.8-f7a35b1`

## Logs
- `.work-agent/logs/594/build.log`
- `.work-agent/logs/594/demo-verifier-tests.log`
- `.work-agent/logs/594/demo-recycle-canonical.log`
- `.work-agent/logs/594/demo-watchdog.log`
- `.work-agent/logs/594/demo-verify-canonical.log`
- `.work-agent/logs/594/demo-runtime-owner-stop.log`