### PR TITLE
chore: pin Service Admin release ecd70d1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-840bd2c` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-ecd70d1` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-840bd2c"
+      "tag": "2026.6.19-ecd70d1"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-840bd2c");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-ecd70d1");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Part of service-lasso/lasso-serviceadmin#171 release-to-demo gate.

## Summary
- Pins the core `@serviceadmin` baseline manifest from `2026.6.19-840bd2c` to `2026.6.19-ecd70d1`.
- Updates README baseline source tag and the manifest discovery assertion to match.

## Scope
- In scope: core demo/service manifest pin for the Service Admin release produced by lasso-serviceadmin PR #215.
- Out of scope: runtime behavior changes, service contract shape changes, unrelated baseline service pins.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release source tag and matching README/test fixture assertion.
- No schema/API change.

## Validation
- PASS `npm run build`; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\core-pin-serviceadmin-build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js`; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\core-pin-serviceadmin-manifest-test.log`
- LOCAL BLOCKED `npm test`; most tests passed, but 11 failed due live canonical demo executables locking checked-in extracted artifacts (`EPERM unlink ... services/*/.state/extracted/current/*.exe`). Log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\core-pin-serviceadmin-full-test.log`

## Release / demo gate
- Expected Service Admin release tag: `2026.6.19-ecd70d1`
- Source release commit: `ecd70d1cb8324408eb67fec00f2a79b843ecd4a7`
- Canonical demo recycle/verification will be run after this pin PR merges.

## Cleanup
- Branch: `chore/171-pin-serviceadmin-ecd70d1`
- Post-merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.
