### PR TITLE
chore(demo): pin serviceadmin release 2026.6.20-64ba4d9

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-a56901a"
+      "tag": "2026.6.20-64ba4d9"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231
Follows service-lasso/lasso-serviceadmin#236

## Summary
- Pins the canonical demo `@serviceadmin` manifest to the newly published lasso-serviceadmin release `2026.6.20-64ba4d9`.

## Scope
- In scope: core demo/service manifest release pin for Service Admin.
- Out of scope: additional Service Admin UI changes; those landed in service-lasso/lasso-serviceadmin#236.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` demo-consumed release tag.
- Public API/schema change: not required; release pin only.

## Service release evidence
- lasso-serviceadmin PR #236 merged at `64ba4d96c54f1cd57e98de1f7f4db98d63623e9a`.
- Release workflow PASS: `27877256397`.
- Published release: `2026.6.20-64ba4d9` targeting `64ba4d96c54f1cd57e98de1f7f4db98d63623e9a`.
- Release assets include `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260621T0230/core-pin-build.log`
- Pending after merge: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.

## Approval trail
- Required: no special approval identified for this manifest pin.
- Evidence: this is the mandatory release-to-demo pin after a merged demo-consumed Service Admin release.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-64ba4d9`
- Post-merge: delete branch when safe and verify local repo cleanup.