### PR TITLE
feat(audit): define metadata-only event contract

### DIFF
--- a/src/contracts/audit.compile-check.ts
+++ b/src/contracts/audit.compile-check.ts
@@ -1,0 +1,45 @@
+import { defineAuditEventInput } from "./audit.js";
+
+defineAuditEventInput({
+  source: "runtime",
+  actor: {
+    type: "system",
+    id: "runtime",
+  },
+  action: "runtime.reload",
+  outcome: "success",
+  subjectType: "runtime",
+  summary: "Runtime reload completed",
+});
+
+defineAuditEventInput({
+  source: "service",
+  actor: {
+    type: "operator",
+    id: "operator:test",
+  },
+  action: "service.config.save",
+  outcome: "success",
+  subjectType: "service-config",
+  serviceId: "service-a",
+  relatedRevisionId: "rev_123",
+  summary: "Service config saved with revision metadata",
+  metadata: {
+    changedFieldCount: 3,
+    currentHash: "sha256:abc123",
+  },
+});
+
+defineAuditEventInput({
+  source: "runtime",
+  actor: {
+    type: "system",
+    id: "runtime",
+  },
+  action: "unsafe.example",
+  outcome: "failure",
+  subjectType: "runtime",
+  summary: "Compile-time unsafe field check",
+  // @ts-expect-error raw token payloads are not accepted as first-class audit fields.
+  token: "never-store-token-material",
+});

--- a/src/contracts/audit.ts
+++ b/src/contracts/audit.ts
@@ -1,0 +1,111 @@
+export const AUDIT_EVENT_CONTRACT_VERSION = "service-lasso.audit-event.v1" as const;
+export const AUDIT_EVENT_KIND = "durable-audit" as const;
+
+export type AuditEventContractVersion = typeof AUDIT_EVENT_CONTRACT_VERSION;
+export type AuditEventKind = typeof AUDIT_EVENT_KIND;
+
+export type AuditEventSource =
+  | "runtime"
+  | "service"
+  | "service-admin"
+  | "secrets-broker"
+  | "operator"
+  | "workflow"
+  | "system";
+
+export type AuditEventOutcome = "success" | "failure" | "denied" | "skipped";
+
+export type AuditSubjectType =
+  | "runtime"
+  | "service"
+  | "service-config"
+  | "service-meta"
+  | "operator-action"
+  | "operator-confirmation"
+  | "setup-step"
+  | "recovery-check"
+  | "update"
+  | "workflow"
+  | "workflow-run"
+  | "broker-ref"
+  | "provider";
+
+export type AuditActorType = "system" | "operator" | "service" | "agent" | "unknown";
+export type AuditHttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type AuditChainStatus = "verified" | "broken" | "unavailable";
+
+export type AuditSafeMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AuditSafeMetadataValue[]
+  | { [key: string]: AuditSafeMetadataValue };
+
+export interface AuditActor {
+  type: AuditActorType;
+  id: string;
+  source?: string;
+  display?: string;
+}
+
+export interface AuditTamperEvidence {
+  chainId?: string;
+  sequence?: number;
+  previousHash?: string;
+  eventHash?: string;
+  chainStatus?: AuditChainStatus;
+}
+
+export type AuditUnsafeFieldGuard = {
+  password?: never;
+  token?: never;
+  secret?: never;
+  authorization?: never;
+  cookie?: never;
+  privateKey?: never;
+  body?: never;
+  raw?: never;
+};
+
+export interface AuditEventBase {
+  contractVersion: AuditEventContractVersion;
+  kind: AuditEventKind;
+  id: string;
+  timestamp: string;
+  source: AuditEventSource;
+  actor: AuditActor;
+  action: string;
+  outcome: AuditEventOutcome;
+  subjectType: AuditSubjectType;
+  subjectId?: string;
+  serviceId?: string;
+  routeTemplate?: string;
+  method?: AuditHttpMethod;
+  statusCode?: number;
+  summary: string;
+  reason?: string;
+  correlationId?: string;
+  traceId?: string;
+  relatedRevisionId?: string;
+  metadata?: Record<string, AuditSafeMetadataValue>;
+}
+
+export type AuditEvent = AuditEventBase & AuditTamperEvidence;
+
+export type AuditEventInput = AuditUnsafeFieldGuard &
+  Omit<AuditEventBase, "contractVersion" | "kind" | "id" | "timestamp"> &
+  Partial<Pick<AuditEventBase, "id" | "timestamp">> &
+  AuditTamperEvidence;
+
+export interface AuditReadResponse {
+  events: AuditEvent[];
+  nextCursor: string | null;
+  source: "runtime-audit";
+  chainStatus: AuditChainStatus | "mixed";
+  rawMaterialReturned: false;
+}
+
+export function defineAuditEventInput(input: AuditEventInput): AuditEventInput {
+  return input;
+}

--- a/src/runtime/audit/events.ts
+++ b/src/runtime/audit/events.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from "node:crypto";
+import {
+  AUDIT_EVENT_CONTRACT_VERSION,
+  AUDIT_EVENT_KIND,
+  type AuditEvent,
+  type AuditEventInput,
+  type AuditSafeMetadataValue,
+} from "../../contracts/audit.js";
+
+const UNSAFE_AUDIT_FIELD_NAMES = new Set([
+  "password",
+  "token",
+  "secret",
+  "authorization",
+  "cookie",
+  "privatekey",
+  "body",
+  "raw",
+]);
+
+export function createAuditEventId(prefix = "audit"): string {
+  const safePrefix = prefix.replace(/[^a-z0-9-]/gi, "-").replace(/^-+|-+$/g, "").toLowerCase() || "audit";
+  return `${safePrefix}_${randomUUID()}`;
+}
+
+export function createAuditTimestamp(now = new Date()): string {
+  return now.toISOString();
+}
+
+export function createAuditSummary(parts: Array<string | number | boolean | null | undefined>, maxLength = 240): string {
+  const summary = parts
+    .filter((part) => part !== undefined && part !== null && String(part).trim().length > 0)
+    .map((part) => String(part).replace(/\s+/g, " ").trim())
+    .join(" ")
+    .slice(0, maxLength)
+    .trim();
+
+  if (!summary) {
+    throw new Error("Audit summary must not be empty.");
+  }
+
+  return summary;
+}
+
+export function buildAuditEvent(input: AuditEventInput): AuditEvent {
+  assertNoUnsafeAuditKeys(input, "audit event");
+  if (input.metadata) {
+    assertSafeAuditMetadata(input.metadata);
+  }
+
+  return {
+    contractVersion: AUDIT_EVENT_CONTRACT_VERSION,
+    kind: AUDIT_EVENT_KIND,
+    id: input.id ?? createAuditEventId(input.source),
+    timestamp: input.timestamp ?? createAuditTimestamp(),
+    source: input.source,
+    actor: input.actor,
+    action: input.action,
+    outcome: input.outcome,
+    subjectType: input.subjectType,
+    subjectId: input.subjectId,
+    serviceId: input.serviceId,
+    routeTemplate: input.routeTemplate,
+    method: input.method,
+    statusCode: input.statusCode,
+    summary: input.summary,
+    reason: input.reason,
+    correlationId: input.correlationId,
+    traceId: input.traceId,
+    relatedRevisionId: input.relatedRevisionId,
+    metadata: input.metadata,
+    chainId: input.chainId,
+    sequence: input.sequence,
+    previousHash: input.previousHash,
+    eventHash: input.eventHash,
+    chainStatus: input.chainStatus,
+  };
+}
+
+export function assertSafeAuditMetadata(metadata: Record<string, AuditSafeMetadataValue>): void {
+  assertNoUnsafeAuditKeys(metadata, "audit metadata");
+}
+
+function assertNoUnsafeAuditKeys(value: unknown, context: string): void {
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoUnsafeAuditKeys(item, `${context}[${index}]`));
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+    if (UNSAFE_AUDIT_FIELD_NAMES.has(normalized)) {
+      throw new Error(`Unsafe audit field "${key}" is not allowed in ${context}. Store safe metadata instead.`);
+    }
+    assertNoUnsafeAuditKeys(nested, `${context}.${key}`);
+  }
+}

--- a/tests/audit-contract.test.js
+++ b/tests/audit-contract.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildAuditEvent,
+  createAuditEventId,
+  createAuditSummary,
+  createAuditTimestamp,
+} from "../dist/runtime/audit/events.js";
+
+test("audit contract builds durable metadata-only events", () => {
+  const event = buildAuditEvent({
+    id: "audit_test_1",
+    timestamp: "2026-06-28T00:00:00.000Z",
+    source: "runtime",
+    actor: {
+      type: "operator",
+      id: "operator:test",
+      source: "web",
+      display: "Operator",
+    },
+    action: "runtime.reload",
+    outcome: "success",
+    subjectType: "runtime",
+    routeTemplate: "/api/runtime/actions/:action",
+    method: "POST",
+    statusCode: 200,
+    summary: createAuditSummary(["Runtime", "reload", "completed"]),
+    correlationId: "corr_1",
+    metadata: {
+      targetCount: 1,
+      changedFieldCount: 0,
+      policyDecision: "allowed",
+    },
+    chainStatus: "unavailable",
+  });
+
+  assert.equal(event.contractVersion, "service-lasso.audit-event.v1");
+  assert.equal(event.kind, "durable-audit");
+  assert.equal(event.source, "runtime");
+  assert.equal(event.outcome, "success");
+  assert.equal(event.rawMaterialReturned, undefined);
+  assert.equal(JSON.stringify(event).includes("ACTUAL_SECRET"), false);
+});
+
+test("audit helpers create safe ids, timestamps, and summaries", () => {
+  assert.match(createAuditEventId("Runtime Action"), /^runtime-action_[0-9a-f-]+$/);
+  assert.equal(createAuditTimestamp(new Date("2026-06-28T00:01:02.003Z")), "2026-06-28T00:01:02.003Z");
+  assert.equal(createAuditSummary(["config", "save", 2, "fields"]), "config save 2 fields");
+  assert.throws(() => createAuditSummary(["  ", null, undefined]), /must not be empty/);
+});
+
+test("audit event builder rejects unsafe top-level and metadata field names", () => {
+  const baseEvent = {
+    source: "service",
+    actor: {
+      type: "operator",
+      id: "operator:test",
+    },
+    action: "service.config.save",
+    outcome: "success",
+    subjectType: "service-config",
+    serviceId: "alpha-service",
+    summary: "Service config saved with safe revision metadata",
+  };
+
+  assert.throws(
+    () =>
+      buildAuditEvent({
+        ...baseEvent,
+        raw: "raw request body",
+      }),
+    /Unsafe audit field "raw"/,
+  );
+
+  assert.throws(
+    () =>
+      buildAuditEvent({
+        ...baseEvent,
+        metadata: {
+          safeHash: "sha256:abc123",
+          nested: {
+            authorization: "Bearer example",
+          },
+        },
+      }),
+    /Unsafe audit field "authorization"/,
+  );
+});


### PR DESCRIPTION
## Summary
- Adds the `service-lasso.audit-event.v1` durable audit contract with typed sources, outcomes, subject types, actor shape, and tamper-evidence fields.
- Adds runtime helpers for event IDs, timestamps, summaries, metadata safety checks, and event construction.
- Adds compile-time unsafe-field checks and a focused JS regression test for metadata-only event creation and unsafe key rejection.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/audit-contract.test.js`

## Canonical demo
- Deployed with `npm run demo:deploy-canonical -- --ref=403aa187b2bf96ab586f15a4e7a1eb8027f59e76`
- Service Admin: `http://192.168.1.53:17700/` -> HTTP 200
- Runtime health: `http://192.168.1.53:17883/api/health` -> HTTP 200, status `ok`

## Logs
- `.work-agent/logs/cron-9e9b19ce-20260628-0427/`

Closes #750.
