### PR TITLE
chore(demo): pin serviceadmin 2026.6.19-79889b4

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-3da912d"
+      "tag": "2026.6.19-79889b4"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#172 after PR service-lasso/lasso-serviceadmin#222.

## Summary
- Update the canonical demo `@serviceadmin` manifest pin to lasso-serviceadmin release `2026.6.19-79889b4`.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: other service pins and runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for the Service Admin release generated from merge commit `79889b4150b33f1db221444106471c7a77cb1b3b`.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-consumed Service Admin release before #172 is claimed done.
- Preservation proof: this PR moves the expected release tag from `2026.6.19-3da912d` to `2026.6.19-79889b4`.

## Validation
- PASS `node -e "JSON.parse(require('fs').readFileSync('services/@serviceadmin/service.json','utf8')); console.log('serviceadmin manifest json ok')"`.
- PASS lasso-serviceadmin PR #222 branch CI `install-lint-build`.
- PASS lasso-serviceadmin master workflows at merge commit `79889b4`: Continuous Integration, validate-template, Release. Release tag: `2026.6.19-79889b4`.

## Approval trail
- Required: no explicit human approval found in issue trail.
- Evidence: Service Admin #172 is a demo-consumed change; mandatory release-to-demo gate requires this core pin before demo recycle/verify.

## Cleanup
- After merge: recycle canonical demo on port 17883, run `npm run demo:verify-canonical`, verify LAN Service Admin/runtime, then delete branch.