### PR TITLE
fix: pin Service Admin demo release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-f2b616e"
+      "tag": "2026.6.19-e3a7578"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-f2b616e");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-e3a7578");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#210 release-to-demo gate after service-lasso/lasso-serviceadmin#217.

## Summary
- Pin the core `@serviceadmin` manifest to the newly released Service Admin artifact `2026.6.19-e3a7578`.
- Update the manifest discovery regression expectation for the pinned tag.

## Scope
- In scope: core demo/service manifest pin for `@serviceadmin`.
- Out of scope: runtime behavior changes, Service Admin UI code, other service pins.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and matching `tests/manifest-discovery.test.js` fixture assertion.

## Nash invariant impact
- Invariant: the canonical demo consumes exact released service artifacts.
- Preservation proof: `@serviceadmin` now points at the release produced from lasso-serviceadmin merge commit `e3a75787e93c7ef27082cc3ce0a86e98734e7bdb`.

## Validation
- PASS `npm run build`
- PASS `node --test tests/manifest-discovery.test.js` — 23 tests passed; log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-032515\issue-210-core-manifest-test.log`

## Demo / release gate
- Expected Service Admin release: `2026.6.19-e3a7578`.
- Previous live canonical artifact before this pin/recycle: `2026.6.19-f2b616e`.
- After this PR merges, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live `services/@serviceadmin/.state/install.json` reports `2026.6.19-e3a7578`.

## Approval trail
- Required: repo checks/mergeability.
- Evidence: to be inspected after PR creation.

## Cleanup
- Branch: `fix/210-serviceadmin-demo-pin`
- Commit: `979b0eb`