### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-778f227

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.21-cfd880d"
+      "tag": "2026.6.21-778f227"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to `2026.6.21-778f227`.
- This consumes the lasso-serviceadmin PR #260 release in the core demo manifest.

## Scope
- In scope: core demo/service manifest release pin only.
- Out of scope: additional Service Admin UI changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact tag.
- Not required because: no API/schema/contract shape changed in core.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact before this Service Admin slice can be considered demo-gated.
- Preservation proof: manifest tag matches Service Admin release `2026.6.21-778f227`, target commit `778f227afaed77f1fa59f07187cde51797fdc043`.

## Validation
- PASS `npm run build` - `.work-agent/logs/issue-231/core-pin-build-778f227.log`
- Pending after merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.

## Approval trail
- Required: no special approval requirement found for this single manifest pin.
- Evidence: isolated demo-consumed artifact pin for the already released Service Admin merge.

## Cleanup
- Branch `agent/issue-231-serviceadmin-demo-pin-778f227` tracks origin.
- Post-merge cleanup will remove local/remote branch when safe.