### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-9b50c07

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.20-d0e6d5b"
+      "tag": "2026.6.21-9b50c07"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to lasso-serviceadmin release `2026.6.21-9b50c07`.
- This consumes the merged Service Admin PR #245 action-readiness slice.

## Scope
- In scope: demo manifest tag update for `@serviceadmin`.
- Out of scope: further Service Admin UI behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag only.
- Not required because: no service contract/schema changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release before #231 slice can be considered demo-gated.
- Preservation proof: expected tag is `2026.6.21-9b50c07`; recycle/verify evidence will follow after merge.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-9b50c07.log`

## Approval trail
- Required: no documented approval requirement found for this manifest pin.
- Evidence: generated from merged Service Admin release `2026.6.21-9b50c07` with release workflow success.

## Cleanup
- Branch cleanup after merge: delete `agent/issue-231-serviceadmin-demo-pin-9b50c07` locally/remotely.
- Post-merge: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.