### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-2d3aad1

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-4d9dab0"
+      "tag": "2026.6.21-2d3aad1"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` artifact to the Service Admin release produced from lasso-serviceadmin PR #250.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update.
- Out of scope: other demo service pins or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: core demo service manifest pin.
- Not required because: no schema or runtime API changed.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release before #231 advancement is claimed demo-gated.
- Preservation proof: this PR changes only the tag from `2026.6.21-4d9dab0` to `2026.6.21-2d3aad1`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-2d3aad1.log`

## Approval trail
- Required: no special approval requirement documented for this manifest-only demo pin.
- Evidence: awaits hosted baseline smoke check.

## Cleanup
- After merge, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and delete this branch when safe.