### PR TITLE
Add canonical demo status verification scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ Invoke-RestMethod -Method Post http://127.0.0.1:18080/api/runtime/actions/stopAl
 
 Then stop the Service Lasso process with `Ctrl+C`.
 
+## Canonical Demo Lifecycle
+
+The local canonical demo uses the checked-in services root and a dedicated workspace by default:
+
+```text
+services/
+workspace/demo-instance/
+```
+
+Use these commands when operating or checking the demo:
+
+| Command | Meaning |
+| --- | --- |
+| `npm run demo:start -- --port=17883` | Build and start the demo runtime on the canonical runtime port. |
+| `npm run demo:status -- --port=17883` | Print a non-mutating status report for runtime health, Service Admin reachability, workspace root, lifecycle state path, and demo log path. |
+| `npm run demo:verify-canonical -- --port=17883` | Verify the canonical runtime health endpoint and Service Admin URL. Exits non-zero when either surface is not reachable. |
+| `npm run demo:reset` | Clear the default demo workspace and managed demo service state. |
+| `npm run demo:smoke` | Run an isolated end-to-end smoke test against the bounded demo fixture. |
+
+Canonical LAN checks used by the unattended worker are:
+
+| URL | Purpose |
+| --- | --- |
+| `http://192.168.1.53:17883/api/health` | Service Lasso runtime health |
+| `http://192.168.1.53:17700/` | Service Admin UI |
+
+Status and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, and `--json` for automation. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
+
+On npm/PowerShell combinations that do not pass script flags after the first separator, add a second separator before the script flags:
+
+```powershell
+npm run demo:verify-canonical -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --json
+```
+
 ## Baseline Services
 
 The checked-in baseline proves that a clean clone can acquire and run real service artifacts.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "verify:echo-health": "npm run build && node scripts/verify-release-backed-echo-health.mjs",
     "verify:traefik-release": "npm run build && node scripts/verify-release-backed-traefik.mjs",
     "demo:start": "npm run build && node scripts/demo-start.mjs",
+    "demo:status": "node scripts/demo-status.mjs",
+    "demo:verify-canonical": "node scripts/demo-verify-canonical.mjs",
     "demo:reset": "npm run build && node scripts/demo-reset.mjs",
     "demo:smoke": "npm run build && node scripts/demo-smoke.mjs",
     "docs:start": "docusaurus start docs",

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -6,6 +6,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 export const repoRoot = path.resolve(scriptDir, "..");
 export const defaultDemoServicesRoot = path.join(repoRoot, "services");
 export const defaultDemoWorkspaceRoot = path.join(repoRoot, "workspace", "demo-instance");
+export const defaultDemoLogRoot = path.join(repoRoot, ".demo-logs");
 export const demoServiceIds = ["echo-service", "@node", "node-sample-service"];
 
 function parseFlag(args, name) {
@@ -14,11 +15,25 @@ function parseFlag(args, name) {
   return match ? match.slice(prefix.length) : undefined;
 }
 
+function parseNpmConfig(name) {
+  return process.env[`npm_config_${name.replaceAll("-", "_")}`];
+}
+
+function parseOption(args, name) {
+  return parseFlag(args, name) ?? parseNpmConfig(name);
+}
+
 export function resolveDemoOptions(args = process.argv.slice(2)) {
+  const port = Number(parseOption(args, "port") ?? process.env.SERVICE_LASSO_PORT ?? 18080);
+
   return {
-    servicesRoot: path.resolve(parseFlag(args, "services-root") ?? defaultDemoServicesRoot),
-    workspaceRoot: path.resolve(parseFlag(args, "workspace-root") ?? defaultDemoWorkspaceRoot),
-    port: Number(parseFlag(args, "port") ?? process.env.SERVICE_LASSO_PORT ?? 18080),
+    servicesRoot: path.resolve(parseOption(args, "services-root") ?? defaultDemoServicesRoot),
+    workspaceRoot: path.resolve(parseOption(args, "workspace-root") ?? defaultDemoWorkspaceRoot),
+    port,
+    runtimeUrl: parseOption(args, "runtime-url") ?? process.env.SERVICE_LASSO_RUNTIME_URL ?? `http://127.0.0.1:${port}`,
+    serviceAdminUrl: parseOption(args, "admin-url") ?? process.env.SERVICE_LASSO_ADMIN_URL ?? "http://127.0.0.1:17700/",
+    timeoutMs: Number(parseOption(args, "timeout-ms") ?? process.env.SERVICE_LASSO_DEMO_TIMEOUT_MS ?? 5_000),
+    json: args.includes("--json") || parseNpmConfig("json") === "true",
     preserve: args.includes("--preserve"),
   };
 }
@@ -73,6 +88,134 @@ export async function resetDemoInstance(options = {}) {
 
 async function importDistModule(relativePath) {
   return import(pathToFileURL(path.join(repoRoot, "dist", relativePath)).href);
+}
+
+function joinUrl(baseUrl, pathname) {
+  return new URL(pathname, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
+}
+
+async function fetchStatus(url, timeoutMs, parseJson = false) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      body,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readOptionalJson(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function classifyDemoStatus(runtimeProbe, serviceAdminProbe) {
+  const runtimeHealthy =
+    runtimeProbe.ok
+    && runtimeProbe.status === 200
+    && typeof runtimeProbe.body === "object"
+    && runtimeProbe.body !== null
+    && runtimeProbe.body.status === "ok";
+  const serviceAdminHealthy = serviceAdminProbe.ok && serviceAdminProbe.status === 200;
+
+  if (runtimeHealthy && serviceAdminHealthy) {
+    return "healthy";
+  }
+
+  if (!runtimeHealthy && !serviceAdminHealthy) {
+    return "canonical_endpoints_down";
+  }
+
+  return runtimeHealthy ? "service_admin_down" : "runtime_down";
+}
+
+export async function getDemoStatus(options = {}) {
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+  const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
+  const runtimeUrl = options.runtimeUrl ?? `http://127.0.0.1:${port}`;
+  const serviceAdminUrl = options.serviceAdminUrl ?? "http://127.0.0.1:17700/";
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const lifecycleRoot = path.join(workspaceRoot, ".service-lasso");
+  const lifecycleStatePath = path.join(lifecycleRoot, "demo-lifecycle.json");
+  const recoveryLockPath = path.join(defaultDemoLogRoot, "demo-watchdog.lock.json");
+  const runtimeHealthUrl = joinUrl(runtimeUrl, "/api/health");
+  const [runtimeProbe, serviceAdminProbe, lifecycleState, recoveryLock] = await Promise.all([
+    fetchStatus(runtimeHealthUrl, timeoutMs, true),
+    fetchStatus(serviceAdminUrl, timeoutMs),
+    readOptionalJson(lifecycleStatePath),
+    readOptionalJson(recoveryLockPath),
+  ]);
+  const classification = classifyDemoStatus(runtimeProbe, serviceAdminProbe);
+
+  return {
+    ok: classification === "healthy",
+    classification,
+    checkedAt: new Date().toISOString(),
+    endpoints: {
+      runtime: {
+        url: runtimeUrl,
+        healthUrl: runtimeHealthUrl,
+        ok: runtimeProbe.ok,
+        status: runtimeProbe.status,
+        health: typeof runtimeProbe.body === "object" && runtimeProbe.body !== null ? runtimeProbe.body.status : null,
+        error: runtimeProbe.error ?? null,
+      },
+      serviceAdmin: {
+        url: serviceAdminUrl,
+        ok: serviceAdminProbe.ok,
+        status: serviceAdminProbe.status,
+        error: serviceAdminProbe.error ?? null,
+      },
+    },
+    paths: {
+      servicesRoot,
+      workspaceRoot,
+      lifecycleRoot,
+      lifecycleStatePath,
+      demoLogRoot: defaultDemoLogRoot,
+      recoveryLockPath,
+    },
+    lifecycleState,
+    recoveryLock,
+  };
+}
+
+export function printDemoStatus(status) {
+  console.log(`[service-lasso demo] status ${status.classification}`);
+  console.log(`- ok: ${status.ok ? "yes" : "no"}`);
+  console.log(`- runtime: ${status.endpoints.runtime.healthUrl} -> ${status.endpoints.runtime.status ?? status.endpoints.runtime.error}`);
+  console.log(`- serviceAdmin: ${status.endpoints.serviceAdmin.url} -> ${status.endpoints.serviceAdmin.status ?? status.endpoints.serviceAdmin.error}`);
+  console.log(`- servicesRoot: ${status.paths.servicesRoot}`);
+  console.log(`- workspaceRoot: ${status.paths.workspaceRoot}`);
+  console.log(`- lifecycleState: ${status.paths.lifecycleStatePath}`);
+  console.log(`- demoLogs: ${status.paths.demoLogRoot}`);
 }
 
 export async function startDemoRuntime(options = {}) {

--- a/scripts/demo-status.mjs
+++ b/scripts/demo-status.mjs
@@ -1,0 +1,10 @@
+import { getDemoStatus, printDemoStatus, resolveDemoOptions } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const status = await getDemoStatus(options);
+
+if (options.json) {
+  console.log(JSON.stringify(status, null, 2));
+} else {
+  printDemoStatus(status);
+}

--- a/scripts/demo-verify-canonical.mjs
+++ b/scripts/demo-verify-canonical.mjs
@@ -1,0 +1,14 @@
+import { getDemoStatus, printDemoStatus, resolveDemoOptions } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const status = await getDemoStatus(options);
+
+if (options.json) {
+  console.log(JSON.stringify(status, null, 2));
+} else {
+  printDemoStatus(status);
+}
+
+if (!status.ok) {
+  process.exitCode = 1;
+}

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -1,7 +1,44 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
 import path from "node:path";
+
+async function startFixtureServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+  };
+}
+
+async function runNodeScript(script, args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [path.resolve("scripts", script), ...args], {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
 
 test("demo smoke script validates the bounded demo instance end to end", async () => {
   const demoScript = path.resolve("scripts", "demo-smoke.mjs");
@@ -34,4 +71,80 @@ test("demo smoke script validates the bounded demo instance end to end", async (
   assert.equal(result.code, 0, `Expected demo smoke to pass.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
   assert.match(result.stdout, /\[service-lasso demo] smoke passed/);
   assert.match(result.stdout, /echo-service, @node, node-sample-service/);
+});
+
+test("demo status reports canonical endpoint and lifecycle paths as JSON", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-status-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-status.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const status = JSON.parse(result.stdout);
+
+    assert.equal(status.ok, true);
+    assert.equal(status.classification, "healthy");
+    assert.equal(status.endpoints.runtime.healthUrl, `${runtime.url}/api/health`);
+    assert.equal(status.paths.workspaceRoot, workspaceRoot);
+    assert.match(status.paths.lifecycleStatePath, /[\\/]\.service-lasso[\\/]demo-lifecycle\.json$/);
+    assert.match(status.paths.demoLogRoot, /[\\/]\.demo-logs$/);
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo verify canonical exits non-zero when a canonical endpoint is down", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-verify-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+
+  try {
+    const result = await runNodeScript("demo-verify-canonical.mjs", [
+      `--runtime-url=${runtime.url}`,
+      "--admin-url=http://127.0.0.1:1/",
+      `--workspace-root=${workspaceRoot}`,
+      "--timeout-ms=250",
+      "--json",
+    ]);
+
+    assert.equal(result.code, 1);
+    const status = JSON.parse(result.stdout);
+
+    assert.equal(status.ok, false);
+    assert.equal(status.classification, "service_admin_down");
+    assert.equal(status.endpoints.runtime.status, 200);
+    assert.equal(status.endpoints.serviceAdmin.status, null);
+  } finally {
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Issue
Refs #764

## Summary
- Adds non-mutating canonical demo status and verify commands.
- Reports runtime health, Service Admin reachability, services/workspace roots, lifecycle state path, demo log path, and recovery lock path.
- Documents the canonical demo lifecycle commands in the core README.

## Scope
- In scope: first JS-owned status/verification slice for canonical demo observability.
- Out of scope: start/recycle recovery reconciliation and ownership state writes, which remain follow-up work under #764.

## Spec / contract / fixture impact
- Updated: README canonical demo lifecycle command contract.
- Updated: demo status/verify fixture tests using local HTTP servers.

## Validation
- PASS `node --test --test-concurrency=1 --test-name-pattern="demo status|demo verify canonical" tests/demo-instance.test.js`
- PASS `npm run build`
- PASS `npm run demo:verify-canonical -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json`
- KNOWN LOCAL BLOCKER `node --test --test-concurrency=1 tests/demo-instance.test.js` fails in the pre-existing smoke test because the dirty local worktree contains untracked `services/@secretsbroker/` without `service.json`. The new status/verify tests pass when targeted.

## Demo Evidence
- Deployed branch: `agent/issue-764-demo-gate-status`
- Deployed commit checked by this run: `f6b010e`
- Canonical verify result: `healthy`
- Runtime health: `http://192.168.1.53:17883/api/health` HTTP 200, health `ok`
- Service Admin: `http://192.168.1.53:17700/` HTTP 200
- Note: this slice adds status/verify tooling and docs; it does not change the long-running runtime/service manifests. The canonical demo was not recycled because no `demo:recycle` command exists on the current main branch yet.

## Approval trail
- Required: no
- Evidence: bounded issue slice with targeted validation and live canonical verify output.

## Cleanup
- Branch remains open for review.
- Local repo still has pre-existing untracked demo runtime/workspace artifacts that were not staged or modified by this PR.
