### PR TITLE
fix(demo): pin serviceadmin recovery guidance release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-9b50c07"
+      "tag": "2026.6.21-15169f3"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.21-15169f3`.
- This release contains the #231 single-secret recovery guidance slice from lasso-serviceadmin PR #246.

## Scope
- In scope: core demo/service manifest pin only.
- Out of scope: other service catalog changes.

## Spec / contract / fixture impact
- Service manifest pin updated from `2026.6.21-9b50c07` to `2026.6.21-15169f3`.

## Service Lasso invariant impact
- Preserves canonical `@serviceadmin` release artifact model.
- Expected release target commit: `15169f3b070bef9d884c13a447a2f9f28e54f0f1`.

## Validation
- PASS lasso-serviceadmin PR #246 CI `install-lint-build`.
- PASS lasso-serviceadmin release workflow `27889837396` for `15169f3b070bef9d884c13a447a2f9f28e54f0f1`.
- PASS `npm run build` in core before PR — `.work-agent/logs/issue-231/core-pin-build-15169f3.log`.

## Approval trail
- Required: no special approval documented for demo pin PRs after green checks.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-15169f3`
- After merge: rebuild core, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` tag equals `2026.6.21-15169f3`.