### PR TITLE
chore(demo): pin serviceadmin b2e1faa

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-b832008"
+      "tag": "2026.6.21-b2e1faa"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to lasso-serviceadmin release `2026.6.21-b2e1faa`.
- This consumes the merged Service Admin PR #262 release in the core service catalog.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: Service Admin source changes, other service pins, runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for `@serviceadmin`.
- Not required because: no schema or public API change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-consumed Service Admin release before #231 slice is claimed complete.
- Preservation proof: target release `2026.6.21-b2e1faa` exists, targets Service Admin merge commit `b2e1faa58b0515c4827651baf5c9dbb4e9c31677`, and includes `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` - `.work-agent/logs/issue-231/core-pin-build-b2e1faa.log`

## Approval trail
- Required: no special approval requirement found for a focused demo pin update following merged/released Service Admin work.
- Evidence: this is the mandatory release-to-demo gate for service-lasso/lasso-serviceadmin#231 PR #262.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-b2e1faa`
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; expected/live `@serviceadmin` tag must both be `2026.6.21-b2e1faa`.