### PR TITLE
chore: pin Service Admin release 5965479

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-7c836db` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-5965479` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-7c836db"
+      "tag": "2026.6.19-5965479"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-3e0f0ae");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-5965479");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Related to service-lasso/lasso-serviceadmin#204 and completes the post-merge release-to-demo pin step for service-lasso/lasso-serviceadmin#213.

## Summary
- Pin the core `@serviceadmin` service manifest to the released Service Admin tag `2026.6.19-5965479`.
- Update README baseline documentation to match the new demo-consumed release.
- Update manifest discovery coverage so the checked-in baseline asserts the same release tag.

## Scope
- In scope: core demo/service manifest pin and matching documentation/test expectation.
- Out of scope: additional Service Admin UI changes, runtime API behavior, unrelated service pins.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and baseline README/test expectation.
- Not required beyond this because this is a release artifact pin for an already-merged UI change, not a new runtime/API contract.

## Service Lasso invariant impact
- Invariant: canonical demo consumes pinned release-backed service artifacts from checked-in manifests.
- Preservation proof: the manifest pin references the newly published GitHub release, and `tests/manifest-discovery.test.js` now asserts the same tag.

## Validation
- PASS `npm run build` — log `C:\projects\service-lasso\.work-agent\logs\204\core-build-pin.log`.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — 23 tests passed; log `C:\projects\service-lasso\.work-agent\logs\204\manifest-discovery-pin.log`.
- PASS release existence check — `lasso-serviceadmin` release `2026.6.19-5965479` targets commit `59654796c5eeec117a6a3b0329ede8c974e392d4` and includes `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`.

## Release / demo gate
- Expected `@serviceadmin` tag after this PR merges and demo recycles: `2026.6.19-5965479`.
- Canonical demo recycle and `npm run demo:verify-canonical` remain required after merge.

## Approval trail
- Required: normal core repo PR checks/review if branch rules require them.
- Evidence: this PR, service-lasso/lasso-serviceadmin#204 issue trail, and saved logs above.

## Cleanup
- Branch: `chore/204-pin-serviceadmin-5965479`.
- After merge: pull `develop`, recycle canonical demo on port `17883`, verify installed/live `@serviceadmin` tag equals `2026.6.19-5965479`, then clean local branch when safe.