### PR TITLE
chore(demo): pin serviceadmin release c9c7132

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.21-3948449"
+        "tag": "2026.6.22-c9c7132"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin canonical demo `@serviceadmin` to Service Admin release `2026.6.22-c9c7132`.
- This release contains the focused #231 provider-unavailable recovery metadata slice from lasso-serviceadmin PR #268.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-build-c9c7132.log`
- Service Admin release workflow PASS: `27922562514` for target commit `c9c71325ed4b144acfb10819fdc3a763fbbd3f28`.

## Release-to-demo gate
- Expected `@serviceadmin`: `2026.6.22-c9c7132`
- Demo recycle and `npm run demo:verify-canonical` will run after this pin PR merges.