### PR TITLE
fix(runtime): make start prepare services before launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ GET  /api/recovery
 POST /api/services/:id/recovery/doctor
 ```
 
+`POST /api/services/:id/start` and `POST /api/runtime/actions/startAll` use full start semantics: enabled services are installed, configured, non-manual setup steps are reconciled, and then startable services are started in dependency order. Provider-role services are still prepared, but they do not require a managed daemon process. Disabled services, already-running services, autostart filtering, and truly non-startable services remain skip/blocker cases instead of being forced.
+
 ## Use From npm
 
 The public package is:

--- a/docs/reference/runtime-dry-run-plans.md
+++ b/docs/reference/runtime-dry-run-plans.md
@@ -30,3 +30,5 @@ Plans must not include raw secret values, provider credentials, environment payl
 - `service-lasso plan import {manifestPath} --json`
 
 The CLI commands use the same response contract as the API and add `servicesRoot` and `workspaceRoot` to show which local runtime roots were inspected. The plan commands are read-only: they do not create workspace directories, write service state, copy app-owned manifests, launch processes, or install update candidates.
+
+Start plans mirror mutating start semantics. A service missing install or config state is not a hard blocker when those prerequisites can be repaired by the start action; the plan marks the service as `would_run`, lists `install`, `config`, and any setup reconciliation in `prerequisites`, and reports the expected state changes. Provider-role services can appear as planned preparation without a daemon launch because they only need install/config/setup state.

--- a/src/runtime/lifecycle/prepareStart.ts
+++ b/src/runtime/lifecycle/prepareStart.ts
@@ -1,0 +1,100 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import { LifecycleStateError } from "../../server/errors.js";
+import { hasManagedProcess } from "../execution/supervisor.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { DependencyGraph } from "../manager/DependencyGraph.js";
+import { isProviderRole } from "../roles.js";
+import { listSetupStepIds, runServiceSetup } from "../setup/steps.js";
+import { writeServiceState } from "../state/writeState.js";
+import { configService, installService, startService } from "./actions.js";
+import { getLifecycleState } from "./store.js";
+import type { LifecycleActionResult, ServiceLifecycleState } from "./types.js";
+
+export type PreparedStartSkipReason = "already_running" | "provider_role" | "not_startable";
+
+export interface PreparedStartResult {
+  result: LifecycleActionResult | null;
+  skippedReason: PreparedStartSkipReason | null;
+  state: ServiceLifecycleState;
+}
+
+function hasStartableCommand(service: DiscoveredService, state: ServiceLifecycleState): boolean {
+  return Boolean(service.manifest.execservice || service.manifest.executable || state.installArtifacts.artifact?.command);
+}
+
+async function persistResult(service: DiscoveredService, result: Pick<LifecycleActionResult, "state">): Promise<void> {
+  await writeServiceState(service, result.state);
+}
+
+async function prepareServicePrerequisites(
+  service: DiscoveredService,
+  registry: ServiceRegistry,
+  workspaceRoot?: string,
+): Promise<ServiceLifecycleState> {
+  let state = getLifecycleState(service.manifest.id);
+
+  if (!state.installed) {
+    const result = await installService(service, registry);
+    await persistResult(service, result);
+    state = result.state;
+  }
+
+  if (!state.configured) {
+    const result = await configService(service, registry, { workspaceRoot });
+    await persistResult(service, result);
+    state = result.state;
+  }
+
+  if (listSetupStepIds(service).length > 0) {
+    const result = await runServiceSetup(service, registry);
+    await writeServiceState(service, result.state);
+    state = result.state;
+
+    if (!result.ok) {
+      throw new LifecycleStateError(result.message);
+    }
+  }
+
+  return state;
+}
+
+export async function prepareAndStartService(
+  service: DiscoveredService,
+  registry: ServiceRegistry,
+  options: { workspaceRoot?: string } = {},
+): Promise<PreparedStartResult> {
+  const serviceId = service.manifest.id;
+  const graph = new DependencyGraph(registry);
+
+  for (const dependencyId of graph.getStartupOrder(serviceId)) {
+    const dependency = registry.getById(dependencyId);
+    if (!dependency) {
+      throw new LifecycleStateError(
+        `Cannot start service "${serviceId}" because dependency "${dependencyId}" was not found.`,
+      );
+    }
+
+    await prepareAndStartService(dependency, registry, options);
+  }
+
+  let state = await prepareServicePrerequisites(service, registry, options.workspaceRoot);
+
+  if (state.running || hasManagedProcess(serviceId)) {
+    return { result: null, skippedReason: "already_running", state };
+  }
+
+  if (isProviderRole(service.manifest)) {
+    return { result: null, skippedReason: "provider_role", state };
+  }
+
+  if (!hasStartableCommand(service, state)) {
+    return { result: null, skippedReason: "not_startable", state };
+  }
+
+  const result = await startService(service, registry, options);
+  await writeServiceState(service, result.state);
+  state = result.state;
+
+  return { result, skippedReason: null, state };
+}
+

--- a/src/runtime/operator/dry-run-plan.ts
+++ b/src/runtime/operator/dry-run-plan.ts
@@ -6,6 +6,7 @@ import { loadServiceManifest } from "../discovery/loadManifest.js";
 import { getLifecycleState } from "../lifecycle/store.js";
 import type { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { isProviderRole } from "../roles.js";
 import { readServiceUpdateState } from "../updates/state.js";
 
 type RuntimePlanAction = "startAll" | "stopAll" | "autostart";
@@ -110,28 +111,26 @@ export function buildRuntimeOrchestrationDryRunPlan(
         continue;
       }
 
-      if (!lifecycle.installed) {
-        steps.push(createStep({
-          order,
-          serviceId,
-          action: "start",
-          status: "blocked",
-          reason: "not_installed",
-          prerequisites: ["install"],
-          expectedStateChanges: [],
-          actionEndpoint,
-        }));
-        continue;
-      }
+      const prerequisites = [
+        ...(!lifecycle.installed ? ["install"] : []),
+        ...(!lifecycle.configured ? ["config"] : []),
+        ...(Object.keys(service.manifest.setup?.steps ?? {}).length > 0 ? ["setup"] : []),
+      ];
 
-      if (!lifecycle.configured) {
+      if (
+        lifecycle.installed &&
+        lifecycle.configured &&
+        !isProviderRole(service.manifest) &&
+        !service.manifest.execservice &&
+        !service.manifest.executable &&
+        !lifecycle.installArtifacts.artifact?.command
+      ) {
         steps.push(createStep({
           order,
           serviceId,
           action: "start",
-          status: "blocked",
-          reason: "not_configured",
-          prerequisites: ["config"],
+          status: "skipped",
+          reason: "not_startable",
           expectedStateChanges: [],
           actionEndpoint,
         }));
@@ -144,7 +143,15 @@ export function buildRuntimeOrchestrationDryRunPlan(
         action: "start",
         status: "would_run",
         reason: null,
-        expectedStateChanges: ["running=true", "runtime.pid assigned", "runtime.startedAt updated"],
+        prerequisites,
+        expectedStateChanges: [
+          ...(!lifecycle.installed ? ["installed=true"] : []),
+          ...(!lifecycle.configured ? ["configured=true"] : []),
+          ...(Object.keys(service.manifest.setup?.steps ?? {}).length > 0 ? ["setup steps reconciled"] : []),
+          ...(isProviderRole(service.manifest)
+            ? ["provider daemon not required"]
+            : ["running=true", "runtime.pid assigned", "runtime.startedAt updated"]),
+        ],
         actionEndpoint,
       }));
       continue;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,7 @@ import {
   startService,
   stopService,
 } from "../runtime/lifecycle/actions.js";
+import { prepareAndStartService, type PreparedStartSkipReason } from "../runtime/lifecycle/prepareStart.js";
 import { getLifecycleState } from "../runtime/lifecycle/store.js";
 import { evaluateServiceHealth } from "../runtime/health/evaluateHealth.js";
 import { readServiceHealthHistory, recordServiceHealthTransition } from "../runtime/health/history.js";
@@ -134,7 +135,7 @@ import {
   type WorkflowRunFacadeState,
 } from "../platform/workflowRunFacade.js";
 import type { PlatformEntitlement, PlatformRequestContext } from "../platform/facade.js";
-import { ApiError, toApiErrorBody } from "./errors.js";
+import { ApiError, LifecycleStateError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
   LifecycleActionResponse,
@@ -676,7 +677,7 @@ async function executeLifecycleAction(
       case "config":
         return await configService(service, registry, { workspaceRoot });
       case "start":
-        return await startService(service, registry, { workspaceRoot });
+        return await executePreparedServiceStart(service, registry, workspaceRoot);
       case "stop":
         return await stopService(service);
       case "restart":
@@ -687,6 +688,42 @@ async function executeLifecycleAction(
   })();
 
   return await buildLifecycleActionResponse(service, registry, result);
+}
+
+async function executePreparedServiceStart(
+  service: RuntimeModel["discovered"][number],
+  registry: RuntimeModel["registry"],
+  workspaceRoot?: string,
+): Promise<Awaited<ReturnType<typeof startService>>> {
+  const prepared = await prepareAndStartService(service, registry, { workspaceRoot });
+
+  if (prepared.result) {
+    return prepared.result;
+  }
+
+  if (prepared.skippedReason === "provider_role") {
+    return {
+      action: "start",
+      serviceId: service.manifest.id,
+      ok: true,
+      state: prepared.state,
+      message: `Prepared provider-role service "${service.manifest.id}"; no managed daemon process is required.`,
+    };
+  }
+
+  throw new LifecycleStateError(formatPreparedStartSkipMessage(service.manifest.id, prepared.skippedReason));
+}
+
+function formatPreparedStartSkipMessage(serviceId: string, reason: PreparedStartSkipReason | null): string {
+  if (reason === "already_running") {
+    return `Cannot start service "${serviceId}" because it is already running.`;
+  }
+
+  if (reason === "not_startable") {
+    return `Cannot start service "${serviceId}" because no executable is configured.`;
+  }
+
+  return `Cannot start service "${serviceId}".`;
 }
 
 async function buildLifecycleActionResponse(
@@ -818,18 +855,12 @@ async function executeRuntimeOrchestrationAction(
         continue;
       }
 
-      if (!lifecycle.installed) {
-        skipped.push({ serviceId, reason: "not_installed" });
-        continue;
+      const prepared = await prepareAndStartService(service, runtimeModel.registry, { workspaceRoot });
+      if (prepared.result) {
+        results.push(await buildLifecycleActionResponse(service, runtimeModel.registry, prepared.result));
+      } else {
+        skipped.push({ serviceId, reason: prepared.skippedReason ?? "not_started" });
       }
-
-      if (!lifecycle.configured) {
-        skipped.push({ serviceId, reason: "not_configured" });
-        continue;
-      }
-
-      const result = await startService(service, runtimeModel.registry, { workspaceRoot });
-      results.push(await buildLifecycleActionResponse(service, runtimeModel.registry, result));
       continue;
     }
 

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -490,7 +490,7 @@ test("runtime rejects a missing servicesRoot during startup validation", async (
   await rm(tempRoot, { recursive: true, force: true });
 });
 
-test("POST /api/runtime/actions/startAll and stopAll orchestrate eligible services in deterministic order", async () => {
+test("POST /api/runtime/actions/startAll prepares and starts eligible services in deterministic order", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-actions-");
   await writeExecutableFixtureService(servicesRoot, "alpha-service");
@@ -500,13 +500,6 @@ test("POST /api/runtime/actions/startAll and stopAll orchestrate eligible servic
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    for (const serviceId of ["alpha-service", "bravo-service"]) {
-      let result = await postJson(`${apiServer.url}/api/services/${serviceId}/install`);
-      assert.equal(result.status, 200);
-      result = await postJson(`${apiServer.url}/api/services/${serviceId}/config`);
-      assert.equal(result.status, 200);
-    }
-
     const startAll = await postJson(`${apiServer.url}/api/runtime/actions/startAll`);
     assert.equal(startAll.status, 200);
     assert.equal(startAll.body.action, "startAll");
@@ -516,7 +509,11 @@ test("POST /api/runtime/actions/startAll and stopAll orchestrate eligible servic
       ["alpha-service", "bravo-service"],
     );
     assert.deepEqual(startAll.body.skipped, []);
+    assert.equal(startAll.body.results[0].state.installed, true);
+    assert.equal(startAll.body.results[0].state.configured, true);
     assert.equal(startAll.body.results[0].state.running, true);
+    assert.equal(startAll.body.results[1].state.installed, true);
+    assert.equal(startAll.body.results[1].state.configured, true);
     assert.equal(startAll.body.results[1].state.running, true);
 
     const stopAll = await postJson(`${apiServer.url}/api/runtime/actions/stopAll`);
@@ -537,7 +534,36 @@ test("POST /api/runtime/actions/startAll and stopAll orchestrate eligible servic
   }
 });
 
-test("POST /api/runtime/actions/startAll skips ineligible services deterministically", async () => {
+test("POST /api/services/:id/start prepares missing dependencies before starting it", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-single-start-prepare-");
+  await writeExecutableFixtureService(servicesRoot, "alpha-service");
+  await writeExecutableFixtureService(servicesRoot, "bravo-service", {
+    depend_on: ["alpha-service"],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const start = await postJson(`${apiServer.url}/api/services/bravo-service/start`);
+    assert.equal(start.status, 200);
+    assert.equal(start.body.action, "start");
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.state.installed, true);
+    assert.equal(start.body.state.configured, true);
+    assert.equal(start.body.state.running, true);
+
+    const detail = await getJson(`${apiServer.url}/api/services/alpha-service`);
+    assert.equal(detail.body.service.lifecycle.installed, true);
+    assert.equal(detail.body.service.lifecycle.configured, true);
+    assert.equal(detail.body.service.lifecycle.running, true);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/runtime/actions/startAll preserves only true skip semantics", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-skips-");
   await writeExecutableFixtureService(servicesRoot, "alpha-installed-only");
@@ -558,12 +584,18 @@ test("POST /api/runtime/actions/startAll skips ineligible services deterministic
     assert.equal(startAll.status, 200);
     assert.equal(startAll.body.action, "startAll");
     assert.equal(startAll.body.ok, true);
-    assert.deepEqual(startAll.body.results, []);
+    assert.deepEqual(
+      startAll.body.results.map((actionResult) => actionResult.serviceId),
+      ["alpha-installed-only", "bravo-missing-install"],
+    );
     assert.deepEqual(startAll.body.skipped, [
-      { serviceId: "alpha-installed-only", reason: "not_configured" },
-      { serviceId: "bravo-missing-install", reason: "not_installed" },
       { serviceId: "charlie-running", reason: "already_running" },
     ]);
+    assert.equal(startAll.body.results[0].state.configured, true);
+    assert.equal(startAll.body.results[0].state.running, true);
+    assert.equal(startAll.body.results[1].state.installed, true);
+    assert.equal(startAll.body.results[1].state.configured, true);
+    assert.equal(startAll.body.results[1].state.running, true);
   } finally {
     await apiServer.stop();
     resetLifecycleState();
@@ -590,15 +622,16 @@ test("GET /api/runtime/actions/startAll/plan returns dependency ordered dry-run 
     assert.equal(plan.status, 200);
     assert.equal(plan.body.action, "startAll");
     assert.equal(plan.body.dryRun, true);
-    assert.equal(plan.body.ok, false);
-    assert.deepEqual(plan.body.order, ["alpha-service"]);
+    assert.equal(plan.body.ok, true);
+    assert.deepEqual(plan.body.order, ["alpha-service", "bravo-service"]);
     assert.deepEqual(
       plan.body.steps.map((step) => [step.serviceId, step.status, step.reason]),
       [
         ["alpha-service", "would_run", null],
-        ["bravo-service", "blocked", "not_installed"],
+        ["bravo-service", "would_run", null],
       ],
     );
+    assert.deepEqual(plan.body.steps[1].prerequisites, ["install", "config"]);
     assert.deepEqual(plan.body.mutations, []);
 
     const alphaDetail = await getJson(apiServer.url + "/api/services/alpha-service");


### PR DESCRIPTION
Closes #600.

## Summary
- Adds a shared prepared-start path for API lifecycle start/startAll that installs, configures, runs non-manual setup, and then starts eligible services in dependency order.
- Preserves skip/blocker behavior for already-running, provider-role, disabled, autostart-filtered, and non-startable services.
- Updates runtime dry-run planning and docs to describe repairable install/config prerequisites as planned start work instead of hard blockers.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 --test-name-pattern "startAll|:id/start|dry-run" tests\api-spine.test.js`

## Notes
- A full `tests\api-spine.test.js` run hit a Windows file-lock cleanup failure on `services\@nginx\.state\extracted\current\nginx.exe`; the #600-focused tests in the same run passed, and the focused rerun passed cleanly.