### PR TITLE
feat(demo): persist canonical lifecycle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Use these commands when operating or checking the demo:
 
 | Command | Meaning |
 | --- | --- |
-| `npm run demo:start -- --port=17883` | Build and start the demo runtime on the canonical runtime port. |
+| `npm run demo:start -- --port=17883` | Build, ensure the demo runtime is available on the canonical runtime port, and exit cleanly when the canonical endpoints are already healthy. |
 | `npm run demo:status -- --port=17883` | Print a non-mutating status report for runtime health, Service Admin reachability, workspace root, lifecycle state path, and demo log path. |
 | `npm run demo:verify-canonical -- --port=17883` | Verify the canonical runtime health endpoint and Service Admin URL. Exits non-zero when either surface is not reachable. |
 | `npm run demo:reset` | Clear the default demo workspace and managed demo service state. |
@@ -89,7 +89,7 @@ Canonical LAN checks used by the unattended worker are:
 | `http://192.168.1.53:17883/api/health` | Service Lasso runtime health |
 | `http://192.168.1.53:17700/` | Service Admin UI |
 
-Status and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, and `--json` for automation. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
+Start, status, and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, and `--json` for automation. `demo:start` writes the latest canonical demo ownership/status record to `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when it finds or starts a healthy demo. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
 
 On npm/PowerShell combinations that do not pass script flags after the first separator, add a second separator before the script flags:
 

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { access, readFile, rm } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 export const repoRoot = path.resolve(scriptDir, "..");
@@ -135,6 +135,15 @@ async function readOptionalJson(filePath) {
   }
 }
 
+function getDemoLifecyclePaths(workspaceRoot) {
+  const lifecycleRoot = path.join(workspaceRoot, ".service-lasso");
+
+  return {
+    lifecycleRoot,
+    lifecycleStatePath: path.join(lifecycleRoot, "demo-lifecycle.json"),
+  };
+}
+
 function classifyDemoStatus(runtimeProbe, serviceAdminProbe) {
   const runtimeHealthy =
     runtimeProbe.ok
@@ -162,8 +171,7 @@ export async function getDemoStatus(options = {}) {
   const runtimeUrl = options.runtimeUrl ?? `http://127.0.0.1:${port}`;
   const serviceAdminUrl = options.serviceAdminUrl ?? "http://127.0.0.1:17700/";
   const timeoutMs = options.timeoutMs ?? 5_000;
-  const lifecycleRoot = path.join(workspaceRoot, ".service-lasso");
-  const lifecycleStatePath = path.join(lifecycleRoot, "demo-lifecycle.json");
+  const { lifecycleRoot, lifecycleStatePath } = getDemoLifecyclePaths(workspaceRoot);
   const recoveryLockPath = path.join(defaultDemoLogRoot, "demo-watchdog.lock.json");
   const runtimeHealthUrl = joinUrl(runtimeUrl, "/api/health");
   const [runtimeProbe, serviceAdminProbe, lifecycleState, recoveryLock] = await Promise.all([
@@ -205,6 +213,33 @@ export async function getDemoStatus(options = {}) {
     lifecycleState,
     recoveryLock,
   };
+}
+
+export async function writeDemoLifecycleState(status, updates = {}) {
+  const lifecycleStatePath = status.paths.lifecycleStatePath;
+  const nextState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    phase: updates.phase ?? (status.ok ? "healthy" : "blocked"),
+    classification: updates.classification ?? status.classification,
+    owner: {
+      pid: process.pid,
+      command: path.basename(process.argv[1] ?? "node"),
+      workspaceRoot: status.paths.workspaceRoot,
+      servicesRoot: status.paths.servicesRoot,
+      runtimeUrl: status.endpoints.runtime.url,
+      serviceAdminUrl: status.endpoints.serviceAdmin.url,
+    },
+    endpoints: status.endpoints,
+    paths: status.paths,
+    previousState: status.lifecycleState ?? null,
+    ...updates,
+  };
+
+  await mkdir(path.dirname(lifecycleStatePath), { recursive: true });
+  await writeFile(lifecycleStatePath, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+
+  return nextState;
 }
 
 export function printDemoStatus(status) {

--- a/scripts/demo-start.mjs
+++ b/scripts/demo-start.mjs
@@ -1,18 +1,48 @@
-import { resolveDemoOptions, startDemoRuntime } from "./demo-instance-lib.mjs";
+import {
+  getDemoStatus,
+  printDemoStatus,
+  resolveDemoOptions,
+  startDemoRuntime,
+  writeDemoLifecycleState,
+} from "./demo-instance-lib.mjs";
 
 const options = resolveDemoOptions();
-const runtime = await startDemoRuntime(options);
+const status = await getDemoStatus(options);
 
-console.log("[service-lasso demo] runtime started");
-console.log(`- api: ${runtime.apiServer.url}`);
-console.log(`- servicesRoot: ${runtime.serviceRoot.servicesRoot}`);
-console.log(`- workspaceRoot: ${runtime.serviceRoot.workspaceRoot}`);
-console.log("- stop: Ctrl+C");
+if (status.ok) {
+  const lifecycleState = await writeDemoLifecycleState(status, {
+    phase: "already_healthy",
+  });
 
-const shutdown = async () => {
-  await runtime.apiServer.stop();
-  process.exit(0);
-};
+  if (options.json) {
+    console.log(JSON.stringify({ ...status, lifecycleState }, null, 2));
+  } else {
+    console.log("[service-lasso demo] runtime already healthy");
+    printDemoStatus({ ...status, lifecycleState });
+    console.log(`- lifecyclePhase: ${lifecycleState.phase}`);
+  }
+} else {
+  const runtime = await startDemoRuntime(options);
+  const startedStatus = await getDemoStatus({
+    ...options,
+    runtimeUrl: runtime.apiServer.url,
+  });
+  const lifecycleState = await writeDemoLifecycleState(startedStatus, {
+    phase: "started",
+  });
 
-process.on("SIGINT", () => void shutdown());
-process.on("SIGTERM", () => void shutdown());
+  console.log("[service-lasso demo] runtime started");
+  console.log(`- api: ${runtime.apiServer.url}`);
+  console.log(`- servicesRoot: ${runtime.serviceRoot.servicesRoot}`);
+  console.log(`- workspaceRoot: ${runtime.serviceRoot.workspaceRoot}`);
+  console.log(`- lifecycleState: ${lifecycleState.paths.lifecycleStatePath}`);
+  console.log("- stop: Ctrl+C");
+
+  const shutdown = async () => {
+    await runtime.apiServer.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -107,6 +107,50 @@ test("demo status reports canonical endpoint and lifecycle paths as JSON", async
     assert.equal(status.paths.workspaceRoot, workspaceRoot);
     assert.match(status.paths.lifecycleStatePath, /[\\/]\.service-lasso[\\/]demo-lifecycle\.json$/);
     assert.match(status.paths.demoLogRoot, /[\\/]\.demo-logs$/);
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo start exits cleanly and persists lifecycle state when canonical endpoints are already healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-start-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-start.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const status = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(status.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(status.ok, true);
+    assert.equal(status.classification, "healthy");
+    assert.equal(status.lifecycleState.phase, "already_healthy");
+    assert.equal(persisted.phase, "already_healthy");
+    assert.equal(persisted.classification, "healthy");
+    assert.equal(persisted.owner.workspaceRoot, workspaceRoot);
+    assert.equal(persisted.owner.runtimeUrl, runtime.url);
+    assert.equal(persisted.owner.serviceAdminUrl, `${admin.url}/`);
   } finally {
     await admin.close();
     await runtime.close();


### PR DESCRIPTION
## Issue
Refs #764

## Summary
- Makes `demo:start` classify an already-healthy canonical demo before trying to bind the runtime port.
- Persists a demo lifecycle/ownership record under `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when `demo:start` finds or starts a healthy demo.
- Updates canonical demo docs and adds a focused regression test for the already-healthy start path.

## Scope
- In scope: idempotent healthy-start handling, lifecycle state persistence, command output/docs/tests.
- Out of scope: full recovery/recycle convergence, stale lock remediation, and watcher ownership conflict handling.

## Spec / contract / fixture impact
- Updated: README canonical demo lifecycle command contract.
- Updated: `demo:start` JSON output includes persisted lifecycle state for the already-healthy path.

## Service Lasso invariant impact
- Invariant: canonical demo ownership state belongs under the Service Lasso demo workspace.
- Preservation proof: `demo:start` writes only safe endpoint/path/process metadata to `workspace/demo-instance/.service-lasso/demo-lifecycle.json`; it does not write raw logs, env values, secrets, or service payloads.

## Validation
- PASS `node --test --test-concurrency=1 --test-name-pattern="demo status|demo start|demo verify canonical" tests/demo-instance.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260702-062537\targeted-demo-lifecycle-tests-final.log`
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260702-062537\npm-run-build-final.log`
- PASS `npm run demo:start -- --port=17883 --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json` — classified canonical demo as `healthy` and wrote lifecycle state with `phase: already_healthy`; log `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260702-062537\npm-run-demo-start-canonical-json.log`

## Demo Evidence
- Deployed/exercised branch: `agent/issue-764-demo-lifecycle-state`
- Commit: `804868347ea1065288c06b6ef1907ef9e623ae63`
- Runtime health: `http://192.168.1.53:17883/api/health` HTTP 200, health `ok`
- Service Admin: `http://192.168.1.53:17700/` HTTP 200
- Lifecycle state path: `C:\projects\service-lasso\service-lasso\workspace\demo-instance\.service-lasso\demo-lifecycle.json`

## Approval trail
- Required: yes
- Evidence: issue #764 is Ready/P1/agent-ready; this PR implements the next focused slice from the previous worker handoff.

## Cleanup
- Local repo still has pre-existing untracked demo/runtime artifacts (`.demo-logs/`, `.work-agent/`, `services/...`, `workspace/`) left untouched.
- After merge, continue #764 with the next slice: add the JS gate/reconcile command and stale/blocked recovery classifications.

