### PR TITLE
feat(runtime): expose per-run stdout stderr log streams

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -825,15 +825,19 @@ export interface ServiceMetricsResponse {
 
 export interface ServiceLogInfoResponse {
   serviceId: string;
-  type: "default";
+  type: "default" | "stdout" | "stderr";
   path: string;
-  availableTypes: ["default"];
+  available: boolean;
+  availableTypes: Array<"default" | "stdout" | "stderr">;
+  sources: ServiceLogSourceResponse[];
 }
 
 export interface ServiceLogChunkResponse {
   serviceId: string;
-  type: "default";
+  type: "default" | "stdout" | "stderr";
   path: string;
+  available: boolean;
+  source: ServiceLogSourceResponse;
   totalLines: number;
   start: number;
   end: number;
@@ -861,7 +865,7 @@ export interface ServiceLogLineResponse {
 
 export interface ServiceLogSearchResponse {
   serviceId: string;
-  type: "default";
+  type: "default" | "stdout" | "stderr";
   path: string;
   query: string;
   includeArchives: boolean;
@@ -871,6 +875,15 @@ export interface ServiceLogSearchResponse {
   hasMore: boolean;
   totalScanned: number;
   matches: ServiceLogLineResponse[];
+}
+
+export interface ServiceLogSourceResponse {
+  kind: "current" | "archive";
+  stream: "combined" | "stdout" | "stderr";
+  runId: string;
+  archiveId?: string;
+  path: string;
+  available: boolean;
 }
 
 export interface RuntimeLogShippingPreviewResponse {

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -5,7 +5,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { resolveExecutionArgs, selectPlatformCommandline } from "./commandline.js";
 import { buildServiceVariables, type ServiceVariableResolutionOptions } from "../operator/variables.js";
-import { archiveRuntimeLogs, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
+import { archiveRuntimeLogs, buildServiceRuntimeLogRunId, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
 
 export interface ManagedProcessHandle {
@@ -53,12 +53,12 @@ interface StartProcessOptions {
 const managedProcesses = new Map<string, ManagedProcessRecord>();
 const managedProcessFinalizers = new Map<string, Promise<void>>();
 
-async function prepareRuntimeLogStreams(serviceRoot: string): Promise<{
+async function prepareRuntimeLogStreams(serviceRoot: string, startedAt: string): Promise<{
   paths: ServiceRuntimeLogPaths;
   streams: ManagedProcessRecord["logStreams"];
 }> {
   await archiveRuntimeLogs(serviceRoot);
-  const paths = getServiceRuntimeLogPaths(serviceRoot);
+  const paths = getServiceRuntimeLogPaths(serviceRoot, buildServiceRuntimeLogRunId(startedAt));
   await mkdir(path.dirname(paths.logPath), { recursive: true });
 
   return {
@@ -261,7 +261,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
   );
   const command = buildCommandString(executable, args);
   const startedAt = new Date().toISOString();
-  const { paths: logPaths, streams: logStreams } = await prepareRuntimeLogStreams(service.serviceRoot);
+  const { paths: logPaths, streams: logStreams } = await prepareRuntimeLogStreams(service.serviceRoot, startedAt);
 
   const child = spawn(executable, args, {
     cwd: workingDirectory,

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -709,6 +709,7 @@ export async function startService(
       provider: executionPlan.provider,
       providerServiceId: executionPlan.providerServiceId,
       logPath: handle.logs.logPath,
+      runId: handle.logs.runId,
       stdoutPath: handle.logs.stdoutPath,
       stderrPath: handle.logs.stderrPath,
     },
@@ -729,6 +730,7 @@ export async function startService(
       lastTermination: null,
       ports: resolvedPorts,
       logs: {
+        runId: handle.logs.runId,
         logPath: handle.logs.logPath,
         stdoutPath: handle.logs.stdoutPath,
         stderrPath: handle.logs.stderrPath,
@@ -923,6 +925,7 @@ export async function restartService(
       lastTermination: null,
       ports: resolvedPorts,
       logs: {
+        runId: handle.logs.runId,
         logPath: handle.logs.logPath,
         stdoutPath: handle.logs.stdoutPath,
         stderrPath: handle.logs.stderrPath,

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -87,6 +87,7 @@ function createInitialState(): ServiceLifecycleState {
       lastTermination: null,
       ports: {},
       logs: {
+        runId: null,
         logPath: null,
         stdoutPath: null,
         stderrPath: null,
@@ -174,6 +175,7 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
       lastTermination: current.runtime.lastTermination,
       ports: { ...current.runtime.ports },
       logs: {
+        runId: current.runtime.logs.runId,
         logPath: current.runtime.logs.logPath,
         stdoutPath: current.runtime.logs.stdoutPath,
         stderrPath: current.runtime.logs.stderrPath,
@@ -252,6 +254,7 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
       lastTermination: nextState.runtime.lastTermination,
       ports: { ...nextState.runtime.ports },
       logs: {
+        runId: nextState.runtime.logs.runId,
         logPath: nextState.runtime.logs.logPath,
         stdoutPath: nextState.runtime.logs.stdoutPath,
         stderrPath: nextState.runtime.logs.stderrPath,

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -118,6 +118,7 @@ export interface ServiceRuntimeState {
   lastTermination: "stopped" | "exited" | "crashed" | null;
   ports: Record<string, number>;
   logs: {
+    runId: string | null;
     logPath: string | null;
     stdoutPath: string | null;
     stderrPath: string | null;

--- a/src/runtime/operator/logs.ts
+++ b/src/runtime/operator/logs.ts
@@ -9,6 +9,7 @@ export interface ServiceLogEntry {
 }
 
 export interface ServiceRuntimeLogPaths {
+  runId: string;
   logPath: string;
   stdoutPath: string;
   stderrPath: string;
@@ -16,6 +17,7 @@ export interface ServiceRuntimeLogPaths {
 
 export interface ServiceRuntimeLogArchive {
   archiveId: string;
+  runId: string;
   archivedAt: string;
   directoryPath: string;
   logPath: string;
@@ -34,15 +36,19 @@ export interface ServiceLogsPayload extends ServiceRuntimeLogPaths {
 
 export interface ServiceLogInfoPayload {
   serviceId: string;
-  type: "default";
+  type: ServiceLogReadType;
   path: string;
-  availableTypes: ["default"];
+  available: boolean;
+  availableTypes: ServiceLogReadType[];
+  sources: ServiceLogSourceInfo[];
 }
 
 export interface ServiceLogChunkPayload {
   serviceId: string;
-  type: "default";
+  type: ServiceLogReadType;
   path: string;
+  available: boolean;
+  source: ServiceLogSourceInfo;
   totalLines: number;
   start: number;
   end: number;
@@ -70,7 +76,7 @@ export interface ServiceLogLinePayload {
 
 export interface ServiceLogSearchPayload {
   serviceId: string;
-  type: "default";
+  type: ServiceLogReadType;
   path: string;
   query: string;
   includeArchives: boolean;
@@ -87,6 +93,17 @@ interface PersistedRuntimeLogEntry {
   message?: string;
 }
 
+export type ServiceLogReadType = "default" | "stdout" | "stderr";
+
+export interface ServiceLogSourceInfo {
+  kind: "current" | "archive";
+  stream: "combined" | "stdout" | "stderr";
+  runId: string;
+  archiveId?: string;
+  path: string;
+  available: boolean;
+}
+
 export const SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION = 3;
 const DEFAULT_LOG_CHUNK_LIMIT = 100;
 const MAX_LOG_CHUNK_LIMIT = 500;
@@ -99,10 +116,15 @@ export function getServiceRuntimeLogsRoot(serviceRoot: string): string {
   return path.join(serviceRoot, "logs");
 }
 
-export function getServiceRuntimeLogPaths(serviceRoot: string): ServiceRuntimeLogPaths {
+function buildRunId(timestamp = new Date()): string {
+  return timestamp.toISOString().replace(/[:.]/g, "-");
+}
+
+export function getServiceRuntimeLogPaths(serviceRoot: string, runId = "current"): ServiceRuntimeLogPaths {
   const runtimeLogsRoot = path.join(getServiceRuntimeLogsRoot(serviceRoot), "runtime");
 
   return {
+    runId,
     logPath: path.join(runtimeLogsRoot, "service.log"),
     stdoutPath: path.join(runtimeLogsRoot, "stdout.log"),
     stderrPath: path.join(runtimeLogsRoot, "stderr.log"),
@@ -114,7 +136,10 @@ export function getServiceRuntimeArchiveRoot(serviceRoot: string): string {
 }
 
 function getArchiveLogPaths(archiveRoot: string): ServiceRuntimeLogPaths {
+  const runId = path.basename(archiveRoot);
+
   return {
+    runId,
     logPath: path.join(archiveRoot, "service.log"),
     stdoutPath: path.join(archiveRoot, "stdout.log"),
     stderrPath: path.join(archiveRoot, "stderr.log"),
@@ -122,7 +147,7 @@ function getArchiveLogPaths(archiveRoot: string): ServiceRuntimeLogPaths {
 }
 
 function buildArchiveId(timestamp: Date): string {
-  return timestamp.toISOString().replace(/[:.]/g, "-");
+  return buildRunId(timestamp);
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -220,6 +245,19 @@ export async function listRuntimeLogArchives(serviceRoot: string): Promise<Servi
   return pruneRuntimeLogArchives(serviceRoot, SERVICE_RUNTIME_LOG_ARCHIVE_RETENTION);
 }
 
+export function buildServiceRuntimeLogRunId(startedAt?: string | null): string {
+  if (!startedAt) {
+    return buildRunId();
+  }
+
+  const parsed = new Date(startedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return buildRunId();
+  }
+
+  return buildRunId(parsed);
+}
+
 function buildSyntheticEntries(serviceId: string, lifecycle: ServiceLifecycleState): ServiceLogEntry[] {
   return lifecycle.actionHistory.map((action) => ({
     level: "info" as const,
@@ -263,6 +301,10 @@ async function readRuntimeLogLines(logPath: string): Promise<string[]> {
   } catch {
     return [];
   }
+}
+
+async function runtimeLogAvailable(logPath: string): Promise<boolean> {
+  return pathExists(logPath);
 }
 
 function sanitizePositiveInteger(value: number | undefined, fallback: number, max: number): number {
@@ -319,11 +361,48 @@ function createLogLinePayload(
   };
 }
 
+function getLogPathForType(paths: ServiceRuntimeLogPaths, type: ServiceLogReadType): string {
+  if (type === "stdout") return paths.stdoutPath;
+  if (type === "stderr") return paths.stderrPath;
+  return paths.logPath;
+}
+
+function getStreamForType(type: ServiceLogReadType): ServiceLogSourceInfo["stream"] {
+  if (type === "stdout") return "stdout";
+  if (type === "stderr") return "stderr";
+  return "combined";
+}
+
+async function buildCurrentSourceInfo(
+  paths: ServiceRuntimeLogPaths,
+  type: ServiceLogReadType,
+): Promise<ServiceLogSourceInfo> {
+  const logPath = getLogPathForType(paths, type);
+
+  return {
+    kind: "current",
+    stream: getStreamForType(type),
+    runId: paths.runId,
+    path: logPath,
+    available: await runtimeLogAvailable(logPath),
+  };
+}
+
+async function buildLogSources(
+  paths: ServiceRuntimeLogPaths,
+): Promise<ServiceLogSourceInfo[]> {
+  return Promise.all(
+    (["default", "stdout", "stderr"] as const).map((type) =>
+      buildCurrentSourceInfo(paths, type),
+    ),
+  );
+}
+
 export async function buildServiceLogs(
   service: DiscoveredService,
   lifecycle: ServiceLifecycleState,
 ): Promise<ServiceLogsPayload> {
-  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot, lifecycle.runtime.logs.runId ?? "current");
   const capturedEntries = await readRuntimeLogEntries(runtimeLogPaths.logPath);
   const archives = await listRuntimeLogArchives(service.serviceRoot);
 
@@ -338,14 +417,21 @@ export async function buildServiceLogs(
   };
 }
 
-export function buildServiceLogInfo(service: DiscoveredService): ServiceLogInfoPayload {
-  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+export async function buildServiceLogInfo(
+  service: DiscoveredService,
+  type: ServiceLogReadType = "default",
+  runId = "current",
+): Promise<ServiceLogInfoPayload> {
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot, runId);
+  const source = await buildCurrentSourceInfo(runtimeLogPaths, type);
 
   return {
     serviceId: service.manifest.id,
-    type: "default",
-    path: runtimeLogPaths.logPath,
-    availableTypes: ["default"],
+    type,
+    path: source.path,
+    available: source.available,
+    availableTypes: ["default", "stdout", "stderr"],
+    sources: await buildLogSources({ ...runtimeLogPaths, runId }),
   };
 }
 
@@ -353,26 +439,40 @@ export async function readServiceLogChunk(
   service: DiscoveredService,
   before?: number,
   limit = DEFAULT_LOG_CHUNK_LIMIT,
+  type: ServiceLogReadType = "default",
+  runId = "current",
 ): Promise<ServiceLogChunkPayload> {
-  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
-  const lines = await readRuntimeLogLines(runtimeLogPaths.logPath);
+  const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot, runId);
+  const logPath = getLogPathForType(runtimeLogPaths, type);
+  const source = await buildCurrentSourceInfo(runtimeLogPaths, type);
+  const lines = await readRuntimeLogLines(logPath);
   const totalLines = lines.length;
   const safeLimit = sanitizePositiveInteger(limit, DEFAULT_LOG_CHUNK_LIMIT, MAX_LOG_CHUNK_LIMIT);
   const end = sanitizeCursor(before, totalLines, totalLines);
   const start = Math.max(0, end - safeLimit);
   const slice = lines.slice(start, end);
-  const entries = slice.map((line, index) =>
-    createLogLinePayload(line, {
+  const entries = slice.map((line, index) => {
+    const entry = createLogLinePayload(line, {
       kind: "current",
-      path: runtimeLogPaths.logPath,
+      path: logPath,
       lineNumber: start + index + 1,
-    }),
-  );
+    });
+    return type === "default"
+      ? entry
+      : {
+          ...entry,
+          stream: type,
+          message: truncateLogText(line).text,
+          text: truncateLogText(line).text,
+        };
+  });
 
   return {
     serviceId: service.manifest.id,
-    type: "default",
-    path: runtimeLogPaths.logPath,
+    type,
+    path: logPath,
+    available: source.available,
+    source,
     totalLines,
     start,
     end,
@@ -429,13 +529,27 @@ export async function searchServiceLogs(
     cursor?: number;
     includeArchives?: boolean;
     limit?: number;
+    type?: ServiceLogReadType;
   } = {},
 ): Promise<ServiceLogSearchPayload> {
   const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
+  const type = options.type ?? "default";
   const safeQuery = query.trim().slice(0, MAX_LOG_SEARCH_QUERY_LENGTH);
   const includeArchives = options.includeArchives === true;
   const limit = sanitizePositiveInteger(options.limit, DEFAULT_LOG_SEARCH_LIMIT, MAX_LOG_SEARCH_LIMIT);
-  const lines = await collectSearchableLogLines(service, includeArchives);
+  const lines = type === "default"
+    ? await collectSearchableLogLines(service, includeArchives)
+    : (await readRuntimeLogLines(getLogPathForType(runtimeLogPaths, type))).map((line, index) => ({
+        source: {
+          kind: "current" as const,
+          path: getLogPathForType(runtimeLogPaths, type),
+          lineNumber: index + 1,
+        },
+        stream: type,
+        message: truncateLogText(line).text,
+        text: truncateLogText(line).text,
+        truncated: truncateLogText(line).truncated,
+      }));
   const cursor = sanitizeCursor(options.cursor, 0, lines.length);
   const normalizedQuery = safeQuery.toLocaleLowerCase();
   const matches: ServiceLogLinePayload[] = [];
@@ -457,8 +571,8 @@ export async function searchServiceLogs(
 
   return {
     serviceId: service.manifest.id,
-    type: "default",
-    path: runtimeLogPaths.logPath,
+    type,
+    path: getLogPathForType(runtimeLogPaths, type),
     query: safeQuery,
     includeArchives,
     limit,

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -62,6 +62,7 @@ interface StoredRuntimeState {
   lastTermination?: "stopped" | "exited" | "crashed" | null;
   ports?: Record<string, number>;
   logs?: {
+    runId?: string | null;
     logPath?: string | null;
     stdoutPath?: string | null;
     stderrPath?: string | null;
@@ -440,6 +441,7 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
             )
           : {},
       logs: {
+        runId: typeof runtime?.logs?.runId === "string" ? runtime.logs.runId : null,
         logPath: typeof runtime?.logs?.logPath === "string" ? runtime.logs.logPath : null,
         stdoutPath: typeof runtime?.logs?.stdoutPath === "string" ? runtime.logs.stdoutPath : null,
         stderrPath: typeof runtime?.logs?.stderrPath === "string" ? runtime.logs.stderrPath : null,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,6 +50,7 @@ import {
   getServiceRuntimeLogPaths,
   readServiceLogChunk,
   searchServiceLogs,
+  type ServiceLogReadType,
 } from "../runtime/operator/logs.js";
 import { buildDashboardService, buildDashboardSummary } from "../runtime/operator/dashboard.js";
 import {
@@ -226,6 +227,18 @@ function parseOptionalInteger(value: string | null): number | undefined {
 
 function parseBooleanQuery(value: string | null): boolean {
   return value === "1" || value?.toLocaleLowerCase() === "true";
+}
+
+function parseServiceLogReadType(value: string | null): ServiceLogReadType {
+  if (value === null || value === "default") {
+    return "default";
+  }
+
+  if (value === "stdout" || value === "stderr") {
+    return value;
+  }
+
+  throw new ApiError("invalid_request", 400, "Log type must be one of: default, stdout, stderr.");
 }
 
 function cloneWorkflowRunFacadeState(state: WorkflowRunFacadeState): WorkflowRunFacadeState {
@@ -1358,14 +1371,10 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/services/log-info") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
-    const type = url.searchParams.get("type") ?? "default";
+    const type = parseServiceLogReadType(url.searchParams.get("type"));
 
     if (!serviceId) {
       throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
-    }
-
-    if (type !== "default") {
-      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
     }
 
     const service = runtimeModel.registry.getById(serviceId);
@@ -1374,24 +1383,24 @@ async function routeRequest(
       return;
     }
 
-    writeJson(response, 200, createServiceLogInfoResponse(buildServiceLogInfo(service)));
+    writeJson(
+      response,
+      200,
+      createServiceLogInfoResponse(await buildServiceLogInfo(service, type, getLifecycleState(serviceId).runtime.logs.runId ?? "current")),
+    );
     return;
   }
 
   if (request.method === "GET" && url.pathname === "/api/logs/read") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
-    const type = url.searchParams.get("type") ?? "default";
+    const type = parseServiceLogReadType(url.searchParams.get("type"));
     const cursorParam = url.searchParams.get("cursor");
     const beforeParam = url.searchParams.get("before");
     const limitParam = url.searchParams.get("limit");
 
     if (!serviceId) {
       throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
-    }
-
-    if (type !== "default") {
-      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
     }
 
     const service = runtimeModel.registry.getById(serviceId);
@@ -1403,14 +1412,18 @@ async function routeRequest(
     const before = parseOptionalInteger(cursorParam) ?? parseOptionalInteger(beforeParam);
     const limit = parseOptionalInteger(limitParam);
 
-    writeJson(response, 200, createServiceLogChunkResponse(await readServiceLogChunk(service, before, limit)));
+    writeJson(
+      response,
+      200,
+      createServiceLogChunkResponse(await readServiceLogChunk(service, before, limit, type, getLifecycleState(serviceId).runtime.logs.runId ?? "current")),
+    );
     return;
   }
 
   if (request.method === "GET" && url.pathname === "/api/logs/search") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
-    const type = url.searchParams.get("type") ?? "default";
+    const type = parseServiceLogReadType(url.searchParams.get("type"));
     const query = url.searchParams.get("q") ?? url.searchParams.get("query");
     const cursor = parseOptionalInteger(url.searchParams.get("cursor"));
     const limit = parseOptionalInteger(url.searchParams.get("limit"));
@@ -1418,10 +1431,6 @@ async function routeRequest(
 
     if (!serviceId) {
       throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
-    }
-
-    if (type !== "default") {
-      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
     }
 
     if (query === null || query.trim().length === 0) {
@@ -1437,7 +1446,7 @@ async function routeRequest(
     writeJson(
       response,
       200,
-      createServiceLogSearchResponse(await searchServiceLogs(service, query, { cursor, includeArchives, limit })),
+      createServiceLogSearchResponse(await searchServiceLogs(service, query, { cursor, includeArchives, limit, type })),
     );
     return;
   }

--- a/src/server/routes/logs.ts
+++ b/src/server/routes/logs.ts
@@ -3,12 +3,14 @@ import type { ServiceLogEntryResponse } from "../../contracts/api.js";
 export interface ServiceLogsResponse {
   logs: {
     serviceId: string;
+    runId: string;
     logPath: string;
     stdoutPath: string;
     stderrPath: string;
     entries: ServiceLogEntryResponse[];
     archives: {
       archiveId: string;
+      runId: string;
       archivedAt: string;
       directoryPath: string;
       logPath: string;

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { readFile, readdir, rm } from "node:fs/promises";
+import { readFile, readdir, rm, unlink } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { getLifecycleState, resetLifecycleState, setLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
@@ -181,6 +181,8 @@ test("managed stdout/stderr are captured into runtime-owned log files and surfac
     const start = await postJson(`${apiServer.url}/api/services/loggy-service/start`);
 
     assert.equal(start.status, 200);
+    assert.equal(typeof start.body.state.runtime.logs.runId, "string");
+    assert.match(start.body.state.runtime.logs.runId, /^\d{4}-\d{2}-\d{2}T/);
     assert.equal(start.body.state.runtime.logs.logPath.endsWith(path.join("loggy-service", "logs", "runtime", "service.log")), true);
     assert.equal(start.body.state.runtime.logs.stdoutPath.endsWith(path.join("loggy-service", "logs", "runtime", "stdout.log")), true);
     assert.equal(start.body.state.runtime.logs.stderrPath.endsWith(path.join("loggy-service", "logs", "runtime", "stderr.log")), true);
@@ -195,6 +197,7 @@ test("managed stdout/stderr are captured into runtime-owned log files and surfac
     });
 
     assert.equal(logsResponse.response.status, 200);
+    assert.equal(logsResponse.body.logs.runId, start.body.state.runtime.logs.runId);
     assert.equal(logsResponse.body.logs.retention.maxArchives, 3);
     assert.deepEqual(logsResponse.body.logs.archives, []);
     assert.deepEqual(
@@ -258,8 +261,14 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
 
     const infoResponse = await fetch(`${apiServer.url}/api/services/log-info?service=reader-service&type=default`);
     const infoBody = await infoResponse.json();
+    const stdoutInfoResponse = await fetch(`${apiServer.url}/api/services/log-info?service=reader-service&type=stdout`);
+    const stdoutInfoBody = await stdoutInfoResponse.json();
     const chunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=50`);
     const chunkBody = await chunkResponse.json();
+    const stdoutChunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=stdout&limit=50`);
+    const stdoutChunkBody = await stdoutChunkResponse.json();
+    const stderrChunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=stderr&limit=50`);
+    const stderrChunkBody = await stderrChunkResponse.json();
     const cursorResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=1`);
     const cursorBody = await cursorResponse.json();
     const nextCursorResponse = await fetch(
@@ -274,8 +283,16 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     assert.equal(infoResponse.status, 200);
     assert.equal(infoBody.serviceId, "reader-service");
     assert.equal(infoBody.type, "default");
-    assert.deepEqual(infoBody.availableTypes, ["default"]);
+    assert.equal(infoBody.available, true);
+    assert.deepEqual(infoBody.availableTypes, ["default", "stdout", "stderr"]);
+    assert.deepEqual(infoBody.sources.map((source) => source.stream), ["combined", "stdout", "stderr"]);
+    assert.equal(infoBody.sources.every((source) => source.kind === "current"), true);
+    assert.equal(infoBody.sources.every((source) => typeof source.runId === "string" && source.runId.length > 0), true);
     assert.equal(infoBody.path.endsWith(path.join("reader-service", "logs", "runtime", "service.log")), true);
+    assert.equal(stdoutInfoResponse.status, 200);
+    assert.equal(stdoutInfoBody.type, "stdout");
+    assert.equal(stdoutInfoBody.available, true);
+    assert.equal(stdoutInfoBody.path.endsWith(path.join("reader-service", "logs", "runtime", "stdout.log")), true);
 
     assert.equal(chunkResponse.status, 200);
     assert.equal(chunkBody.serviceId, "reader-service");
@@ -286,7 +303,26 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stdout\"")));
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stderr\"")));
     assert.equal(chunkBody.cursor, String(chunkBody.end));
+    assert.equal(chunkBody.available, true);
+    assert.equal(chunkBody.source.stream, "combined");
+    assert.equal(typeof chunkBody.source.runId, "string");
     assert.equal(chunkBody.entries.some((entry) => entry.stream === "stdout" && entry.message === "reader stdout"), true);
+
+    assert.equal(stdoutChunkResponse.status, 200);
+    assert.equal(stdoutChunkBody.type, "stdout");
+    assert.equal(stdoutChunkBody.available, true);
+    assert.equal(stdoutChunkBody.source.stream, "stdout");
+    assert.deepEqual(stdoutChunkBody.lines, ["reader stdout"]);
+    assert.equal(stdoutChunkBody.entries[0].stream, "stdout");
+    assert.equal(stdoutChunkBody.entries[0].message, "reader stdout");
+
+    assert.equal(stderrChunkResponse.status, 200);
+    assert.equal(stderrChunkBody.type, "stderr");
+    assert.equal(stderrChunkBody.available, true);
+    assert.equal(stderrChunkBody.source.stream, "stderr");
+    assert.deepEqual(stderrChunkBody.lines, ["reader stderr"]);
+    assert.equal(stderrChunkBody.entries[0].stream, "stderr");
+    assert.equal(stderrChunkBody.entries[0].message, "reader stderr");
 
     assert.equal(cursorResponse.status, 200);
     assert.equal(cursorBody.lines.length, 1);
@@ -301,6 +337,23 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
     assert.equal(searchBody.matches.length, 1);
     assert.equal(searchBody.matches[0].stream, "stdout");
     assert.equal(searchBody.matches[0].message, "reader stdout");
+
+    const stdoutSearchResponse = await fetch(
+      `${apiServer.url}/api/logs/search?service=reader-service&type=stdout&q=reader%20stdout&limit=5`,
+    );
+    const stdoutSearchBody = await stdoutSearchResponse.json();
+    assert.equal(stdoutSearchResponse.status, 200);
+    assert.equal(stdoutSearchBody.type, "stdout");
+    assert.equal(stdoutSearchBody.matches.length, 1);
+    assert.equal(stdoutSearchBody.matches[0].stream, "stdout");
+
+    await unlink(path.join(servicesRoot, "reader-service", "logs", "runtime", "stderr.log"));
+    const missingStderrResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=stderr&limit=50`);
+    const missingStderrBody = await missingStderrResponse.json();
+    assert.equal(missingStderrResponse.status, 200);
+    assert.equal(missingStderrBody.type, "stderr");
+    assert.equal(missingStderrBody.available, false);
+    assert.deepEqual(missingStderrBody.lines, []);
 
     await postJson(`${apiServer.url}/api/services/reader-service/stop`);
   } finally {
@@ -323,9 +376,11 @@ test("runtime logs archive previous runs and enforce bounded retention", async (
     await postJson(`${apiServer.url}/api/services/archive-loggy-service/install`);
     await postJson(`${apiServer.url}/api/services/archive-loggy-service/config`);
 
+    const runIds = [];
     for (let run = 0; run < 5; run += 1) {
       const start = await postJson(`${apiServer.url}/api/services/archive-loggy-service/start`);
       assert.equal(start.status, 200);
+      runIds.push(start.body.state.runtime.logs.runId);
 
       await waitFor(async () => {
         const response = await fetch(`${apiServer.url}/api/services/archive-loggy-service/logs`);
@@ -346,6 +401,13 @@ test("runtime logs archive previous runs and enforce bounded retention", async (
     assert.equal(logsResponse.status, 200);
     assert.equal(logsBody.logs.retention.maxArchives, 3);
     assert.equal(logsBody.logs.archives.length, 3);
+    assert.equal(new Set(runIds).size, 5);
+    assert.equal(logsBody.logs.runId, runIds.at(-1));
+    assert.deepEqual(
+      logsBody.logs.archives.map((archive) => archive.runId),
+      logsBody.logs.archives.map((archive) => archive.archiveId),
+    );
+    assert.equal(new Set(logsBody.logs.archives.map((archive) => archive.archiveId)).size, 3);
     assert.deepEqual(
       logsBody.logs.entries
         .filter((entry) => entry.message.length > 0)


### PR DESCRIPTION
## Summary
- Add run ids to managed service runtime log state and `/api/services/:id/logs` archive/current metadata.
- Preserve existing combined `type=default` log reads while adding safe `type=stdout` and `type=stderr` read/info/search support.
- Surface source metadata, availability, stream identity, and cursors without exposing env values, command payload values, headers, or raw config.

## Verification
- PASS `npm run build`
- PASS `git diff --check`
- PASS `node --test --test-concurrency=1 --test-name-pattern "managed stdout/stderr|live log info|runtime logs archive" tests/operator-data.test.js`
- PARTIAL `node --test --test-concurrency=1 tests/operator-data.test.js`: the three #685 log tests passed, but unrelated tests that call `clearPersistedFixtureState(servicesRoot)` failed on Windows `EPERM` file locks for live canonical service executables such as `@secretsbroker/.state/extracted/current/secretsbroker.exe`, `@traefik/.state/extracted/current/traefik.exe`, and `@nginx/.state/extracted/current/nginx.exe`.

## Notes
- This is the core/runtime dependency slice for service-lasso/lasso-serviceadmin#281 and service-lasso/lasso-serviceadmin#275.
- Canonical demo evidence remains required after merge before claiming the slice complete.

Fixes #685