### PR TITLE
chore(serviceadmin): pin operations release artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.8-f7a35b1`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.18-ee09119` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.18-6774e44` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.18-ee09119"
+      "tag": "2026.6.18-6774e44"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Related to service-lasso/lasso-serviceadmin#159
Follows merged Service Admin PR service-lasso/lasso-serviceadmin#196

## Summary
- Pins the core `@serviceadmin` baseline manifest to the merged Service Admin release `2026.6.18-6774e44`.
- Updates the README baseline release table to match the manifest.
- Removes the temporary local issue artifact pin from the canonical baseline.

## Scope
- In scope: core baseline Service Admin release pin and README release evidence.
- Out of scope: runtime behavior changes, manifest schema changes, Service Admin UI implementation.

## Spec / contract / fixture impact
- Updated: baseline service manifest release tag and README catalog entry.
- Not required because: no schema/API/lifecycle semantics changed.

## Nash invariant impact
- Invariant: `@serviceadmin` remains optional and release-backed from `service-lasso/lasso-serviceadmin`.
- Preservation proof: release `2026.6.18-6774e44` exists with win32/linux/darwin assets plus `service.json` and SHA256SUMS.

## Validation
- PASS `npm run verify:service-catalog` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/service-lasso-verify-service-catalog.log`
- PASS Service Admin release workflow for `6774e44c527562572064b1af5ff534b2bb93bc12` - https://github.com/service-lasso/lasso-serviceadmin/actions/runs/27761643766
- PASS release assets published - https://github.com/service-lasso/lasso-serviceadmin/releases/tag/2026.6.18-6774e44

## Approval trail
- Required: no explicit reviewer requirement observed before PR creation.
- Evidence: hosted checks will run on this PR before merge.

## Cleanup
- Branch tracks `origin/issue-159-serviceadmin-release-pin`; cleanup after merge will return local repo to clean `develop` and delete the issue branch when safe.