### PR TITLE
chore(demo): pin Service Admin ca78f71 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-4dc7bb2`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-4552234` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-ca78f71` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-4413e19"
+      "tag": "2026.6.20-ca78f71"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.19-4864cd3");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.20-4dc7bb2");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.19-ba5d03f");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-ca78f71");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Follows service-lasso/lasso-serviceadmin#192 and service-lasso/lasso-serviceadmin#228.

## Summary
- Pins core `@serviceadmin` demo manifest to the newly released Service Admin artifact `2026.6.20-ca78f71`.
- Updates README baseline inventory wording for the Service Admin pin.
- Aligns manifest-discovery baseline assertions with the current checked-in release pins for Service Admin and Secrets Broker.

## Scope
- In scope: core demo/service manifest pin and baseline expectation/docs alignment.
- Out of scope: Service Admin UI implementation; merged in service-lasso/lasso-serviceadmin#228.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Updated: clean-clone baseline inventory test fixture expectations.
- Not a schema/API contract change.

## Service Lasso invariant impact
- Invariant: canonical demo consumes exact released service artifacts by pinned GitHub release tag.
- Preservation proof: new tag `2026.6.20-ca78f71` exists and targets lasso-serviceadmin merge commit `ca78f7162fbe220c0cef3cca2033ff2c9eddb153`; release assets include `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`.

## Validation
- PASS `npm run build` — `.work-agent/logs/192/core-build-pin-2.log`
- PASS `node --test tests/manifest-discovery.test.js` — 23 tests passed; `.work-agent/logs/192/core-manifest-discovery-test.log`
- BLOCKED local full `npm test` — `.work-agent/logs/192/core-test-pin.log`; failures are from the live canonical demo holding extracted binaries (`EPERM` unlink on `echo-service.exe`, `traefik.exe`, `nginx.exe`) plus stale baseline assertions fixed by this PR.

## Approval trail
- Required: normal repository PR review/check policy.
- Evidence: branch pushed from clean `develop`; source Service Admin PR merged and release workflow succeeded.

## Cleanup
- Branch: `issue-192-pin-serviceadmin-ca78f71`
- Commit: `45eb3a7`
- Post-merge: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`; expected installed/live `@serviceadmin` tag is `2026.6.20-ca78f71`.