### PR TITLE
chore(demo): pin serviceadmin 2026.6.21-3948449

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.21-641bffd"
+        "tag": "2026.6.21-3948449"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` release to `2026.6.21-3948449`.

## Scope
- In scope: core service manifest pin for the released Service Admin PR #267 slice.
- Out of scope: other demo/service manifest changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag only.

## Nash invariant impact
- Invariant: demo-consumed Service Admin changes must be released and pinned before claiming demo currency.
- Preservation proof: expected release tag is `2026.6.21-3948449`, target commit `39484491bc7837c0e8988aea182278a23ce786af`, with release assets including `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` in core — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/core-pin-build-3948449.log`

## Approval trail
- Required: no special approval requirement found for demo pin-only PRs in the existing #231 trail.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-3948449`
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.
