### PR TITLE
chore(demo): pin serviceadmin ed84aca

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-931c6e8"
+      "tag": "2026.6.21-ed84aca"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` service manifest to lasso-serviceadmin release `2026.6.21-ed84aca`.

## Scope
- In scope: core demo/service manifest pin only.
- Out of scope: additional runtime/core behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required: service schema unchanged.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by demo-consumed Service Admin UI work before completion is claimed.
- Preservation proof: expected tag is `2026.6.21-ed84aca`, targeting Service Admin merge commit `ed84acad3301ff3147ffce8f39f1033dd7014a59`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-ed84aca.log`
- Release exists: service-lasso/lasso-serviceadmin `2026.6.21-ed84aca`, target `ed84acad3301ff3147ffce8f39f1033dd7014a59`, assets include `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.

## Approval trail
- Required: no special approval rule found for manifest pin PR after corresponding Service Admin PR/check/release success.
- Evidence: this PR is the mandatory release-to-demo pin for lasso-serviceadmin#231 / lasso-serviceadmin#254.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-ed84aca`
- Post-merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` tag equals `2026.6.21-ed84aca`.
