### PR TITLE
chore: pin serviceadmin logs fix release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.8-f7a35b1`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.6-6715d14` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.18-ee09119` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.18-e01fc36"
+      "tag": "2026.6.18-ee09119"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.6-6715d14");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.18-ee09119");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#178 and service-lasso/lasso-serviceadmin#181.

## Summary
- Pins the core `@serviceadmin` manifest to the verified Service Admin release `2026.6.18-ee09119` that contains the Logs page service-selector fix.
- Updates README baseline service catalog text and manifest-discovery expectation to match the new pin.

## Scope
- In scope: core baseline release pin only.
- Out of scope: runtime behavior changes, Service Admin UI source changes, unrelated service pins.

## Spec / contract / fixture impact
- Updated checked-in baseline manifest metadata for `@serviceadmin`.
- No public API or schema shape changes.

## Validation
- PASS `npm run build`.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — 23 tests passed.
- PASS `node scripts/verify-service-catalog.mjs`.
- PASS `git diff --check`.

## Demo / release evidence
- Service Admin release exists: `2026.6.18-ee09119` from lasso-serviceadmin merge commit `ee09119f2b7fa5ee8bcb9436863daeb9530349f2`.
- After merge, canonical demo recycle/verify will use this checked-in manifest pin.

## Approval trail
- Required: no explicit human approval found; this is the narrow manifest pin needed to deploy the already-merged P0 Service Admin bug fix to the canonical demo.

## Cleanup
- Branch: `issue-178-serviceadmin-release-pin`
- Post-merge: update local `develop`, run `npm run demo:recycle -- --port=17883`, then `npm run demo:verify-canonical`.