### PR TITLE
chore(demo): pin Service Admin release 2026.6.23-9123442

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.21-8f4b2cd`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.23-809c102` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.23-9123442` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.23-809c102"
+      "tag": "2026.6.23-9123442"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#277

## Summary
- Pin the core `@serviceadmin` demo manifest to the newly published `lasso-serviceadmin` release `2026.6.23-9123442`.
- Update the README service catalog row to match the new Service Admin release tag.

## Scope
- In scope: demo-consumed Service Admin release pin only.
- Out of scope: runtime config editor API and UI implementation; those landed via service-lasso/service-lasso#687 and service-lasso/lasso-serviceadmin#282.

## Spec / contract / fixture impact
- Updated: checked-in baseline manifest/catalog release pin.
- Not required: no API/schema change in this pin PR.

## Service Lasso invariant impact
- Invariant: canonical demo installed artifact must match checked-in service manifest release pins.
- Preservation proof: `node scripts/verify-service-catalog.mjs` passes after updating `services/@serviceadmin/service.json` and README.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260623-212520/core-pin-build.log`
- PASS `node scripts/verify-service-catalog.mjs` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260623-212520/core-pin-verify-service-catalog.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260623-212520/core-pin-git-diff-check.log`
- Release evidence: `lasso-serviceadmin` release `2026.6.23-9123442` targets merge commit `9123442aed26ebbf1220b6a2d3bf4ac65018dba1` and has all expected platform assets.

## Approval trail
- Required: normal merge authorization once checks are green/mergeable.
- Evidence: this is the mandatory release-to-demo pin after merging #687/#282 for #277.

## Cleanup
- After merge: deploy canonical demo to the merged `develop` commit, run `npm run demo:verify-canonical`, and verify live `@serviceadmin` expected tag equals installed tag `2026.6.23-9123442`.