### PR TITLE
chore(demo): pin serviceadmin c9bcea4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.25-337fd83`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-5a630a0` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-c9bcea4` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-5a630a0"
+      "tag": "2026.6.25-c9bcea4"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-5a630a0");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-c9bcea4");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical demo `@serviceadmin` manifest to Service Admin release `2026.6.25-c9bcea4`.
- Updates the README release reference and manifest-discovery expectation.

## Scope
- In scope: core demo/service manifest pin for the merged Service Admin #231 export-guard slice.
- Out of scope: additional Service Admin UI behavior beyond release consumption.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json`, README service release reference, and manifest-discovery test expectation.
- Not required because: manifest schema shape is unchanged.

## Service Lasso invariant impact
- Invariant: canonical demo must consume the exact released service tag after demo-consumed Service Admin changes.
- Preservation proof: expected `@serviceadmin` tag is `2026.6.25-c9bcea4`; release target is `c9bcea4a89a165dd0e04069c0844042c6e1b6c52`.

## Validation
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-core-pin-c9bcea4/build.log`
- PASS `npm run verify:service-catalog` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-core-pin-c9bcea4/verify-service-catalog.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-core-pin-c9bcea4/manifest-discovery-test.log` (23 passed)
- PASS `git diff --check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-core-pin-c9bcea4/git-diff-check.log`

## Approval trail
- Required: no special reviewer requirement found for this release pin.
- Evidence: PR will wait for hosted `Baseline Start Smoke` before merge.

## Cleanup
- After merge: update local `develop`, delete `agent/issue-231-serviceadmin-demo-pin-c9bcea4`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and prove expected/catalog/installed/live tags match.