### PR TITLE
chore(demo): pin Service Admin e3c180e

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-3e7d8b2` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-e3c180e` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-3e7d8b2"
+      "tag": "2026.6.25-e3c180e"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-3e7d8b2");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-e3c180e");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Supports service-lasso/lasso-serviceadmin#284 release-to-demo gate after service-lasso/lasso-serviceadmin#293.

## Summary
- Pins core `@serviceadmin` to lasso-serviceadmin release `2026.6.25-e3c180e`.
- Updates README and manifest discovery test expectation to match the new release.

## Scope
- In scope: Service Admin release tag pin only.
- Out of scope: other service pins, runtime behavior, or unrelated docs.

## Spec / contract / fixture impact
- Updated: baseline service manifest release tag for `@serviceadmin`.
- Not required because: no service.json schema/contract field changed.

## Nash invariant impact
- Invariant: canonical demo consumes the exact Service Admin release containing issue #284.
- Preservation proof: manifest source repo remains `service-lasso/lasso-serviceadmin`; tag now matches `2026.6.25-e3c180e` from release workflow run `28146764035` for merge commit `e3c180e13bb8d24dae63e9a8c799d165e23eefd3`.

## Validation
- PASS `node --test tests/manifest-discovery.test.js` — `.work-agent/logs/284-core-pin-manifest-test.log`
- PASS `npm run build` — `.work-agent/logs/284-core-pin-build.log`

## Approval trail
- Required: no human approval required for exact release pin continuation of merged Service Admin issue #284.
- Evidence: lasso-serviceadmin#293 merged and release `2026.6.25-e3c180e` published.

## Cleanup
- Branch: `issue-284-pin-serviceadmin-e3c180e`
- Commit: `9ec6fc4`
- After merge: recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; expected installed `@serviceadmin` tag must equal `2026.6.25-e3c180e`.