### PR TITLE
chore(demo): pin serviceadmin b832008

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-778f227"
+      "tag": "2026.6.21-b832008"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` service artifact to lasso-serviceadmin release `2026.6.21-b832008`.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: Service Admin source changes, already merged in service-lasso/lasso-serviceadmin#261.

## Spec / contract / fixture impact
- Updated: core service manifest pin for the demo-consumed Service Admin artifact.
- Not required because: this is a release pin only; no core runtime contract/schema changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact before the #231 slice is claimed demo-gated.
- Preservation proof: release `2026.6.21-b832008` targets Service Admin merge commit `b83200869d0b85a88a060ff901e43535fb0d2952` and includes `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` in core before PR — `.work-agent/logs/issue-231/core-pin-build-b832008.log`
- Pending after merge: core build, canonical recycle on port `17883`, `npm run demo:verify-canonical`, LAN Service Admin/runtime checks, and live installed tag comparison.

## Approval trail
- Required: no special approval requirement found for this release-pin PR.
- Evidence: same release-to-demo pin pattern used for prior validated #231 slices.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-b832008`
- Post-merge: recycle canonical demo, verify live installed `@serviceadmin` tag equals `2026.6.21-b832008`, then delete branch when safe.