### PR TITLE
chore(demo): pin serviceadmin 2026.6.22-4bfaab8

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-5738329"
+        "tag": "2026.6.22-4bfaab8"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` artifact to `2026.6.22-4bfaab8`.
- This consumes the lasso-serviceadmin PR #271 release for the focused #231 cancellation-evidence slice.

## Scope
- In scope: update `services/@serviceadmin/service.json` release tag only.
- Out of scope: any other service manifest or runtime behavior change.

## Spec / contract / fixture impact
- Updated: core service manifest pin for demo consumption.
- Not required: no API/schema change; this is a release pin.

## Service Lasso invariant impact
- Invariant: canonical demo must consume the exact changed Service Admin release before completion is claimed.
- Preservation proof: expected tag is `2026.6.22-4bfaab8`, release asset `@serviceadmin-win32.zip`; recycle/verify will run after merge.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/core-pin-build-4bfaab8.log`

## Approval trail
- Required: no special approval requirement found for this demo pin PR.
- Evidence: mandatory release-to-demo gate for demo-consumed Service Admin change.

## Cleanup
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; expected/live `@serviceadmin` tag must match `2026.6.22-4bfaab8`.