### PR TITLE
ISS-231 pin serviceadmin release 7061eab

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-2d3aad1"
+      "tag": "2026.6.21-7061eab"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` service manifest to lasso-serviceadmin release `2026.6.21-7061eab`.

## Scope
- In scope: demo-consumed Service Admin artifact tag update.
- Out of scope: other service manifest changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact tag only.
- Not required because: no schema or public contract change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release produced by the merged UI slice.
- Preservation proof: expected release tag is `2026.6.21-7061eab`, target commit `7061eabc8a2c9cfad84cdde3d6a3a64be0cc8b7d`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-7061eab.log`

## Approval trail
- Required: no special approval documented for release pin advancement after merged Service Admin PR #251.
- Evidence: release-to-demo gate requires this pin before canonical recycle.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-7061eab`
- After merge: recycle canonical demo on port `17883` and run `npm run demo:verify-canonical`.
