### PR TITLE
chore(demo): pin serviceadmin 2026.6.23-2042947

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.22-fb52a47"
+        "tag": "2026.6.23-2042947"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Summary
- Update the canonical @serviceadmin catalog pin to lasso-serviceadmin release 2026.6.23-2042947.
- Completes the core demo pin step for service-lasso/lasso-serviceadmin#231 / PR #279 history review slice.

## Release evidence
- Service Admin PR: https://github.com/service-lasso/lasso-serviceadmin/pull/279
- Service Admin merge commit: 204294758582e8201aa9457980981988a6e473e8
- Service Admin release: https://github.com/service-lasso/lasso-serviceadmin/releases/tag/2026.6.23-2042947
- Release workflow: https://github.com/service-lasso/lasso-serviceadmin/actions/runs/27997038634

## Verification
- PASS gh run post-merge Service Admin validate-template / Continuous Integration / Release for 204294758582e8201aa9457980981988a6e473e8.
- PASS npm run build
- PASS git diff --check

Refs service-lasso/lasso-serviceadmin#231