### PR TITLE
chore(serviceadmin): pin release 2026.6.18-e01fc36

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.6-6715d14"
+      "tag": "2026.6.18-e01fc36"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#157

## Summary
- Updates the core `@serviceadmin` service manifest to the Service Admin release created from lasso-serviceadmin PR #176.
- Pins `service-lasso/lasso-serviceadmin` artifact tag `2026.6.18-e01fc36` for canonical demo recycle.

## Scope
- In scope: release tag pin only.
- Out of scope: Service Admin UI code changes, runtime behavior changes, provider/service manifest shape changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact source tag.
- Not required because the manifest schema and service contract are unchanged.

## Nash invariant impact
- Invariant: canonical demo service manifest must match the released Service Admin artifact used for operator validation.
- Preservation proof: release assets exist for tag `2026.6.18-e01fc36`, including `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`.

## Validation
- PASS `git diff --check`.
- PASS `gh release view 2026.6.18-e01fc36 --repo service-lasso/lasso-serviceadmin --json tagName,targetCommitish,assets,url` — assets present.
- Pending after merge: recycle canonical demo and verify LAN Service Admin/runtime health.

## Approval trail
- Required: normal core PR/CI rules.
- Evidence: this PR and lasso-serviceadmin PR #176.

## Cleanup
- After merge: pull `develop`, recycle canonical demo, verify installed `@serviceadmin` tag is `2026.6.18-e01fc36`, verify LAN URLs, then update/close serviceadmin #157.
