### PR TITLE
chore(demo): pin serviceadmin cf9a386

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-c9c7132"
+        "tag": "2026.6.22-cf9a386"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231
Follows service-lasso/lasso-serviceadmin#269

## Summary
- Pin the canonical demo `@serviceadmin` service artifact to lasso-serviceadmin release `2026.6.22-cf9a386`.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: other service manifest or runtime changes.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\core-pin-build-cf9a386.log`
- Release source verified: `service-lasso/lasso-serviceadmin` release `2026.6.22-cf9a386`, target commit `cf9a386d2217c2f594a91fb9f13f8c72d1447468`, includes `@serviceadmin-win32.zip`, linux/darwin archives, `service.json`, and `SHA256SUMS.txt`.

## Demo Gate
- Pending after merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.