### PR TITLE
fix(telemetry): redact sensitive allowlisted attributes

### DIFF
--- a/docs/reference/redacted-telemetry-preview.md
+++ b/docs/reference/redacted-telemetry-preview.md
@@ -14,7 +14,7 @@ The runtime also includes a bounded in-memory `apiRequests` preview for recent o
 
 ## Redaction Contract
 
-Telemetry attributes use an allowlist. The API may return:
+Telemetry attributes use an allowlist and value-level redaction. The API may return:
 
 - service id, role, enabled state, version, artifact tag, and artifact asset name
 - lifecycle booleans and last lifecycle action
@@ -25,6 +25,8 @@ Telemetry attributes use an allowlist. The API may return:
 - deterministic trace id, span id, and Service Lasso correlation id
 
 The API must not return raw secret values, environment values, provider credentials, cookies, authorization headers, private keys, recovery material, raw URL paths or query strings, raw request/response bodies, full file contents, or raw service config values.
+
+Allowed string attributes are still checked for sensitive-looking content before they are returned or sent to the local mock collector. Bearer tokens, GitHub-style tokens, AWS access keys, private-key blocks, basic-auth URLs, sensitive key/value pairs, and Service Lasso secret regression sentinels are replaced with `[REDACTED]`. This prevents an otherwise allowed field such as service version, artifact metadata, health detail, or provider metadata from carrying secret-shaped values through the preview.
 
 Exporter endpoint values, OTLP headers, and payload bodies are never returned. `/api/telemetry` only reports whether `SERVICE_LASSO_OTEL_ENABLED` and `OTEL_EXPORTER_OTLP_ENDPOINT` make export configured.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -163,6 +163,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/redacted-telemetry-preview",
+          label: "Redacted Telemetry Preview",
+        },
+        {
+          type: "doc",
           id: "reference/operator-mcp",
           label: "Operator MCP",
         },

--- a/src/runtime/operator/telemetry.ts
+++ b/src/runtime/operator/telemetry.ts
@@ -14,8 +14,10 @@ export type ApiRequestOutcome = "success" | "client_error" | "server_error" | "r
 
 export interface TelemetryAttributePolicy {
   mode: "allowlist";
+  redactedValue: "[REDACTED]";
   allowedAttributes: string[];
   forbiddenFieldClasses: string[];
+  patternClasses: string[];
   omittedFieldExamples: string[];
 }
 
@@ -131,9 +133,11 @@ const allowedTelemetryAttributes = [
 ] as const;
 
 const allowedTelemetryAttributeSet = new Set<string>(allowedTelemetryAttributes);
+const REDACTED = "[REDACTED]";
 
 export const telemetryAttributePolicy: TelemetryAttributePolicy = {
   mode: "allowlist",
+  redactedValue: REDACTED,
   allowedAttributes: [...allowedTelemetryAttributes],
   forbiddenFieldClasses: [
     "raw secret values",
@@ -145,6 +149,15 @@ export const telemetryAttributePolicy: TelemetryAttributePolicy = {
     "raw URL paths and query strings",
     "full file contents",
     "raw service config values",
+  ],
+  patternClasses: [
+    "bearer tokens",
+    "GitHub-style tokens",
+    "AWS access keys",
+    "private key blocks",
+    "basic-auth URLs",
+    "sensitive key-value pairs",
+    "Service Lasso secret regression sentinels",
   ],
   omittedFieldExamples: [
     "env",
@@ -159,6 +172,30 @@ export const telemetryAttributePolicy: TelemetryAttributePolicy = {
     "providerCredential",
   ],
 };
+
+function redactTelemetryString(value: string): string {
+  const patterns: RegExp[] = [
+    /Bearer\s+[A-Za-z0-9._~+/-]{12,}/g,
+    /gh[pousr]_[A-Za-z0-9_]{20,}/g,
+    /AKIA[0-9A-Z]{16}/g,
+    /https?:\/\/[^\s/:]+:[^\s/@]{6,}@/g,
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    /SERVICE_LASSO_FAKE_[A-Z0-9_]*(SECRET|TOKEN|PASSWORD|CREDENTIAL)[A-Z0-9_]*_DO_NOT_USE/g,
+    /\b(api[_-]?key|auth|authorization|bearer|cookie|credential|env|password|private[_-]?key|secret|token)\b\s*[:=]\s*("[^"]+"|'[^']+'|[^\s,;]+)/gi,
+  ];
+  let redacted = value;
+
+  for (const pattern of patterns) {
+    redacted = redacted.replace(pattern, (match, key: string | undefined) => {
+      if (typeof key === "string" && key.length > 0 && /[:=]\s*/.test(match)) {
+        return match.replace(/[:=]\s*("[^"]+"|'[^']+'|[^\s,;]+)/, `=${REDACTED}`);
+      }
+      return REDACTED;
+    });
+  }
+
+  return redacted;
+}
 
 function hashHex(input: string, length: number): string {
   return createHash("sha256").update(input).digest("hex").slice(0, length);
@@ -197,7 +234,7 @@ function allowlistedAttributes(
     if (!allowedTelemetryAttributeSet.has(key) || value === null || value === undefined) {
       continue;
     }
-    result[key] = value;
+    result[key] = typeof value === "string" ? redactTelemetryString(value) : value;
   }
 
   return result;

--- a/tests/telemetry-preview.test.js
+++ b/tests/telemetry-preview.test.js
@@ -4,7 +4,7 @@ import { createServer } from "node:http";
 import { rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { assertNoSecretMaterial } from "../dist/testing/secretLeakHarness.js";
-import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+import { makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 const rawSecretSentinel = "SERVICE_LASSO_FAKE_OTEL_SECRET_SENTINEL_DO_NOT_USE";
 const sentinels = [
@@ -287,6 +287,44 @@ test("POST /api/telemetry/export-test sends only sanitized metadata to a local m
     }
     await apiServer.stop();
     await collector.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/telemetry redacts sensitive-looking values even on allowlisted attributes", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-telemetry-attribute-redaction-");
+  await writeManifest(servicesRoot, "telemetry-redaction", {
+    id: "telemetry-redaction",
+    name: "telemetry-redaction",
+    description: "Fixture with sensitive-looking metadata.",
+    version: rawSecretSentinel,
+    executable: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+    healthcheck: { type: "process" },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(apiServer.url + "/api/telemetry");
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.telemetry.redaction.redactedValue, "[REDACTED]");
+    assert.deepEqual(result.body.telemetry.redaction.patternClasses, [
+      "bearer tokens",
+      "GitHub-style tokens",
+      "AWS access keys",
+      "private key blocks",
+      "basic-auth URLs",
+      "sensitive key-value pairs",
+      "Service Lasso secret regression sentinels",
+    ]);
+    const attributes = result.body.telemetry.services[0].signals[0].attributes;
+    assert.equal(attributes["service.version"], "[REDACTED]");
+    assertAllowlistedSignals(result.body.telemetry);
+    assertNoSecretMaterial(result.body, { sentinels });
+  } finally {
+    await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Issue
Refs #635

## Summary
- Add value-level redaction for sensitive-looking strings that appear on otherwise allowlisted telemetry attributes.
- Expose the telemetry redaction marker and pattern classes in the preview policy so Service Admin can explain the safety boundary.
- Link the Redacted Telemetry Preview reference page in the docs sidebar.

## Scope
- In scope: core telemetry preview/export-test attribute redaction, focused regression coverage, docs/navigation.
- Out of scope: production OTLP exporter, Secrets Broker telemetry implementation, Service Admin telemetry UI, and canonical demo release/pin/recycle before merge.

## Spec / contract / fixture impact
- Updated: `docs/reference/redacted-telemetry-preview.md`, `docs/sidebars.js`.
- Contract impact: additive `redactedValue` and `patternClasses` fields on the existing telemetry redaction policy; existing allowlisted fields remain.
- Spec binding: `.governance/specs/SPEC-002-core-standalone-runtime.md` AC-4AL/AC-4AM/AC-4AP/AC-4AR require allowlisted redacted telemetry and no raw secret/config values.

## Service Lasso invariant impact
- Invariant: telemetry must never leak raw secrets, credentials, env values, request/response bodies, full file contents, or raw service config values.
- Preservation proof: allowed string attributes are now pattern-redacted before preview/export payload construction, and the focused test proves a Service Lasso OTEL secret sentinel in `service.version` becomes `[REDACTED]` and does not appear in the API response.

## Validation
- PASS `npm run build && node --test --test-concurrency=1 tests/telemetry-preview.test.js` — `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260623-172543\issue-635-telemetry-focused-test-rerun.log`
- PASS `npm run docs:build` — `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260623-172543\issue-635-docs-build.log`
- PASS `git diff --check` — `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260623-172543\issue-635-git-diff-check.log`

## Approval trail
- Required: normal PR review/merge authorization.
- Evidence: selected from Project #1 Ready / Ready for Agent after canonical demo preflight and open PR gate documentation on #635.

## Cleanup
- Branch cleanup after merge.
- Release-to-demo gate applies after merge because this changes demo-consumed core runtime code. This PR does not claim #635 done; it advances the core telemetry redaction baseline only.
