### PR TITLE
chore(demo): pin Service Admin efb6bb5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-417a58a` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-efb6bb5` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-417a58a"
+      "tag": "2026.6.20-efb6bb5"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Part of service-lasso/lasso-serviceadmin#232 release-to-demo gate after Service Admin PR #234.

## Summary
- Pins the core `@serviceadmin` release-backed manifest to `2026.6.20-efb6bb5`.
- Updates the README baseline table to match the checked-in manifest.

## Scope
- In scope: core demo/baseline Service Admin release pin only.
- Out of scope: Service Admin UI implementation changes, runtime API/schema changes, and unrelated service manifest updates.

## Spec / contract / fixture impact
- Updated: checked-in Service Admin release pin and README baseline release reference.
- Not required: no runtime API/schema or service contract shape changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by demo-consumed service repo changes before #232 can be completed.
- Preservation proof: this PR points core `@serviceadmin` to Service Admin release `2026.6.20-efb6bb5`, target commit `efb6bb517b7f77c1e9ab60b5eceb76f754f9a20c`.

## Validation
- PASS `npm run build` — log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260621T0030+1000\core-pin-build.log`.
- PASS `npm run verify:service-catalog` — log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260621T0030+1000\core-pin-verify-service-catalog.log`.

## Approval trail
- Required: normal core PR checks/review rules apply.
- Evidence: focused branch from `develop`; no direct push to `develop`.

## Cleanup
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live `@serviceadmin` installed tag equals `2026.6.20-efb6bb5`.
