### PR TITLE
chore(demo): pin serviceadmin a4512dd

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.25-337fd83`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-985e414` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.25-a4512dd` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.25-985e414"
+      "tag": "2026.6.25-a4512dd"
     },
     "platforms": {
       "win32": {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-985e414");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.6.25-a4512dd");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-serviceadmin#231

## Summary
- Pins the canonical `@serviceadmin` demo service to Service Admin release `2026.6.25-a4512dd`.
- Updates the README catalog row and manifest-discovery assertion to match the new release.

## Scope
- In scope: core demo/service manifest pin for lasso-serviceadmin#308 closure-review slice.
- Out of scope: additional Service Admin UI changes.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag, README catalog reference, and `tests/manifest-discovery.test.js` expectation.

## Nash invariant impact
- Invariant: canonical demo must consume the exact demo-consumed service release before the Service Admin slice is considered demo-current.
- Preservation proof: core pin points to `2026.6.25-a4512dd`, the release published for merge commit `a4512dde047cbe73c29007a0aa8d954ae2f279d8`.

## Validation
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin-a4512dd/build.log`
- PASS `npm run verify:service-catalog` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin-a4512dd/verify-service-catalog.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin-a4512dd/manifest-discovery.log` (23 passed)
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-core-pin-a4512dd/git-diff-check.log`

## Approval trail
- Required: no special approval requirement found for this release pin.

## Cleanup
- Branch: `agent/issue-231-serviceadmin-demo-pin-a4512dd`
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and prove expected/catalog/installed `@serviceadmin` tag is `2026.6.25-a4512dd`.