### PR TITLE
chore(demo): pin Service Admin 2026.6.20-a56901a

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-efb6bb5` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-a56901a` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-efb6bb5"
+      "tag": "2026.6.20-a56901a"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-417a58a");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-a56901a");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#231 release-to-demo gate after service-lasso/lasso-serviceadmin#235.

## Summary
- Pins `@serviceadmin` to release `2026.6.20-a56901a`.
- Updates README baseline release table and manifest discovery expectation.

## Scope
- In scope: core demo/service manifest pin for the merged Service Admin release.
- Out of scope: Service Admin feature code, unrelated service pins.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and matching baseline docs/test expectation.
- Not required because: no runtime API/schema behavior changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact merged Service Admin release before completion.
- Preservation proof: release `2026.6.20-a56901a` targets `a56901a87118cf94024eda8094aceb37932015dc` from lasso-serviceadmin#235.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-manifest-test.log`
- PASS `npm run verify:service-catalog` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-verify-service-catalog.log`

## Approval trail
- Required: no special approval identified for a release pin-only PR.
- Evidence: PR remains subject to branch checks before merge.

## Demo / release gate
- Required after merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and record expected vs live `@serviceadmin` tag/commit.

## Cleanup
- Branch: `pin-serviceadmin-2026-6-20-a56901a`
- Local cleanup after merge/demo verification.
