### PR TITLE
feat(mcp): expose read-only operator MCP surface

### DIFF
--- a/docs/reference/operator-mcp.md
+++ b/docs/reference/operator-mcp.md
@@ -1,0 +1,28 @@
+# Operator MCP
+
+Service Lasso exposes a first read-only operator MCP surface at `POST /api/mcp`, with discovery metadata at `GET /api/mcp`.
+
+The MCP surface is intentionally scoped to inspection. It does not expose lifecycle actions, runtime orchestration, command confirmation execution, setup runs, update installs, or any other mutating operation.
+
+## Tools
+
+- `service_lasso_list_services`: safe service inventory, lifecycle booleans, dependencies, ports, and paths.
+- `service_lasso_get_health`: health metadata for one service or all services.
+- `service_lasso_list_routes`: route and port metadata for one service or all services.
+- `service_lasso_dependency_status`: dependency readiness, blockers, and next-action metadata.
+- `service_lasso_logs_summary`: bounded recent runtime log lines for one service.
+- `service_lasso_diagnostics_summary`: dependency and secret-reference audit summaries.
+
+## Resources
+
+- `servicelasso://services`
+- `servicelasso://health`
+- `servicelasso://routes`
+- `servicelasso://dependencies`
+- `servicelasso://diagnostics`
+
+## Redaction Boundary
+
+MCP responses must not include raw secret values, provider tokens, passwords, private keys, cookies, broker payloads, or raw manifest `env`/`globalenv` values.
+
+Route URLs strip username, password, query string, and fragment before returning to clients. Log summaries omit file paths and apply the diagnostics redactor to line text before serializing MCP content.

--- a/docs/reference/runtime-capabilities.md
+++ b/docs/reference/runtime-capabilities.md
@@ -11,6 +11,7 @@ The response includes:
 - option-derived flags for autostart, monitor, and update scheduler state
 - discovered service roles and default-baseline membership
 - Service Admin compatibility hints
+- the read-only operator MCP endpoint group
 
 The endpoint exposes metadata only. It must not include raw environment values, provider credentials, secret payloads, tokens, cookies, private keys, or recovery material.
 
@@ -48,6 +49,7 @@ Example shape:
       "operatorNetwork": true,
       "operatorMetrics": true,
       "operatorLogs": true,
+      "operatorMcp": true,
       "providerConnections": false,
       "workflowFacade": false,
       "localRouteGeneration": true,

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -158,6 +158,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/operator-mcp",
+          label: "Operator MCP",
+        },
+        {
+          type: "doc",
           id: "development/telegram-group-control-plan",
           label: "Telegram Group Control Plan",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -183,6 +183,7 @@ export interface RuntimeFeatureFlags {
   operatorNetwork: boolean;
   operatorMetrics: boolean;
   operatorLogs: boolean;
+  operatorMcp: boolean;
   providerConnections: boolean;
   workflowFacade: boolean;
   localRouteGeneration: boolean;

--- a/src/runtime/operator/mcp.ts
+++ b/src/runtime/operator/mcp.ts
@@ -1,0 +1,625 @@
+import type { DiscoveredService } from "../../contracts/service.js";
+import type { ServiceHealthResult } from "../health/types.js";
+import { evaluateServiceHealth } from "../health/evaluateHealth.js";
+import { getLifecycleState } from "../lifecycle/store.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import type { DependencyGraph } from "../manager/DependencyGraph.js";
+import { buildServiceNetwork } from "./network.js";
+import { readServiceLogChunk } from "./logs.js";
+import { buildBaselineDependencyDiagnostics } from "./dependencyDiagnostics.js";
+import { buildSecretReferenceAudit } from "./secret-audit.js";
+import { redactDiagnosticsValue } from "../diagnostics/bundle.js";
+
+export interface ServiceLassoMcpContext {
+  version: string;
+  servicesRoot: string;
+  workspaceRoot?: string;
+  discovered: DiscoveredService[];
+  registry: ServiceRegistry;
+  graph: DependencyGraph;
+  sharedGlobalEnv: Record<string, string>;
+}
+
+export interface McpJsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+interface McpToolDefinition {
+  name: ServiceLassoMcpToolName;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+    additionalProperties: false;
+  };
+}
+
+interface McpResourceDefinition {
+  uri: ServiceLassoMcpResourceUri;
+  name: string;
+  description: string;
+  mimeType: "application/json";
+}
+
+type ServiceLassoMcpToolName =
+  | "service_lasso_list_services"
+  | "service_lasso_get_health"
+  | "service_lasso_list_routes"
+  | "service_lasso_dependency_status"
+  | "service_lasso_logs_summary"
+  | "service_lasso_diagnostics_summary";
+
+type ServiceLassoMcpResourceUri =
+  | "servicelasso://services"
+  | "servicelasso://health"
+  | "servicelasso://routes"
+  | "servicelasso://dependencies"
+  | "servicelasso://diagnostics";
+
+interface McpJsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+const CONTRACT_VERSION = "service-lasso-mcp.v1";
+const MCP_PROTOCOL_VERSION = "2024-11-05";
+const REDACTION_VALUE = "[REDACTED]";
+const DEFAULT_LOG_LIMIT = 20;
+const MAX_LOG_LIMIT = 50;
+
+const serviceIdInputSchema = {
+  serviceId: {
+    type: "string",
+    description: "Optional Service Lasso service id. Omit to return all services.",
+  },
+};
+
+const mcpTools: McpToolDefinition[] = [
+  {
+    name: "service_lasso_list_services",
+    description: "List Service Lasso services with safe manifest, lifecycle, and dependency metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "service_lasso_get_health",
+    description: "Read health metadata for one service or every service.",
+    inputSchema: {
+      type: "object",
+      properties: serviceIdInputSchema,
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "service_lasso_list_routes",
+    description: "List safe route and port metadata for one service or every service.",
+    inputSchema: {
+      type: "object",
+      properties: serviceIdInputSchema,
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "service_lasso_dependency_status",
+    description: "Read dependency readiness, blockers, and next-action metadata.",
+    inputSchema: {
+      type: "object",
+      properties: serviceIdInputSchema,
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "service_lasso_logs_summary",
+    description: "Read a bounded, redacted runtime log summary for one service.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serviceId: {
+          type: "string",
+          description: "Service Lasso service id.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum recent log lines to return. Defaults to 20 and is capped at 50.",
+        },
+      },
+      required: ["serviceId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "service_lasso_diagnostics_summary",
+    description: "Read safe diagnostic counts, dependency status, and secret-reference audit summaries.",
+    inputSchema: {
+      type: "object",
+      properties: serviceIdInputSchema,
+      additionalProperties: false,
+    },
+  },
+];
+
+const mcpResources: McpResourceDefinition[] = [
+  {
+    uri: "servicelasso://services",
+    name: "Service inventory",
+    description: "Safe Service Lasso service list metadata.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "servicelasso://health",
+    name: "Service health",
+    description: "Safe service health metadata.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "servicelasso://routes",
+    name: "Service routes",
+    description: "Safe route and port metadata without URL credentials, query strings, or fragments.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "servicelasso://dependencies",
+    name: "Dependency status",
+    description: "Baseline dependency readiness and blocker metadata.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "servicelasso://diagnostics",
+    name: "Diagnostics summary",
+    description: "Safe operator diagnostic summary with redaction policy.",
+    mimeType: "application/json",
+  },
+];
+
+function generatedAt(): string {
+  return new Date().toISOString();
+}
+
+function clampLogLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_LOG_LIMIT;
+  }
+
+  return Math.max(1, Math.min(MAX_LOG_LIMIT, Math.trunc(value)));
+}
+
+function safeArguments(params: unknown): Record<string, unknown> {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return {};
+  }
+
+  const args = (params as { arguments?: unknown }).arguments;
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return {};
+  }
+
+  return args as Record<string, unknown>;
+}
+
+function serviceIdFromArguments(args: Record<string, unknown>): string | undefined {
+  return typeof args.serviceId === "string" && args.serviceId.trim().length > 0 ? args.serviceId.trim() : undefined;
+}
+
+function selectedServices(context: ServiceLassoMcpContext, serviceId?: string): DiscoveredService[] {
+  if (!serviceId) {
+    return [...context.discovered].sort((left, right) => left.manifest.id.localeCompare(right.manifest.id));
+  }
+
+  const service = context.registry.getById(serviceId);
+  if (!service) {
+    throw new Error("Unknown service id: " + serviceId);
+  }
+
+  return [service];
+}
+
+function resolvedPorts(service: DiscoveredService): Record<string, number> {
+  const lifecycle = getLifecycleState(service.manifest.id);
+  return Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
+}
+
+function sanitizeUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    const safePath = String(redactDiagnosticsValue(url.pathname));
+    return `${url.protocol}//${url.host}${safePath}`;
+  } catch {
+    const redacted = String(redactDiagnosticsValue(value));
+    return redacted.split("?")[0]?.split("#")[0] ?? redacted;
+  }
+}
+
+function redactLogValue(value: string): string {
+  return String(redactDiagnosticsValue(value));
+}
+
+function sanitizeHealth(health: ServiceHealthResult): ServiceHealthResult {
+  return redactDiagnosticsValue(health) as ServiceHealthResult;
+}
+
+export function getServiceLassoMcpCapabilities(context: ServiceLassoMcpContext) {
+  return {
+    contractVersion: CONTRACT_VERSION,
+    protocolVersion: MCP_PROTOCOL_VERSION,
+    serverInfo: {
+      name: "service-lasso-operator",
+      version: context.version,
+    },
+    scope: {
+      mutatingOperations: "omitted",
+      tools: "read-only",
+      resources: "read-only",
+      redaction: {
+        value: REDACTION_VALUE,
+        rules: [
+          "raw manifest env/globalenv values are not returned",
+          "runtime log text is pattern-redacted before MCP responses",
+          "route URLs strip username, password, query string, and fragment",
+          "mutating lifecycle and command-confirmation operations are not exposed as MCP tools",
+        ],
+      },
+    },
+    tools: mcpTools,
+    resources: mcpResources,
+    runtime: {
+      servicesRoot: context.servicesRoot,
+      workspaceRoot: context.workspaceRoot ?? null,
+      serviceCount: context.discovered.length,
+    },
+  };
+}
+
+export async function buildMcpServicesPayload(context: ServiceLassoMcpContext, serviceId?: string) {
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    services: selectedServices(context, serviceId).map((service) => {
+      const lifecycle = getLifecycleState(service.manifest.id);
+      const dependencySummary = context.graph.getServiceDependencies(service.manifest.id);
+      return {
+        id: service.manifest.id,
+        name: service.manifest.name,
+        description: service.manifest.description,
+        enabled: service.manifest.enabled !== false,
+        role: service.manifest.role ?? "service",
+        version: service.manifest.version ?? null,
+        installed: lifecycle.installed,
+        configured: lifecycle.configured,
+        running: lifecycle.running,
+        dependencies: dependencySummary.dependencies,
+        dependents: dependencySummary.dependents,
+        ports: resolvedPorts(service),
+        manifestPath: service.manifestPath,
+        serviceRoot: service.serviceRoot,
+      };
+    }),
+    safety: {
+      mutating: false,
+      redacted: true,
+      omittedSensitiveFields: ["manifest.env", "manifest.globalenv", "manifest.broker secret payloads"],
+    },
+  };
+}
+
+export async function buildMcpHealthPayload(context: ServiceLassoMcpContext, serviceId?: string) {
+  const services = await Promise.all(
+    selectedServices(context, serviceId).map(async (service) => {
+      const lifecycle = getLifecycleState(service.manifest.id);
+      return {
+        serviceId: service.manifest.id,
+        running: lifecycle.running,
+        health: sanitizeHealth(
+          await evaluateServiceHealth(service.manifest, lifecycle, service.serviceRoot, service, context.sharedGlobalEnv),
+        ),
+      };
+    }),
+  );
+
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    services,
+    summary: {
+      total: services.length,
+      healthy: services.filter((service) => service.health.healthy).length,
+      unhealthy: services.filter((service) => !service.health.healthy).length,
+    },
+    safety: {
+      mutating: false,
+      redacted: true,
+    },
+  };
+}
+
+export async function buildMcpRoutesPayload(context: ServiceLassoMcpContext, serviceId?: string) {
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    services: selectedServices(context, serviceId).map((service) => {
+      const network = buildServiceNetwork(service, context.sharedGlobalEnv, resolvedPorts(service));
+      return {
+        serviceId: service.manifest.id,
+        ports: network.ports,
+        portmapping: redactDiagnosticsValue(network.portmapping),
+        endpoints: network.endpoints.map((endpoint) => ({
+          label: endpoint.label,
+          kind: endpoint.kind,
+          url: sanitizeUrl(endpoint.url),
+        })),
+      };
+    }),
+    safety: {
+      mutating: false,
+      redacted: true,
+      omittedSensitiveFields: ["url.username", "url.password", "url.search", "url.hash"],
+    },
+  };
+}
+
+export async function buildMcpDependencyStatusPayload(context: ServiceLassoMcpContext, serviceId?: string) {
+  const diagnostics = await buildBaselineDependencyDiagnostics(
+    context.discovered,
+    context.registry,
+    context.graph,
+    context.sharedGlobalEnv,
+  );
+  const selected = serviceId
+    ? diagnostics.services.filter((service) => service.id === serviceId)
+    : diagnostics.services;
+
+  if (serviceId && selected.length === 0) {
+    throw new Error("Unknown service id: " + serviceId);
+  }
+
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    diagnostics: {
+      summary: diagnostics.summary,
+      services: selected.map((service) => ({
+        ...service,
+        endpoints: service.endpoints.map((endpoint) => ({
+          ...endpoint,
+          url: sanitizeUrl(endpoint.url),
+        })),
+        health: sanitizeHealth(service.health),
+      })),
+    },
+    safety: {
+      mutating: false,
+      redacted: true,
+    },
+  };
+}
+
+export async function buildMcpLogsSummaryPayload(context: ServiceLassoMcpContext, serviceId: string, limit = DEFAULT_LOG_LIMIT) {
+  const service = context.registry.getById(serviceId);
+  if (!service) {
+    throw new Error("Unknown service id: " + serviceId);
+  }
+
+  const logs = await readServiceLogChunk(service, undefined, clampLogLimit(limit));
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    serviceId,
+    log: {
+      type: logs.type,
+      totalLines: logs.totalLines,
+      start: logs.start,
+      end: logs.end,
+      hasMore: logs.hasMore,
+      nextCursor: logs.nextCursor,
+      limit: logs.limit,
+      entries: logs.entries.map((entry) => ({
+        source: {
+          kind: entry.source.kind,
+          archiveId: entry.source.archiveId,
+          lineNumber: entry.source.lineNumber,
+        },
+        stream: entry.stream,
+        message: redactLogValue(entry.message),
+        text: redactLogValue(entry.text),
+        truncated: entry.truncated,
+      })),
+    },
+    safety: {
+      mutating: false,
+      redacted: true,
+      omittedSensitiveFields: ["log.path", "log.source.path", "raw secret-like log text"],
+    },
+  };
+}
+
+export async function buildMcpDiagnosticsSummaryPayload(context: ServiceLassoMcpContext, serviceId?: string) {
+  const dependencies = await buildMcpDependencyStatusPayload(context, serviceId);
+  const secretAudit = buildSecretReferenceAudit(selectedServices(context, serviceId));
+
+  return {
+    contractVersion: CONTRACT_VERSION,
+    generatedAt: generatedAt(),
+    runtime: {
+      version: context.version,
+      servicesRoot: context.servicesRoot,
+      workspaceRoot: context.workspaceRoot ?? null,
+      serviceCount: selectedServices(context, serviceId).length,
+    },
+    dependencies: dependencies.diagnostics.summary,
+    secretReferences: secretAudit.summary,
+    services: secretAudit.services.map((service) => ({
+      serviceId: service.serviceId,
+      summary: service.summary,
+      findings: service.findings.map((finding) => ({
+        ref: finding.ref,
+        namespace: finding.namespace,
+        key: finding.key,
+        status: finding.status,
+        source: finding.source,
+        location: finding.location,
+        required: finding.required,
+        accessPolicy: finding.accessPolicy,
+      })),
+    })),
+    redaction: getServiceLassoMcpCapabilities(context).scope.redaction,
+    safety: {
+      mutating: false,
+      redacted: true,
+      omittedSensitiveFields: ["raw secret values", "manifest env/globalenv values", "runtime command payloads"],
+    },
+  };
+}
+
+async function callTool(context: ServiceLassoMcpContext, name: string, args: Record<string, unknown>) {
+  const serviceId = serviceIdFromArguments(args);
+
+  switch (name) {
+    case "service_lasso_list_services":
+      return buildMcpServicesPayload(context);
+    case "service_lasso_get_health":
+      return buildMcpHealthPayload(context, serviceId);
+    case "service_lasso_list_routes":
+      return buildMcpRoutesPayload(context, serviceId);
+    case "service_lasso_dependency_status":
+      return buildMcpDependencyStatusPayload(context, serviceId);
+    case "service_lasso_logs_summary":
+      if (!serviceId) {
+        throw new Error("service_lasso_logs_summary requires serviceId.");
+      }
+      return buildMcpLogsSummaryPayload(context, serviceId, clampLogLimit(args.limit));
+    case "service_lasso_diagnostics_summary":
+      return buildMcpDiagnosticsSummaryPayload(context, serviceId);
+    default:
+      throw new Error("Unknown MCP tool: " + name);
+  }
+}
+
+async function readResource(context: ServiceLassoMcpContext, uri: string) {
+  switch (uri) {
+    case "servicelasso://services":
+      return buildMcpServicesPayload(context);
+    case "servicelasso://health":
+      return buildMcpHealthPayload(context);
+    case "servicelasso://routes":
+      return buildMcpRoutesPayload(context);
+    case "servicelasso://dependencies":
+      return buildMcpDependencyStatusPayload(context);
+    case "servicelasso://diagnostics":
+      return buildMcpDiagnosticsSummaryPayload(context);
+    default:
+      throw new Error("Unknown MCP resource: " + uri);
+  }
+}
+
+function jsonContent(payload: unknown) {
+  return [
+    {
+      type: "text",
+      text: JSON.stringify(payload, null, 2),
+    },
+  ];
+}
+
+function success(id: McpJsonRpcRequest["id"], result: unknown): McpJsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    result,
+  };
+}
+
+function failure(id: McpJsonRpcRequest["id"], code: number, message: string): McpJsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+export async function handleServiceLassoMcpJsonRpcRequest(
+  context: ServiceLassoMcpContext,
+  request: McpJsonRpcRequest,
+): Promise<McpJsonRpcResponse> {
+  try {
+    if (request.jsonrpc !== "2.0" || typeof request.method !== "string") {
+      return failure(request.id, -32600, "Invalid JSON-RPC 2.0 request.");
+    }
+
+    if (request.method === "initialize") {
+      return success(request.id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {
+          tools: {},
+          resources: {},
+        },
+        serverInfo: {
+          name: "service-lasso-operator",
+          version: context.version,
+        },
+      });
+    }
+
+    if (request.method === "tools/list") {
+      return success(request.id, {
+        tools: mcpTools,
+      });
+    }
+
+    if (request.method === "tools/call") {
+      const params = request.params && typeof request.params === "object" ? request.params as Record<string, unknown> : {};
+      const name = typeof params.name === "string" ? params.name : "";
+      const payload = await callTool(context, name, safeArguments(request.params));
+      return success(request.id, {
+        content: jsonContent(payload),
+        isError: false,
+      });
+    }
+
+    if (request.method === "resources/list") {
+      return success(request.id, {
+        resources: mcpResources,
+      });
+    }
+
+    if (request.method === "resources/read") {
+      const params = request.params && typeof request.params === "object" ? request.params as Record<string, unknown> : {};
+      const uri = typeof params.uri === "string" ? params.uri : "";
+      const payload = await readResource(context, uri);
+      return success(request.id, {
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      });
+    }
+
+    if (request.method === "notifications/initialized") {
+      return success(request.id, {});
+    }
+
+    return failure(request.id, -32601, "Unsupported MCP method: " + request.method);
+  } catch (error) {
+    return failure(request.id, -32000, error instanceof Error ? error.message : "MCP request failed.");
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -74,6 +74,11 @@ import {
   buildServiceSecretRotationReadinessReport,
 } from "../runtime/operator/secret-audit.js";
 import {
+  getServiceLassoMcpCapabilities,
+  handleServiceLassoMcpJsonRpcRequest,
+  type McpJsonRpcRequest,
+} from "../runtime/operator/mcp.js";
+import {
   mutateOperatorActionItem,
   readOperatorActionAcknowledgementHistory,
   readOperatorActionQueue,
@@ -988,6 +993,39 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/health") {
     writeJson(response, 200, createHealthResponse(config.version));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/mcp") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(
+      response,
+      200,
+      getServiceLassoMcpCapabilities({
+        ...runtimeModel,
+        version: config.version,
+        workspaceRoot: config.workspaceRoot,
+        sharedGlobalEnv: collectRuntimeGlobalEnv(runtimeModel.registry.list()),
+      }),
+    );
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/mcp") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(
+      response,
+      200,
+      await handleServiceLassoMcpJsonRpcRequest(
+        {
+          ...runtimeModel,
+          version: config.version,
+          workspaceRoot: config.workspaceRoot,
+          sharedGlobalEnv: collectRuntimeGlobalEnv(runtimeModel.registry.list()),
+        },
+        await readJsonBody(request) as McpJsonRpcRequest,
+      ),
+    );
     return;
   }
 

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -92,6 +92,13 @@ const endpointGroups: RuntimeEndpointGroupResponse[] = [
     pathPrefix: "/api/variables",
     mutating: false,
   },
+  {
+    id: "operator-mcp",
+    label: "Operator MCP",
+    methods: ["GET", "POST"],
+    pathPrefix: "/api/mcp",
+    mutating: false,
+  },
 ];
 
 function createDefaultFeatureFlags(
@@ -111,6 +118,7 @@ function createDefaultFeatureFlags(
     operatorNetwork: true,
     operatorMetrics: true,
     operatorLogs: true,
+    operatorMcp: true,
     providerConnections: false,
     workflowFacade: false,
     localRouteGeneration: true,

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -371,8 +371,10 @@ test("GET /api/runtime/capabilities returns versioned runtime capability metadat
     assert.equal(result.body.capabilities.runtime.version, "capability-test-version");
     assert.equal(result.body.capabilities.api.contractVersion, "service-lasso.runtime-capabilities.v1");
     assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "runtime"));
+    assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "operator-mcp" && group.mutating === false));
     assert.equal(result.body.capabilities.features.lifecycleActions, true);
     assert.equal(result.body.capabilities.features.dashboardAdapter, true);
+    assert.equal(result.body.capabilities.features.operatorMcp, true);
     assert.equal(result.body.capabilities.features.providerConnections, false);
     assert.equal(result.body.capabilities.features.workflowFacade, false);
     assert.equal(result.body.capabilities.features.autostart, false);

--- a/tests/operator-mcp.test.js
+++ b/tests/operator-mcp.test.js
@@ -1,0 +1,219 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { getServiceRuntimeLogPaths } from "../dist/runtime/operator/logs.js";
+import {
+  assertNoSecretMaterial,
+  serviceLassoSecretLeakSentinels,
+} from "../dist/testing/secretLeakHarness.js";
+import { makeTempServicesRoot, writeManifest } from "./test-helpers.js";
+
+async function rpc(apiServer, request) {
+  const response = await fetch(apiServer.url + "/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function writeSecretLog(serviceRoot) {
+  const logPaths = getServiceRuntimeLogPaths(serviceRoot);
+  await mkdir(path.dirname(logPaths.logPath), { recursive: true });
+  await writeFile(
+    logPaths.logPath,
+    JSON.stringify({
+      level: "stdout",
+      message:
+        "token=" +
+        serviceLassoSecretLeakSentinels[0].value +
+        " Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456",
+    }) + "\n",
+  );
+}
+
+test("MCP endpoint advertises read-only operator tools and resources", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-mcp-");
+  let apiServer;
+
+  try {
+    await writeManifest(servicesRoot, "mcp-service", {
+      id: "mcp-service",
+      name: "MCP Service",
+      description: "MCP fixture.",
+      ports: {
+        web: 43101,
+      },
+      urls: [
+        {
+          label: "ui",
+          url: "http://operator:secret@127.0.0.1:${WEB_PORT}/admin?token=keep-out#frag",
+        },
+      ],
+      healthcheck: {
+        type: "process",
+      },
+    });
+
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, version: "test-version" });
+
+    const capabilitiesResponse = await fetch(apiServer.url + "/api/mcp");
+    const capabilities = await capabilitiesResponse.json();
+    const tools = await rpc(apiServer, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    const resources = await rpc(apiServer, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/list",
+    });
+
+    assert.equal(capabilitiesResponse.status, 200);
+    assert.equal(capabilities.contractVersion, "service-lasso-mcp.v1");
+    assert.equal(capabilities.scope.mutatingOperations, "omitted");
+    assert.equal(capabilities.runtime.serviceCount, 1);
+    assert.equal(tools.status, 200);
+    assert.deepEqual(
+      tools.body.result.tools.map((tool) => tool.name),
+      [
+        "service_lasso_list_services",
+        "service_lasso_get_health",
+        "service_lasso_list_routes",
+        "service_lasso_dependency_status",
+        "service_lasso_logs_summary",
+        "service_lasso_diagnostics_summary",
+      ],
+    );
+    assert.equal(
+      tools.body.result.tools.some((tool) => /start|stop|restart|install|config|execute/i.test(tool.name)),
+      false,
+    );
+    assert.deepEqual(
+      resources.body.result.resources.map((resource) => resource.uri),
+      [
+        "servicelasso://services",
+        "servicelasso://health",
+        "servicelasso://routes",
+        "servicelasso://dependencies",
+        "servicelasso://diagnostics",
+      ],
+    );
+  } finally {
+    await apiServer?.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("MCP tool calls return redacted log summaries and sanitized routes", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-mcp-redaction-");
+  let apiServer;
+
+  try {
+    const serviceRoot = await writeManifest(servicesRoot, "mcp-secret-service", {
+      id: "mcp-secret-service",
+      name: "MCP Secret Service",
+      description: "MCP fixture with secret-shaped data.",
+      env: {
+        SERVICE_TOKEN: serviceLassoSecretLeakSentinels[0].value,
+      },
+      globalenv: {
+        SHARED_PASSWORD: serviceLassoSecretLeakSentinels[1].value,
+      },
+      ports: {
+        web: 43102,
+      },
+      urls: [
+        {
+          label: "admin",
+          url: "https://user:password@example.invalid:${WEB_PORT}/admin?access_token=keep-out#frag",
+        },
+      ],
+      broker: {
+        imports: [
+          {
+            ref: "identity.CLIENT_SECRET",
+            namespace: "identity",
+            required: true,
+          },
+        ],
+        accessPolicy: {
+          grants: [
+            {
+              namespace: "identity",
+              operations: ["resolve"],
+              refs: ["identity.CLIENT_SECRET"],
+              purpose: "MCP metadata redaction fixture.",
+            },
+          ],
+        },
+      },
+      healthcheck: {
+        type: "process",
+      },
+    });
+    await writeSecretLog(serviceRoot);
+
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, version: "test-version" });
+
+    const routes = await rpc(apiServer, {
+      jsonrpc: "2.0",
+      id: "routes",
+      method: "tools/call",
+      params: {
+        name: "service_lasso_list_routes",
+        arguments: {
+          serviceId: "mcp-secret-service",
+        },
+      },
+    });
+    const logs = await rpc(apiServer, {
+      jsonrpc: "2.0",
+      id: "logs",
+      method: "tools/call",
+      params: {
+        name: "service_lasso_logs_summary",
+        arguments: {
+          serviceId: "mcp-secret-service",
+          limit: 5,
+        },
+      },
+    });
+    const diagnostics = await rpc(apiServer, {
+      jsonrpc: "2.0",
+      id: "diagnostics",
+      method: "resources/read",
+      params: {
+        uri: "servicelasso://diagnostics",
+      },
+    });
+
+    assert.equal(routes.status, 200);
+    assert.equal(logs.status, 200);
+    assert.equal(diagnostics.status, 200);
+
+    const routePayload = JSON.parse(routes.body.result.content[0].text);
+    const logPayload = JSON.parse(logs.body.result.content[0].text);
+    const diagnosticsPayload = JSON.parse(diagnostics.body.result.contents[0].text);
+    const serialized = JSON.stringify({ routePayload, logPayload, diagnosticsPayload });
+
+    assert.equal(routePayload.services[0].endpoints[0].url, "https://example.invalid:43102/admin");
+    assert.equal(logPayload.log.entries[0].message.includes("[REDACTED]"), true);
+    assert.equal(diagnosticsPayload.secretReferences.references, 1);
+    assertNoSecretMaterial(routePayload);
+    assertNoSecretMaterial(logPayload);
+    assertNoSecretMaterial(diagnosticsPayload);
+    assert.doesNotMatch(serialized, /keep-out|user:password|SERVICE_LASSO_FAKE_SECRET_SENTINEL|abcdefghijklmnopqrstuvwxyz123456/);
+  } finally {
+    await apiServer?.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #592.

## Summary
- Adds a read-only Service Lasso operator MCP JSON-RPC endpoint at `POST /api/mcp` plus discovery metadata at `GET /api/mcp`.
- Exposes service inventory, health, routes, dependency status, bounded log summaries, and diagnostics summaries as MCP tools/resources.
- Omits mutating lifecycle/orchestration/confirmation operations and documents the MCP safety boundary.
- Advertises the read-only MCP endpoint in runtime capabilities.

## Safety / redaction
- MCP route URLs strip username, password, query string, and fragment.
- MCP log summaries omit file paths and redact secret-like line text with the diagnostics redactor.
- MCP service inventory omits raw manifest env/globalenv values and broker payloads.

## Validation
- PASS: `npm run build`
- PASS: `node --test --test-concurrency=1 tests/operator-mcp.test.js`
- PASS: `node --test --test-concurrency=1 tests/operator-mcp.test.js tests/api-spine.test.js tests/operator-data.test.js tests/diagnostics-bundle.test.js tests/secret-leak-harness.test.js`
- PASS: `npm run docs:build`
- BASELINE FAIL: `npm test` fails on 3 pre-existing `origin/develop` lifecycle/plan assertions unrelated to this branch. Reproduced on clean `origin/develop@1e8bb17`: `tests/cli-dry-run-plan.test.js`, `tests/lifecycle-actions.test.js`, `tests/service-start-trace.test.js`.