### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-daf8a60

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-51cc0a5"
+        "tag": "2026.6.21-daf8a60"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to Service Admin release `2026.6.21-daf8a60`.
- This consumes the merged lasso-serviceadmin#258 audit-unavailable single-secret outcome slice.

## Scope
- In scope: update `services/@serviceadmin/service.json` release tag only.
- Out of scope: other service pins and runtime behavior changes.

## Spec / contract / fixture impact
- Updated: core demo service manifest release pin.
- Not required: no schema change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin build before validation.
- Preservation proof: release `2026.6.21-daf8a60` targets `daf8a60473513a212658c77e4ddf68e25d7c30ad` and includes `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` - `.work-agent/logs/issue-231/core-pin-build-daf8a60.log`
- Pending hosted `baseline-start-smoke` on this PR.
- Demo recycle/verify follows after merge.

## Approval trail
- Required: no special approval documented for demo pin update.
- Evidence: required release-to-demo gate for lasso-serviceadmin#258.

## Cleanup
- Branch `agent/issue-231-serviceadmin-demo-pin-daf8a60` will be deleted after merge.