### PR TITLE
chore(demo): pin Service Admin release 2026.6.20-b54d3ab

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.20-176636f`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-d28b01e` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.20-b54d3ab` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-d28b01e"
+      "tag": "2026.6.20-b54d3ab"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-d28b01e");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.20-b54d3ab");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Related to service-lasso/lasso-serviceadmin#239 and drains service-lasso/lasso-serviceadmin#242.

## Summary
- Pin the core baseline `@serviceadmin` manifest to the newly released Service Admin artifact `2026.6.20-b54d3ab`.
- Update README baseline service documentation and manifest discovery assertion to match the new release tag.

## Scope
- In scope: core demo/baseline Service Admin release pin after the Service Admin UI cleanup merge.
- Out of scope: additional runtime behavior, Service Admin UI changes, or unrelated baseline service pins.

## Spec / contract / fixture impact
- Updated: checked-in baseline service manifest and regression assertion for `@serviceadmin` release provenance.
- Not required because: no schema/API/lifecycle contract changes; this is a release pin of an existing service artifact contract.

## Nash invariant impact
- Invariant: canonical demo must consume the exact merged/released Service Admin artifact before the UI cleanup can be considered done.
- Preservation proof: `services/@serviceadmin/service.json`, README, and manifest discovery test all reference `2026.6.20-b54d3ab`, which targets Service Admin commit `b54d3abdf5a5684b5784d78ff718a06ce9a3b6b3`.

## Validation
- PASS `npm run build` — TypeScript compile completed; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-20260621T073219+1000\core-build.log`.
- PASS `node --test tests/manifest-discovery.test.js` — 23 tests passed; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-20260621T073219+1000\core-manifest-discovery-node-test.log`.
- NOTE `npm test -- tests/manifest-discovery.test.js` was attempted first, but the npm script ignored the path and began the full suite; it exceeded the bounded cron timeout with unrelated existing API/network failures in `core-manifest-discovery-test.log`.

## Release / demo gate
- Service Admin PR merged: service-lasso/lasso-serviceadmin#242.
- Service Admin release: `2026.6.20-b54d3ab`, target commit `b54d3abdf5a5684b5784d78ff718a06ce9a3b6b3`, assets include `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.
- Canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status ok; log `canonical-health-preflight.log`.
- Pending after this PR merges: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; expected and installed/live Service Admin tag must both be `2026.6.20-b54d3ab` before final completion.

## Approval trail
- Required: normal repository review/check policy.
- Evidence: this PR, linked Service Admin PR/issue, GitHub Actions for both repos.

## Cleanup
- Branch cleanup after merge: delete `chore/issue-239-pin-serviceadmin-2026-6-20-b54d3ab` and verify local repos are clean.