### PR TITLE
chore(demo): pin Service Admin release d28b01e

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-439a8b9` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-d28b01e` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-439a8b9"
+      "tag": "2026.6.20-d28b01e"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-439a8b9");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-d28b01e");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Follows service-lasso/lasso-serviceadmin#238 and service-lasso/lasso-serviceadmin#241.

## Summary
- Pins the core `@serviceadmin` manifest to the newly published Service Admin release `2026.6.20-d28b01e`.
- Updates the clean-clone manifest discovery assertion and README baseline table to the same release tag.

## Scope
- In scope: core demo/service manifest pin and matching docs/test expectation.
- Out of scope: Service Admin UI implementation, already merged/released in service-lasso/lasso-serviceadmin#241.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact tag and manifest discovery fixture expectation.
- Not required: no API/schema/lifecycle behavior changes beyond consuming the new release.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by demo-consumed service changes.
- Preservation proof: pin equals published lasso-serviceadmin release `2026.6.20-d28b01e` targeting `d28b01e607e7189ed8d2fd90069d31c2d4ca26e0`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260621T052513/core-npm-build.log`.
- PASS `node --test tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-20260621T052513/core-manifest-discovery-test.log`, 23 passed.
- PASS lasso-serviceadmin Release workflow for merge commit `d28b01e607e7189ed8d2fd90069d31c2d4ca26e0`; published release `2026.6.20-d28b01e` with win32/linux/darwin/service.json/SHA256SUMS assets.

## Demo / release gate
- Pending this PR merge, canonical demo recycle on port `17883`, and `npm run demo:verify-canonical`.

## Approval trail
- Required: no branch protection reported for develop by GitHub branch protection API unless checks indicate otherwise.
- Evidence: this PR and linked issue/PR comments.

## Cleanup
- Branch `issue-238-serviceadmin-release-pin` can be deleted after merge and canonical demo verification.