### PR TITLE
chore(demo): pin serviceadmin 17194bb release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.25-337fd83`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-f05b02c` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-17194bb` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-f05b02c"
+      "tag": "2026.6.25-17194bb"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -186,7 +186,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.artifact?.source.repo, "service-lasso/lasso-traefik");
   assert.equal(byId.get("@traefik")?.artifact?.source.tag, "2026.5.9-9511770");
   assert.equal(byId.get("@secretsbroker")?.artifact?.source.repo, "service-lasso/lasso-secretsbroker");
-  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.23-a55fd80");
+  assert.equal(byId.get("@secretsbroker")?.artifact?.source.tag, "2026.6.25-337fd83");
   assert.equal(byId.get("@secretsbroker")?.ports?.service, 17890);
   assert.match(byId.get("@traefik")?.commandline?.win32 ?? "", /--providers\.file\.filename="\$\{SERVICE_ROOT\}\\runtime\\dynamic\.yml"/);
   assert.match(byId.get("@traefik")?.commandline?.linux ?? "", /--entryPoints\.mongo\.address=":\$\{MONGO_PORT\}"/);
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-f05b02c");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-17194bb");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin the core canonical demo `@serviceadmin` manifest to the released `lasso-serviceadmin` artifact `2026.6.25-17194bb` from PR #297.
- Keep README and manifest discovery assertions aligned with the new demo-consumed release.

## Scope
- In scope: core service manifest/docs/test pin update for `@serviceadmin`.
- Out of scope: additional Service Admin UI/product changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json`, README service inventory, manifest discovery test fixture expectation.
- Not required: no runtime API/schema behavior changed.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release that was merged for #231.
- Preservation proof: release `2026.6.25-17194bb` exists and targets `17194bb4e026be167456a0585276a5caf4a51935`; this PR pins that exact release tag.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260625-201820/core-pin-build.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-20260625-201820/core-pin-manifest-test.log` (23 passed)
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260625-201820/core-pin-diff-check.log`
- PENDING hosted `baseline-start-smoke` before merge.
- PENDING canonical recycle/`npm run demo:verify-canonical` after merge.

## Approval trail
- Required: no separate code review required for mechanical release pin if hosted checks are green and PR is mergeable, matching prior core pin PR workflow for this issue.
- Evidence: this PR only updates the Service Admin release pin to an already published release from merged Service Admin PR #297.

## Cleanup
- After merge: pull `develop`, delete local/remote topic branch when safe, recycle canonical demo on port `17883`, verify live expected/catalog/installed tag `2026.6.25-17194bb`, and leave final evidence on lasso-serviceadmin#231.