### PR TITLE
chore(demo): pin serviceadmin d28cf82

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-5ad70c0"
+      "tag": "2026.6.21-d28cf82"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.21-d28cf82`.
- Carries the merged PR #256 Secrets submit-envelope slice into the core service catalog.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: unrelated manifest or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for `@serviceadmin`.
- Not required: no core API/schema change.

## Nash invariant impact
- Invariant: demo-consumed Service Admin changes must be pinned and installed in the canonical demo before claiming done.
- Preservation proof: build passes before PR; recycle and `npm run demo:verify-canonical` will run after merge.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-d28cf82.log`

## Approval trail
- Required: no special approval requirement found for this demo pin.
- Evidence: mandatory release-to-demo gate for lasso-serviceadmin#231.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-d28cf82`
- Post-merge: build core, recycle canonical demo on port 17883, run `npm run demo:verify-canonical`, verify live installed `@serviceadmin` tag equals `2026.6.21-d28cf82`, then clean branches.
