### PR TITLE
chore(demo): pin Service Admin 2026.6.20-57b5b8d

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.19-4864cd3`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-6ce909a` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-57b5b8d` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-6ce909a"
+      "tag": "2026.6.20-57b5b8d"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#188 release-to-demo gate.

## Summary
- Pins the canonical core demo `@serviceadmin` manifest from `2026.6.20-6ce909a` to `2026.6.20-57b5b8d`.
- Updates the README baseline service table to match the new Service Admin release.

## Scope
- In scope: core demo/service manifest pin and matching documentation line.
- Out of scope: runtime behavior changes outside the release pin.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because: no service manifest schema or API contract changed.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by lasso-serviceadmin#224 before #188 is reported complete.
- Preservation proof: Service Admin release `2026.6.20-57b5b8d` exists and targets commit `57b5b8d29b84acd6ba6809967b24eb95c05a823b` with all expected assets.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-188/core-build-pin-20260620-1259.log`
- PASS Service Admin post-merge CI/release/validate workflows for commit `57b5b8d`.

## Approval trail
- Required: no explicit approval requirement found for this manifest pin PR.
- Evidence: mandatory release-to-demo gate in worker prompt requires core pin update after Service Admin release.

## Cleanup
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; expected Service Admin release tag is `2026.6.20-57b5b8d`.