### PR TITLE
fix(docs): align quick start API port

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,6 +17,8 @@ If you use the bundled GitHub release artifact instead of cloning source, the ba
 
 ## 1. Clone the Repo
 
+The plain clone path is the supported Quick Start path:
+
 ```powershell
 git clone https://github.com/service-lasso/service-lasso.git
 cd service-lasso
@@ -32,10 +34,12 @@ npm run build
 ## 3. Start Service Lasso
 
 ```powershell
-node dist/cli.js start --services-root ./services --workspace-root ./workspace --port 18080 --json
+node dist/cli.js start --services-root ./services --workspace-root ./workspace --port 18090 --json
 ```
 
 This starts the Service Lasso API and runs the baseline service set from `services/`.
+
+The API uses port `18090` so it does not collide with the checked-in `@nginx` baseline service on port `18080`.
 
 Keep this terminal open while you test. Stop it later with `Ctrl+C`.
 
@@ -43,10 +47,11 @@ Keep this terminal open while you test. Stop it later with `Ctrl+C`.
 
 | URL | Purpose |
 | --- | --- |
-| `http://127.0.0.1:18080/api/health` | Service Lasso API health |
-| `http://127.0.0.1:18080/api/services` | discovered services and lifecycle state |
+| `http://127.0.0.1:18090/api/health` | Service Lasso API health |
+| `http://127.0.0.1:18090/api/services` | discovered services and lifecycle state |
 | `http://127.0.0.1:17700/` | Service Admin UI |
 | `http://127.0.0.1:4010/` | Echo Service UI/API |
+| `http://127.0.0.1:18080/` | NGINX baseline web page |
 | `http://127.0.0.1:19081/dashboard/` | Traefik dashboard |
 
 ## 5. Stop Services
@@ -54,7 +59,7 @@ Keep this terminal open while you test. Stop it later with `Ctrl+C`.
 Before closing the runtime, stop managed services:
 
 ```powershell
-Invoke-RestMethod -Method Post http://127.0.0.1:18080/api/runtime/actions/stopAll
+Invoke-RestMethod -Method Post http://127.0.0.1:18090/api/runtime/actions/stopAll
 ```
 
 Then press `Ctrl+C` in the terminal running Service Lasso.


### PR DESCRIPTION
## Issue
Closes #608

## Summary
- Align `docs/quick-start.md` with the validated startup command by using API port `18090`.
- Make the plain clone path explicit as the supported Quick Start path.
- Document why `18090` is used: the baseline `@nginx` service owns `18080`.

## Scope
- In scope: Quick Start source documentation and default-clone branch evidence.
- Out of scope: runtime behavior changes, service manifest changes, release artifact changes.

## Spec / contract / fixture impact
- Updated: `docs/quick-start.md` operator-facing Quick Start instructions.
- Not required: runtime API/schema/manifest fixtures are unchanged.

## Service Lasso invariant impact
- Invariant: core baseline services remain started from checked-in `services/` manifests without moving the Service Lasso API onto a service-owned port.
- Preservation proof: docs only; canonical demo verifier remains green.

## Validation
- PASS `npm run docs:build` — log: `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\docs-build.log`
- PASS `gh repo view service-lasso/service-lasso --json defaultBranchRef --jq .defaultBranchRef.name` — returned `develop` after default-branch update.
- PASS `git ls-remote --symref https://github.com/service-lasso/service-lasso.git HEAD` — returned `ref: refs/heads/develop HEAD` at `251eaaea04a0e1f1e08372ad90dcdd02efc9b2b9` before this docs PR merge.
- PASS `node scripts/demo-verify-canonical.mjs` — log: `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\canonical-demo.log`

## Approval trail
- Required: no special approval identified for docs-only change.
- Evidence: no open org PRs at worker gate; latest sampled target branch checks were green before selection.

## Cleanup
- After merge: update local `develop`, delete `fix/608-default-clone-quick-start`, verify clean status.
