### PR TITLE
chore(serviceadmin): pin template value release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-f2b616e` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-ba5d03f` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-c4bb625"
+      "tag": "2026.6.19-ba5d03f"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-e3a7578");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-ba5d03f");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Follows service-lasso/lasso-serviceadmin#202 and service-lasso/lasso-serviceadmin#220.

## Summary
- Pins the core @serviceadmin manifest to the released Service Admin template-value column build 2026.6.19-ba5d03f.
- Aligns the clean-clone manifest discovery assertion and README baseline table with the new release.

## Scope
- In scope: core demo/baseline Service Admin release pin and documentation/test references.
- Out of scope: new runtime API support for 	emplateValue; lasso-serviceadmin renders Not recorded until core emits the field.

## Spec / contract / fixture impact
- Updated: services/@serviceadmin/service.json release tag and manifest discovery fixture assertion.
- Public behavior: canonical demo installs the Service Admin build that includes the new template-value column UI.

## Nash invariant impact
- Invariant: demo-consumed service repos must be consumed by the canonical core manifest before done claims.
- Preservation proof: this PR pins the core baseline to the exact Service Admin release created from merge commit a5d03ff26c934d8339280bc753f019251211322.

## Validation
- PASS 
pm run build — .work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0646/core-build.log.
- PASS 
ode --test tests/manifest-discovery.test.js — .work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0646/core-manifest-discovery-test.log (23 tests passed).
- Release evidence: lasso-serviceadmin release 2026.6.19-ba5d03f targets a5d03ff26c934d8339280bc753f019251211322 and includes win32/linux/darwin artifacts, service.json, and SHA256SUMS.txt.

## Approval trail
- Required: normal core PR checks/review before merge unless repo rules allow self-merge after green checks.
- Evidence: branch chore/serviceadmin-202-pin-template-column-release, commit 6798a44976aeda4e7bf65791e966f4287ebc2dbb.

## Cleanup
- After merge, recycle canonical demo on port 17883, run 
pm run demo:verify-canonical, and confirm live @serviceadmin expected tag equals installed tag 2026.6.19-ba5d03f.