### PR TITLE
fix(demo): pin Service Admin reload fix release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-ecd70d1` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-f2b616e` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-ecd70d1"
+      "tag": "2026.6.19-f2b616e"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-ecd70d1");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-f2b616e");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#209

## Summary
- Pin the core `@serviceadmin` baseline manifest to Service Admin release `2026.6.19-f2b616e`, which contains the merged runtime reload feedback fix from lasso-serviceadmin#216.
- Keep the README baseline table and manifest discovery test expectation aligned with the new release.

## Scope
- In scope: core demo/baseline Service Admin release pin and matching catalog/test references.
- Out of scope: runtime behavior changes, Service Admin source changes, unrelated baseline services.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and catalog/test references.
- No public API/schema change; this is release-to-demo pinning for an already merged Service Admin fix.

## Nash invariant impact
- Invariant: demo-consumed service manifests must pin exact release artifacts.
- Preservation proof: the core manifest now points to exact published Service Admin release `2026.6.19-f2b616e`, and the service catalog verifier passed.

## Validation
- PASS `npm run verify:service-catalog` — log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0231\core-verify-service-catalog-2.log`.
- PASS `npm run build && node --test --test-concurrency=1 tests/manifest-discovery.test.js` — 23 tests passed; logs `core-build-for-focused-test.log` and `core-manifest-discovery-focused.log` in the same run directory.
- PENDING release-to-demo gate: after merge, recycle canonical demo on port `17883` and run `npm run demo:verify-canonical` to prove live `@serviceadmin` installed tag matches `2026.6.19-f2b616e`.

## Approval trail
- Required: normal PR checks/review per repo rules.
- Evidence: Service Admin PR #216 merged to `master` at `f2b616e5d0f373294b99057b45930cbb96532bb2`; Service Admin release workflow run `27837612077` succeeded and published `2026.6.19-f2b616e`.

## Cleanup
- Branch cleanup after merge: checkout `develop`, fast-forward pull, delete `fix/serviceadmin-209-demo-pin` when safe.