### PR TITLE
chore(demo): pin Service Admin 2026.6.20 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.19-3da912d` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-6ce909a` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.19-79889b4"
+      "tag": "2026.6.20-6ce909a"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#186 release-to-demo gate.

## Summary
- Pins core demo `@serviceadmin` manifest to lasso-serviceadmin release `2026.6.20-6ce909a`.
- Updates README baseline service release table to the same Service Admin release.

## Scope
- In scope: demo/service manifest pin and matching documentation.
- Out of scope: runtime behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact source tag.
- Not required beyond pin update because public service schema/API behavior is unchanged.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact for lasso-serviceadmin#186 before done.
- Preservation proof: manifest expected tag is `2026.6.20-6ce909a`, matching the published release target commit `6ce909acca1832187bee70cdf6854a06ed5c0c38`.

## Validation
- PASS `npm run build` — TypeScript build completed. Log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-111925\core-build-pin.log`
- Service Admin release published: `2026.6.20-6ce909a`; target commit `6ce909acca1832187bee70cdf6854a06ed5c0c38`. Log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-111925\serviceadmin-release.json`
- Canonical demo recycle and `npm run demo:verify-canonical` are pending this pin merge.

## Approval trail
- Required: no explicit approval requirement found for demo pin PR.
- Evidence: required by release-to-demo gate after service-lasso/lasso-serviceadmin#223 merged.

## Cleanup
- Branch: `issue-186-serviceadmin-demo-pin`
- Commit: `38e7cb3`