### PR TITLE
chore(demo): pin serviceadmin a16071e release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-4bfaab8"
+        "tag": "2026.6.22-a16071e"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` artifact to lasso-serviceadmin release `2026.6.22-a16071e`.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: service behavior changes beyond consuming the released Service Admin artifact.

## Spec / contract / fixture impact
- Updated service manifest release pin for the canonical demo.
- No schema change.

## Service Lasso invariant impact
- Invariant: demo manifest must consume the exact released Service Admin artifact for the merged #231 slice.
- Preservation proof: release tag `2026.6.22-a16071e` targets Service Admin merge commit `a16071eb847fcfc9df4c2955782b46977bd1790f`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260622T142859+1000/issue-231-reveal-lifecycle/core-build-pin-a16071e.log`

## Approval trail
- Required: no special approval requirement found for this manifest pin.
- Evidence: this is the required release-to-demo pin for lasso-serviceadmin PR #272.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-a16071e`
- Commit: `79cebdb`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` tag equals `2026.6.22-a16071e`.