### PR TITLE
chore: pin serviceadmin telemetry release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The checked-in baseline proves that a clean clone can acquire and run real servi
 | `@python` | release-backed Python runtime provider | acquired from [`service-lasso/lasso-python`](https://github.com/service-lasso/lasso-python) release `2026.4.27-63f915c` on supported hosts; the current pinned release is Windows-only, so other platforms report an explicit unsupported-platform skip instead of a broken install; installed/configured but not launched as a daemon when supported |
 | `@secretsbroker` | release-backed local-first secrets broker for service identities, policy, audit, and secret resolution | acquired from [`service-lasso/lasso-secretsbroker`](https://github.com/service-lasso/lasso-secretsbroker) release `2026.6.26-a4e41fa`; started as a managed daemon with HTTP `/health` |
 | `echo-service` | test harness service with UI/API/log/state behavior | acquired from [`service-lasso/lasso-echoservice`](https://github.com/service-lasso/lasso-echoservice) release `2026.5.3-6d3dc19` |
-| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.26-10be879` |
+| `@serviceadmin` | core browser UI for the Service Lasso runtime | acquired from [`service-lasso/lasso-serviceadmin`](https://github.com/service-lasso/lasso-serviceadmin) release `2026.6.26-6c99752` |
 
 Additional manifests such as `node-sample-service` exist for provider-backed fixture coverage, but the canonical baseline and demo instance install the production baseline service set. `@archive` and supported `@python` artifacts are part of that baseline so archive-capable and Python-backed services can rely on prepared providers instead of fixture-only installs.
 

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -24,7 +24,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.6.26-10be879"
+      "tag": "2026.6.26-6c99752"
     },
     "platforms": {
       "win32": {


### PR DESCRIPTION
## Issue
Advances #635 after service-lasso/lasso-serviceadmin#321.

## Summary
- Pins the canonical `@serviceadmin` demo manifest to lasso-serviceadmin release `2026.6.26-6c99752`.
- Updates the README baseline table to the same release tag.

## Scope
- In scope: core demo/service manifest pin for the exact Service Admin release produced from the telemetry correlation posture UI slice.
- Out of scope: other service pins, runtime behavior, or additional telemetry implementation.

## Spec / contract / fixture impact
- Updated: `services/@serviceadmin/service.json` artifact source tag.
- Updated: `README.md` baseline release row.

## Nash invariant impact
- Invariant: demo-consumed service changes must be pinned into core before the canonical demo can claim currentness.
- Preservation proof: manifest and README both reference the same release tag.

## Validation
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/core-build-pin.log`
- PASS `npm run verify:service-catalog` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/core-verify-service-catalog-pin.log`
- PASS manifest/README pin check — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/core-manifest-pin-check.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/core-diff-check-pin.log`

## Approval trail
- Required: no explicit human approval identified for this release-to-demo pin.
- Evidence: mandatory release-to-demo gate after merging demo-consumed `lasso-serviceadmin` PR #321.

## Cleanup
- Branch: `feature/635-pin-serviceadmin-6c99752`.
- After merge, recycle canonical demo on port 17883 and run `npm run demo:verify-canonical`; final status must show expected/catalog/installed `@serviceadmin` tag `2026.6.26-6c99752`.
