### PR TITLE
feat: add broker transport binding metadata

### DIFF
--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -317,8 +317,10 @@ When `broker.writeback` is present, the runtime mints a per-launch scoped broker
 - `SERVICE_LASSO_BROKER_IDENTITY_ID`
 - `SERVICE_LASSO_BROKER_CREDENTIAL`
 - `SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT`
+- `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND`
+- `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT`
 
-The raw credential is launch-only authority: it is not stored in lifecycle state or logs. Persisted lifecycle metadata is limited to non-secret identity/audit fields and revocation/expiry timestamps.
+The raw credential is launch-only authority: it is not stored in lifecycle state or logs. Persisted lifecycle metadata is limited to non-secret identity/audit fields, optional transport-binding kind/subject, and revocation/expiry timestamps.
 
 ## Union skeleton (keys only)
 

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -515,7 +515,8 @@ Launch-time writeback identity:
 - Services with `broker.writeback` declared receive a short-lived per-launch broker credential from the runtime.
 - The credential is scoped to the service id plus `writeback.allowedNamespaces`, `writeback.allowedRefs`, and `writeback.allowedOperations`.
 - Runtime injects the credential through reserved process env keys: `SERVICE_LASSO_BROKER_IDENTITY_ID`, `SERVICE_LASSO_BROKER_CREDENTIAL`, and `SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT`.
-- Lifecycle state may persist non-secret identity metadata for audit (`id`, service id, issued/expires/revoked timestamps, scope, audit reason), but must not persist the raw credential value.
+- When the launcher identity is known, runtime also includes transport-binding metadata through `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND` and `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT`. Unix launchers default this to the current launcher UID; Windows launchers should provide a stable service-account SID once the launcher policy is fixed.
+- Lifecycle state may persist non-secret identity metadata for audit (`id`, service id, issued/expires/revoked timestamps, scope, audit reason, transport-binding kind/subject), but must not persist the raw credential value.
 - Stop/restart revokes active launch credentials; expiry also denies later writeback attempts.
 - Broker writeback audit records should use the launched service identity and the optional `writeback.auditReason`.
 

--- a/docs/reference/startup-broker-resolution.md
+++ b/docs/reference/startup-broker-resolution.md
@@ -41,6 +41,8 @@ Precedence at launch is:
 3. broker imports with `as` names that do not override existing manifest env keys
 4. scoped broker writeback identity env, when the service declares broker writeback permissions
 
+When scoped broker writeback identity env is issued, Service Lasso also records safe transport-binding metadata when the launcher identity is known. Unix launchers default to the current launcher UID as `unix-uid`. Windows launchers can provide a stable service-account or launcher SID with `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND=windows-sid` and `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT=<sid>`. These values are metadata only; the scoped credential value remains secret and must not be logged or persisted.
+
 Raw broker values may be present only in the process environment/config handed to the launched service. They must not be written to logs, status payloads, diagnostics, issue comments, PR bodies, or test artifacts.
 
 ## Startup pipeline
@@ -59,7 +61,8 @@ The runtime startup path is formalized as:
    - `degraded`
 5. Fail closed before process spawn when any `required: true` import is unresolved.
 6. Materialize resolved values only into the launched service environment/config.
-7. Emit safe metadata only: ref name, classification, `required`, and `as` target.
+7. Issue a scoped broker writeback identity when the service declares writeback permissions, including transport-binding metadata when available.
+8. Emit safe metadata only: ref name, classification, `required`, `as` target, identity id, expiry, and transport-binding kind/subject when present.
 
 Policy-denied refs are intentionally separate from missing refs. Operators should see that access was denied, not that config disappeared.
 

--- a/src/runtime/broker/identity.ts
+++ b/src/runtime/broker/identity.ts
@@ -4,8 +4,17 @@ import type { DiscoveredService, ServiceBrokerWritebackOperation } from "../../c
 export const BROKER_IDENTITY_ID_ENV = "SERVICE_LASSO_BROKER_IDENTITY_ID";
 export const BROKER_CREDENTIAL_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL";
 export const BROKER_CREDENTIAL_EXPIRES_AT_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT";
+export const BROKER_TRANSPORT_BINDING_KIND_ENV = "SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND";
+export const BROKER_TRANSPORT_BINDING_SUBJECT_ENV = "SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT";
 
 const DEFAULT_CREDENTIAL_TTL_MS = 60 * 60 * 1000;
+
+export type BrokerTransportBindingKind = "unix-uid" | "windows-sid";
+
+export interface BrokerTransportBinding {
+  kind: BrokerTransportBindingKind;
+  subject: string;
+}
 
 export interface ScopedBrokerIdentityScope {
   namespaces: string[];
@@ -27,6 +36,7 @@ export interface ScopedBrokerIdentityMetadata {
   issuedAt: string;
   expiresAt: string;
   revokedAt: string | null;
+  transportBinding: BrokerTransportBinding | null;
   scope: ScopedBrokerIdentityScope;
   audit: ScopedBrokerIdentityAuditContext;
 }
@@ -71,6 +81,7 @@ function cloneMetadata(metadata: ScopedBrokerIdentityMetadata): ScopedBrokerIden
     issuedAt: metadata.issuedAt,
     expiresAt: metadata.expiresAt,
     revokedAt: metadata.revokedAt,
+    transportBinding: metadata.transportBinding ? { ...metadata.transportBinding } : null,
     scope: {
       namespaces: [...metadata.scope.namespaces],
       operations: [...metadata.scope.operations],
@@ -90,9 +101,43 @@ export function serviceNeedsScopedBrokerIdentity(service: DiscoveredService): bo
   return service.manifest.broker?.writeback !== undefined;
 }
 
+function normalizeTransportBinding(
+  binding: BrokerTransportBinding | null | undefined,
+): BrokerTransportBinding | null {
+  if (!binding) {
+    return null;
+  }
+
+  const kind = binding.kind.trim().toLowerCase();
+  const subject = binding.subject.trim();
+  if ((kind !== "unix-uid" && kind !== "windows-sid") || subject === "") {
+    return null;
+  }
+
+  return { kind, subject };
+}
+
+export function resolveLauncherTransportBinding(
+  env: Record<string, string | undefined> = process.env,
+): BrokerTransportBinding | null {
+  const configured = normalizeTransportBinding({
+    kind: (env[BROKER_TRANSPORT_BINDING_KIND_ENV] ?? "") as BrokerTransportBindingKind,
+    subject: env[BROKER_TRANSPORT_BINDING_SUBJECT_ENV] ?? "",
+  });
+  if (configured) {
+    return configured;
+  }
+
+  if (process.platform !== "win32" && typeof process.getuid === "function") {
+    return { kind: "unix-uid", subject: String(process.getuid()) };
+  }
+
+  return null;
+}
+
 export function mintScopedBrokerIdentity(
   service: DiscoveredService,
-  options: { now?: Date; ttlMs?: number } = {},
+  options: { now?: Date; ttlMs?: number; transportBinding?: BrokerTransportBinding | null } = {},
 ): ScopedBrokerCredential | null {
   const writeback = service.manifest.broker?.writeback;
   if (!writeback) {
@@ -106,12 +151,17 @@ export function mintScopedBrokerIdentity(
   const identityId = randomUUID();
   const token = `slb_${randomBytes(32).toString("base64url")}`;
   const allowedOperations = writeback.allowedOperations ?? ["create", "update", "rotate", "delete"];
+  const transportBinding =
+    options.transportBinding === undefined
+      ? resolveLauncherTransportBinding()
+      : normalizeTransportBinding(options.transportBinding);
   const metadata: ScopedBrokerIdentityMetadata = {
     id: identityId,
     serviceId: service.manifest.id,
     issuedAt,
     expiresAt,
     revokedAt: null,
+    transportBinding,
     scope: {
       namespaces: [...(writeback.allowedNamespaces ?? [])],
       operations: [...allowedOperations],
@@ -139,6 +189,12 @@ export function mintScopedBrokerIdentity(
       [BROKER_IDENTITY_ID_ENV]: identityId,
       [BROKER_CREDENTIAL_ENV]: token,
       [BROKER_CREDENTIAL_EXPIRES_AT_ENV]: expiresAt,
+      ...(transportBinding
+        ? {
+            [BROKER_TRANSPORT_BINDING_KIND_ENV]: transportBinding.kind,
+            [BROKER_TRANSPORT_BINDING_SUBJECT_ENV]: transportBinding.subject,
+          }
+        : {}),
     },
   };
 }

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -13,6 +13,9 @@ function cloneBrokerIdentity(identity: ServiceLifecycleState["runtime"]["brokerI
     issuedAt: identity.issuedAt,
     expiresAt: identity.expiresAt,
     revokedAt: identity.revokedAt,
+    transportBinding: identity.transportBinding
+      ? { ...identity.transportBinding }
+      : null,
     scope: {
       namespaces: [...identity.scope.namespaces],
       operations: [...identity.scope.operations],

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -11,6 +11,7 @@ import type {
   ServiceStartTracePhase,
   SetupStepStatus,
 } from "../lifecycle/types.js";
+import type { BrokerTransportBinding } from "../broker/identity.js";
 import type { ProviderKind } from "../providers/types.js";
 import type { ServiceBrokerWritebackOperation } from "../../contracts/service.js";
 import { readStoredState } from "./readState.js";
@@ -100,6 +101,26 @@ function isWritebackOperation(value: unknown): value is ServiceBrokerWritebackOp
   return value === "create" || value === "update" || value === "rotate" || value === "delete";
 }
 
+function parseBrokerTransportBinding(value: unknown): BrokerTransportBinding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as { kind?: unknown; subject?: unknown };
+  if (
+    (record.kind !== "unix-uid" && record.kind !== "windows-sid") ||
+    typeof record.subject !== "string" ||
+    record.subject.trim() === ""
+  ) {
+    return null;
+  }
+
+  return {
+    kind: record.kind,
+    subject: record.subject.trim(),
+  };
+}
+
 function parseBrokerIdentity(value: unknown): ServiceLifecycleState["runtime"]["brokerIdentity"] {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -131,6 +152,7 @@ function parseBrokerIdentity(value: unknown): ServiceLifecycleState["runtime"]["
     issuedAt: record.issuedAt,
     expiresAt: record.expiresAt,
     revokedAt: typeof record.revokedAt === "string" ? record.revokedAt : null,
+    transportBinding: parseBrokerTransportBinding(record.transportBinding),
     scope: {
       namespaces: record.scope.namespaces.filter((entry): entry is string => typeof entry === "string"),
       operations: record.scope.operations.filter(isWritebackOperation),

--- a/tests/broker-scoped-identity.test.js
+++ b/tests/broker-scoped-identity.test.js
@@ -8,7 +8,10 @@ import {
   BROKER_CREDENTIAL_ENV,
   BROKER_CREDENTIAL_EXPIRES_AT_ENV,
   BROKER_IDENTITY_ID_ENV,
+  BROKER_TRANSPORT_BINDING_KIND_ENV,
+  BROKER_TRANSPORT_BINDING_SUBJECT_ENV,
   mintScopedBrokerIdentity,
+  resolveLauncherTransportBinding,
   resetScopedBrokerIdentities,
 } from "../dist/runtime/broker/identity.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
@@ -124,6 +127,49 @@ test("scoped broker credentials allow only the launched service writeback scope"
     "expired",
   );
   assert.equal(JSON.stringify(credential.metadata).includes(credential.token), false);
+});
+
+test("scoped broker credentials can carry transport binding metadata", () => {
+  resetScopedBrokerIdentities();
+  const issuedAt = new Date("2026-05-08T06:00:00.000Z");
+  const credential = mintScopedBrokerIdentity(fixtureService(), {
+    now: issuedAt,
+    ttlMs: 1_000,
+    transportBinding: {
+      kind: "windows-sid",
+      subject: "S-1-5-21-1000",
+    },
+  });
+  assert.ok(credential);
+
+  assert.deepEqual(credential.metadata.transportBinding, {
+    kind: "windows-sid",
+    subject: "S-1-5-21-1000",
+  });
+  assert.equal(credential.env[BROKER_TRANSPORT_BINDING_KIND_ENV], "windows-sid");
+  assert.equal(credential.env[BROKER_TRANSPORT_BINDING_SUBJECT_ENV], "S-1-5-21-1000");
+  assert.equal(JSON.stringify(credential.metadata).includes(credential.token), false);
+});
+
+test("launcher transport binding prefers explicit policy environment", () => {
+  assert.deepEqual(
+    resolveLauncherTransportBinding({
+      [BROKER_TRANSPORT_BINDING_KIND_ENV]: "windows-sid",
+      [BROKER_TRANSPORT_BINDING_SUBJECT_ENV]: "S-1-5-21-2000",
+    }),
+    {
+      kind: "windows-sid",
+      subject: "S-1-5-21-2000",
+    },
+  );
+  assert.deepEqual(
+    resolveLauncherTransportBinding({
+      [BROKER_TRANSPORT_BINDING_KIND_ENV]: "windows-sid",
+    }),
+    process.platform === "win32"
+      ? null
+      : { kind: "unix-uid", subject: String(process.getuid()) },
+  );
 });
 
 test("runtime injects scoped broker credential without persisting or logging raw authority", async () => {


### PR DESCRIPTION
## Issue
Advances service-lasso/lasso-secretsbroker#31

## Summary
- Add non-secret transport-binding metadata to scoped broker writeback identities.
- Default Unix launchers to the current launcher UID and allow Windows service-account SID policy via explicit env.
- Preserve existing unbound credential compatibility and rehydrate old lifecycle identity records as `transportBinding: null`.
- Document the reserved env keys and safe metadata boundary.

## Scope
- In scope: core launch identity metadata/env, lifecycle clone/rehydrate compatibility, docs, focused tests.
- Out of scope: cross-user Windows denial evidence and full signed `identityLease` broker request wiring.

## Spec / Contract Impact
- Updated `docs/reference/startup-broker-resolution.md`.
- Updated `docs/reference/service-json-reference.md`.
- Updated `docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md`.

## Service Lasso Invariant Impact
- Secrets remain out of logs/state: raw broker credential is still launch-only and tests assert it is not persisted in lifecycle metadata.
- Transport binding kind/subject are treated as safe metadata only.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-20260626-153036\core-build.log`
- PASS `node --test --test-concurrency=1 tests/broker-scoped-identity.test.js` — `broker-scoped-identity-test.log`
- PASS `npm run verify:service-catalog` — `core-verify-service-catalog.log`
- PASS `git diff --check` — `core-git-diff-check.log`
- INCOMPLETE `npm test` — bounded tool call timed out after 120s; saved log `core-npm-test.log` shows many passing tests and no visible failure before timeout. Hosted CI is required for the full gate.
- PASS canonical preflight health: Service Admin HTTP 200 and runtime health HTTP 200/status `ok` before selection.

## Approval Trail
- Required: normal PR checks/review rules.
- Evidence: hosted CI pending on this PR.

## Cleanup
- Branch will be cleaned after merge. This PR does not change service release pins; release-to-demo gate applies if this core change is merged and demo is recycled to the merge commit.