### PR TITLE
chore(demo): pin Service Admin release 2026.6.19-3da912d

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-ba5d03f` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-3da912d` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-ba5d03f"
+      "tag": "2026.6.19-3da912d"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#203 and service-lasso/lasso-serviceadmin#221.

## Summary
- Pins the core baseline `@serviceadmin` manifest to the Service Admin release produced from merged commit `3da912d`.
- Updates the README baseline service table to match the manifest pin.

## Scope
- In scope: `services/@serviceadmin/service.json`, README release tag text.
- Out of scope: runtime behavior changes.

## Spec / contract / fixture impact
- Updated service manifest pin only; no schema/contract shape change.
- Release-to-demo gate applies because `@serviceadmin` is demo-consumed.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release generated from merged Service Admin code before work is marked done.
- Preservation proof: Service Admin release `2026.6.19-3da912d` targets commit `3da912d11211bac43137e1e4c8855273dd23ec31` and includes expected assets (`@serviceadmin-win32.zip`, POSIX archives, `service.json`, `SHA256SUMS.txt`).

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-203-core-build.log`
- Release asset check: `gh release view 2026.6.19-3da912d --repo service-lasso/lasso-serviceadmin --json tagName,targetCommitish,assets,url`

## Approval trail
- Required: no explicit approval requested; this is the mandatory core pin follow-through for the merged Service Admin change.

## Cleanup
- Branch: `issue-203-pin-serviceadmin-3da912d`
- Commit: `d22482c`
- After merge: recycle canonical demo on runtime port `17883`, run `npm run demo:verify-canonical`, and record expected vs live Service Admin tag evidence.
