### PR TITLE
chore(demo): pin serviceadmin f2bb79b

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-18fa82a"
+        "tag": "2026.6.22-f2bb79b"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the canonical demo `@serviceadmin` manifest to lasso-serviceadmin release `2026.6.22-f2bb79b`.
- This consumes the Service Admin PR #274 rotation safety preview release.

## Scope
- In scope: `services/@serviceadmin/service.json` release tag only.
- Out of scope: any other core service manifest or runtime behavior change.

## Spec / contract / fixture impact
- Updated: demo service manifest pin.
- Public API/schema: unchanged.

## Nash invariant impact
- Invariant: canonical demo must consume the exact changed demo-consumed service release before #231 slice handoff claims completion.
- Preservation proof: expected Service Admin release/tag is `2026.6.22-f2bb79b`, targeting `f2bb79b23d64751a3edbd1366172aba95850ccd3`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/core-pin-build-f2bb79b.log`
- Pending after merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.

## Approval trail
- Required: no special approval requirement found for this manifest-only pin.
- Evidence: Service Admin release workflow succeeded for `2026.6.22-f2bb79b`.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-f2bb79b`
- After merge: recycle canonical demo and verify expected/live tag match.