### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-931c6e8

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-7061eab"
+      "tag": "2026.6.21-931c6e8"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` manifest to lasso-serviceadmin release `2026.6.21-931c6e8`.
- This consumes the merged Service Admin #231 policy-preview slice from PR service-lasso/lasso-serviceadmin#253.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: Service Admin source changes, unrelated service pins.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for `@serviceadmin`.
- Not required because: no core API/schema change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact changed service release before #231 slice can be validated as demo-gated.
- Preservation proof: expected Service Admin release tag is `2026.6.21-931c6e8`, target commit `931c6e8b616e8fe78ddc8e7fbc44fc4c5bb7f429`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-931c6e8.log`
- Release exists: service-lasso/lasso-serviceadmin `2026.6.21-931c6e8`, target `931c6e8b616e8fe78ddc8e7fbc44fc4c5bb7f429`, includes `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.

## Approval trail
- Required: no special approval requirement found for manifest-only demo pin.
- Evidence: PR CI will run `baseline-start-smoke`.

## Cleanup
- After merge: pull `develop`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify live installed `@serviceadmin` tag equals `2026.6.21-931c6e8`, then delete `agent/issue-231-serviceadmin-demo-pin-931c6e8`.