### PR TITLE
chore(demo): pin serviceadmin cfd880d release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.21-daf8a60"
+        "tag": "2026.6.21-cfd880d"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins canonical demo `@serviceadmin` to lasso-serviceadmin release `2026.6.21-cfd880d`.
- Carries the merged #231 auth-required single-secret UI slice into the core demo manifest.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: other service pins or runtime behavior changes.

## Spec / contract / fixture impact
- Not required because this is a demo release pin update only.

## Validation
- PASS `npm run build` — `.work-agent/logs/issue-231/core-pin-build-cfd880d.log`
- Service Admin release verified: `2026.6.21-cfd880d` targets `cfd880d9499ad2b449d1761aa9e552fba29ecb70` and includes `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.

## Release-to-demo gate
- Pending until this PR is merged, canonical demo is recycled on port `17883`, and `npm run demo:verify-canonical` proves live installed `@serviceadmin` tag equals `2026.6.21-cfd880d`.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-cfd880d`