### PR TITLE
chore(demo): pin serviceadmin 5738329 release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-cf9a386"
+        "tag": "2026.6.22-5738329"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.22-5738329`.

## Scope
- In scope: core demo service manifest pin only.
- Out of scope: other service manifests and runtime behavior changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Not required: no API/schema change.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact before the Service Admin issue slice is considered demo-gated.
- Preservation proof: expected tag `2026.6.22-5738329`, release target commit `573832986352666b2a90e74e39afcf623f11d664`, asset `@serviceadmin-win32.zip`.

## Validation
- PASS `npm run build` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/core-pin-build-5738329.log`

## Approval trail
- Required: no special approval requirement found for this manifest pin.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-5738329`
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical` to prove live installed tag matches `2026.6.22-5738329`.
