### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-73c4c8e

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-be222ec"
+      "tag": "2026.6.21-73c4c8e"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` service manifest to Service Admin release `2026.6.21-73c4c8e`.

## Scope
- In scope: core demo manifest release pin only.
- Out of scope: Service Admin UI implementation, already merged in service-lasso/lasso-serviceadmin#264.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required because: no API/schema change in core; this consumes an existing Service Admin release artifact.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release before #231 slice is claimed demo-gated.
- Preservation proof: expected release `2026.6.21-73c4c8e` targets Service Admin commit `73c4c8ebd3a7c37e920e4a639c19d9e0bd51605a` and includes `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-build-73c4c8e.log`

## Approval trail
- Required: no special approval requirement found for this release pin.
- Evidence: focused manifest-only pin branch from clean `develop`.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-73c4c8e`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected/live `@serviceadmin` tags match `2026.6.21-73c4c8e`.