### PR TITLE
feat(runtime): add service config editor API

### DIFF
--- a/docs/reference/service-config-editor-api.md
+++ b/docs/reference/service-config-editor-api.md
@@ -1,0 +1,28 @@
+# Service config editor API
+
+Service Admin uses the runtime-backed config editor API to read and update a service's manifest file as `server.json`.
+
+## Endpoints
+
+`GET /api/services/{serviceId}/config`
+
+- Returns the current service manifest content, file path, SHA-256 hash, update time, backup count, revision list, and safety metadata.
+- The runtime response is limited to the service manifest file and does not include resolved environment values, provider credentials, authorization headers, or runtime-only process state.
+
+`PUT /api/services/{serviceId}/config`
+
+- Accepts `{ "content": "<json string>", "actor": "<optional>", "reason": "<optional>" }`.
+- Fails closed unless `content` parses as a JSON object.
+- Creates a backup revision of the previous manifest before replacing the current manifest.
+- Writes through a temporary file and rename so failed writes do not partially replace the manifest.
+
+`GET /api/services/{serviceId}/config/backups`
+
+- Returns backup revisions for the service, newest first.
+- Revision records include id, creation time, actor, optional reason, backup path, previous hash, current hash, validation status, and previous content for compare views.
+
+## Safety
+
+- The editor API is scoped to the discovered service's own `service.json` manifest path.
+- Backup files are stored under the runtime workspace in `service-config-backups/{serviceId}/`.
+- Raw secret values, resolved environment values, provider credentials, authorization headers, request bodies from other APIs, and runtime-only process state must not be added to these responses.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -73,6 +73,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/service-config-editor-api",
+          label: "Service Config Editor API",
+        },
+        {
+          type: "doc",
           id: "reference/config-snapshot",
           label: "Configuration Snapshot",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -103,6 +103,43 @@ export interface ServiceConfigDriftResponse {
   drift: ConfigDriftReport;
 }
 
+export interface ServiceConfigRevisionResponse {
+  id: string;
+  createdAt: string;
+  actor: string;
+  reason: string | null;
+  path: string;
+  previousHash: string;
+  currentHash: string;
+  validationStatus: "valid";
+  content: string;
+}
+
+export interface ServiceConfigDocumentResponse {
+  serviceId: string;
+  fileName: "server.json";
+  path: string;
+  content: string;
+  hash: string;
+  updatedAt: string;
+  backupCount: number;
+  revisions: ServiceConfigRevisionResponse[];
+  safety: {
+    rawSecretValuesLoaded: false;
+    omittedSensitiveFields: string[];
+  };
+}
+
+export interface ServiceConfigSaveResponse {
+  serviceId: string;
+  fileName: "server.json";
+  path: string;
+  hash: string;
+  savedAt: string;
+  backup: ServiceConfigRevisionResponse;
+  validationStatus: "valid";
+}
+
 export interface ServiceMetaResponse {
   serviceId: string;
   meta: {

--- a/src/runtime/operator/service-config-editor.ts
+++ b/src/runtime/operator/service-config-editor.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  ServiceConfigDocumentResponse,
+  ServiceConfigRevisionResponse,
+  ServiceConfigSaveResponse,
+} from "../../contracts/api.js";
+import type { DiscoveredService } from "../../contracts/service.js";
+
+type ServiceConfigSaveInput = {
+  content: string;
+  actor?: string;
+  reason?: string | null;
+};
+
+const BACKUP_ROOT_NAME = "service-config-backups";
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function safeServiceId(serviceId: string): string {
+  return serviceId.replace(/[^A-Za-z0-9_.-]/g, "_");
+}
+
+function safeRevisionTimestamp(date = new Date()): string {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function backupRoot(workspaceRoot: string, serviceId: string): string {
+  return path.join(workspaceRoot, BACKUP_ROOT_NAME, safeServiceId(serviceId));
+}
+
+function metadataPathForRevision(contentPath: string): string {
+  return `${contentPath}.metadata.json`;
+}
+
+function normalizeJsonContent(content: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("server.json content must be valid JSON before save.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("server.json content must be a JSON object.");
+  }
+
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+async function fileUpdatedAt(filePath: string): Promise<string> {
+  try {
+    return (await stat(filePath)).mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+async function readRevision(contentPath: string): Promise<ServiceConfigRevisionResponse | null> {
+  try {
+    const [content, rawMetadata] = await Promise.all([
+      readFile(contentPath, "utf8"),
+      readFile(metadataPathForRevision(contentPath), "utf8"),
+    ]);
+    const metadata = JSON.parse(rawMetadata) as Omit<ServiceConfigRevisionResponse, "content">;
+    return {
+      ...metadata,
+      content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function listServiceConfigRevisions(
+  service: DiscoveredService,
+  workspaceRoot: string,
+): Promise<ServiceConfigRevisionResponse[]> {
+  const root = backupRoot(workspaceRoot, service.manifest.id);
+  let entries: string[] = [];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+
+  const revisions = await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith(".server.json"))
+      .map((entry) => readRevision(path.join(root, entry))),
+  );
+
+  return revisions
+    .filter((revision): revision is ServiceConfigRevisionResponse => revision !== null)
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function readServiceConfigDocument(
+  service: DiscoveredService,
+  workspaceRoot: string,
+): Promise<ServiceConfigDocumentResponse> {
+  const content = await readFile(service.manifestPath, "utf8");
+  const revisions = await listServiceConfigRevisions(service, workspaceRoot);
+
+  return {
+    serviceId: service.manifest.id,
+    fileName: "server.json",
+    path: service.manifestPath,
+    content,
+    hash: sha256(content),
+    updatedAt: await fileUpdatedAt(service.manifestPath),
+    backupCount: revisions.length,
+    revisions,
+    safety: {
+      rawSecretValuesLoaded: false,
+      omittedSensitiveFields: [
+        "resolved environment values",
+        "provider credentials",
+        "authorization headers",
+        "runtime-only process state",
+      ],
+    },
+  };
+}
+
+export async function saveServiceConfigDocument(
+  service: DiscoveredService,
+  workspaceRoot: string,
+  input: ServiceConfigSaveInput,
+): Promise<ServiceConfigSaveResponse> {
+  const previousContent = await readFile(service.manifestPath, "utf8");
+  const normalizedContent = normalizeJsonContent(input.content);
+  const previousHash = sha256(previousContent);
+  const currentHash = sha256(normalizedContent);
+  const savedAt = new Date();
+  const revisionId = `${safeRevisionTimestamp(savedAt)}-${previousHash.slice(0, 12)}`;
+  const revisionPath = path.join(backupRoot(workspaceRoot, service.manifest.id), `${revisionId}.server.json`);
+  const revision: ServiceConfigRevisionResponse = {
+    id: revisionId,
+    createdAt: savedAt.toISOString(),
+    actor: input.actor?.trim() || "service-admin",
+    reason: input.reason?.trim() || null,
+    path: revisionPath,
+    previousHash,
+    currentHash,
+    validationStatus: "valid",
+    content: previousContent,
+  };
+
+  await mkdir(path.dirname(revisionPath), { recursive: true });
+  await writeFile(revisionPath, previousContent, "utf8");
+  await writeFile(
+    metadataPathForRevision(revisionPath),
+    JSON.stringify({ ...revision, content: undefined }, null, 2),
+    "utf8",
+  );
+
+  const tempPath = path.join(path.dirname(service.manifestPath), `.service.json.${process.pid}.${Date.now()}.tmp`);
+  await writeFile(tempPath, normalizedContent, "utf8");
+  await rename(tempPath, service.manifestPath);
+
+  return {
+    serviceId: service.manifest.id,
+    fileName: "server.json",
+    path: service.manifestPath,
+    hash: currentHash,
+    savedAt: savedAt.toISOString(),
+    backup: revision,
+    validationStatus: "valid",
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -82,6 +82,11 @@ import { buildRestartSafetyPreflightReport } from "../runtime/operator/restart-s
 import { buildServiceCompatibilityReport } from "../runtime/operator/catalog-compatibility.js";
 import { buildServiceConfigDriftReport } from "../runtime/operator/config-drift.js";
 import {
+  listServiceConfigRevisions,
+  readServiceConfigDocument,
+  saveServiceConfigDocument,
+} from "../runtime/operator/service-config-editor.js";
+import {
   buildSecretProviderAuthRequiredSummary,
   buildSecretReferenceAudit,
   buildSecretRotationReadinessReport,
@@ -419,6 +424,38 @@ function parseUpdateInstallBody(input: unknown): { force?: boolean } {
 
   return {
     force: typeof candidate.force === "boolean" ? candidate.force : undefined,
+  };
+}
+
+function parseServiceConfigSaveBody(input: unknown): { content: string; actor?: string; reason?: string | null } {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Service config save body must be a JSON object.");
+  }
+
+  const candidate = input as Record<string, unknown>;
+  if (typeof candidate.content !== "string") {
+    throw new ApiError("invalid_body", 400, '"content" must be a JSON string.');
+  }
+  if (candidate.actor !== undefined && candidate.actor !== null && typeof candidate.actor !== "string") {
+    throw new ApiError("invalid_body", 400, '"actor" must be a string when present.');
+  }
+  if (candidate.reason !== undefined && candidate.reason !== null && typeof candidate.reason !== "string") {
+    throw new ApiError("invalid_body", 400, '"reason" must be a string or null when present.');
+  }
+
+  try {
+    const parsed = JSON.parse(candidate.content) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("not_object");
+    }
+  } catch {
+    throw new ApiError("invalid_body", 400, '"content" must be a valid JSON object string.');
+  }
+
+  return {
+    content: candidate.content,
+    actor: typeof candidate.actor === "string" ? candidate.actor : undefined,
+    reason: typeof candidate.reason === "string" ? candidate.reason : null,
   };
 }
 
@@ -1532,6 +1569,26 @@ async function routeRequest(
         200,
         createServiceNetworkResponse(buildServiceNetwork(service, sharedGlobalEnv, resolvedPorts)),
       );
+      return;
+    }
+
+    if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "config") {
+      writeJson(response, 200, await readServiceConfigDocument(service, config.workspaceRoot));
+      return;
+    }
+
+    if (request.method === "PUT" && pathParts.length === 4 && pathParts[3] === "config") {
+      const body = parseServiceConfigSaveBody(await readJsonBody(request));
+      writeJson(response, 200, await saveServiceConfigDocument(service, config.workspaceRoot, body));
+      return;
+    }
+
+    if (request.method === "GET" && pathParts.length === 5 && pathParts[3] === "config" && pathParts[4] === "backups") {
+      writeJson(response, 200, {
+        serviceId,
+        fileName: "server.json",
+        revisions: await listServiceConfigRevisions(service, config.workspaceRoot),
+      });
       return;
     }
 

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -166,6 +166,97 @@ test("service meta routes persist favorites and dependency graph layout across r
   }
 });
 
+test("service config editor routes read, validate, save, and retain backups", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-config-editor-");
+  await writeManifest(servicesRoot, "editable-service", {
+    id: "editable-service",
+    name: "Editable Service",
+    description: "Service with editable manifest.",
+    env: {
+      TOKEN_REF: "secret://editable-service/token",
+    },
+    healthcheck: { type: "process" },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const readResponse = await fetch(`${apiServer.url}/api/services/editable-service/config`);
+    const readBody = await readResponse.json();
+
+    assert.equal(readResponse.status, 200);
+    assert.equal(readBody.serviceId, "editable-service");
+    assert.equal(readBody.fileName, "server.json");
+    assert.match(readBody.path, /service\.json$/);
+    assert.match(readBody.content, /Editable Service/);
+    assert.equal(readBody.safety.rawSecretValuesLoaded, false);
+    assert.deepEqual(readBody.revisions, []);
+
+    const invalidResponse = await fetch(`${apiServer.url}/api/services/editable-service/config`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "{not-json" }),
+    });
+    const invalidBody = await invalidResponse.json();
+    assert.equal(invalidResponse.status, 400);
+    assert.equal(invalidBody.error, "invalid_body");
+
+    const nextContent = JSON.stringify(
+      {
+        id: "editable-service",
+        name: "Editable Service",
+        description: "Updated safely from Service Admin.",
+        enabled: true,
+        env: {
+          TOKEN_REF: "secret://editable-service/token",
+        },
+        healthcheck: { type: "process" },
+      },
+      null,
+      2,
+    );
+    const saveResponse = await fetch(`${apiServer.url}/api/services/editable-service/config`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        content: nextContent,
+        actor: "service-admin-test",
+        reason: "operator config editor save test",
+      }),
+    });
+    const saveBody = await saveResponse.json();
+
+    assert.equal(saveResponse.status, 200);
+    assert.equal(saveBody.serviceId, "editable-service");
+    assert.equal(saveBody.validationStatus, "valid");
+    assert.equal(saveBody.backup.actor, "service-admin-test");
+    assert.equal(saveBody.backup.reason, "operator config editor save test");
+    assert.equal(saveBody.backup.validationStatus, "valid");
+    assert.match(saveBody.backup.content, /Editable Service/);
+    assert.match(saveBody.backup.content, /secret:\/\/editable-service\/token/);
+
+    const updatedManifest = JSON.parse(await readFile(path.join(servicesRoot, "editable-service", "service.json"), "utf8"));
+    assert.equal(updatedManifest.description, "Updated safely from Service Admin.");
+
+    const backupsResponse = await fetch(`${apiServer.url}/api/services/editable-service/config/backups`);
+    const backupsBody = await backupsResponse.json();
+    assert.equal(backupsResponse.status, 200);
+    assert.equal(backupsBody.revisions.length, 1);
+    assert.equal(backupsBody.revisions[0].id, saveBody.backup.id);
+    assert.equal(backupsBody.revisions[0].previousHash, saveBody.backup.previousHash);
+
+    const rereadResponse = await fetch(`${apiServer.url}/api/services/editable-service/config`);
+    const rereadBody = await rereadResponse.json();
+    assert.equal(rereadResponse.status, 200);
+    assert.equal(rereadBody.backupCount, 1);
+    assert.match(rereadBody.content, /Updated safely from Service Admin/);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("managed stdout/stderr are captured into runtime-owned log files and surfaced through API/state", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-runtime-logs-");


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#277

## Summary
- Add runtime-backed `server.json` config editor API endpoints for Service Admin.
- Validate JSON object content before save, create backup revisions, and write through a temp file/rename path.
- Document the API and expose typed response contracts.

## Scope
- In scope: `GET/PUT /api/services/{serviceId}/config`, `GET /api/services/{serviceId}/config/backups`, backup metadata/content, focused route tests.
- Out of scope: Service Admin UI wiring, which is in the paired `lasso-serviceadmin` branch/PR.

## Spec / contract / fixture impact
- Updated: `src/contracts/api.ts`, `docs/reference/service-config-editor-api.md`, `docs/sidebars.js`.

## Service Lasso invariant impact
- Invariant: service manifests remain the source of truth.
- Preservation proof: the API is scoped to each discovered service manifest path and backups live under the runtime workspace.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-277-config-editor/core-build-rerun.log`
- PASS `node --test --test-concurrency=1 --test-name-pattern "service config editor routes" tests/operator-data.test.js` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-277-config-editor/core-config-editor-test-rerun.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-277-config-editor/core-git-diff-check-docs.log`

## Approval trail
- Required: normal PR review/merge authorization.
- Evidence: opened as dependency PR for Service Admin #277.

## Cleanup
- Branch cleanup after merge; canonical demo recycle/verify required after merge because runtime API changes are demo-consumed.