### PR TITLE
chore(demo): pin Service Admin 2026.6.20-417a58a

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-6be45c6` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-417a58a` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-6be45c6"
+      "tag": "2026.6.20-417a58a"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-6be45c6");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-417a58a");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#230 and Service Admin PR service-lasso/lasso-serviceadmin#233.

## Summary
- Pin core `@serviceadmin` manifest from `2026.6.20-6be45c6` to `2026.6.20-417a58a`.
- Update README baseline release table and manifest discovery test expectation.

## Scope
- In scope: core demo/service manifest pin for the newly released Service Admin artifact.
- Out of scope: runtime contract changes, service lifecycle code changes, and unrelated service pins.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and matching manifest discovery expectation.
- Not required otherwise because the service contract shape is unchanged.

## Nash invariant impact
- Invariant: demo-consumed service pins must match the intended release exactly.
- Preservation proof: focused manifest test passes with expected tag `2026.6.20-417a58a`.

## Validation
- PASS `npm run build`
- PASS `node --test tests/manifest-discovery.test.js`
- Evidence log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-232514\core-build-and-manifest-test.log`
- Service Admin release evidence: `2026.6.20-417a58a`, target commit `417a58a5f65750874cb602eed39ecdc7e6bf7b49`, Release workflow run `https://github.com/service-lasso/lasso-serviceadmin/actions/runs/27872923062` successful.

## Approval trail
- Required: no explicit review gate identified before merging this demo pin PR if checks are green and mergeable.
- Evidence: mandatory release-to-demo gate requires core pin before canonical recycle.

## Cleanup
- Branch: `agent/issue-230-pin-serviceadmin-417a58a`
- Commit: `ced9459`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and confirm live `@serviceadmin` release tag matches `2026.6.20-417a58a`.