### PR TITLE
chore(demo): pin Service Admin ce92a44 release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-4552234"
+      "tag": "2026.6.20-ce92a44"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#190 after Service Admin PR #226 merged.

## Summary
- Pins canonical demo `@serviceadmin` to release `2026.6.20-ce92a44` from Service Admin merge commit `ce92a446898637acb28a3f4b1a519bac6355fd70`.

## Scope
- In scope: canonical demo service manifest pin only.
- Out of scope: core runtime behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because: no schema, runtime API, or lifecycle contract changed.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release that contains the validated UI change.
- Preservation proof: after merge, run `npm run build`, recycle canonical demo on port 17883, and run `npm run demo:verify-canonical`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-190/core-build-pin-20260620-1439.log`
- Pending after merge: canonical recycle and `npm run demo:verify-canonical`.

## Approval trail
- Required: no explicit review requirement known for demo pin PR.
- Evidence: Service Admin release workflow succeeded for `2026.6.20-ce92a44`.

## Cleanup
- Branch: `pin/serviceadmin-2026-6-20-ce92a44`
- Post-merge: delete branch and return local repo to clean `develop` after canonical verification.