### PR TITLE
chore: pin Service Admin 2026.6.25-4bee563 for issue 231

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.25-337fd83`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-17194bb` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-4bee563` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-17194bb"
+      "tag": "2026.6.25-4bee563"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-17194bb");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-4bee563");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pin core `@serviceadmin` to lasso-serviceadmin release `2026.6.25-4bee563`.
- Keep the root baseline table and manifest-discovery expected release tag aligned with the manifest.

## Scope
- In scope: core demo/service manifest release pin for the merged Service Admin #231 slice.
- Out of scope: additional Service Admin UI behavior; that landed in service-lasso/lasso-serviceadmin#298.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json`, `README.md`, `tests/manifest-discovery.test.js`.
- Not required because: this is a release pin to an existing service manifest contract, not a new runtime API/schema.

## Nash invariant impact
- Invariant: baseline service catalog and docs must match checked-in service manifests.
- Preservation proof: `npm run verify:service-catalog` passed after the pin update.

## Validation
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin/build-after-readme.log`
- PASS `npm run verify:service-catalog` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin/verify-service-catalog-after-readme.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin/manifest-discovery-test.log` (23 passed)
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin/git-diff-check.log`

## Approval trail
- Required: no explicit human approval requirement observed for this manifest-only pin PR; merge only after hosted checks are green and GitHub reports mergeable.
- Evidence: Service Admin release `2026.6.25-4bee563` is published and corresponds to lasso-serviceadmin#298 merge commit `4bee5638bf284b411fd5913128a2755b3ea59cd8`.

## Cleanup
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify Service Admin `17700`, runtime health/runtime metadata, and expected vs installed `@serviceadmin` tag all match `2026.6.25-4bee563`.