### PR TITLE
chore: pin Service Admin release for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.24-5900783` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-f3e58e5` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.24-5900783"
+      "tag": "2026.6.25-f3e58e5"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#287 after lasso-serviceadmin#290.

## Summary
- Pins the core `@serviceadmin` demo manifest to Service Admin release `2026.6.25-f3e58e5`.
- Updates the README service catalog row to match the pinned release.

## Scope
- In scope: core demo/service catalog pin for the newly released Service Admin artifact.
- Out of scope: unrelated local formatting change currently present in `services/node-sample-service/service.json` and not included in this PR.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release pin and README catalog row.
- Not required because: no API/schema/runtime behavior contract changed.

## Service Lasso invariant impact
- Invariant: canonical demo manifests must pin exact released service artifacts.
- Preservation proof: `@serviceadmin` expected release tag now matches the published lasso-serviceadmin release `2026.6.25-f3e58e5`, targeting commit `f3e58e5d13806a30b99a3fd0287b732beb17a031`.

## Validation
- PASS `npm run build` — TypeScript build passed (`.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-287-core-build.log`).
- PASS `npm run verify:service-catalog` — service catalog drift verification passed after README update (`.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-287-core-service-catalog-rerun.log`).

## Approval trail
- Required: GitHub branch protection/review requirements as configured.
- Evidence: merge only after checks are green and the PR is mergeable.

## Cleanup
- Branch can be deleted after merge. Canonical demo recycle/verify is required after this pin merges so live demo consumes `2026.6.25-f3e58e5`.