### PR TITLE
chore(demo): pin serviceadmin 2026.6.23-809c102

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.21-8f4b2cd`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.21-6a509d1` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.23-809c102` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-        "tag": "2026.6.23-2042947"
+      "tag": "2026.6.23-809c102"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#278 release-to-demo gate.

## Summary
- Pins core demo `@serviceadmin` manifest to lasso-serviceadmin release `2026.6.23-809c102`.
- Updates README baseline table to match the manifest pin.

## Scope
- In scope: core demo/service manifest pin for Service Admin.
- Out of scope: Service Admin UI implementation, already merged in service-lasso/lasso-serviceadmin#280.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and README catalog line.
- Not required: no schema/API behavior changes.

## Nash invariant impact
- Invariant: canonical demo must consume the exact released Service Admin artifact for the merged UI change.
- Preservation proof: release `2026.6.23-809c102` targets `809c102bc86e04425c43a92e540dc18a53addd0c` and includes `@serviceadmin-win32.zip`, `@serviceadmin-linux.tar.gz`, `@serviceadmin-darwin.tar.gz`, `service.json`, and `SHA256SUMS.txt`.

## Validation
- PASS `npm run build` — log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\core-build.log`
- PASS `npm run verify:service-catalog` — log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\core-verify-service-catalog.log`

## Approval trail
- Required: no explicit human approval requested before PR; normal repo check/merge rules apply.
- Evidence: Service Admin PR #280 merged; release workflow succeeded for `809c102`.

## Cleanup
- Branch: `agent/issue-278-serviceadmin-pin-809c102`
- Commit: `40e6007`
- Post-merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`.