### PR TITLE
chore(demo): pin serviceadmin 2026.6.20-6be45c6

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-ca78f71"
+      "tag": "2026.6.20-6be45c6"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#173 and service-lasso/lasso-serviceadmin#229 release-to-demo gate.

## Summary
- Pin canonical demo `@serviceadmin` from `2026.6.20-ca78f71` to `2026.6.20-6be45c6`.

## Scope
- In scope: core service manifest pin only.
- Out of scope: Service Admin implementation changes, already merged in service-lasso/lasso-serviceadmin#229.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because this is a demo/service manifest pin refresh to an existing release artifact.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact before issue #173 can be called done.
- Preservation proof: expected release tag is `2026.6.20-6be45c6`, matching the lasso-serviceadmin release tag that points at merge commit `6be45c6f6c74bc87d66c19a6e90d863d3e6d1261`.

## Validation
- PASS `npm run build` in core — log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\core-build-before-serviceadmin-pin-pr.log`

## Approval trail
- Required: no explicit human approval requirement found before opening this pin PR.
- Evidence: lasso-serviceadmin#229 merged with green checks and release `2026.6.20-6be45c6` published.

## Cleanup
- Branch: `sl-173-serviceadmin-pin-6be45c6`
- Commit: `0b15cdf`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify LAN Service Admin/runtime health. Expected installed `@serviceadmin` tag: `2026.6.20-6be45c6`.