### PR TITLE
chore(demo): pin serviceadmin f05b02c release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.23-a55fd80`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-d8b970d` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-f05b02c` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-d8b970d"
+      "tag": "2026.6.25-f05b02c"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-d8b970d");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-f05b02c");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` manifest to the newly released Service Admin tag `2026.6.25-f05b02c`.
- Updates README service inventory and manifest discovery assertion to match the release consumed by demo.

## Scope
- In scope: core demo/service manifest pin for the merged Service Admin replay guard release.
- Out of scope: further Service Admin UI work beyond the already released lasso-serviceadmin#296 slice.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json`, README service inventory, and manifest discovery test expected tag.
- Not required: no runtime API/schema change; this is a demo-consumed artifact pin.

## Service Lasso invariant impact
- Invariant: demo-consumed service manifests must point at an exact released artifact and the live canonical demo must consume that exact tag before claiming the Service Admin slice demo-gated.
- Preservation proof: release `2026.6.25-f05b02c` exists, is non-draft/non-prerelease, targets lasso-serviceadmin merge commit `f05b02c6d882a833970387810056f81a280ed45b`, and includes the expected platform assets plus `service.json` and `SHA256SUMS.txt`.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\core-pin-f05b02c\build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\core-pin-f05b02c\manifest-discovery.test.log` (23 passed)
- PASS `git diff --check` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\core-pin-f05b02c\git-diff-check.log`

## Approval trail
- Required: normal PR review/merge rules.
- Evidence: focused manifest pin; hosted checks pending after PR creation.

## Cleanup
- Branch cleanup after merge: delete `agent/pin-serviceadmin-f05b02c` locally/remotely.
- Post-merge gate: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live expected/installed `@serviceadmin` tag is `2026.6.25-f05b02c`.
