### PR TITLE
chore: pin serviceadmin 2026.6.26-10be879

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.26-bebede7`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.26-00cd33d` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.26-10be879` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.26-00cd33d"
+      "tag": "2026.6.26-10be879"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Advances #635 after service-lasso/lasso-serviceadmin#315

## Summary
- Pins the core `@serviceadmin` managed-service manifest to Service Admin release `2026.6.26-10be879`.
- Updates the README catalog reference to the same release tag.

## Scope
- In scope: core demo/catalog pin only.
- Out of scope: Service Admin implementation changes, already merged in service-lasso/lasso-serviceadmin#315.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` release tag.
- Updated: `README.md` release reference.

## Nash invariant impact
- Invariant: canonical demo must consume the exact Service Admin release created from the merged UI slice.
- Preservation proof: manifest tag and README reference both point to `2026.6.26-10be879`; service catalog verification passed.

## Validation
- PASS `npm run verify:service-catalog` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/core-verify-service-catalog-serviceadmin-10be879.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/core-build-serviceadmin-10be879.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/core-diff-check-serviceadmin-10be879.log`

## Approval trail
- Required: no explicit human approval identified for this release pin.
- Evidence: mandatory release-to-demo gate after demo-consumed `lasso-serviceadmin` merge/release.

## Cleanup
- Branch: `feature/635-pin-serviceadmin-10be879`.
- After merge: recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and confirm installed/live `@serviceadmin` tag matches `2026.6.26-10be879`.