### PR TITLE
chore: pin Service Admin 2026.6.25-dc03902

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-f3e58e5` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-dc03902` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-f3e58e5"
+      "tag": "2026.6.25-dc03902"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Closes service-lasso/lasso-serviceadmin#286

## Summary
- Pins the core `@serviceadmin` manifest to lasso-serviceadmin release `2026.6.25-dc03902`.
- Updates the README baseline service catalog entry to match the new Service Admin release.

## Scope
- In scope: release-to-demo pin for the merged Service Admin shortcut change.
- Out of scope: Service Admin UI source changes, already merged in lasso-serviceadmin#291.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and README catalog documentation.
- Not required because: no API/schema/lifecycle contract changed beyond consuming the published Service Admin artifact.

## Nash invariant impact
- Invariant: checked-in core manifest pin must match the demo-consumed Service Admin release.
- Preservation proof: manifest now points at `service-lasso/lasso-serviceadmin` tag `2026.6.25-dc03902`, whose release targets commit `dc03902ef27f7b5534ff72290ea6e22a17318275`.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-build-pin.log`
- PASS `git diff --check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/core-pin-diff-check.log`
- PENDING canonical demo recycle/verify after merge.

## Approval trail
- Required: no branch protection reported for this pin branch; merging will still require green checks and mergeable state.
- Evidence: lasso-serviceadmin#291 was merged after hosted CI passed, and release `2026.6.25-dc03902` was published by release run `28143104911`.

## Cleanup
- After merge: fast-forward local `develop`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify live `@serviceadmin` catalog/installed tag equals `2026.6.25-dc03902`, then delete the local/remote pin branch if safe.