### PR TITLE
chore(demo): pin serviceadmin d0e6d5b

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.20-aa4c02d"
+        "tag": "2026.6.20-d0e6d5b"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.20-d0e6d5b`.
- This consumes the merged Service Admin PR #244 release in the core service catalog.

## Scope
- In scope: `services/@serviceadmin/service.json` tag update only.
- Out of scope: additional service catalog changes or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin only.
- Not required because service contract, ports, args, healthcheck, and platform asset names are unchanged.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin tag before the #231 slice can be treated as demo-gated.
- Preservation proof: expected tag is `2026.6.20-d0e6d5b`; release targets Service Admin merge commit `d0e6d5bc1047d50b363b17437998ac6a42e6b835` and includes `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-d0e6d5b.log`
- Release evidence: `gh release view 2026.6.20-d0e6d5b --repo service-lasso/lasso-serviceadmin` shows target commit `d0e6d5bc1047d50b363b17437998ac6a42e6b835`, not draft/prerelease, and required assets.

## Approval trail
- Required: not known for this manifest-only demo pin; awaiting repository checks/review.

## Cleanup
- Branch will be deleted after merge.
- After merge: build core, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and compare expected/catalog/live installed `@serviceadmin` tag.
