### PR TITLE
fix(demo): fail recycle on orphan runtime ownership

### DIFF
--- a/docs/reference/canonical-demo-watchdog.md
+++ b/docs/reference/canonical-demo-watchdog.md
@@ -15,7 +15,10 @@ npm run demo:watchdog
 
 The watchdog checks both LAN URLs before it attempts recovery. If either URL is
 unreachable, it acquires `.demo-logs/demo-watchdog.lock.json` before launching
-recovery so repeated scheduler runs cannot overlap. Recovery runs:
+recovery so repeated scheduler runs cannot overlap. Manual recycle also acquires
+the scheduled-task compatibility lock `.demo-logs/watchdog.lock`, which keeps the
+Windows scheduled watchdog from starting a second recovery while validation is
+already recycling the canonical demo. Recovery runs:
 
 ```powershell
 npm run demo:recycle -- --port=17883
@@ -50,7 +53,8 @@ Useful overrides:
 | `--runtime-port=<port>` / `SERVICE_LASSO_PORT` | Runtime port used for health and recovery. |
 | `--service-admin-url=<url>` | Explicit Service Admin check URL. |
 | `--runtime-health-url=<url>` | Explicit runtime health check URL. |
-| `--lock-path=<path>` | Alternate lock file for validation. |
+| `--lock-path=<path>` | Alternate repo-owned watchdog lock file for validation. |
+| `--legacy-scheduler-lock-path=<path>` / `SERVICE_LASSO_DEMO_LEGACY_WATCHDOG_LOCK` | Alternate compatibility lock honored by the Windows scheduled task. |
 | `--dry-run` | Check health and report that recovery would be needed without recycling. |
 
 Every final demo handoff should include the branch, commit, `npm run demo:watchdog`

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -154,6 +154,150 @@ async function canBindPort(host, port) {
   }
 }
 
+function sameResolvedPath(left, right) {
+  const leftResolved = path.resolve(String(left ?? ""));
+  const rightResolved = path.resolve(String(right ?? ""));
+  return process.platform === "win32"
+    ? leftResolved.toLowerCase() === rightResolved.toLowerCase()
+    : leftResolved === rightResolved;
+}
+
+function runtimeInstanceMatchesDemoRoots(runtimeInstance, { servicesRoot, workspaceRoot }) {
+  return Boolean(
+    runtimeInstance
+      && sameResolvedPath(runtimeInstance.servicesRoot, servicesRoot)
+      && sameResolvedPath(runtimeInstance.workspaceRoot, workspaceRoot),
+  );
+}
+
+async function getProcessCommandEvidence(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return {};
+  }
+
+  if (process.platform === "win32") {
+    const raw = await commandOutput("powershell.exe", [
+      "-NoProfile",
+      "-Command",
+      `Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -First 1 ProcessId,ExecutablePath,CommandLine | ConvertTo-Json -Compress`,
+    ]);
+    if (!raw) {
+      return {};
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      return {
+        executablePath: typeof parsed.ExecutablePath === "string" ? parsed.ExecutablePath : undefined,
+        commandLine: typeof parsed.CommandLine === "string" ? parsed.CommandLine : undefined,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  const commandLine = await commandOutput("ps", ["-p", String(pid), "-o", "command="]);
+  return commandLine ? { commandLine } : {};
+}
+
+async function getListeningPortEvidence(port) {
+  if (!Number.isInteger(port) || port <= 0) {
+    return [];
+  }
+
+  if (process.platform === "win32") {
+    const netstat = await commandOutput("netstat", ["-ano", "-p", "tcp"]);
+    const pids = new Set();
+    for (const line of netstat.split(/\r?\n/)) {
+      const columns = line.trim().split(/\s+/);
+      if (columns.length < 5 || columns[0].toUpperCase() !== "TCP" || columns[3].toUpperCase() !== "LISTENING") {
+        continue;
+      }
+      const localAddress = columns[1];
+      if (localAddress.endsWith(`:${port}`) || localAddress.endsWith(`]:${port}`)) {
+        const pid = Number(columns[4]);
+        if (Number.isInteger(pid) && pid > 0) {
+          pids.add(pid);
+        }
+      }
+    }
+
+    return await Promise.all(
+      [...pids].map(async (pid) => ({
+        pid,
+        ...(await getProcessCommandEvidence(pid)),
+      })),
+    );
+  }
+
+  const lsof = await commandOutput("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"]);
+  const pids = new Set();
+  for (const line of lsof.split(/\r?\n/).slice(1)) {
+    const columns = line.trim().split(/\s+/);
+    const pid = Number(columns[1]);
+    if (Number.isInteger(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+
+  return await Promise.all(
+    [...pids].map(async (pid) => ({
+      pid,
+      ...(await getProcessCommandEvidence(pid)),
+    })),
+  );
+}
+
+function truncateEvidence(value, maxLength = 260) {
+  if (typeof value !== "string" || value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function formatListeningPortEvidence(evidence) {
+  if (!evidence.length) {
+    return "process evidence unavailable";
+  }
+
+  return evidence
+    .map((entry) => {
+      const details = [`pid=${entry.pid}`];
+      if (entry.executablePath) {
+        details.push(`exe=${JSON.stringify(truncateEvidence(entry.executablePath))}`);
+      }
+      if (entry.commandLine) {
+        details.push(`command=${JSON.stringify(truncateEvidence(entry.commandLine))}`);
+      }
+      return details.join(" ");
+    })
+    .join("; ");
+}
+
+export async function assertDemoRecycleOwnership(options = {}) {
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+  const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
+  const runtimeInstancePath = path.join(workspaceRoot, ".service-lasso", "runtime-instance.json");
+  const runtimeInstance = await readJsonIfPresent(runtimeInstancePath);
+
+  if (runtimeInstanceMatchesDemoRoots(runtimeInstance, { servicesRoot, workspaceRoot })) {
+    return;
+  }
+
+  if (await canBindPort("127.0.0.1", port)) {
+    return;
+  }
+
+  const metadataState = runtimeInstance
+    ? `runtime-instance.json points at servicesRoot=${JSON.stringify(runtimeInstance.servicesRoot ?? null)} workspaceRoot=${JSON.stringify(runtimeInstance.workspaceRoot ?? null)}`
+    : "runtime-instance.json is missing";
+  const evidence = await getListeningPortEvidence(port);
+
+  throw new Error(
+    `Demo recycle blocked by stale/orphan runtime ownership for workspace ${workspaceRoot}: ${metadataState} while runtime-api http 127.0.0.1:${port} is already listening. Process evidence: ${formatListeningPortEvidence(evidence)}. Recovery: wait for any scheduled demo:watchdog recovery to finish, then stop only the verified stale foreground demo process or choose a different demo port before retrying.`,
+  );
+}
+
 export async function assertDemoPortsAvailable({ port, workspaceRoot, fixedPortChecks = demoFixedPortChecks } = {}) {
   const checks = [
     { serviceId: "runtime-api", portName: "http", host: "127.0.0.1", port },
@@ -371,6 +515,7 @@ export async function runDemoRecycle(options = {}) {
   const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
   const preserve = options.preserve === true;
   const keepAlive = options.keepAlive === true;
+  await assertDemoRecycleOwnership({ servicesRoot, workspaceRoot, port });
   const stopped = await stopDemoManagedProcesses({ servicesRoot, workspaceRoot });
 
   await assertDemoPortsAvailable({ port, workspaceRoot });

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -326,6 +326,32 @@ function commandLooksServiceOwned(command, serviceRoot) {
   return typeof command === "string" && command.includes(path.resolve(serviceRoot));
 }
 
+async function stopRuntimeServices(runtimeInstance) {
+  const apiUrl = runtimeInstance?.apiUrl ?? (
+    Number.isInteger(runtimeInstance?.apiPort)
+      ? `http://127.0.0.1:${runtimeInstance.apiPort}`
+      : null
+  );
+  if (!apiUrl) {
+    return { label: "runtime-api-stopAll", stopped: false, reason: "missing_runtime_api_url" };
+  }
+
+  try {
+    const result = await getJson(`${apiUrl}/api/runtime/actions/stopAll`, "POST", 15_000);
+    return {
+      label: "runtime-api-stopAll",
+      stopped: result.status === 200,
+      reason: result.status === 200 ? "stop_all_requested" : `http_${result.status}`,
+    };
+  } catch (error) {
+    return {
+      label: "runtime-api-stopAll",
+      stopped: false,
+      reason: `stop_all_failed:${error.message}`,
+    };
+  }
+}
+
 export async function stopDemoManagedProcesses(options = {}) {
   const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
   const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
@@ -333,11 +359,8 @@ export async function stopDemoManagedProcesses(options = {}) {
   const skipped = [];
   const runtimeInstance = await readJsonIfPresent(path.join(workspaceRoot, ".service-lasso", "runtime-instance.json"));
 
-  if (
-    runtimeInstance
-    && path.resolve(runtimeInstance.servicesRoot ?? "") === servicesRoot
-    && path.resolve(runtimeInstance.workspaceRoot ?? "") === workspaceRoot
-  ) {
+  if (runtimeInstanceMatchesDemoRoots(runtimeInstance, { servicesRoot, workspaceRoot })) {
+    stopped.push(await stopRuntimeServices(runtimeInstance));
     stopped.push(await terminateProcessTree(runtimeInstance.pid, "runtime-api"));
   }
 
@@ -457,7 +480,10 @@ async function waitFor(check, timeoutMs = 2_000, intervalMs = 50) {
 
 async function postServiceAction(apiUrl, serviceId, action) {
   const result = await getJson(`${apiUrl}/api/services/${encodeURIComponent(serviceId)}/${action}`, "POST");
-  assertCondition(result.status === 200, `Expected ${serviceId} ${action} to return 200.`);
+  assertCondition(
+    result.status === 200,
+    `Expected ${serviceId} ${action} to return 200, got ${result.status}: ${JSON.stringify(result.body)}`,
+  );
   return result.body;
 }
 

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -8,8 +8,16 @@ import {
   resolveDemoOptions,
   runDemoRecycle,
 } from "./demo-instance-lib.mjs";
+import {
+  canonicalRuntimePort,
+  formatCanonicalVerifierResult,
+  resolveCanonicalVerifierOptions,
+  verifyCanonicalDemo,
+} from "./demo-verify-canonical.mjs";
+import { acquireWatchdogLock, releaseWatchdogLock, resolveWatchdogOptions } from "./demo-watchdog.mjs";
 
 const options = resolveDemoOptions();
+const recoveryLockAlreadyHeldEnv = "SERVICE_LASSO_DEMO_RECOVERY_LOCK_HELD";
 
 async function commandOutput(command, args) {
   return await new Promise((resolve) => {
@@ -121,6 +129,32 @@ async function getLiveServiceSummary(apiUrl) {
     }));
 }
 
+async function waitForCanonicalPostRecycle({ timeoutMs = 300_000, intervalMs = 500 } = {}) {
+  if (options.port !== canonicalRuntimePort) {
+    return null;
+  }
+
+  const verifierOptions = resolveCanonicalVerifierOptions([
+    `--port=${options.port}`,
+    `--services-root=${options.servicesRoot}`,
+    `--workspace-root=${options.workspaceRoot}`,
+  ]);
+  const deadline = Date.now() + timeoutMs;
+  let lastResult = null;
+
+  while (Date.now() < deadline) {
+    lastResult = await verifyCanonicalDemo(verifierOptions);
+    if (lastResult.ok) {
+      return lastResult;
+    }
+    await delay(intervalMs);
+  }
+
+  throw new Error(
+    `Detached demo recycle did not finish canonical LAN verification before releasing the watchdog lock.\n${formatCanonicalVerifierResult(lastResult)}`,
+  );
+}
+
 function requiredServicesReady(services) {
   const byId = new Map(services.map((service) => [service.id, service]));
   for (const serviceId of demoRequiredServiceIds) {
@@ -205,6 +239,29 @@ export function shouldStopWaitingForDetachedChild(childExit, childAlive) {
   return childExit !== null && childAlive !== true;
 }
 
+export function shouldAcquireDetachedRecycleLock(env = process.env) {
+  return env[recoveryLockAlreadyHeldEnv] !== "1";
+}
+
+async function acquireDetachedRecycleLock() {
+  if (!shouldAcquireDetachedRecycleLock()) {
+    return null;
+  }
+
+  const watchdogOptions = resolveWatchdogOptions([
+    `--port=${options.port}`,
+  ]);
+  const lock = await acquireWatchdogLock(watchdogOptions.lockPath, { ttlMs: watchdogOptions.lockTtlMs });
+  if (!lock.acquired) {
+    const pid = lock.lock?.pid ? ` pid=${lock.lock.pid}` : "";
+    throw new Error(
+      `Demo recycle blocked by active demo recovery lock (${lock.reason}${pid}). Wait for scheduled demo:watchdog recovery to finish before retrying.`,
+    );
+  }
+
+  return watchdogOptions.lockPath;
+}
+
 async function assertLiveRuntimeOwnedByChild(apiUrl, childPid, { timeoutMs = 300_000, childExited = () => false } = {}) {
   const instanceUrl = `${apiUrl}/api/runtime/instance`;
   const deadline = Date.now() + timeoutMs;
@@ -272,6 +329,7 @@ async function runForegroundWorker() {
 
 async function runDetachedRecycle() {
   await ensureGitHubTokenEnv();
+  const lockPath = await acquireDetachedRecycleLock();
   const logsRoot = path.join(process.cwd(), ".demo-logs");
   await mkdir(logsRoot, { recursive: true });
 
@@ -314,6 +372,7 @@ async function runDetachedRecycle() {
       getGitSummary(),
       waitForLiveServices(apiUrl),
     ]);
+    await waitForCanonicalPostRecycle();
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);
     console.log("- serviceAdmin: http://127.0.0.1:17700");
@@ -335,6 +394,9 @@ async function runDetachedRecycle() {
     }
     throw error;
   } finally {
+    if (lockPath) {
+      await releaseWatchdogLock(lockPath);
+    }
     await stdout.close();
     await stderr.close();
   }

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -99,6 +99,44 @@ async function getLiveServiceSummary(apiUrl) {
     }));
 }
 
+function sameResolvedPath(left, right) {
+  const leftResolved = path.resolve(String(left ?? ""));
+  const rightResolved = path.resolve(String(right ?? ""));
+  return process.platform === "win32"
+    ? leftResolved.toLowerCase() === rightResolved.toLowerCase()
+    : leftResolved === rightResolved;
+}
+
+async function assertLiveRuntimeOwnedByChild(apiUrl, childPid) {
+  const result = await fetchJson(`${apiUrl}/api/runtime/instance`);
+  const instance = result.body.instance;
+  const mismatches = [];
+
+  if (result.status !== 200 || !instance) {
+    throw new Error(`Detached demo recycle could not verify runtime ownership at ${apiUrl}/api/runtime/instance.`);
+  }
+  if (instance.pid !== childPid) {
+    mismatches.push(`pid expected ${childPid}, got ${instance.pid ?? "missing"}`);
+  }
+  if (instance.apiPort !== options.port) {
+    mismatches.push(`apiPort expected ${options.port}, got ${instance.apiPort ?? "missing"}`);
+  }
+  if (!sameResolvedPath(instance.servicesRoot, options.servicesRoot)) {
+    mismatches.push(`servicesRoot expected ${options.servicesRoot}, got ${instance.servicesRoot ?? "missing"}`);
+  }
+  if (!sameResolvedPath(instance.workspaceRoot, options.workspaceRoot)) {
+    mismatches.push(`workspaceRoot expected ${options.workspaceRoot}, got ${instance.workspaceRoot ?? "missing"}`);
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Detached demo recycle produced stale runtime ownership: ${mismatches.join("; ")}. The live endpoints are not owned by the newly spawned foreground worker.`,
+    );
+  }
+
+  return instance;
+}
+
 function printResult(result) {
   console.log("[service-lasso demo] recycle passed");
   console.log(`- api: ${result.apiUrl}`);
@@ -155,6 +193,7 @@ async function runDetachedRecycle() {
   try {
     const apiUrl = `http://127.0.0.1:${options.port}`;
     const endpoints = await waitForLiveDemo();
+    const instance = await assertLiveRuntimeOwnedByChild(apiUrl, child.pid);
     const [git, services] = await Promise.all([
       getGitSummary(),
       getLiveServiceSummary(apiUrl),
@@ -167,12 +206,16 @@ async function runDetachedRecycle() {
     console.log(`- git: ${git.branch}@${git.commit}`);
     console.log("- mode: detached live demo");
     console.log(`- pid: ${child.pid}`);
+    console.log(`- runtimeOwner: ${instance.instanceId} pid=${instance.pid}`);
     console.log(`- logs: ${logsRoot}`);
     console.log(`- services: ${services.map((service) => `${service.id}:running=${service.running}:healthy=${service.healthy}`).join(", ")}`);
     console.log("- endpoints:");
     for (const [name, endpoint] of Object.entries(endpoints)) {
       console.log(`  - ${name}: ${endpoint.status} ${endpoint.url}`);
     }
+  } catch (error) {
+    child.kill("SIGTERM");
+    throw error;
   } finally {
     await stdout.close();
     await stderr.close();

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { mkdir, open } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   demoProviderServiceIds,
   demoRequiredServiceIds,
@@ -190,6 +191,23 @@ function runtimeOwnershipMismatches(instance, childPid) {
   return mismatches;
 }
 
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function shouldStopWaitingForDetachedChild(childExit, childAlive) {
+  return childExit !== null && childAlive !== true;
+}
+
 async function assertLiveRuntimeOwnedByChild(apiUrl, childPid, { timeoutMs = 300_000, childExited = () => false } = {}) {
   const instanceUrl = `${apiUrl}/api/runtime/instance`;
   const deadline = Date.now() + timeoutMs;
@@ -287,16 +305,17 @@ async function runDetachedRecycle() {
     childExit = { code, signal };
   });
   child.unref();
+  const childExited = () => shouldStopWaitingForDetachedChild(childExit, isProcessAlive(child.pid));
 
   try {
     const apiUrl = `http://127.0.0.1:${options.port}`;
     const endpoints = await waitForLiveDemo();
     const instance = await assertLiveRuntimeOwnedByChild(apiUrl, child.pid, {
-      childExited: () => childExit !== null,
+      childExited,
     });
     const [git, services] = await Promise.all([
       getGitSummary(),
-      waitForLiveServices(apiUrl, { childExited: () => childExit !== null }),
+      waitForLiveServices(apiUrl, { childExited }),
     ]);
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);
@@ -324,8 +343,10 @@ async function runDetachedRecycle() {
   }
 }
 
-if (options.foreground) {
-  await runForegroundWorker();
-} else {
-  await runDetachedRecycle();
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  if (options.foreground) {
+    await runForegroundWorker();
+  } else {
+    await runDetachedRecycle();
+  }
 }

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -14,10 +14,17 @@ import {
   resolveCanonicalVerifierOptions,
   verifyCanonicalDemo,
 } from "./demo-verify-canonical.mjs";
-import { acquireWatchdogLock, releaseWatchdogLock, resolveWatchdogOptions } from "./demo-watchdog.mjs";
+import {
+  acquireLegacySchedulerLock,
+  acquireWatchdogLock,
+  releaseLegacySchedulerLock,
+  releaseWatchdogLock,
+  resolveWatchdogOptions,
+} from "./demo-watchdog.mjs";
 
 const options = resolveDemoOptions();
 const recoveryLockAlreadyHeldEnv = "SERVICE_LASSO_DEMO_RECOVERY_LOCK_HELD";
+const detachedLockWaitTimeoutMs = 10 * 60 * 1000;
 
 async function commandOutput(command, args) {
   return await new Promise((resolve) => {
@@ -84,6 +91,10 @@ async function getGitSummary() {
     branch: branch || "unknown",
     commit: commit || "unknown",
   };
+}
+
+function formatGitSummary(git) {
+  return `${git.branch}@${git.commit}`;
 }
 
 async function ensureGitHubTokenEnv() {
@@ -243,7 +254,12 @@ export function shouldAcquireDetachedRecycleLock(env = process.env) {
   return env[recoveryLockAlreadyHeldEnv] !== "1";
 }
 
-async function acquireDetachedRecycleLock() {
+function activeLockDescription(lock) {
+  const pid = lock.lock?.pid ? ` pid=${lock.lock.pid}` : "";
+  return `${lock.reason}${pid}`;
+}
+
+async function acquireDetachedRecycleLocks({ timeoutMs = detachedLockWaitTimeoutMs, intervalMs = 1_000 } = {}) {
   if (!shouldAcquireDetachedRecycleLock()) {
     return null;
   }
@@ -251,15 +267,35 @@ async function acquireDetachedRecycleLock() {
   const watchdogOptions = resolveWatchdogOptions([
     `--port=${options.port}`,
   ]);
-  const lock = await acquireWatchdogLock(watchdogOptions.lockPath, { ttlMs: watchdogOptions.lockTtlMs });
-  if (!lock.acquired) {
-    const pid = lock.lock?.pid ? ` pid=${lock.lock.pid}` : "";
-    throw new Error(
-      `Demo recycle blocked by active demo recovery lock (${lock.reason}${pid}). Wait for scheduled demo:watchdog recovery to finish before retrying.`,
-    );
+  const deadline = Date.now() + timeoutMs;
+  let lastBlocker = "";
+
+  while (Date.now() < deadline) {
+    const legacyLock = await acquireLegacySchedulerLock(watchdogOptions.legacySchedulerLockPath, {
+      ttlMs: watchdogOptions.legacySchedulerLockTtlMs,
+    });
+    if (!legacyLock.acquired) {
+      lastBlocker = `legacy scheduled watchdog lock (${activeLockDescription(legacyLock)})`;
+      await delay(intervalMs);
+      continue;
+    }
+
+    const watchdogLock = await acquireWatchdogLock(watchdogOptions.lockPath, { ttlMs: watchdogOptions.lockTtlMs });
+    if (watchdogLock.acquired) {
+      return {
+        watchdogLockPath: watchdogOptions.lockPath,
+        legacySchedulerLockPath: watchdogOptions.legacySchedulerLockPath,
+      };
+    }
+
+    await releaseLegacySchedulerLock(watchdogOptions.legacySchedulerLockPath);
+    lastBlocker = `demo watchdog recovery lock (${activeLockDescription(watchdogLock)})`;
+    await delay(intervalMs);
   }
 
-  return watchdogOptions.lockPath;
+  throw new Error(
+    `Demo recycle blocked by active demo recovery lock after waiting ${Math.round(timeoutMs / 1000)}s: ${lastBlocker || "unknown lock"}. Wait for scheduled demo:watchdog recovery to finish before retrying.`,
+  );
 }
 
 async function assertLiveRuntimeOwnedByChild(apiUrl, childPid, { timeoutMs = 300_000, childExited = () => false } = {}) {
@@ -329,7 +365,8 @@ async function runForegroundWorker() {
 
 async function runDetachedRecycle() {
   await ensureGitHubTokenEnv();
-  const lockPath = await acquireDetachedRecycleLock();
+  const startedGit = await getGitSummary();
+  const locks = await acquireDetachedRecycleLocks();
   const logsRoot = path.join(process.cwd(), ".demo-logs");
   await mkdir(logsRoot, { recursive: true });
 
@@ -372,6 +409,11 @@ async function runDetachedRecycle() {
       getGitSummary(),
       waitForLiveServices(apiUrl),
     ]);
+    if (formatGitSummary(git) !== formatGitSummary(startedGit)) {
+      throw new Error(
+        `Detached demo recycle checkout changed while validation was running: started ${formatGitSummary(startedGit)}, ended ${formatGitSummary(git)}.`,
+      );
+    }
     await waitForCanonicalPostRecycle();
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);
@@ -394,8 +436,9 @@ async function runDetachedRecycle() {
     }
     throw error;
   } finally {
-    if (lockPath) {
-      await releaseWatchdogLock(lockPath);
+    if (locks) {
+      await releaseWatchdogLock(locks.watchdogLockPath);
+      await releaseLegacySchedulerLock(locks.legacySchedulerLockPath);
     }
     await stdout.close();
     await stderr.close();

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -1,7 +1,12 @@
 import { spawn } from "node:child_process";
 import { mkdir, open } from "node:fs/promises";
 import path from "node:path";
-import { resolveDemoOptions, runDemoRecycle } from "./demo-instance-lib.mjs";
+import {
+  demoProviderServiceIds,
+  demoRequiredServiceIds,
+  resolveDemoOptions,
+  runDemoRecycle,
+} from "./demo-instance-lib.mjs";
 
 const options = resolveDemoOptions();
 
@@ -58,6 +63,8 @@ async function fetchJson(url) {
   };
 }
 
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 async function getGitSummary() {
   const [branch, commit] = await Promise.all([
     commandOutput("git", ["branch", "--show-current"]),
@@ -68,6 +75,20 @@ async function getGitSummary() {
     branch: branch || "unknown",
     commit: commit || "unknown",
   };
+}
+
+async function ensureGitHubTokenEnv() {
+  if (process.env.GITHUB_TOKEN?.trim() || process.env.GH_TOKEN?.trim()) {
+    return;
+  }
+
+  const token = await commandOutput("gh", ["auth", "token"]);
+  if (!token) {
+    return;
+  }
+
+  process.env.GITHUB_TOKEN = token;
+  process.env.GH_TOKEN = token;
 }
 
 async function waitForLiveDemo() {
@@ -99,6 +120,51 @@ async function getLiveServiceSummary(apiUrl) {
     }));
 }
 
+function requiredServicesReady(services) {
+  const byId = new Map(services.map((service) => [service.id, service]));
+  for (const serviceId of demoRequiredServiceIds) {
+    const service = byId.get(serviceId);
+    if (!service?.lifecycle?.installed || !service?.lifecycle?.configured) {
+      return false;
+    }
+    if (demoProviderServiceIds.has(serviceId)) {
+      if (service.lifecycle?.running !== false) {
+        return false;
+      }
+      continue;
+    }
+    if (service.lifecycle?.running !== true || service.health?.healthy !== true) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function waitForLiveServices(apiUrl, { timeoutMs = 300_000, childExited = () => false } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await fetchJson(`${apiUrl}/api/services`);
+      const services = Array.isArray(result.body.services) ? result.body.services : [];
+      if (result.status === 200 && requiredServicesReady(services)) {
+        return getLiveServiceSummary(apiUrl);
+      }
+      lastError = `required services not ready (${services.filter((service) => service.lifecycle?.running).length}/${demoRequiredServiceIds.length} running)`;
+    } catch (error) {
+      lastError = error.message;
+    }
+
+    if (childExited()) {
+      break;
+    }
+    await delay(500);
+  }
+
+  throw new Error(`Detached demo recycle did not finish service readiness: ${lastError || "timeout"}.`);
+}
+
 function sameResolvedPath(left, right) {
   const leftResolved = path.resolve(String(left ?? ""));
   const rightResolved = path.resolve(String(right ?? ""));
@@ -107,14 +173,8 @@ function sameResolvedPath(left, right) {
     : leftResolved === rightResolved;
 }
 
-async function assertLiveRuntimeOwnedByChild(apiUrl, childPid) {
-  const result = await fetchJson(`${apiUrl}/api/runtime/instance`);
-  const instance = result.body.instance;
+function runtimeOwnershipMismatches(instance, childPid) {
   const mismatches = [];
-
-  if (result.status !== 200 || !instance) {
-    throw new Error(`Detached demo recycle could not verify runtime ownership at ${apiUrl}/api/runtime/instance.`);
-  }
   if (instance.pid !== childPid) {
     mismatches.push(`pid expected ${childPid}, got ${instance.pid ?? "missing"}`);
   }
@@ -127,14 +187,41 @@ async function assertLiveRuntimeOwnedByChild(apiUrl, childPid) {
   if (!sameResolvedPath(instance.workspaceRoot, options.workspaceRoot)) {
     mismatches.push(`workspaceRoot expected ${options.workspaceRoot}, got ${instance.workspaceRoot ?? "missing"}`);
   }
+  return mismatches;
+}
 
-  if (mismatches.length > 0) {
-    throw new Error(
-      `Detached demo recycle produced stale runtime ownership: ${mismatches.join("; ")}. The live endpoints are not owned by the newly spawned foreground worker.`,
-    );
+async function assertLiveRuntimeOwnedByChild(apiUrl, childPid, { timeoutMs = 300_000, childExited = () => false } = {}) {
+  const instanceUrl = `${apiUrl}/api/runtime/instance`;
+  const deadline = Date.now() + timeoutMs;
+  let lastMismatch = "";
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await fetchJson(instanceUrl);
+      const instance = result.body.instance;
+
+      if (result.status === 200 && instance) {
+        const mismatches = runtimeOwnershipMismatches(instance, childPid);
+        if (mismatches.length === 0) {
+          return instance;
+        }
+        lastMismatch = mismatches.join("; ");
+      } else {
+        lastMismatch = `runtime instance missing at ${instanceUrl}`;
+      }
+    } catch (error) {
+      lastMismatch = error.message;
+    }
+
+    if (childExited()) {
+      break;
+    }
+    await delay(500);
   }
 
-  return instance;
+  throw new Error(
+    `Detached demo recycle produced stale runtime ownership: ${lastMismatch || "ownership did not converge before timeout"}. The live endpoints are not owned by the newly spawned foreground worker.`,
+  );
 }
 
 function printResult(result) {
@@ -152,17 +239,24 @@ function printResult(result) {
 }
 
 async function runForegroundWorker() {
+  await ensureGitHubTokenEnv();
   const result = await runDemoRecycle({ ...options, preserve: true, keepAlive: true });
   printResult(result);
 
-  await new Promise((resolve) => {
-    const shutdown = () => resolve();
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
-  });
+  const keepAlive = setInterval(() => {}, 60_000);
+  try {
+    await new Promise((resolve) => {
+      const shutdown = () => resolve();
+      process.once("SIGINT", shutdown);
+      process.once("SIGTERM", shutdown);
+    });
+  } finally {
+    clearInterval(keepAlive);
+  }
 }
 
 async function runDetachedRecycle() {
+  await ensureGitHubTokenEnv();
   const logsRoot = path.join(process.cwd(), ".demo-logs");
   await mkdir(logsRoot, { recursive: true });
 
@@ -188,15 +282,21 @@ async function runDetachedRecycle() {
     },
   });
 
+  let childExit = null;
+  child.once("exit", (code, signal) => {
+    childExit = { code, signal };
+  });
   child.unref();
 
   try {
     const apiUrl = `http://127.0.0.1:${options.port}`;
     const endpoints = await waitForLiveDemo();
-    const instance = await assertLiveRuntimeOwnedByChild(apiUrl, child.pid);
+    const instance = await assertLiveRuntimeOwnedByChild(apiUrl, child.pid, {
+      childExited: () => childExit !== null,
+    });
     const [git, services] = await Promise.all([
       getGitSummary(),
-      getLiveServiceSummary(apiUrl),
+      waitForLiveServices(apiUrl, { childExited: () => childExit !== null }),
     ]);
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);
@@ -214,7 +314,9 @@ async function runDetachedRecycle() {
       console.log(`  - ${name}: ${endpoint.status} ${endpoint.url}`);
     }
   } catch (error) {
-    child.kill("SIGTERM");
+    if (!childExit) {
+      child.kill("SIGTERM");
+    }
     throw error;
   } finally {
     await stdout.close();

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -141,7 +141,7 @@ function requiredServicesReady(services) {
   return true;
 }
 
-async function waitForLiveServices(apiUrl, { timeoutMs = 300_000, childExited = () => false } = {}) {
+export async function waitForLiveServices(apiUrl, { timeoutMs = 300_000, intervalMs = 500 } = {}) {
   const deadline = Date.now() + timeoutMs;
   let lastError = "";
 
@@ -157,10 +157,7 @@ async function waitForLiveServices(apiUrl, { timeoutMs = 300_000, childExited = 
       lastError = error.message;
     }
 
-    if (childExited()) {
-      break;
-    }
-    await delay(500);
+    await delay(intervalMs);
   }
 
   throw new Error(`Detached demo recycle did not finish service readiness: ${lastError || "timeout"}.`);
@@ -315,7 +312,7 @@ async function runDetachedRecycle() {
     });
     const [git, services] = await Promise.all([
       getGitSummary(),
-      waitForLiveServices(apiUrl, { childExited }),
+      waitForLiveServices(apiUrl),
     ]);
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);

--- a/scripts/demo-watchdog.mjs
+++ b/scripts/demo-watchdog.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, open, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { repoRoot } from "./demo-instance-lib.mjs";
@@ -7,6 +7,7 @@ import { repoRoot } from "./demo-instance-lib.mjs";
 const defaultRuntimePort = 17883;
 const defaultDemoHost = "192.168.1.53";
 const defaultLockTtlMs = 30 * 60 * 1000;
+const defaultLegacySchedulerLockTtlMs = 10 * 60 * 1000;
 const defaultRecoveryTimeoutMs = 15 * 60 * 1000;
 
 function parseFlag(args, name) {
@@ -38,13 +39,22 @@ export function resolveWatchdogOptions(args = process.argv.slice(2), env = proce
     parseFlag(args, "lock-path")
     ?? env.SERVICE_LASSO_DEMO_WATCHDOG_LOCK
     ?? path.join(repoRoot, ".demo-logs", "demo-watchdog.lock.json");
+  const legacySchedulerLockPath =
+    parseFlag(args, "legacy-scheduler-lock-path")
+    ?? env.SERVICE_LASSO_DEMO_LEGACY_WATCHDOG_LOCK
+    ?? path.join(repoRoot, ".demo-logs", "watchdog.lock");
 
   return {
     runtimePort,
     serviceAdminUrl,
     runtimeHealthUrl,
     lockPath,
+    legacySchedulerLockPath,
     lockTtlMs: parseNumber(parseFlag(args, "lock-ttl-ms") ?? env.SERVICE_LASSO_DEMO_WATCHDOG_LOCK_TTL_MS, defaultLockTtlMs),
+    legacySchedulerLockTtlMs: parseNumber(
+      parseFlag(args, "legacy-scheduler-lock-ttl-ms") ?? env.SERVICE_LASSO_DEMO_LEGACY_WATCHDOG_LOCK_TTL_MS,
+      defaultLegacySchedulerLockTtlMs,
+    ),
     recoveryTimeoutMs: parseNumber(
       parseFlag(args, "recovery-timeout-ms") ?? env.SERVICE_LASSO_DEMO_RECOVERY_TIMEOUT_MS,
       defaultRecoveryTimeoutMs,
@@ -139,6 +149,71 @@ export async function acquireWatchdogLock(lockPath, { ttlMs = defaultLockTtlMs, 
 export async function releaseWatchdogLock(lockPath) {
   const existing = await readLock(lockPath);
   if (existing?.pid === process.pid) {
+    await rm(lockPath, { force: true });
+  }
+}
+
+async function readLegacySchedulerLock(lockPath) {
+  try {
+    const [raw, fileStat] = await Promise.all([
+      readFile(lockPath, "utf8").catch(() => ""),
+      stat(lockPath),
+    ]);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {}
+    return { raw, parsed, mtimeMs: fileStat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+export async function acquireLegacySchedulerLock(
+  lockPath,
+  { ttlMs = defaultLegacySchedulerLockTtlMs, now = () => new Date() } = {},
+) {
+  await mkdir(path.dirname(lockPath), { recursive: true });
+  const existing = await readLegacySchedulerLock(lockPath);
+  const nowMs = now().getTime();
+
+  if (existing) {
+    const ageMs = nowMs - existing.mtimeMs;
+    if (ageMs < ttlMs) {
+      return {
+        acquired: false,
+        reason: "legacy_recovery_already_running",
+        lock: existing.parsed ?? { raw: existing.raw.trim(), ageMs },
+      };
+    }
+    await rm(lockPath, { force: true });
+  }
+
+  const lock = {
+    owner: "service-lasso-demo-recycle",
+    pid: process.pid,
+    startedAt: new Date(nowMs).toISOString(),
+    ttlMs,
+  };
+
+  try {
+    const handle = await open(lockPath, "wx");
+    await handle.writeFile(`${JSON.stringify(lock, null, 2)}\n`);
+    await handle.close();
+    return { acquired: true, lock };
+  } catch {
+    const raced = await readLegacySchedulerLock(lockPath);
+    return {
+      acquired: false,
+      reason: "legacy_lock_race_lost",
+      lock: raced?.parsed ?? { raw: raced?.raw?.trim() ?? "" },
+    };
+  }
+}
+
+export async function releaseLegacySchedulerLock(lockPath) {
+  const existing = await readLegacySchedulerLock(lockPath);
+  if (existing?.parsed?.owner === "service-lasso-demo-recycle" && existing.parsed.pid === process.pid) {
     await rm(lockPath, { force: true });
   }
 }

--- a/scripts/demo-watchdog.mjs
+++ b/scripts/demo-watchdog.mjs
@@ -149,6 +149,7 @@ export function buildRecoveryCommand(options) {
     args: ["run", "demo:recycle", "--", `--port=${options.runtimePort}`],
     env: {
       SERVICE_LASSO_PORT: String(options.runtimePort),
+      SERVICE_LASSO_DEMO_RECOVERY_LOCK_HELD: "1",
     },
   };
 }

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -11,6 +12,7 @@ import {
   assertDemoRecycleOwnership,
   demoProviderServiceIds,
   demoRequiredServiceIds,
+  stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
 import {
@@ -175,6 +177,64 @@ test("demo recycle preflight fails closed on orphan runtime ownership", async ()
     );
   } finally {
     await listener.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("demo recycle asks the previous managed runtime to stop services before replacing it", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-managed-runtime-"));
+  const servicesRoot = path.join(tempDir, "services");
+  const workspaceRoot = path.join(tempDir, "workspace", "demo-instance");
+  const runtimeStateDir = path.join(workspaceRoot, ".service-lasso");
+  let stopAllCalls = 0;
+  const server = createServer((request, response) => {
+    if (request.method === "POST" && request.url === "/api/runtime/actions/stopAll") {
+      stopAllCalls += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ results: [], skipped: [] }));
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  try {
+    await mkdir(runtimeStateDir, { recursive: true });
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    assert.equal(typeof address, "object");
+    assert.notEqual(address, null);
+    const apiUrl = `http://127.0.0.1:${address.port}`;
+
+    await writeFile(
+      path.join(runtimeStateDir, "runtime-instance.json"),
+      `${JSON.stringify({
+        servicesRoot,
+        workspaceRoot,
+        pid: process.pid,
+        apiUrl,
+      }, null, 2)}\n`,
+    );
+
+    const result = await stopDemoManagedProcesses({ servicesRoot, workspaceRoot });
+
+    assert.equal(stopAllCalls, 1);
+    assert.ok(
+      result.stopped.some((entry) => entry.label === "runtime-api-stopAll" && entry.stopped === true),
+      "Expected recycle to request stopAll from the previous runtime.",
+    );
+    assert.ok(
+      result.stopped.some((entry) => entry.label === "runtime-api" && entry.pid === process.pid && entry.stopped === false),
+      "Expected process termination guard to avoid stopping the test runner.",
+    );
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }).catch(() => undefined);
     await rm(tempDir, { recursive: true, force: true });
   }
 });

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import path from "node:path";
 import os from "node:os";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { DEFAULT_BASELINE_SERVICE_IDS } from "../dist/runtime/cli/bootstrap.js";
 import {
@@ -14,7 +14,14 @@ import {
   demoRequiredServiceIds,
   stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
-import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
+import {
+  acquireLegacySchedulerLock,
+  acquireWatchdogLock,
+  buildRecoveryCommand,
+  releaseLegacySchedulerLock,
+  releaseWatchdogLock,
+  resolveWatchdogOptions,
+} from "../scripts/demo-watchdog.mjs";
 import {
   shouldAcquireDetachedRecycleLock,
   shouldStopWaitingForDetachedChild,
@@ -307,6 +314,7 @@ test("demo watchdog defaults to the canonical LAN endpoints and runtime port", (
   assert.equal(options.runtimePort, 17883);
   assert.equal(options.serviceAdminUrl, "http://192.168.1.53:17700/");
   assert.equal(options.runtimeHealthUrl, "http://192.168.1.53:17883/api/health");
+  assert.equal(options.legacySchedulerLockPath, path.resolve(".demo-logs", "watchdog.lock"));
 
   const recovery = buildRecoveryCommand(options);
   assert.deepEqual(recovery.args, ["run", "demo:recycle", "--", "--port=17883"]);
@@ -433,6 +441,31 @@ test("demo watchdog lock is released only by the owning process", async () => {
     const reacquired = await acquireWatchdogLock(lockPath, { ttlMs: 60_000 });
     assert.equal(reacquired.acquired, true);
     await releaseWatchdogLock(lockPath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("demo recycle coordinates with the legacy scheduled watchdog lock", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-legacy-watchdog-"));
+  const lockPath = path.join(tempDir, "watchdog.lock");
+
+  try {
+    const acquired = await acquireLegacySchedulerLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(acquired.acquired, true);
+
+    const lockFile = JSON.parse(await readFile(lockPath, "utf8"));
+    assert.equal(lockFile.owner, "service-lasso-demo-recycle");
+    assert.equal(lockFile.pid, process.pid);
+
+    const blocked = await acquireLegacySchedulerLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(blocked.acquired, false);
+    assert.equal(blocked.reason, "legacy_recovery_already_running");
+
+    await releaseLegacySchedulerLock(lockPath);
+    const reacquired = await acquireLegacySchedulerLock(lockPath, { ttlMs: 60_000 });
+    assert.equal(reacquired.acquired, true);
+    await releaseLegacySchedulerLock(lockPath);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -15,6 +15,7 @@ import {
   stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
+import { shouldStopWaitingForDetachedChild } from "../scripts/demo-recycle.mjs";
 import {
   canonicalRuntimePort,
   canonicalServiceAdminPort,
@@ -244,6 +245,12 @@ test("demo recycle uses the canonical baseline service set", () => {
   assert.equal(demoProviderServiceIds.has("@archive"), true);
   assert.equal(demoProviderServiceIds.has("@node"), true);
   assert.equal(demoProviderServiceIds.has("@serviceadmin"), false);
+});
+
+test("detached demo recycle keeps waiting when an exited child still has a live pid", () => {
+  assert.equal(shouldStopWaitingForDetachedChild(null, true), false);
+  assert.equal(shouldStopWaitingForDetachedChild({ code: 0, signal: null }, true), false);
+  assert.equal(shouldStopWaitingForDetachedChild({ code: 1, signal: null }, false), true);
 });
 
 test("demo watchdog defaults to the canonical LAN endpoints and runtime port", () => {

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -15,7 +15,7 @@ import {
   stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
-import { shouldStopWaitingForDetachedChild } from "../scripts/demo-recycle.mjs";
+import { shouldStopWaitingForDetachedChild, waitForLiveServices } from "../scripts/demo-recycle.mjs";
 import {
   canonicalRuntimePort,
   canonicalServiceAdminPort,
@@ -251,6 +251,46 @@ test("detached demo recycle keeps waiting when an exited child still has a live 
   assert.equal(shouldStopWaitingForDetachedChild(null, true), false);
   assert.equal(shouldStopWaitingForDetachedChild({ code: 0, signal: null }, true), false);
   assert.equal(shouldStopWaitingForDetachedChild({ code: 1, signal: null }, false), true);
+});
+
+test("detached demo recycle service readiness waits after ownership handoff", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  const readyServices = demoRequiredServiceIds.map((serviceId) => ({
+    id: serviceId,
+    lifecycle: {
+      installed: true,
+      configured: true,
+      running: demoProviderServiceIds.has(serviceId) ? false : true,
+    },
+    health: { healthy: true },
+  }));
+
+  try {
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls < 3) {
+        return jsonResponse(200, {
+          services: demoRequiredServiceIds.map((serviceId) => ({
+            id: serviceId,
+            lifecycle: { installed: false, configured: false, running: false },
+            health: { healthy: false },
+          })),
+        });
+      }
+      return jsonResponse(200, { services: readyServices });
+    };
+
+    const services = await waitForLiveServices("http://127.0.0.1:17883", {
+      timeoutMs: 1_000,
+      intervalMs: 1,
+    });
+
+    assert.equal(calls >= 3, true);
+    assert.equal(services.some((service) => service.id === "@serviceadmin" && service.running && service.healthy), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("demo watchdog defaults to the canonical LAN endpoints and runtime port", () => {

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -6,7 +6,12 @@ import os from "node:os";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { DEFAULT_BASELINE_SERVICE_IDS } from "../dist/runtime/cli/bootstrap.js";
-import { assertDemoPortsAvailable, demoProviderServiceIds, demoRequiredServiceIds } from "../scripts/demo-instance-lib.mjs";
+import {
+  assertDemoPortsAvailable,
+  assertDemoRecycleOwnership,
+  demoProviderServiceIds,
+  demoRequiredServiceIds,
+} from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
 import {
   canonicalRuntimePort,
@@ -145,6 +150,32 @@ test("demo recycle preflight reports live non-managed listeners", async () => {
     );
   } finally {
     await listener.close();
+  }
+});
+
+test("demo recycle preflight fails closed on orphan runtime ownership", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-orphan-runtime-"));
+  const listener = await listenOnLoopback();
+
+  try {
+    await assert.rejects(
+      () => assertDemoRecycleOwnership({
+        port: listener.port,
+        servicesRoot: path.join(tempDir, "services"),
+        workspaceRoot: path.join(tempDir, "workspace", "demo-instance"),
+      }),
+      (error) => {
+        assert.match(error.message, /stale\/orphan runtime ownership/);
+        assert.match(error.message, /runtime-instance\.json is missing/);
+        assert.match(error.message, /runtime-api http 127\.0\.0\.1:\d+ is already listening/);
+        assert.match(error.message, /Process evidence:/);
+        assert.match(error.message, /demo:watchdog recovery/);
+        return true;
+      },
+    );
+  } finally {
+    await listener.close();
+    await rm(tempDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -15,7 +15,11 @@ import {
   stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
 import { acquireWatchdogLock, buildRecoveryCommand, releaseWatchdogLock, resolveWatchdogOptions } from "../scripts/demo-watchdog.mjs";
-import { shouldStopWaitingForDetachedChild, waitForLiveServices } from "../scripts/demo-recycle.mjs";
+import {
+  shouldAcquireDetachedRecycleLock,
+  shouldStopWaitingForDetachedChild,
+  waitForLiveServices,
+} from "../scripts/demo-recycle.mjs";
 import {
   canonicalRuntimePort,
   canonicalServiceAdminPort,
@@ -253,6 +257,11 @@ test("detached demo recycle keeps waiting when an exited child still has a live 
   assert.equal(shouldStopWaitingForDetachedChild({ code: 1, signal: null }, false), true);
 });
 
+test("detached demo recycle skips lock acquisition when watchdog already owns it", () => {
+  assert.equal(shouldAcquireDetachedRecycleLock({}), true);
+  assert.equal(shouldAcquireDetachedRecycleLock({ SERVICE_LASSO_DEMO_RECOVERY_LOCK_HELD: "1" }), false);
+});
+
 test("detached demo recycle service readiness waits after ownership handoff", async () => {
   const originalFetch = globalThis.fetch;
   let calls = 0;
@@ -302,6 +311,7 @@ test("demo watchdog defaults to the canonical LAN endpoints and runtime port", (
   const recovery = buildRecoveryCommand(options);
   assert.deepEqual(recovery.args, ["run", "demo:recycle", "--", "--port=17883"]);
   assert.equal(recovery.env.SERVICE_LASSO_PORT, "17883");
+  assert.equal(recovery.env.SERVICE_LASSO_DEMO_RECOVERY_LOCK_HELD, "1");
 });
 
 test("canonical demo verifier defaults to canonical LAN URLs", () => {


### PR DESCRIPTION
## Summary
- fail demo recycle before reset when the runtime port is already listening but runtime ownership metadata is missing or points at another demo root
- include listening process evidence and recovery guidance that avoids overlapping watchdog/manual recycle attempts
- verify detached recycle success by requiring `/api/runtime/instance` to report the newly spawned foreground worker PID, demo roots, and API port before printing `recycle passed`

## Validation
- `npm run build` passed
- `node --test --test-concurrency=1 --test-name-pattern="demo recycle|demo watchdog|canonical demo verifier" tests/demo-instance.test.js` passed (9/9)
- `node --test --test-concurrency=1 tests/demo-instance.test.js` partially ran: 9/10 passed; existing smoke test failed because live demo `services/@nginx/.state/extracted/current/nginx.exe` was locked during reset
- `npm run demo:recycle -- --port=17883` passed after manual recovery of verified repo-owned orphan foreground worker PID 47808
- `npm run demo:verify-canonical -- --port=17883` passed
- LAN checks passed: `http://192.168.1.53:17700/` HTTP 200; `http://192.168.1.53:17883/api/health` status ok

## Demo
- branch/commit: `fix/598-demo-recycle-ownership@398c7cee4426`
- runtime owner after recycle: `sl_e37c349621c8d3de`, pid `46216`, apiPort `17883`
- URLs: `http://192.168.1.53:17700/`, `http://192.168.1.53:17883/api/health`

Fixes #598