### PR TITLE
feat(sample): make node sample service a log validation target

### DIFF
--- a/services/node-sample-service/runtime/server.mjs
+++ b/services/node-sample-service/runtime/server.mjs
@@ -1,7 +1,42 @@
+import http from "node:http";
 import path from "node:path";
+import readline from "node:readline";
 import { mkdir, writeFile } from "node:fs/promises";
 
-const heartbeat = setInterval(() => {}, 1000);
+const serviceId = "node-sample-service";
+const startedAt = new Date().toISOString();
+const requestedPort = Number.parseInt(process.env.NODE_SAMPLE_PORT ?? process.env.SERVICE_PORT ?? "4020", 10);
+const port = Number.isFinite(requestedPort) && requestedPort >= 0 ? requestedPort : 4020;
+const heartbeatMs = Math.max(1_000, Number.parseInt(process.env.NODE_SAMPLE_HEARTBEAT_MS ?? "5000", 10) || 5000);
+const counters = {
+  heartbeat: 0,
+  stdout: 0,
+  stderr: 0,
+  commands: 0,
+};
+
+let server;
+let heartbeat;
+let shuttingDown = false;
+
+function sanitizeMessage(value) {
+  const fallback = "sample validation event";
+  const text = typeof value === "string" && value.trim().length > 0 ? value : fallback;
+  const stripped = text.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  return (stripped || fallback).slice(0, 120);
+}
+
+function emitStdout(message) {
+  counters.stdout += 1;
+  console.log(`${serviceId} ${message}`);
+  void writeProviderEnvSnapshot();
+}
+
+function emitStderr(message) {
+  counters.stderr += 1;
+  console.error(`${serviceId} ${message}`);
+  void writeProviderEnvSnapshot();
+}
 
 async function writeProviderEnvSnapshot() {
   const targetPath = path.resolve(process.cwd(), process.env.NODE_SAMPLE_ENV_PATH ?? "./.state/provider-env.json");
@@ -13,6 +48,10 @@ async function writeProviderEnvSnapshot() {
         NODE_ENV: process.env.NODE_ENV ?? null,
         SERVICE_PORT: process.env.SERVICE_PORT ?? null,
         NODE_SAMPLE_PORT: process.env.NODE_SAMPLE_PORT ?? null,
+        pid: process.pid,
+        port: server?.address() && typeof server.address() === "object" ? server.address().port : port,
+        startedAt,
+        outputCounters: counters,
       },
       null,
       2,
@@ -21,12 +60,138 @@ async function writeProviderEnvSnapshot() {
   );
 }
 
-function shutdown() {
+function sendJson(response, status, body) {
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(`${JSON.stringify(body)}\n`);
+}
+
+function getRequestMessage(url) {
+  return sanitizeMessage(url.searchParams.get("message"));
+}
+
+function handleRequest(request, response) {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+
+  if (request.method === "GET" && url.pathname === "/") {
+    sendJson(response, 200, {
+      serviceId,
+      status: "running",
+      startedAt,
+      rawMaterialReturned: false,
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/health") {
+    sendJson(response, 200, {
+      ok: true,
+      serviceId,
+      uptimeMs: Math.max(0, Math.round(process.uptime() * 1000)),
+      rawMaterialReturned: false,
+    });
+    return;
+  }
+
+  if ((request.method === "GET" || request.method === "POST") && url.pathname === "/demo/log") {
+    const message = getRequestMessage(url);
+    emitStdout(`demo log message="${message}"`);
+    sendJson(response, 200, {
+      ok: true,
+      emitted: true,
+      stream: "stdout",
+      message,
+      rawMaterialReturned: false,
+    });
+    return;
+  }
+
+  if ((request.method === "GET" || request.method === "POST") && url.pathname === "/demo/error") {
+    const message = getRequestMessage(url);
+    emitStderr(`demo error message="${message}"`);
+    sendJson(response, 200, {
+      ok: true,
+      emitted: true,
+      stream: "stderr",
+      message,
+      rawMaterialReturned: false,
+    });
+    return;
+  }
+
+  sendJson(response, 404, {
+    ok: false,
+    error: "not_found",
+    rawMaterialReturned: false,
+  });
+}
+
+function handleCommand(line) {
+  const command = sanitizeMessage(line);
+  counters.commands += 1;
+
+  if (command === "help") {
+    emitStdout("command help supported=help,ping,status,emit");
+    return;
+  }
+
+  if (command === "ping") {
+    emitStdout("command pong");
+    return;
+  }
+
+  if (command === "status") {
+    emitStdout(`command status uptimeMs=${Math.max(0, Math.round(process.uptime() * 1000))} stdout=${counters.stdout} stderr=${counters.stderr}`);
+    return;
+  }
+
+  if (command.startsWith("emit ")) {
+    emitStdout(`command emit message="${sanitizeMessage(command.slice(5))}"`);
+    return;
+  }
+
+  emitStderr("command rejected reason=unsupported");
+}
+
+async function shutdown() {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
   clearInterval(heartbeat);
+  await writeProviderEnvSnapshot().catch(() => undefined);
+
+  if (server?.listening) {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 2_000).unref();
+    return;
+  }
+
   process.exit(0);
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());
 
-void writeProviderEnvSnapshot();
+if (!process.stdin.isTTY) {
+  const input = readline.createInterface({ input: process.stdin });
+  input.on("line", handleCommand);
+}
+
+emitStdout("starting");
+
+server = http.createServer(handleRequest);
+server.listen(port, "127.0.0.1", () => {
+  const address = server.address();
+  const boundPort = address && typeof address === "object" ? address.port : port;
+  emitStdout(`listening on 127.0.0.1:${boundPort}`);
+  void writeProviderEnvSnapshot();
+});
+
+heartbeat = setInterval(() => {
+  counters.heartbeat += 1;
+  emitStdout(`heartbeat count=${counters.heartbeat} uptimeMs=${Math.max(0, Math.round(process.uptime() * 1000))}`);
+}, heartbeatMs);

--- a/tests/node-sample-service-runtime.test.js
+++ b/tests/node-sample-service-runtime.test.js
@@ -1,0 +1,241 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+
+function waitForLine(lines, matcher, timeoutMs = 2_000) {
+  const existing = lines.find((line) => matcher.test(line));
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${matcher}`));
+    }, timeoutMs);
+
+    const onLine = (line) => {
+      if (matcher.test(line)) {
+        cleanup();
+        resolve(line);
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      lines.listeners.delete(onLine);
+    };
+
+    lines.listeners.add(onLine);
+  });
+}
+
+function makeLineCollector() {
+  const lines = [];
+  lines.listeners = new Set();
+  lines.pushChunk = (chunk) => {
+    for (const line of String(chunk).replace(/\r\n/g, "\n").split("\n")) {
+      if (!line) {
+        continue;
+      }
+      lines.push(line);
+      for (const listener of lines.listeners) {
+        listener(line);
+      }
+    }
+  };
+  return lines;
+}
+
+test("node sample service emits safe stdout, stderr, health, and metadata snapshot", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "node-sample-runtime-"));
+  const runtimePath = path.resolve("services", "node-sample-service", "runtime", "server.mjs");
+  const stdout = makeLineCollector();
+  const stderr = makeLineCollector();
+  const child = spawn(process.execPath, [runtimePath], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      NODE_SAMPLE_PORT: "0",
+      NODE_SAMPLE_HEARTBEAT_MS: "1000",
+      NODE_SAMPLE_ENV_PATH: "./.state/provider-env.json",
+      SERVICE_PORT: "0",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => stdout.pushChunk(chunk));
+  child.stderr.on("data", (chunk) => stderr.pushChunk(chunk));
+
+  try {
+    assert.match(await waitForLine(stdout, /node-sample-service starting/), /starting/);
+    const listeningLine = await waitForLine(stdout, /node-sample-service listening on 127\.0\.0\.1:\d+/);
+    const port = Number(listeningLine.match(/:(\d+)$/)?.[1]);
+    assert.ok(port > 0);
+
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).rawMaterialReturned, false);
+
+    const logResponse = await fetch(`http://127.0.0.1:${port}/demo/log?message=${encodeURIComponent("alpha\nsecret-looking")}`);
+    assert.equal(logResponse.status, 200);
+    assert.equal((await logResponse.json()).message, "alpha secret-looking");
+    assert.match(await waitForLine(stdout, /demo log message="alpha secret-looking"/), /alpha secret-looking/);
+
+    const errorResponse = await fetch(`http://127.0.0.1:${port}/demo/error?message=${encodeURIComponent("beta\twarning")}`);
+    assert.equal(errorResponse.status, 200);
+    assert.equal((await errorResponse.json()).stream, "stderr");
+    assert.match(await waitForLine(stderr, /demo error message="beta warning"/), /beta warning/);
+
+    child.stdin.write("ping\n");
+    assert.match(await waitForLine(stdout, /command pong/), /command pong/);
+    assert.match(await waitForLine(stdout, /heartbeat count=1 uptimeMs=/, 2_500), /heartbeat count=1/);
+
+    const snapshot = await waitFor(async () => {
+      try {
+        return JSON.parse(await readFile(path.join(tempRoot, ".state", "provider-env.json"), "utf8"));
+      } catch {
+        return null;
+      }
+    });
+    assert.equal(snapshot.NODE_ENV, "development");
+    assert.equal(snapshot.SERVICE_PORT, "0");
+    assert.equal(snapshot.NODE_SAMPLE_PORT, "0");
+    assert.equal(snapshot.port, port);
+    assert.equal(snapshot.outputCounters.stderr, 1);
+    assert.ok(snapshot.outputCounters.stdout >= 4);
+    assert.equal(JSON.stringify(snapshot).includes("alpha"), false);
+    assert.equal(JSON.stringify(snapshot).includes("beta"), false);
+  } finally {
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.once("close", resolve));
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+async function postJson(url) {
+  const response = await fetch(url, { method: "POST" });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function waitFor(readinessCheck, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await readinessCheck();
+    if (result) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function writeManifest(servicesRoot, serviceId, manifest) {
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  await mkdir(serviceRoot, { recursive: true });
+  await writeFile(path.join(serviceRoot, "service.json"), JSON.stringify(manifest, null, 2), "utf8");
+  return serviceRoot;
+}
+
+test("runtime log API captures node sample normal and error validation output", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "node-sample-runtime-api-"));
+  const servicesRoot = path.join(tempRoot, "services");
+  await mkdir(servicesRoot, { recursive: true });
+
+  try {
+    await writeManifest(servicesRoot, "@node", {
+      id: "@node",
+      name: "Node Runtime",
+      description: "Node provider shim for sample service log validation.",
+      role: "provider",
+      executable: process.execPath,
+      env: {
+        NODE_ENV: "development",
+      },
+    });
+
+    const serviceRoot = await writeManifest(servicesRoot, "node-sample-service", {
+      id: "node-sample-service",
+      name: "Node Sample Service",
+      description: "Node sample service runtime log validation target.",
+      depend_on: ["@node"],
+      execservice: "@node",
+      args: ["runtime/server.mjs"],
+      env: {
+        NODE_SAMPLE_ENV_PATH: "./.state/provider-env.json",
+        NODE_SAMPLE_HEARTBEAT_MS: "1000",
+        NODE_SAMPLE_PORT: "${SERVICE_PORT}",
+      },
+      ports: {
+        service: 0,
+      },
+      healthcheck: {
+        type: "process",
+      },
+    });
+    await mkdir(path.join(serviceRoot, "runtime"), { recursive: true });
+    await writeFile(
+      path.join(serviceRoot, "runtime", "server.mjs"),
+      await readFile(path.resolve("services", "node-sample-service", "runtime", "server.mjs"), "utf8"),
+      "utf8",
+    );
+
+    const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+    try {
+      await postJson(`${apiServer.url}/api/services/@node/install`);
+      await postJson(`${apiServer.url}/api/services/@node/config`);
+      await postJson(`${apiServer.url}/api/services/node-sample-service/install`);
+      await postJson(`${apiServer.url}/api/services/node-sample-service/config`);
+      const start = await postJson(`${apiServer.url}/api/services/node-sample-service/start`);
+      assert.equal(start.status, 200);
+
+      const listeningEntry = await waitFor(async () => {
+        const response = await fetch(`${apiServer.url}/api/services/node-sample-service/logs`);
+        const body = await response.json();
+        return body.logs.entries.find((entry) => /listening on 127\.0\.0\.1:\d+/.test(entry.message));
+      });
+      const port = Number(listeningEntry.message.match(/:(\d+)$/)?.[1]);
+      assert.ok(port > 0);
+
+      await fetch(`http://127.0.0.1:${port}/demo/log?message=${encodeURIComponent("runtime api normal")}`);
+      await fetch(`http://127.0.0.1:${port}/demo/error?message=${encodeURIComponent("runtime api error")}`);
+
+      const logs = await waitFor(async () => {
+        const response = await fetch(`${apiServer.url}/api/services/node-sample-service/logs`);
+        const body = await response.json();
+        const messages = body.logs.entries.map((entry) => `${entry.level}:${entry.message}`);
+        if (
+          messages.some((message) => message.includes('stdout:node-sample-service demo log message="runtime api normal"')) &&
+          messages.some((message) => message.includes('stderr:node-sample-service demo error message="runtime api error"'))
+        ) {
+          return body.logs;
+        }
+        return null;
+      });
+
+      assert.equal(logs.serviceId, "node-sample-service");
+      assert.equal(JSON.stringify(logs).includes("ACTUAL_SECRET"), false);
+
+      const snapshot = JSON.parse(await readFile(path.join(serviceRoot, ".state", "provider-env.json"), "utf8"));
+      assert.equal(snapshot.outputCounters.stderr, 1);
+    } finally {
+      await postJson(`${apiServer.url}/api/services/node-sample-service/stop`).catch(() => null);
+      await apiServer.stop();
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- turns 
ode-sample-service into a safe HTTP validation target with /, /health, /demo/log, and /demo/error
- emits deterministic startup, listening, heartbeat, stdout, stderr, and optional stdin command output
- expands the provider snapshot with safe process/output metadata only
- adds focused tests for direct runtime behavior and managed runtime log API capture

## Validation
- 
ode --test --test-concurrency=1 tests/node-sample-service-runtime.test.js
- 
pm run build

## Notes
- A broader 
pm test invocation was attempted and the new focused test passed, but unrelated local demo state caused existing failures: missing services/@secretsbroker/service.json and locked extracted .exe files under existing service .state directories. Output is saved in the run log.

Fixes #762