### PR TITLE
chore: pin Service Admin demo release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-3e0f0ae` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-7c836db` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-3e0f0ae"
+      "tag": "2026.6.19-7c836db"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#205 and release-to-demo gate for service-lasso/lasso-serviceadmin#212.

## Summary
- Pin the core `@serviceadmin` manifest to the new Service Admin release `2026.6.19-7c836db`.
- Keep the README baseline service table aligned with the manifest pin.

## Scope
- In scope: core demo/baseline release pin for `@serviceadmin`.
- Out of scope: unrelated baseline service releases or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and README traceability row.
- Not changing service schema or runtime API contract.

## Nash invariant impact
- Invariant: checked-in baseline manifests and README release documentation agree.
- Preservation proof: `npm run verify:service-catalog` passed.

## Validation
- PASS `npm run build`.
- PASS `npm run verify:service-catalog`.
- Service Admin release proof: `service-lasso/lasso-serviceadmin` release `2026.6.19-7c836db`, target commit `7c836db6afdf2368029679bc1567ad8e948e2352`, assets uploaded by Release run https://github.com/service-lasso/lasso-serviceadmin/actions/runs/27823490724.

## Approval trail
- Required: no explicit review gate detected for this release-pin PR.
- Evidence: release-to-demo gate requires the canonical demo to consume the changed service repo release.

## Cleanup
- After merge, recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.
