### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-6a509d1

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-73c4c8e"
+      "tag": "2026.6.21-6a509d1"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to lasso-serviceadmin release `2026.6.21-6a509d1`.
- This consumes the Service Admin PR #265 merge commit in the core service manifest.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: other service pins or runtime behavior changes.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for `@serviceadmin`.
- Not required: schema/API/spec changes; release artifact contract is unchanged.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-consumed service release before claiming #231 advancement complete.
- Preservation proof: this PR changes only the release tag and will be followed by canonical recycle/verify after merge.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-build-6a509d1.log`
- Service Admin release `2026.6.21-6a509d1` published successfully from merge commit `6a509d1fecd20e9e393cc2689f22fe12f029c4fb` with `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.

## Approval trail
- Required: no special approval requirement found for demo pin PRs; previous #231 slices used mergeable green checks for core pin updates.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-6a509d1`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` tag equals `2026.6.21-6a509d1`.