### PR TITLE
chore(demo): pin Secrets Broker 2026.6.20-4dc7bb2

### DIFF
--- a/.work-agent/logs/issue-101/core-build-pin-20260620T1100.log
+++ b/.work-agent/logs/issue-101/core-build-pin-20260620T1100.log
@@ -1,0 +1,5 @@
+# npm run build
+
+> service-lasso@0.1.0 build
+> tsc -p tsconfig.json
+

--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -2,7 +2,7 @@
   "id": "@secretsbroker",
   "name": "Service Lasso Secrets Broker",
   "description": "Release-backed local-first secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
-  "version": "2026.6.19-4864cd3",
+  "version": "2026.6.20-4dc7bb2",
   "enabled": true,
   "ports": {
     "service": 17890
@@ -27,7 +27,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-secretsbroker",
-      "tag": "2026.6.19-4864cd3"
+      "tag": "2026.6.20-4dc7bb2"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-secretsbroker#101 after service repo PR service-lasso/lasso-secretsbroker#105 merged.

## Summary
- Pins the core canonical demo `@secretsbroker` service manifest to release `2026.6.20-4dc7bb2`.
- Keeps `version` and `artifact.source.tag` aligned so the demo consumes the exact Secrets Broker release generated from merge commit `4dc7bb24f75dc2b59fe59130c9f1f7f496e568fc`.

## Scope
- In scope: core demo/service manifest pin only.
- Out of scope: product runtime code changes.

## Spec / contract / fixture impact
- Updated: `services/@secretsbroker/service.json` release pin.
- Not required beyond the pin because the public Secrets Sync API/CLI contract lives in `lasso-secretsbroker` and was updated in PR #105.

## Validation
- PASS JSON pin check: `version` equals `artifact.source.tag` = `2026.6.20-4dc7bb2`.
- PASS `npm run build` — `.work-agent/logs/issue-101/core-build-pin-20260620T1100.log`

## Demo / release gate
- Pending after this PR merges: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.
- Expected `@secretsbroker` release tag after recycle: `2026.6.20-4dc7bb2`.

## Cleanup
- Branch: `chore/101-pin-secretsbroker-2026-6-20`
- Commit: `07b740c`
