### PR TITLE
chore(demo): pin Service Admin release 2026.6.25-a2227c8

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-e3c180e` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-a2227c8` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-e3c180e"
+      "tag": "2026.6.25-a2227c8"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-e3c180e");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-a2227c8");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Follows service-lasso/lasso-serviceadmin#275 and service-lasso/lasso-serviceadmin#294.

## Summary
- Pins the core `@serviceadmin` demo manifest to the Service Admin release published from the merged Terminal tab commit.
- Updates the manifest discovery assertion and README baseline release note to the same tag.

## Scope
- In scope: core demo/service manifest pin from `2026.6.25-e3c180e` to `2026.6.25-a2227c8`.
- Out of scope: runtime behavior changes, Service Admin UI implementation changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag and matching fixture/docs expectations.
- Not required because: no service contract shape changed; this only advances the artifact version consumed by the canonical demo.

## Nash invariant impact
- Invariant: core demo consumes exact released service artifacts.
- Preservation proof: release `2026.6.25-a2227c8` exists in service-lasso/lasso-serviceadmin and targets commit `a2227c8469b23d6d9e72bef8d13c4d317f998675`; manifest test confirms the core pin.

## Validation
- PASS `npm run build`.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — 23 tests passed.
- PASS `git diff --check`.
- Service Admin release evidence: https://github.com/service-lasso/lasso-serviceadmin/releases/tag/2026.6.25-a2227c8
- Evidence logs: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260625-153031`.

## Approval trail
- Required: normal core PR checks/review gate.
- Evidence: branch was created from `develop` and targets `develop`.

## Cleanup
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected vs live `@serviceadmin` tag is `2026.6.25-a2227c8`.