### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-51cc0a5

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-d28cf82"
+      "tag": "2026.6.21-51cc0a5"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to lasso-serviceadmin release `2026.6.21-51cc0a5`.

## Scope
- In scope: core demo service manifest pin only.
- Out of scope: Service Admin feature code, runtime behavior beyond consuming the new release.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because: this is a release pin update for an already released Service Admin artifact.

## Nash invariant impact
- Invariant: demo-consumed Service Admin changes must be pinned and verified in canonical demo before claiming done.
- Preservation proof: this PR points core at the exact release for lasso-serviceadmin commit `51cc0a59f421054031134278ceb81a56ee820e8d`; canonical recycle/verify follows after merge.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-51cc0a5.log`

## Approval trail
- Required: no special approval requirement found for this release pin.
- Evidence: release-to-demo gate requires this pin before demo recycle.

## Cleanup
- Branch will be deleted after merge.
- After merge, recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.