### PR TITLE
chore(demo): pin Service Admin release 2026.6.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.23-9123442` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.24-5900783` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.23-9123442"
+      "tag": "2026.6.24-5900783"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.21-8f4b2cd");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.23-a55fd80");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.21-6a509d1");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.24-5900783");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#281
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the checked-in core `@serviceadmin` manifest to released `lasso-serviceadmin` tag `2026.6.24-5900783`.
- Update the README release table to match the demo-consumed Service Admin release.
- Refresh the manifest-discovery test expectations for the current Service Admin and already-merged Secrets Broker pins.

## Scope
- In scope: core demo/service catalog release pin and matching manifest test/doc references.
- Out of scope: new runtime/API behavior; Service Admin feature implementation already landed in `lasso-serviceadmin` PRs #283 and #285.

## Spec / contract / fixture impact
- Updated: demo-consumed `services/@serviceadmin/service.json` release tag.
- Not required: no schema/API contract change.

## Service Lasso invariant impact
- Invariant: demo-consumed service manifests must point at exact released artifacts.
- Preservation proof: `@serviceadmin` now pins the exact released tag created from Service Admin commit `5900783120f7f14dbfef49c31992d7d9e4759cef`.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260625T082641/core-build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-20260625T082641/core-manifest-discovery-test-rerun.log` (`23` tests passed)
- PASS `git diff --check -- README.md services/@serviceadmin/service.json tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-20260625T082641/core-git-diff-check.log`

## Approval trail
- Required: normal core PR merge authorization/checks.
- Evidence: mandatory release-to-demo gate after merging Service Admin PRs #283 and #285 requires core pin to new release before canonical recycle.

## Cleanup
- After merge: pull `develop`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live `@serviceadmin` installed tag equals `2026.6.24-5900783`.
- Local unrelated dirty file intentionally left untouched: `services/node-sample-service/service.json` formatting-only diff existed before this pin branch.