### PR TITLE
chore(demo): pin serviceadmin 18fa82a release

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-a16071e"
+        "tag": "2026.6.22-18fa82a"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` service artifact to lasso-serviceadmin release `2026.6.22-18fa82a`.
- This completes the core catalog side of the release-to-demo gate for lasso-serviceadmin PR #273.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag update only.
- Out of scope: Service Admin UI code changes; those landed in service-lasso/lasso-serviceadmin#273.

## Spec / contract / fixture impact
- Updated: core demo service manifest pin.
- Not required: no API/schema/lifecycle contract change in core.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-consumed release before #231 slice completion is claimed.
- Preservation proof: expected release `2026.6.22-18fa82a` targets Service Admin merge commit `18fa82acf063e11be9249217583910bd8b034efa`; this PR updates the catalog pin to that exact tag.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/core-pin-build-before-pr-18fa82a.log`

## Approval trail
- Required: no special approval requirement found for this focused demo pin.
- Evidence: Service Admin PR #273 merged and release workflow passed.

## Cleanup
- After merge: pull develop, build core, recycle canonical demo on port 17883 with `node scripts/demo-recycle.mjs --port=17883`, run `npm run demo:verify-canonical`, verify LAN Service Admin/runtime and live `@serviceadmin` installed tag equals `2026.6.22-18fa82a`.