### PR TITLE
chore(demo): pin serviceadmin aa4c02d

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-b54d3ab"
+      "tag": "2026.6.20-aa4c02d"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` service to lasso-serviceadmin release `2026.6.20-aa4c02d`.
- This consumes the Service Admin merge commit from PR #243 in the core demo manifest.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: additional service manifest or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin.
- Not required because: no API/schema change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-service release before completion is claimed.
- Preservation proof: expected `@serviceadmin` tag is `2026.6.20-aa4c02d`; post-merge recycle/verifier evidence will be attached to issue #231.

## Validation
- PASS `npm run build` in core — `.work-agent/logs/issue-231/core-pin-build-aa4c02d.log`

## Approval trail
- Required: no special approval rule found for this single-line demo pin.
- Evidence: pin follows merged/released lasso-serviceadmin PR #243.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-aa4c02d`
- Post-merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed tag matches `2026.6.20-aa4c02d`.