### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-5ad70c0

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-ed84aca"
+      "tag": "2026.6.21-5ad70c0"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` service manifest to `lasso-serviceadmin` release `2026.6.21-5ad70c0`.
- Completes the core side of the release-to-demo gate for lasso-serviceadmin PR #255.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: any other service manifest or runtime behavior change.

## Spec / contract / fixture impact
- Updated: demo service manifest pin.
- Not required: API/schema/spec changes because this only consumes an already-published Service Admin release.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by demo-consumed Service Admin changes.
- Preservation proof: manifest pin changes from `2026.6.21-ed84aca` to `2026.6.21-5ad70c0`; release exists and targets `5ad70c0ac3f454ea27ee1c36be1510bc2944f01e`.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-5ad70c0.log`
- Pending after merge: `npm run build`, `node scripts/demo-recycle.mjs --port=17883`, `npm run demo:verify-canonical`, and LAN `/api/health`, `/api/runtime`, `/api/services` checks.

## Approval trail
- Required: no special approval requirement found for this focused demo manifest pin.
- Evidence: Service Admin PR #255 merged; release workflow `27898907255` succeeded and published `2026.6.21-5ad70c0`.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-5ad70c0`
- Delete branch after merge and demo verification.