### PR TITLE
chore: pin serviceadmin demo release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-e3a7578"
+      "tag": "2026.6.19-c4bb625"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#206 and service-lasso/lasso-serviceadmin#218 release-to-demo gate.

## Summary
- Pins the canonical core `@serviceadmin` service manifest to the Service Admin release generated from merged commit `c4bb625`.

## Scope
- In scope: update `services/@serviceadmin/service.json` GitHub release tag from `2026.6.19-e3a7578` to `2026.6.19-c4bb625`.
- Out of scope: runtime behavior, service contracts, or unrelated demo services.

## Spec / contract / fixture impact
- Updated: demo service manifest pin only.
- Not required because: no public API/schema/lifecycle semantics changed.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-core-pin-npm-build.log`

## Demo / release gate
- Expected Service Admin release: `2026.6.19-c4bb625` / commit `c4bb6259a828208dd32b8331b458f4fe59b331e2`.
- Current PR updates the canonical demo manifest pin. After merge, recycle the canonical demo on port `17883` and run `npm run demo:verify-canonical`.

## Approval trail
- Required: no additional human approval detected; merge after checks are green and PR is mergeable.

## Cleanup
- Branch: `chore/206-serviceadmin-release-pin`