### PR TITLE
feat(policy): define service secret access policy

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -434,6 +434,26 @@ Shape:
       "required": false
     }
   ],
+  "accessPolicy": {
+    "serviceId": "consumer",
+    "workspace": "local-demo",
+    "grants": [
+      {
+        "namespace": "shared/database",
+        "scope": "shared",
+        "refs": ["database.PASSWORD"],
+        "operations": ["resolve"],
+        "purpose": "connect to the shared database at runtime"
+      },
+      {
+        "namespace": "services/producer",
+        "scope": "service",
+        "refs": ["producer.API_TOKEN"],
+        "operations": ["create", "rotate"],
+        "purpose": "capture and rotate generated service token metadata"
+      }
+    ]
+  },
   "writeback": {
     "allowedNamespaces": ["services/producer"],
     "allowedOperations": ["create", "update", "rotate"],
@@ -470,6 +490,15 @@ Fields:
 - `exports[].ref`: dotted broker selector such as `producer.PUBLIC_URL`.
 - `exports[].source`: local selector or literal value to export, for example `${SERVICE_URL}`.
 - `exports[].required`: optional boolean; required exports should fail closed when the source is unavailable.
+- `accessPolicy`: optional manifest-side assignment for Secrets Broker authorization. It does not carry secret values.
+- `accessPolicy.serviceId`: optional service id the assignment applies to; when present it must match the top-level manifest `id`.
+- `accessPolicy.workspace`: optional workspace/deployment scope such as `local-demo` or an operator-defined site/workspace id.
+- `accessPolicy.grants[]`: allowed namespace/ref operation grants with purpose metadata.
+- `accessPolicy.grants[].namespace`: broker namespace boundary such as `shared/database` or `services/producer`.
+- `accessPolicy.grants[].scope`: optional scope classification: `workspace`, `service`, `app`, `shared`, or `global`.
+- `accessPolicy.grants[].refs`: optional array of dotted refs. Omit only when a namespace-wide grant is intentional for the listed operations.
+- `accessPolicy.grants[].operations`: allowed operations: `resolve`, `create`, `update`, `rotate`, or `delete`.
+- `accessPolicy.grants[].purpose`: non-empty audit/review purpose metadata.
 - `writeback.allowedNamespaces`: optional array limiting namespaces this service may write generated secrets into.
 - `writeback.allowedOperations`: optional array of allowed generated-secret operations: `create`, `update`, `rotate`, `delete`.
 - `writeback.allowedRefs`: optional array limiting generated-secret refs within the allowed namespaces.
@@ -498,6 +527,8 @@ Selector semantics:
 - Broker refs must be dotted. This keeps broker access reviewable and prevents accidental secret reads from ordinary env selectors.
 - Duplicate bucket namespaces, duplicate import refs, duplicate `imports[].as` names, duplicate export namespace/ref pairs, duplicate writeback refs, and duplicate generated-secret refs are invalid.
 - `imports[].as` may intentionally line up with an `env` key only when that env value is exactly the same dotted broker selector, for example `"DB_PASSWORD": "${database.PASSWORD}"`. It must not collide with `globalenv` output names.
+- If `broker.accessPolicy` is present, every declared broker import must have a matching `resolve` grant, and every generated writeback capture must have a matching operation grant for the export namespace.
+- Selectors used without a matching `broker.imports[]` declaration or access-policy grant are treated as missing policy metadata, not as implicit broker access. See [Service Secret Access Policy](./service-secret-access-policy.md).
 
 Producer example:
 

--- a/docs/reference/service-secret-access-policy.md
+++ b/docs/reference/service-secret-access-policy.md
@@ -1,0 +1,146 @@
+# Service Secret Access Policy
+
+_Status: first manifest-side contract for Secrets Broker resolve authorization._
+
+Service Lasso service manifests declare secret use in `broker.imports`,
+`broker.exports`, and `broker.writeback`. `broker.accessPolicy` is the
+manifest-side assignment that says which service identity is allowed to use
+which broker namespace/ref for a specific operation and purpose.
+
+This contract is metadata only. It must never contain raw secret values,
+provider tokens, private keys, recovery material, cookies, passwords, or
+credential payloads.
+
+## Shape
+
+```json
+{
+  "id": "api-service",
+  "broker": {
+    "enabled": true,
+    "accessPolicy": {
+      "serviceId": "api-service",
+      "workspace": "local-demo",
+      "grants": [
+        {
+          "namespace": "shared/database",
+          "scope": "shared",
+          "refs": ["database.PASSWORD"],
+          "operations": ["resolve"],
+          "purpose": "connect to the shared database at runtime"
+        }
+      ]
+    }
+  }
+}
+```
+
+Fields:
+
+- `serviceId`: optional service id the assignment applies to. When present it
+  must match the top-level manifest `id`.
+- `workspace`: optional workspace or deployment scope such as `local-demo`,
+  `site-a`, or another operator-owned name.
+- `grants`: optional list of allowed namespace/ref operations.
+- `grants[].namespace`: broker namespace boundary such as `shared/database`,
+  `services/api-service`, or `global`.
+- `grants[].scope`: optional scope classification: `workspace`, `service`,
+  `app`, `shared`, or `global`.
+- `grants[].refs`: optional explicit dotted refs. Omit only when the grant is
+  intentionally namespace-wide for the listed operations.
+- `grants[].operations`: allowed operations. Supported values are `resolve`,
+  `create`, `update`, `rotate`, and `delete`.
+- `grants[].purpose`: non-empty review/audit purpose metadata.
+
+## Allowed and denied refs
+
+Allowed runtime import:
+
+```json
+{
+  "env": {
+    "DB_PASSWORD": "${database.PASSWORD}"
+  },
+  "broker": {
+    "imports": [
+      {
+        "namespace": "shared/database",
+        "ref": "database.PASSWORD",
+        "as": "DB_PASSWORD",
+        "required": true
+      }
+    ],
+    "accessPolicy": {
+      "serviceId": "api-service",
+      "workspace": "local-demo",
+      "grants": [
+        {
+          "namespace": "shared/database",
+          "scope": "shared",
+          "refs": ["database.PASSWORD"],
+          "operations": ["resolve"],
+          "purpose": "connect api-service to the shared database"
+        }
+      ]
+    }
+  }
+}
+```
+
+Denied runtime import:
+
+```json
+{
+  "env": {
+    "DB_ROOT_PASSWORD": "${database.ROOT_PASSWORD}"
+  },
+  "broker": {
+    "accessPolicy": {
+      "serviceId": "api-service",
+      "workspace": "local-demo",
+      "grants": [
+        {
+          "namespace": "shared/database",
+          "scope": "shared",
+          "refs": ["database.PASSWORD"],
+          "operations": ["resolve"],
+          "purpose": "connect api-service to the shared database"
+        }
+      ]
+    }
+  }
+}
+```
+
+The denied example uses `database.ROOT_PASSWORD` but does not declare a
+matching `broker.imports[]` entry or a matching `broker.accessPolicy` grant.
+Service Lasso reports this as missing policy metadata without revealing a
+secret value.
+
+## Runtime validation
+
+Manifest parsing validates malformed assignments:
+
+- `broker.accessPolicy.serviceId` must match the top-level manifest `id`.
+- grant namespaces and refs must use the same bounded broker namespace/ref
+  syntax as imports and writeback policy.
+- grant operations must be one of `resolve`, `create`, `update`, `rotate`, or
+  `delete`.
+- if `broker.accessPolicy` is present, each `broker.imports[]` ref must have a
+  matching `resolve` grant.
+- if `broker.accessPolicy` is present, generated writeback refs must have a
+  matching operation grant for their export namespace.
+
+The secret reference audit also reports missing access-policy assignment for
+declared broker imports. That report includes service id, namespace/ref,
+operation, status, and reason only; it does not include resolved secret values.
+
+## Integration boundary
+
+This is the Service Lasso manifest-side contract. Actual Secrets Broker
+authorization enforcement is tracked by
+`service-lasso/lasso-secretsbroker#30`.
+
+Service Admin policy simulation remains a UI follow-up: it should consume this
+metadata and broker enforcement/audit results, not claim enforcement from the UI
+alone.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -98,6 +98,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/service-secret-access-policy",
+          label: "Service Secret Access Policy",
+        },
+        {
+          type: "doc",
           id: "reference/legacy-globalenv-migration",
           label: "Legacy globalenv Migration",
         },

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -50,6 +50,26 @@
         "required": false
       }
     ],
+    "accessPolicy": {
+      "serviceId": "node-sample-service",
+      "workspace": "local-demo",
+      "grants": [
+        {
+          "namespace": "shared/sample",
+          "scope": "shared",
+          "refs": ["sample.API_TOKEN"],
+          "operations": ["resolve"],
+          "purpose": "read sample API token metadata during runtime startup"
+        },
+        {
+          "namespace": "services/node-sample-service",
+          "scope": "service",
+          "refs": ["sample.GENERATED_TOKEN"],
+          "operations": ["create", "rotate"],
+          "purpose": "capture and rotate sample generated token metadata"
+        }
+      ]
+    },
     "writeback": {
       "allowedNamespaces": [
         "services/node-sample-service"

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -177,6 +177,22 @@ export interface ServiceBrokerExport {
 }
 
 export type ServiceBrokerWritebackOperation = "create" | "update" | "rotate" | "delete";
+export type ServiceBrokerAccessOperation = "resolve" | ServiceBrokerWritebackOperation;
+export type ServiceBrokerAccessScope = "workspace" | "service" | "app" | "shared" | "global";
+
+export interface ServiceBrokerAccessGrant {
+  namespace: string;
+  scope?: ServiceBrokerAccessScope;
+  refs?: string[];
+  operations: ServiceBrokerAccessOperation[];
+  purpose: string;
+}
+
+export interface ServiceBrokerAccessPolicy {
+  serviceId?: string;
+  workspace?: string;
+  grants?: ServiceBrokerAccessGrant[];
+}
 
 export interface ServiceBrokerWritebackPolicy {
   allowedNamespaces?: string[];
@@ -193,6 +209,7 @@ export interface ServiceBrokerPolicy {
   buckets?: ServiceBrokerBucket[];
   imports?: ServiceBrokerImport[];
   exports?: ServiceBrokerExport[];
+  accessPolicy?: ServiceBrokerAccessPolicy;
   writeback?: ServiceBrokerWritebackPolicy;
 }
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1,4 +1,6 @@
 import type {
+  ServiceBrokerAccessOperation,
+  ServiceBrokerAccessScope,
   ServiceBrokerBucketKind,
   ServiceBrokerWritebackOperation,
   ServiceHookFailurePolicy,
@@ -19,6 +21,8 @@ const updateRunningServicePolicies = new Set(["skip", "require-stopped", "stop-s
 const updateWindowDays = new Set(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 const serviceRoles = new Set(["service", "provider"]);
 const setupRerunPolicies = new Set(["manual", "ifMissing", "always"]);
+const brokerAccessOperations = new Set(["resolve", "create", "update", "rotate", "delete"]);
+const brokerAccessScopes = new Set(["workspace", "service", "app", "shared", "global"]);
 const brokerWritebackOperations = new Set(["create", "update", "rotate", "delete"]);
 const brokerBucketKinds = new Set(["service", "app", "shared", "global"]);
 const brokerNamespacePattern = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.-]*)*$/;
@@ -426,7 +430,7 @@ function validateUniqueEntries(values: string[], field: string, manifestPath: st
   }
 }
 
-function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest["broker"] | undefined {
+function readBrokerPolicy(value: unknown, manifestPath: string, serviceId: string): ServiceManifest["broker"] | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -448,6 +452,66 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
   if (exports !== undefined && !Array.isArray(exports)) {
     throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.exports" to be an array.`);
   }
+
+  const accessPolicy = record.accessPolicy;
+  if (accessPolicy !== undefined && (!accessPolicy || typeof accessPolicy !== "object" || Array.isArray(accessPolicy))) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.accessPolicy" to be an object.`);
+  }
+  const accessPolicyRecord = accessPolicy as Record<string, unknown> | undefined;
+  const accessPolicyServiceId =
+    accessPolicyRecord?.serviceId === undefined
+      ? undefined
+      : expectNonEmptyString(accessPolicyRecord.serviceId, "broker.accessPolicy.serviceId", manifestPath);
+  if (accessPolicyServiceId !== undefined && accessPolicyServiceId !== serviceId) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: broker.accessPolicy.serviceId must match manifest id "${serviceId}".`,
+    );
+  }
+  const accessPolicyWorkspace =
+    accessPolicyRecord?.workspace === undefined
+      ? undefined
+      : expectNonEmptyString(accessPolicyRecord.workspace, "broker.accessPolicy.workspace", manifestPath);
+  const accessPolicyGrants = accessPolicyRecord?.grants;
+  if (accessPolicyGrants !== undefined && !Array.isArray(accessPolicyGrants)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker.accessPolicy.grants" to be an array.`);
+  }
+  const parsedAccessPolicyGrants = Array.isArray(accessPolicyGrants)
+    ? accessPolicyGrants.map((entry, index) => {
+        const field = `broker.accessPolicy.grants[${index}]`;
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+        }
+        const grantRecord = entry as Record<string, unknown>;
+        const rawScope = grantRecord.scope;
+        if (rawScope !== undefined && (typeof rawScope !== "string" || !brokerAccessScopes.has(rawScope))) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "${field}.scope" to be one of workspace, service, app, shared, or global.`,
+          );
+        }
+        const operations = readNonEmptyStringArray(grantRecord.operations, `${field}.operations`, manifestPath);
+        if (!operations || operations.length === 0 || operations.some((operation) => !brokerAccessOperations.has(operation))) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "${field}.operations" to contain resolve, create, update, rotate, or delete.`,
+          );
+        }
+        validateUniqueEntries(operations, `${field}.operations`, manifestPath);
+        const refs = readNonEmptyStringArray(grantRecord.refs, `${field}.refs`, manifestPath);
+        refs?.forEach((ref) => expectBrokerRef(ref, `${field}.refs`, manifestPath));
+        validateUniqueEntries(refs ?? [], `${field}.refs`, manifestPath);
+        return {
+          namespace: expectBrokerNamespace(grantRecord.namespace, `${field}.namespace`, manifestPath),
+          ...(rawScope === undefined ? {} : { scope: rawScope as ServiceBrokerAccessScope }),
+          refs,
+          operations: operations as ServiceBrokerAccessOperation[],
+          purpose: expectNonEmptyString(grantRecord.purpose, `${field}.purpose`, manifestPath),
+        };
+      })
+    : undefined;
+  validateUniqueEntries(
+    (parsedAccessPolicyGrants ?? []).map((grant) => `${grant.namespace}:${grant.scope ?? ""}:${(grant.refs ?? ["*"]).join(",")}:${grant.operations.join(",")}`),
+    "broker.accessPolicy.grants",
+    manifestPath,
+  );
 
   const writeback = record.writeback;
   if (writeback !== undefined && (!writeback || typeof writeback !== "object" || Array.isArray(writeback))) {
@@ -559,7 +623,14 @@ function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest
             source: expectNonEmptyString(exportRecord.source, `${field}.source`, manifestPath),
             required: expectOptionalBoolean(exportRecord.required, `${field}.required`, manifestPath),
           };
-        })
+      })
+      : undefined,
+    accessPolicy: accessPolicyRecord
+      ? {
+          serviceId: accessPolicyServiceId,
+          workspace: accessPolicyWorkspace,
+          grants: parsedAccessPolicyGrants,
+        }
       : undefined,
     writeback: writebackRecord
       ? {
@@ -598,6 +669,23 @@ function validateBrokerCollisions(
   const allowedWritebackNamespaces = new Set(broker.writeback?.allowedNamespaces ?? []);
   const allowedWritebackRefs = new Set(broker.writeback?.allowedRefs ?? []);
   const allowedWritebackOperations = new Set(broker.writeback?.allowedOperations ?? []);
+  const accessGrants = broker.accessPolicy?.grants ?? [];
+  const accessGrantAllows = (namespace: string, ref: string, operation: ServiceBrokerAccessOperation): boolean =>
+    accessGrants.some((grant) => {
+      if (grant.namespace !== namespace || !grant.operations.includes(operation)) {
+        return false;
+      }
+      return (grant.refs ?? []).length === 0 || (grant.refs ?? []).includes(ref);
+    });
+
+  for (const entry of broker.imports ?? []) {
+    if (broker.accessPolicy && !accessGrantAllows(entry.namespace, entry.ref, "resolve")) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.imports ref "${entry.ref}" is outside broker.accessPolicy resolve grants for namespace "${entry.namespace}".`,
+      );
+    }
+  }
+
   for (const entry of broker.writeback?.generatedSecrets ?? []) {
     const exportEntry = (broker.exports ?? []).find((candidate) => candidate.ref === entry.ref);
     if (!exportEntry) {
@@ -618,6 +706,12 @@ function validateBrokerCollisions(
     if (entry.operation && allowedWritebackOperations.size > 0 && !allowedWritebackOperations.has(entry.operation)) {
       throw new Error(
         `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" uses operation "${entry.operation}" outside broker.writeback.allowedOperations.`,
+      );
+    }
+    const operation = entry.operation ?? "create";
+    if (broker.accessPolicy && !accessGrantAllows(exportEntry.namespace, entry.ref, operation)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: broker.writeback.generatedSecrets ref "${entry.ref}" uses operation "${operation}" outside broker.accessPolicy grants for namespace "${exportEntry.namespace}".`,
       );
     }
   }
@@ -907,6 +1001,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   }
 
   const record = input as Record<string, unknown>;
+  const serviceId = expectNonEmptyString(record.id, "id", manifestPath);
 
   const dependOn = record.depend_on;
   if (
@@ -1052,7 +1147,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     throw new Error(`Invalid service manifest at ${manifestPath}: expected \"urls\" to be an array of { label, url } objects.`);
   }
 
-  const broker = readBrokerPolicy(record.broker, manifestPath);
+  const broker = readBrokerPolicy(record.broker, manifestPath, serviceId);
   const env = rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined;
   const globalenv = rawGlobalEnv
     ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
@@ -1069,7 +1164,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const updates = readUpdatePolicy(record.updates, artifact, manifestPath);
 
   return {
-    id: expectNonEmptyString(record.id, "id", manifestPath),
+    id: serviceId,
     name: expectNonEmptyString(record.name, "name", manifestPath),
     description: expectNonEmptyString(record.description, "description", manifestPath),
     version: typeof record.version === "string" ? record.version : undefined,

--- a/src/runtime/operator/secret-audit.ts
+++ b/src/runtime/operator/secret-audit.ts
@@ -1,6 +1,7 @@
 import type { DiscoveredService, ServiceBrokerImport } from "../../contracts/service.js";
 
 export type SecretReferenceAuditStatus = "present" | "missing" | "malformed";
+export type SecretAccessPolicyAssignmentStatus = "allowed" | "missing" | "not_applicable";
 export type SecretReferenceAuditSource =
   | "env"
   | "globalenv"
@@ -20,6 +21,11 @@ export interface SecretReferenceAuditFinding {
   location: string;
   required?: boolean;
   reason: string;
+  accessPolicy: {
+    operation: "resolve";
+    status: SecretAccessPolicyAssignmentStatus;
+    reason: string;
+  };
 }
 
 export interface ServiceSecretReferenceAudit {
@@ -145,6 +151,7 @@ export interface SecretProviderAuthRequiredSummary {
 
 interface CandidateRef {
   ref: string;
+  namespace?: string;
   source: SecretReferenceAuditSource;
   location: string;
   required?: boolean;
@@ -229,6 +236,7 @@ function addBrokerImport(
   }
   candidates.push({
     ref: entry.ref,
+    namespace: entry.namespace,
     source: "broker.import",
     location: "broker.imports[" + index + "].ref",
     required: entry.required !== false,
@@ -248,6 +256,7 @@ function collectCandidates(service: DiscoveredService): CandidateRef[] {
     declaredRefs.add(entry.ref);
     candidates.push({
       ref: entry.ref,
+      namespace: entry.namespace,
       source: "broker.export",
       location: "broker.exports[" + index + "].ref",
       required: entry.required !== false,
@@ -288,22 +297,69 @@ function collectCandidates(service: DiscoveredService): CandidateRef[] {
   return candidates;
 }
 
-function toFinding(serviceId: string, candidate: CandidateRef): SecretReferenceAuditFinding {
+function accessPolicyAssignment(
+  service: DiscoveredService,
+  candidate: CandidateRef,
+  parsed: { namespace: string; key: string } | null,
+): SecretReferenceAuditFinding["accessPolicy"] {
+  if (!parsed || candidate.source !== "broker.import") {
+    return {
+      operation: "resolve",
+      status: "not_applicable",
+      reason: "Resolve access policy applies to declared broker imports only.",
+    };
+  }
+
+  const policy = service.manifest.broker?.accessPolicy;
+  if (!policy) {
+    return {
+      operation: "resolve",
+      status: "missing",
+      reason: "No broker.accessPolicy assignment declares resolve access for this import.",
+    };
+  }
+
+  const policyNamespace = candidate.namespace ?? parsed.namespace;
+  const allowed = (policy.grants ?? []).some((grant) => {
+    if (grant.namespace !== policyNamespace) {
+      return false;
+    }
+    if (!grant.operations.includes("resolve")) {
+      return false;
+    }
+    return (grant.refs ?? []).length === 0 || (grant.refs ?? []).includes(candidate.ref);
+  });
+
+  return allowed
+    ? {
+        operation: "resolve",
+        status: "allowed",
+        reason: "broker.accessPolicy grants resolve access for this namespace/ref.",
+      }
+    : {
+        operation: "resolve",
+        status: "missing",
+        reason: "broker.accessPolicy is present but does not grant resolve access for this namespace/ref.",
+      };
+}
+
+function toFinding(service: DiscoveredService, candidate: CandidateRef): SecretReferenceAuditFinding {
   const parsed = parseBrokerRef(candidate.ref);
   if (!parsed) {
     return {
-      serviceId,
+      serviceId: service.manifest.id,
       ref: candidate.ref,
       status: "malformed",
       source: candidate.source,
       location: candidate.location,
       required: candidate.required,
       reason: "Reference is secret-shaped but is not a supported broker ref in namespace.key form.",
+      accessPolicy: accessPolicyAssignment(service, candidate, parsed),
     };
   }
 
   return {
-    serviceId,
+    serviceId: service.manifest.id,
     ref: candidate.ref,
     namespace: parsed.namespace,
     key: parsed.key,
@@ -314,6 +370,7 @@ function toFinding(serviceId: string, candidate: CandidateRef): SecretReferenceA
     reason: candidate.declared
       ? "Broker reference is declared in the service manifest."
       : "Broker selector is used but not declared in broker imports, exports, or writeback policy.",
+    accessPolicy: accessPolicyAssignment(service, candidate, parsed),
   };
 }
 
@@ -327,7 +384,7 @@ function summarize(findings: SecretReferenceAuditFinding[]): ServiceSecretRefere
 
 export function buildServiceSecretReferenceAudit(service: DiscoveredService): ServiceSecretReferenceAudit {
   const findings = collectCandidates(service)
-    .map((candidate) => toFinding(service.manifest.id, candidate))
+    .map((candidate) => toFinding(service, candidate))
     .sort((left, right) =>
       left.status.localeCompare(right.status) ||
       left.ref.localeCompare(right.ref) ||

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.7-eecdb39");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.8-f7a35b1");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);
@@ -499,6 +499,26 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
               required: false,
             },
           ],
+          accessPolicy: {
+            serviceId: "broker-consumer",
+            workspace: "local-demo",
+            grants: [
+              {
+                namespace: "shared/database",
+                scope: "shared",
+                refs: ["database.PASSWORD"],
+                operations: ["resolve"],
+                purpose: "connect to the shared database during runtime startup",
+              },
+              {
+                namespace: "broker-consumer/runtime",
+                scope: "service",
+                refs: ["runtime.API_TOKEN"],
+                operations: ["create", "rotate"],
+                purpose: "capture and rotate generated runtime token metadata",
+              },
+            ],
+          },
           writeback: {
             allowedNamespaces: ["broker-consumer/runtime"],
             allowedOperations: ["create", "update", "rotate"],
@@ -550,6 +570,26 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
           required: false,
         },
       ],
+      accessPolicy: {
+        serviceId: "broker-consumer",
+        workspace: "local-demo",
+        grants: [
+          {
+            namespace: "shared/database",
+            scope: "shared",
+            refs: ["database.PASSWORD"],
+            operations: ["resolve"],
+            purpose: "connect to the shared database during runtime startup",
+          },
+          {
+            namespace: "broker-consumer/runtime",
+            scope: "service",
+            refs: ["runtime.API_TOKEN"],
+            operations: ["create", "rotate"],
+            purpose: "capture and rotate generated runtime token metadata",
+          },
+        ],
+      },
       writeback: {
         allowedNamespaces: ["broker-consumer/runtime"],
         allowedOperations: ["create", "update", "rotate"],
@@ -650,6 +690,59 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
         },
       },
     });
+    await writeManifest(servicesRoot, "bad-access-policy-service", {
+      id: "bad-access-policy-service",
+      name: "Bad Access Policy Service",
+      description: "Access policy assigned to a different service id.",
+      broker: {
+        accessPolicy: {
+          serviceId: "other-service",
+          grants: [
+            {
+              namespace: "shared/database",
+              refs: ["database.PASSWORD"],
+              operations: ["resolve"],
+              purpose: "connect to shared database",
+            },
+          ],
+        },
+      },
+    });
+    await writeManifest(servicesRoot, "bad-access-policy-operation", {
+      id: "bad-access-policy-operation",
+      name: "Bad Access Policy Operation",
+      description: "Access policy uses an unsupported operation.",
+      broker: {
+        accessPolicy: {
+          grants: [
+            {
+              namespace: "shared/database",
+              refs: ["database.PASSWORD"],
+              operations: ["reveal"],
+              purpose: "connect to shared database",
+            },
+          ],
+        },
+      },
+    });
+    await writeManifest(servicesRoot, "access-policy-missing-resolve", {
+      id: "access-policy-missing-resolve",
+      name: "Access Policy Missing Resolve",
+      description: "Broker import outside access policy grants.",
+      broker: {
+        imports: [{ namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD" }],
+        accessPolicy: {
+          grants: [
+            {
+              namespace: "shared/database",
+              refs: ["database.USER"],
+              operations: ["resolve"],
+              purpose: "connect to shared database as a non-secret user",
+            },
+          ],
+        },
+      },
+    });
 
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "bad-enabled", "service.json")),
@@ -682,6 +775,18 @@ test("loadServiceManifest rejects malformed broker manifest policy", async () =>
     await assert.rejects(
       () => loadServiceManifest(path.join(servicesRoot, "writeback-denied-operation", "service.json")),
       /outside broker\.writeback\.allowedOperations/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-access-policy-service", "service.json")),
+      /broker\.accessPolicy\.serviceId must match manifest id/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-access-policy-operation", "service.json")),
+      /broker\.accessPolicy\.grants\[0\]\.operations/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "access-policy-missing-resolve", "service.json")),
+      /outside broker\.accessPolicy resolve grants/i,
     );
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });

--- a/tests/secret-reference-audit.test.js
+++ b/tests/secret-reference-audit.test.js
@@ -175,7 +175,8 @@ test("secret reference audit reports declared missing and malformed refs without
     assertNoSecretMaterial(result.body);
 
     const findings = result.body.services[0].findings;
-    assert.ok(findings.some((finding) => finding.ref === "secretsbroker.API_TOKEN" && finding.status === "present"));
+    const declaredToken = findings.find((finding) => finding.ref === "secretsbroker.API_TOKEN" && finding.status === "present");
+    assert.equal(declaredToken.accessPolicy.status, "missing");
     assert.ok(findings.some((finding) => finding.ref === "secretsbroker.DB_PASSWORD" && finding.status === "missing"));
     assert.ok(findings.some((finding) => finding.ref === "LOCAL_SECRET_TOKEN" && finding.status === "malformed"));
 
@@ -184,6 +185,62 @@ test("secret reference audit reports declared missing and malformed refs without
     assert.equal(serviceResult.body.serviceId, "audit-consumer");
     assert.deepEqual(serviceResult.body.summary, result.body.services[0].summary);
     assertNoSecretMaterial(serviceResult.body);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("secret reference audit reports broker access policy assignment without raw values", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-secret-policy-audit-");
+  await writeManifest(servicesRoot, "policy-consumer", {
+    id: "policy-consumer",
+    name: "Policy Consumer",
+    description: "Service with explicit broker access policy assignment.",
+    env: {
+      API_TOKEN: "\${secretsbroker.API_TOKEN}",
+      DENIED_TOKEN: "\${secretsbroker.DENIED_TOKEN}",
+      RAW_SENTINEL: rawSecretSentinel,
+    },
+    broker: {
+      imports: [
+        {
+          namespace: "shared/secretsbroker",
+          ref: "secretsbroker.API_TOKEN",
+          as: "API_TOKEN",
+          required: true,
+        },
+      ],
+      accessPolicy: {
+        serviceId: "policy-consumer",
+        workspace: "local-demo",
+        grants: [
+          {
+            namespace: "shared/secretsbroker",
+            scope: "shared",
+            refs: ["secretsbroker.API_TOKEN"],
+            operations: ["resolve"],
+            purpose: "read API token metadata for runtime startup",
+          },
+        ],
+      },
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/secrets/audit");
+    assert.equal(result.status, 200);
+    assertNoSecretMaterial(result.body);
+
+    const findings = result.body.services[0].findings;
+    const allowed = findings.find((finding) => finding.ref === "secretsbroker.API_TOKEN" && finding.source === "broker.import");
+    assert.equal(allowed.accessPolicy.status, "allowed");
+    assert.equal(allowed.accessPolicy.operation, "resolve");
+
+    const denied = findings.find((finding) => finding.ref === "secretsbroker.DENIED_TOKEN");
+    assert.equal(denied.status, "missing");
+    assert.equal(denied.accessPolicy.status, "not_applicable");
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Adds the `broker.accessPolicy` manifest assignment contract with service/workspace scope, namespace/ref grants, operations, and purpose metadata.
- Extends manifest validation to fail safely on malformed assignments, import grants without resolve permission, and writeback grants outside policy.
- Adds safe operator audit/readiness reporting for declared, missing, malformed, and access-policy-granted secret refs, plus docs and sample manifest coverage.

Closes #591.

## Validation
- `npm run build` ✅
- `node --test --test-concurrency=1 tests/secret-reference-audit.test.js` ✅
- `node --test --test-concurrency=1 --test-name-pattern "broker manifest policy" tests/manifest-discovery.test.js` ✅
- `npm test` ⚠️ built, then failed 16 tests due existing local/demo state and develop baseline issues: live executable `EPERM` locks under checked-in service `.state` directories, dirty local `services/@serviceadmin/service.json` pin drift, and existing start-preparation expectation drift from merged runtime behavior.

## Demo
- Canonical LAN preflight was healthy before branch handoff:
  - `http://192.168.1.53:17700/` -> 200
  - `http://192.168.1.53:17883/api/health` -> 200 `status: ok`
- Canonical recycle/verification evidence will be added by the developer worker run comment.