### PR TITLE
feat: issue broker launch leases from core launcher

### DIFF
--- a/docs/reference/startup-broker-resolution.md
+++ b/docs/reference/startup-broker-resolution.md
@@ -43,6 +43,8 @@ Precedence at launch is:
 
 When scoped broker writeback identity env is issued, Service Lasso also records safe transport-binding metadata when the launcher identity is known. Unix launchers default to the current launcher UID as `unix-uid`. Windows launchers can provide a stable service-account or launcher SID with `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND=windows-sid` and `SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT=<sid>`. These values are metadata only; the scoped credential value remains secret and must not be logged or persisted.
 
+When an installed or configured Secrets Broker helper and signing material are available, the launcher also asks `secretsbroker admin launch-lease issue` for a signed launch identity lease and injects it through `SERVICE_LASSO_BROKER_IDENTITY_LEASE`. The helper receives service id, workspace id, allowed refs/namespaces, allowed operations, expiry, one-time identity id, and optional transport binding. If the helper is unavailable or no signing key/API token is configured, the runtime keeps the existing local scoped credential path so bootstrap and tests remain compatible. The signed lease is launch-only authority and must not be written to lifecycle state, logs, diagnostics, issue comments, PR bodies, or persisted fixtures.
+
 Raw broker values may be present only in the process environment/config handed to the launched service. They must not be written to logs, status payloads, diagnostics, issue comments, PR bodies, or test artifacts.
 
 ## Startup pipeline
@@ -62,7 +64,8 @@ The runtime startup path is formalized as:
 5. Fail closed before process spawn when any `required: true` import is unresolved.
 6. Materialize resolved values only into the launched service environment/config.
 7. Issue a scoped broker writeback identity when the service declares writeback permissions, including transport-binding metadata when available.
-8. Emit safe metadata only: ref name, classification, `required`, `as` target, identity id, expiry, and transport-binding kind/subject when present.
+8. Issue a broker-signed launch identity lease through the Secrets Broker helper when available and inject it only into the launched process environment.
+9. Emit safe metadata only: ref name, classification, `required`, `as` target, identity id, expiry, and transport-binding kind/subject when present.
 
 Policy-denied refs are intentionally separate from missing refs. Operators should see that access was denied, not that config disappeared.
 

--- a/src/runtime/broker/identity.ts
+++ b/src/runtime/broker/identity.ts
@@ -1,13 +1,19 @@
+import { execFile } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import type { DiscoveredService, ServiceBrokerWritebackOperation } from "../../contracts/service.js";
+import { promisify } from "node:util";
+import type { DiscoveredService, ServiceBrokerAccessOperation, ServiceBrokerWritebackOperation } from "../../contracts/service.js";
 
 export const BROKER_IDENTITY_ID_ENV = "SERVICE_LASSO_BROKER_IDENTITY_ID";
 export const BROKER_CREDENTIAL_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL";
 export const BROKER_CREDENTIAL_EXPIRES_AT_ENV = "SERVICE_LASSO_BROKER_CREDENTIAL_EXPIRES_AT";
 export const BROKER_TRANSPORT_BINDING_KIND_ENV = "SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND";
 export const BROKER_TRANSPORT_BINDING_SUBJECT_ENV = "SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT";
+export const BROKER_IDENTITY_LEASE_ENV = "SERVICE_LASSO_BROKER_IDENTITY_LEASE";
 
 const DEFAULT_CREDENTIAL_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_WORKSPACE_ID = "local-demo";
+
+const execFileAsync = promisify(execFile);
 
 export type BrokerTransportBindingKind = "unix-uid" | "windows-sid";
 
@@ -18,7 +24,7 @@ export interface BrokerTransportBinding {
 
 export interface ScopedBrokerIdentityScope {
   namespaces: string[];
-  operations: ServiceBrokerWritebackOperation[];
+  operations: ServiceBrokerAccessOperation[];
   refs: string[];
 }
 
@@ -45,6 +51,23 @@ export interface ScopedBrokerCredential {
   token: string;
   env: Record<string, string>;
   metadata: ScopedBrokerIdentityMetadata;
+}
+
+export interface SecretsBrokerLaunchLeaseCommand {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+}
+
+export interface SecretsBrokerLaunchLeaseIssuer {
+  command: SecretsBrokerLaunchLeaseCommand;
+  workspaceId?: string;
+}
+
+interface SecretsBrokerLaunchLeaseResponse {
+  outcome?: string;
+  lease?: unknown;
 }
 
 interface ScopedBrokerCredentialRecord {
@@ -98,7 +121,7 @@ function rememberServiceIdentity(serviceId: string, identityId: string): void {
 }
 
 export function serviceNeedsScopedBrokerIdentity(service: DiscoveredService): boolean {
-  return service.manifest.broker?.writeback !== undefined;
+  return (service.manifest.broker?.imports?.length ?? 0) > 0 || service.manifest.broker?.writeback !== undefined;
 }
 
 function normalizeTransportBinding(
@@ -115,6 +138,141 @@ function normalizeTransportBinding(
   }
 
   return { kind, subject };
+}
+
+function namespacedRef(namespace: string, ref: string): string {
+  const normalizedNamespace = namespace.trim().replace(/\/+$/g, "");
+  const normalizedRef = ref.trim().replace(/^\/+/g, "");
+  return normalizedNamespace && normalizedRef ? `${normalizedNamespace}/${normalizedRef}` : normalizedRef || normalizedNamespace;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
+}
+
+function collectLaunchLeaseScope(service: DiscoveredService): {
+  refs: string[];
+  namespaces: string[];
+  operations: ServiceBrokerAccessOperation[];
+} {
+  const imports = service.manifest.broker?.imports ?? [];
+  const writeback = service.manifest.broker?.writeback;
+  const writebackOperations = writeback?.allowedOperations ?? ["create", "update", "rotate", "delete"];
+  const operations = new Set<ServiceBrokerAccessOperation>();
+  const namespaces = new Set<string>();
+  const refs: string[] = [];
+
+  for (const entry of imports) {
+    operations.add("resolve");
+    namespaces.add(entry.namespace);
+    refs.push(namespacedRef(entry.namespace, entry.ref));
+  }
+
+  for (const namespace of writeback?.allowedNamespaces ?? []) {
+    namespaces.add(namespace);
+  }
+  for (const operation of writebackOperations) {
+    operations.add(operation);
+  }
+  for (const namespace of writeback?.allowedNamespaces ?? []) {
+    for (const ref of writeback?.allowedRefs ?? []) {
+      refs.push(namespacedRef(namespace, ref));
+    }
+  }
+
+  return {
+    refs: uniqueSorted(refs),
+    namespaces: uniqueSorted([...namespaces]),
+    operations: [...operations].sort(),
+  };
+}
+
+function buildLaunchLeaseArgs(
+  service: DiscoveredService,
+  metadata: ScopedBrokerIdentityMetadata,
+  workspaceId: string,
+): string[] {
+  const scope = collectLaunchLeaseScope(service);
+  const args = [
+    "admin",
+    "launch-lease",
+    "issue",
+    "--service-id",
+    service.manifest.id,
+    "--workspace-id",
+    workspaceId,
+    "--jti",
+    metadata.id,
+    "--issued-at",
+    metadata.issuedAt,
+    "--expires-at",
+    metadata.expiresAt,
+  ];
+
+  for (const ref of scope.refs) {
+    args.push("--allowed-ref", ref);
+  }
+  for (const namespace of scope.namespaces) {
+    args.push("--allowed-namespace", namespace);
+  }
+  for (const operation of scope.operations) {
+    args.push("--operation", operation);
+  }
+  if (metadata.transportBinding) {
+    args.push("--transport-binding-kind", metadata.transportBinding.kind);
+    args.push("--transport-binding-subject", metadata.transportBinding.subject);
+  }
+  return args;
+}
+
+function parseLaunchLeaseResponse(stdout: string): unknown | null {
+  let parsed: SecretsBrokerLaunchLeaseResponse;
+  try {
+    parsed = JSON.parse(stdout) as SecretsBrokerLaunchLeaseResponse;
+  } catch {
+    return null;
+  }
+  if (parsed.outcome !== "ready" || parsed.lease === null || typeof parsed.lease !== "object") {
+    return null;
+  }
+  return parsed.lease;
+}
+
+async function issueLaunchLease(
+  service: DiscoveredService,
+  metadata: ScopedBrokerIdentityMetadata,
+  issuer: SecretsBrokerLaunchLeaseIssuer | undefined,
+): Promise<unknown | null> {
+  if (!issuer?.command.command) {
+    return null;
+  }
+
+  const commandEnv = issuer.command.env ?? process.env;
+  if (!commandEnv.SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY && !commandEnv.SECRETSBROKER_API_TOKEN) {
+    return null;
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      issuer.command.command,
+      [
+        ...(issuer.command.args ?? []),
+        ...buildLaunchLeaseArgs(service, metadata, issuer.workspaceId ?? DEFAULT_WORKSPACE_ID),
+      ],
+      {
+        cwd: issuer.command.cwd,
+        env: {
+          ...process.env,
+          ...issuer.command.env,
+        },
+        maxBuffer: 1024 * 1024,
+        windowsHide: true,
+      },
+    );
+    return parseLaunchLeaseResponse(stdout);
+  } catch {
+    return null;
+  }
 }
 
 export function resolveLauncherTransportBinding(
@@ -140,7 +298,7 @@ export function mintScopedBrokerIdentity(
   options: { now?: Date; ttlMs?: number; transportBinding?: BrokerTransportBinding | null } = {},
 ): ScopedBrokerCredential | null {
   const writeback = service.manifest.broker?.writeback;
-  if (!writeback) {
+  if (!serviceNeedsScopedBrokerIdentity(service)) {
     return null;
   }
 
@@ -150,7 +308,7 @@ export function mintScopedBrokerIdentity(
   const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
   const identityId = randomUUID();
   const token = `slb_${randomBytes(32).toString("base64url")}`;
-  const allowedOperations = writeback.allowedOperations ?? ["create", "update", "rotate", "delete"];
+  const leaseScope = collectLaunchLeaseScope(service);
   const transportBinding =
     options.transportBinding === undefined
       ? resolveLauncherTransportBinding()
@@ -163,16 +321,16 @@ export function mintScopedBrokerIdentity(
     revokedAt: null,
     transportBinding,
     scope: {
-      namespaces: [...(writeback.allowedNamespaces ?? [])],
-      operations: [...allowedOperations],
-      refs: [...(writeback.allowedRefs ?? [])],
+      namespaces: writeback ? [...(writeback.allowedNamespaces ?? [])] : leaseScope.namespaces,
+      operations: writeback ? [...(writeback.allowedOperations ?? ["create", "update", "rotate", "delete"])] : leaseScope.operations,
+      refs: writeback ? [...(writeback.allowedRefs ?? [])] : leaseScope.refs,
     },
     audit: {
       serviceId: service.manifest.id,
       identityId,
       issuedAt,
       expiresAt,
-      reason: writeback.auditReason ?? null,
+      reason: writeback?.auditReason ?? null,
     },
   };
 
@@ -195,6 +353,34 @@ export function mintScopedBrokerIdentity(
             [BROKER_TRANSPORT_BINDING_SUBJECT_ENV]: transportBinding.subject,
           }
         : {}),
+    },
+  };
+}
+
+export async function issueScopedBrokerIdentity(
+  service: DiscoveredService,
+  options: {
+    now?: Date;
+    ttlMs?: number;
+    transportBinding?: BrokerTransportBinding | null;
+    launchLeaseIssuer?: SecretsBrokerLaunchLeaseIssuer;
+  } = {},
+): Promise<ScopedBrokerCredential | null> {
+  const credential = mintScopedBrokerIdentity(service, options);
+  if (!credential) {
+    return null;
+  }
+
+  const lease = await issueLaunchLease(service, credential.metadata, options.launchLeaseIssuer);
+  if (!lease) {
+    return credential;
+  }
+
+  return {
+    ...credential,
+    env: {
+      ...credential.env,
+      [BROKER_IDENTITY_LEASE_ENV]: JSON.stringify(lease),
     },
   };
 }

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,12 +1,14 @@
 import type { DiscoveredService } from "../../contracts/service.js";
+import path from "node:path";
 import { LifecycleStateError } from "../../server/errors.js";
 import {
   startManagedProcess,
   stopManagedProcess,
 } from "../execution/supervisor.js";
 import {
-  mintScopedBrokerIdentity,
+  issueScopedBrokerIdentity,
   revokeServiceScopedBrokerIdentities,
+  type SecretsBrokerLaunchLeaseIssuer,
 } from "../broker/identity.js";
 import {
   mergeServiceVariableResolutionOptions,
@@ -46,6 +48,10 @@ import type {
 } from "./types.js";
 
 const START_TRACE_HISTORY_LIMIT = 5;
+const SECRETSBROKER_SERVICE_ID = "@secretsbroker";
+const LAUNCH_LEASE_COMMAND_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND";
+const LAUNCH_LEASE_ARGS_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON";
+const WORKSPACE_ID_ENV = "SERVICE_LASSO_WORKSPACE_ID";
 const SECRET_LIKE_VALUE_PATTERN =
   /(BEGIN PRIVATE KEY|access_token\s*[:=]\s*[^\s,;}]+|refresh_token\s*[:=]\s*[^\s,;}]+|id_token\s*[:=]\s*[^\s,;}]+|session_cookie\s*[:=]\s*[^\s,;}]+|client_secret\s*[:=]\s*[^\s,;}]+|provider_credential\s*[:=]\s*[^\s,;}]+|raw_secret\s*[:=]\s*[^\s,;}]+|password\s*[:=]\s*[^\s,;}]+|token\s*[:=]\s*[^\s,;}]+|Bearer\s+[A-Za-z0-9._~+/-]{12,})/gi;
 const SECRET_LIKE_KEY_PATTERN = /(secret|token|password|credential|private|cookie|key)/i;
@@ -89,6 +95,59 @@ function applyRunCompletionMetrics(
     totalRunDurationMs:
       current.runtime.metrics.totalRunDurationMs + (runDurationMs ?? 0),
     lastRunDurationMs: runDurationMs,
+  };
+}
+
+function parseConfiguredLaunchLeaseArgs(): string[] {
+  const raw = process.env[LAUNCH_LEASE_ARGS_ENV]?.trim();
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) && parsed.every((value) => typeof value === "string")
+      ? parsed
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function resolveInstalledCommand(extractedPath: string, command: string): string {
+  return path.isAbsolute(command) ? command : path.resolve(extractedPath, command);
+}
+
+function resolveSecretsBrokerLaunchLeaseIssuer(
+  registry?: ServiceRegistry,
+): SecretsBrokerLaunchLeaseIssuer | undefined {
+  const configuredCommand = process.env[LAUNCH_LEASE_COMMAND_ENV]?.trim();
+  if (configuredCommand) {
+    return {
+      command: {
+        command: configuredCommand,
+        args: parseConfiguredLaunchLeaseArgs(),
+        env: process.env,
+      },
+      workspaceId: process.env[WORKSPACE_ID_ENV],
+    };
+  }
+
+  if (!registry?.getById(SECRETSBROKER_SERVICE_ID)) {
+    return undefined;
+  }
+
+  const artifact = getLifecycleState(SECRETSBROKER_SERVICE_ID).installArtifacts.artifact;
+  if (!artifact?.command || !artifact.extractedPath) {
+    return undefined;
+  }
+
+  return {
+    command: {
+      command: resolveInstalledCommand(artifact.extractedPath, artifact.command),
+      cwd: artifact.extractedPath,
+      env: process.env,
+    },
+    workspaceId: process.env[WORKSPACE_ID_ENV],
   };
 }
 
@@ -618,7 +677,9 @@ export async function startService(
     ? collectRuntimeGlobalEnv(registry.list())
     : {};
   revokeServiceScopedBrokerIdentities(serviceId);
-  const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
+  const scopedBrokerIdentity = await issueScopedBrokerIdentity(service, {
+    launchLeaseIssuer: resolveSecretsBrokerLaunchLeaseIssuer(registry),
+  });
   const resolvedPorts =
     Object.keys(current.runtime.ports).length > 0
       ? current.runtime.ports
@@ -883,7 +944,9 @@ export async function restartService(
   const sharedGlobalEnv = registry
     ? collectRuntimeGlobalEnv(registry.list())
     : {};
-  const scopedBrokerIdentity = mintScopedBrokerIdentity(service);
+  const scopedBrokerIdentity = await issueScopedBrokerIdentity(service, {
+    launchLeaseIssuer: resolveSecretsBrokerLaunchLeaseIssuer(registry),
+  });
   const resolvedPorts =
     Object.keys(current.runtime.ports).length > 0
       ? current.runtime.ports

--- a/tests/broker-scoped-identity.test.js
+++ b/tests/broker-scoped-identity.test.js
@@ -1,13 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import {
   authorizeScopedBrokerWriteback,
   BROKER_CREDENTIAL_ENV,
   BROKER_CREDENTIAL_EXPIRES_AT_ENV,
   BROKER_IDENTITY_ID_ENV,
+  BROKER_IDENTITY_LEASE_ENV,
   BROKER_TRANSPORT_BINDING_KIND_ENV,
   BROKER_TRANSPORT_BINDING_SUBJECT_ENV,
   mintScopedBrokerIdentity,
@@ -241,6 +242,139 @@ test("runtime injects scoped broker credential without persisting or logging raw
     );
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    resetScopedBrokerIdentities();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("runtime can inject a broker-issued signed launch lease without persisting raw authority", async () => {
+  resetLifecycleState();
+  resetScopedBrokerIdentities();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-lease-");
+  const helperPath = path.join(tempRoot, "issue-lease-helper.mjs");
+  await writeFile(
+    helperPath,
+    `
+const args = process.argv.slice(2);
+function flag(name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : null;
+}
+const refs = args.flatMap((arg, index) => arg === "--allowed-ref" ? [args[index + 1]] : []);
+const namespaces = args.flatMap((arg, index) => arg === "--allowed-namespace" ? [args[index + 1]] : []);
+const operations = args.flatMap((arg, index) => arg === "--operation" ? [args[index + 1]] : []);
+const lease = {
+  issuer: "service-lasso-local-launcher",
+  serviceId: flag("--service-id"),
+  workspaceId: flag("--workspace-id"),
+  allowedRefs: refs,
+  allowedNamespaces: namespaces,
+  allowedOperations: operations,
+  issuedAt: flag("--issued-at"),
+  expiresAt: flag("--expires-at"),
+  jti: flag("--jti"),
+  transportBinding: {
+    kind: flag("--transport-binding-kind"),
+    subject: flag("--transport-binding-subject"),
+  },
+  signature: "hmac-sha256:test-signature"
+};
+process.stdout.write(JSON.stringify({ serviceId: "@secretsbroker", apiVersion: "test", outcome: "ready", lease }));
+`.trim(),
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "writer", {
+    captureEnvKeys: [BROKER_IDENTITY_ID_ENV, BROKER_CREDENTIAL_ENV, BROKER_IDENTITY_LEASE_ENV],
+    broker: {
+      imports: [
+        {
+          namespace: "shared/writer",
+          ref: "writer.API_TOKEN",
+          required: false,
+        },
+      ],
+      writeback: {
+        allowedNamespaces: ["services/writer"],
+        allowedOperations: ["create", "rotate"],
+        allowedRefs: ["writer.GENERATED_TOKEN"],
+        auditReason: "capture writer token",
+      },
+    },
+  });
+  const priorCommand = process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND;
+  const priorArgs = process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON;
+  const priorSigningKey = process.env.SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY;
+  const priorBindingKind = process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND;
+  const priorBindingSubject = process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT;
+  process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND = process.execPath;
+  process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON = JSON.stringify([helperPath]);
+  process.env.SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY = "SERVICE_LASSO_FAKE_SIGNING_KEY_DO_NOT_USE";
+  process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND = "windows-sid";
+  process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT = "S-1-5-21-lease-test";
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/writer/install`);
+    await postJson(`${apiServer.url}/api/services/writer/config`);
+    const start = await postJson(`${apiServer.url}/api/services/writer/start`);
+    assert.equal(start.status, 200);
+
+    const envPath = path.join(serviceRoot, "runtime", "env.json");
+    await waitFor(async () => {
+      try {
+        const env = JSON.parse(await readFile(envPath, "utf8"));
+        return typeof env[BROKER_IDENTITY_LEASE_ENV] === "string";
+      } catch {
+        return false;
+      }
+    });
+
+    const env = JSON.parse(await readFile(envPath, "utf8"));
+    const lease = JSON.parse(env[BROKER_IDENTITY_LEASE_ENV]);
+    assert.equal(lease.serviceId, "writer");
+    assert.equal(lease.workspaceId, "local-demo");
+    assert.deepEqual(lease.transportBinding, {
+      kind: "windows-sid",
+      subject: "S-1-5-21-lease-test",
+    });
+    assert.deepEqual(lease.allowedNamespaces, ["services/writer", "shared/writer"]);
+    assert.deepEqual(lease.allowedOperations, ["create", "resolve", "rotate"]);
+    assert.equal(lease.allowedRefs.includes("shared/writer/writer.API_TOKEN"), true);
+    assert.equal(lease.allowedRefs.includes("services/writer/writer.GENERATED_TOKEN"), true);
+
+    const storedRunning = await readStoredState(serviceRoot);
+    assert.equal(JSON.stringify(start.body).includes("SERVICE_LASSO_FAKE_SIGNING_KEY_DO_NOT_USE"), false);
+    assert.equal(JSON.stringify(storedRunning.runtime).includes("SERVICE_LASSO_FAKE_SIGNING_KEY_DO_NOT_USE"), false);
+    assert.equal(JSON.stringify(storedRunning.runtime).includes("hmac-sha256:test-signature"), false);
+
+    await postJson(`${apiServer.url}/api/services/writer/stop`);
+  } finally {
+    await apiServer.stop();
+    if (priorCommand === undefined) {
+      delete process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND;
+    } else {
+      process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND = priorCommand;
+    }
+    if (priorArgs === undefined) {
+      delete process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON;
+    } else {
+      process.env.SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON = priorArgs;
+    }
+    if (priorSigningKey === undefined) {
+      delete process.env.SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY;
+    } else {
+      process.env.SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY = priorSigningKey;
+    }
+    if (priorBindingKind === undefined) {
+      delete process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND;
+    } else {
+      process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_KIND = priorBindingKind;
+    }
+    if (priorBindingSubject === undefined) {
+      delete process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT;
+    } else {
+      process.env.SERVICE_LASSO_BROKER_TRANSPORT_BINDING_SUBJECT = priorBindingSubject;
+    }
     resetLifecycleState();
     resetScopedBrokerIdentities();
     await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Issue
Refs service-lasso/lasso-secretsbroker#31

## Summary
- Add an async core launcher identity path that can call `secretsbroker admin launch-lease issue` when a configured or installed helper and signing material are available.
- Inject the broker-signed launch lease as `SERVICE_LASSO_BROKER_IDENTITY_LEASE` only into the launched service environment, while preserving the existing local scoped credential fallback.
- Document the launch-time lease injection behavior and add lifecycle coverage proving the helper path does not persist signing keys or lease signatures.

## Scope
- In scope: core runtime launch identity issuance, helper discovery/configuration, scoped lease args, fallback behavior, and tests/docs.
- Out of scope: changing the pinned `@secretsbroker` release, cross-user Windows denial proof, or closing lasso-secretsbroker#31.

## Spec / contract / fixture impact
- Updated: `docs/reference/startup-broker-resolution.md` for `SERVICE_LASSO_BROKER_IDENTITY_LEASE` and helper fallback behavior.
- Not required: service manifest pin/catalog changes are not part of this PR.

## Nash invariant impact
- Invariant: launch-only secret authority must not be logged or persisted.
- Preservation proof: tests assert the helper signing key and lease signature do not appear in API start response or persisted runtime state; lease is only captured by the fixture child process env.

## Validation
- PASS `npm run build && node --test --test-concurrency=1 tests/broker-scoped-identity.test.js` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-core-launch-lease-20260627-0404/core-build-and-broker-identity-test.log`
- PASS `npm run verify:service-catalog` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-core-launch-lease-20260627-0404/core-verify-service-catalog.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-core-launch-lease-20260627-0404/core-manifest-discovery-test.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-core-launch-lease-20260627-0404/core-git-diff-check.log`
- PARTIAL/BLOCKED `npm test` — exceeded the 120s cron command bound. Individual reruns of the reported failing files show EPERM unlink failures against running canonical-demo binaries under `services/.state` (`@secretsbroker`, `@nginx`, `@traefik`, `echo-service`), not assertion failures from this patch. Logs: `core-npm-test.log`, `api-spine-rerun.log`, `registry-runtime-state-rerun.log`, `operator-data-rerun.log`.

## Approval trail
- Required: normal core PR review/check rules.
- Evidence: PR branch is pushed; no merge attempted in this run.

## Cleanup
- Branch: `feature/issue-31-core-launch-lease-helper`
- Local cleanup pending PR review/merge.
- Release-to-demo gate: not yet applicable because this PR is open/unmerged and does not change a demo service pin. If merged, recycle/verify canonical demo before claiming demo-current.