### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-641bffd

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-6a509d1"
+      "tag": "2026.6.21-641bffd"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` manifest to Service Admin release `2026.6.21-641bffd`.
- This completes the core manifest half of the release-to-demo gate for lasso-serviceadmin PR #266.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: product-code changes in core.

## Spec / contract / fixture impact
- Updated: demo service manifest pin for `@serviceadmin`.
- Not required because: no API/schema/behavior contract changes in core.

## Nash invariant impact
- Invariant: canonical demo must consume the exact release produced by demo-consumed Service Admin changes.
- Preservation proof: Service Admin release `2026.6.21-641bffd` targets merge commit `641bffdb7555a4616577f7b9b265539f975af444` and includes `@serviceadmin-win32.zip`; this PR pins the core manifest to that exact tag.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/core-pin-build-641bffd.log`
- PASS Service Admin PR #266 CI `install-lint-build` run `27919652597`.
- PASS Service Admin merge CI `27919741840`, template validation `27919741842`, and release workflow `27919741843` for `641bffdb7555a4616577f7b9b265539f975af444`.

## Approval trail
- Required: no special approval documented for this manifest pin.
- Evidence: this is the mandatory pin PR after merged/released demo-consumed Service Admin work.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-641bffd`
- After merge: run core build, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify LAN Service Admin/runtime and installed/live `@serviceadmin` tag match `2026.6.21-641bffd`, then delete branch when safe.