### PR TITLE
chore(demo): pin Service Admin 2026.6.20-439a8b9

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-a56901a` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-439a8b9` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-64ba4d9"
+      "tag": "2026.6.20-439a8b9"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-a56901a");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-439a8b9");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Related to service-lasso/lasso-serviceadmin#237 and service-lasso/lasso-serviceadmin#240.

## Summary
- Pins the core `@serviceadmin` baseline manifest to the newly released `lasso-serviceadmin` tag `2026.6.20-439a8b9`.
- Updates the manifest discovery expectation and README baseline release table to match.

## Scope
- In scope: core demo/service manifest pin and matching source docs/tests.
- Out of scope: Service Admin UI implementation, already merged/released in `service-lasso/lasso-serviceadmin#240`.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because: manifest shape/API/schema is unchanged; only the pinned release tag changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact after UI code changes.
- Preservation proof: expected Service Admin tag is `2026.6.20-439a8b9`, targeting lasso-serviceadmin merge commit `439a8b9d7105b98015ac31585994e31bd071f8d6`.

## Validation
- PASS `npm run build` — TypeScript build passed.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — 23 tests passed.
- Log: `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\20260621T032624\core-pin-build-manifest-test.log`

## Demo / release gate
- Pending until this pin PR merges, canonical demo recycles on port `17883`, and `npm run demo:verify-canonical` proves live `@serviceadmin` tag matches `2026.6.20-439a8b9`.

## Approval trail
- Required: repo checks/review according to service-lasso branch rules.

## Cleanup
- Branch: `issue-237-pin-serviceadmin-2026-6-20-439a8b9` from `develop`.