### PR TITLE
chore(demo): pin serviceadmin 4d9dab0 release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-62d1631"
+      "tag": "2026.6.21-4d9dab0"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.21-4d9dab0`.
- This consumes the Service Admin #231 single-secret typed status outcomes slice merged in service-lasso/lasso-serviceadmin#249.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: Service Admin source changes and other service manifest pins.

## Spec / contract / fixture impact
- Updated: core demo service manifest pin for demo-consumed Service Admin release.
- Not required: API/schema changes; this is a release pin only.

## Nash invariant impact
- Invariant: canonical demo must consume the exact new demo-consumed service release before done is claimed.
- Preservation proof: expected release tag is `2026.6.21-4d9dab0`, targeting Service Admin merge commit `4d9dab038b36a481379e0afcf0e1addae89ed43d`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-4d9dab0.log`

## Approval trail
- Required: no special approval requirement identified for a focused demo manifest pin.
- Evidence: this PR follows merged Service Admin PR #249 and release workflow success.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-4d9dab0`
- After merge: rebuild core, recycle canonical demo on port 17883, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` tag matches `2026.6.21-4d9dab0`.