### PR TITLE
chore: pin Service Admin issue 191 release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-ce92a44"
+      "tag": "2026.6.20-4413e19"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Part of service-lasso/lasso-serviceadmin#191 release-to-demo gate.

## Summary
- Pins the core `@serviceadmin` baseline manifest to the released Service Admin artifact `2026.6.20-4413e19`.
- Keeps the canonical demo from consuming the previous Service Admin release `2026.6.20-ce92a44` after the #191 UI change merged.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: runtime behavior, service contract changes, or unrelated baseline service pins.

## Spec / contract / fixture impact
- Updated: core demo/service manifest pin for `@serviceadmin`.
- Not required because: no schema or public runtime contract changed; this is a release pin update.

## Nash invariant impact
- Invariant: demo-consumed service repo changes must be installed/running in the canonical demo at the exact released tag before done is claimed.
- Preservation proof: this PR points the core manifest at the #191 Service Admin release tag; canonical recycle/verify will be run after merge.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-191-core-pin/build-20260620-1546.log`
- PASS release asset existence check by `gh release view 2026.6.20-4413e19 --repo service-lasso/lasso-serviceadmin --json tagName,targetCommitish,assets,url` — assets include `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`; target commit `4413e19cb04a576c2547b970eb47cecff90bdbb8`.

## Approval trail
- Required: no explicit approval requirement found for this release pin PR.
- Evidence: required by the mandatory release-to-demo gate after lasso-serviceadmin PR #227 merged.

## Cleanup
- Branch: `chore/issue-191-serviceadmin-demo-pin`
- Cleanup plan: merge after checks are green and repo rules allow; then recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.