### PR TITLE
chore(demo): pin serviceadmin d8b970d release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-a2227c8` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-d8b970d` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-a2227c8"
+      "tag": "2026.6.25-d8b970d"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-a2227c8");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-d8b970d");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical core `@serviceadmin` manifest to the Service Admin release produced by lasso-serviceadmin#295.
- Updates README/test expectations to the same exact tag.

## Scope
- In scope: canonical demo manifest pin for `@serviceadmin` release `2026.6.25-d8b970d`.
- Out of scope: other service manifest changes or broader #231 workflow completion.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json`, README catalog row, and manifest discovery expectation.
- Not required because: no core runtime API/schema contract changed.

## Nash invariant impact
- Invariant: demo-consumed Service Admin UI changes must be pinned to the exact released artifact before any demo-current claim.
- Preservation proof: expected release tag `2026.6.25-d8b970d` targets lasso-serviceadmin merge commit `d8b970d9da5bf83afd86fc442e7bcdbd74523a0e`.

## Validation
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/core-manifest-discovery.log` (23 passed)
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/core-build.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/core-git-diff-check.log`

## Approval trail
- Required: no special approval requirement found for this exact release-pin PR.
- Evidence: generated from the merged/released Service Admin PR #295 and limited to the core demo pin.

## Cleanup
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live `@serviceadmin` catalog/installed tag equals `2026.6.25-d8b970d`.