### PR TITLE
chore: pin Service Admin providers fix

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-15169f3"
+      "tag": "2026.6.21-62d1631"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Summary
- Pins `@serviceadmin` to `2026.6.21-62d1631` for service-lasso/lasso-serviceadmin#247.
- This release includes the Providers page usable Add provider dialog and row action detail fix from lasso-serviceadmin PR #248.

## Validation
- PASS `npm run build`
- PASS `node scripts/baseline-start-smoke.mjs`

## Demo gate
Pending after merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical` plus LAN checks.
