### PR TITLE
chore(demo): pin serviceadmin be222ec

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-b2e1faa"
+      "tag": "2026.6.21-be222ec"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` artifact to `2026.6.21-be222ec`.
- This consumes the Service Admin release produced from lasso-serviceadmin PR #263 / merge commit `be222ecd91db99ce01d9ecd2c03a38c275a2a49c`.

## Scope
- In scope: core demo/service manifest release pin only.
- Out of scope: unrelated service manifest changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required: no schema change.

## Service Lasso invariant impact
- Invariant: canonical demo must consume the exact new demo-consumed service release before the #231 slice can be called demo-gated.
- Preservation proof: expected Service Admin tag is `2026.6.21-be222ec`; this PR pins that exact tag.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/core-pin-build-be222ec.log`

## Approval trail
- Required: no special approval documented for release pin updates after merged Service Admin UI slices.

## Cleanup
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; verify live installed `@serviceadmin` tag equals `2026.6.21-be222ec`.