### PR TITLE
chore(demo): pin Service Admin 840bd2c release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-5965479` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-840bd2c` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-5965479"
+      "tag": "2026.6.19-840bd2c"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-5965479");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-840bd2c");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#207 after lasso-serviceadmin#214 merged and released.

## Summary
- Pins the canonical `@serviceadmin` baseline manifest to lasso-serviceadmin release `2026.6.19-840bd2c`.
- Updates the README baseline release table and manifest discovery assertion to match the new release.

## Scope
- In scope: core demo/service manifest pin for the released Service Admin UI artifact.
- Out of scope: runtime behavior changes beyond consuming the new Service Admin release.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and matching docs/test assertion.
- Not required because: no public API/schema contract changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release produced from the merged fix.
- Preservation proof: expected Service Admin tag is `2026.6.19-840bd2c`, targeting commit `840bd2cf5bb950410f7614ce25e59b8a229d2ac9`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/core-npm-build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/core-manifest-discovery-test.log`

## Approval trail
- Required: no known mandatory human approval rule discovered before PR creation.
- Evidence: branch created from clean `origin/develop`.

## Cleanup
- Branch: `chore/pin-serviceadmin-840bd2c`
- After merge: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical` to prove installed/live tag equals `2026.6.19-840bd2c`.
