### PR TITLE
Restore canonical demo recovery entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "verify:echo-health": "npm run build && node scripts/verify-release-backed-echo-health.mjs",
     "verify:traefik-release": "npm run build && node scripts/verify-release-backed-traefik.mjs",
     "demo:start": "npm run build && node scripts/demo-start.mjs",
+    "demo:watchdog": "npm run build && node scripts/demo-watchdog.mjs",
+    "demo:recycle": "npm run build && node scripts/demo-recycle.mjs",
     "demo:status": "node scripts/demo-status.mjs",
     "demo:verify-canonical": "node scripts/demo-verify-canonical.mjs",
     "demo:reset": "npm run build && node scripts/demo-reset.mjs",

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -1,0 +1,51 @@
+import {
+  getDemoStatus,
+  printDemoStatus,
+  resetDemoInstance,
+  resolveDemoOptions,
+  startDemoRuntime,
+  writeDemoLifecycleState,
+} from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const status = await getDemoStatus(options);
+
+if (status.ok) {
+  const lifecycleState = await writeDemoLifecycleState(status, {
+    phase: "recycle_verified_existing",
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify({ ...status, lifecycleState }, null, 2));
+  } else {
+    console.log("[service-lasso demo] recycle verified existing runtime");
+    printDemoStatus({ ...status, lifecycleState });
+    console.log(`- lifecyclePhase: ${lifecycleState.phase}`);
+  }
+} else {
+  await resetDemoInstance(options);
+
+  const runtime = await startDemoRuntime(options);
+  const recycledStatus = await getDemoStatus({
+    ...options,
+    runtimeUrl: runtime.apiServer.url,
+  });
+  const lifecycleState = await writeDemoLifecycleState(recycledStatus, {
+    phase: "recycled_started",
+  });
+
+  console.log("[service-lasso demo] recycle started runtime");
+  console.log(`- api: ${runtime.apiServer.url}`);
+  console.log(`- servicesRoot: ${runtime.serviceRoot.servicesRoot}`);
+  console.log(`- workspaceRoot: ${runtime.serviceRoot.workspaceRoot}`);
+  console.log(`- lifecycleState: ${lifecycleState.paths.lifecycleStatePath}`);
+  console.log("- stop: Ctrl+C");
+
+  const shutdown = async () => {
+    await runtime.apiServer.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}

--- a/scripts/demo-watchdog.mjs
+++ b/scripts/demo-watchdog.mjs
@@ -1,0 +1,48 @@
+import {
+  getDemoStatus,
+  printDemoStatus,
+  resolveDemoOptions,
+  startDemoRuntime,
+  writeDemoLifecycleState,
+} from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const status = await getDemoStatus(options);
+
+if (status.ok) {
+  const lifecycleState = await writeDemoLifecycleState(status, {
+    phase: "watchdog_healthy",
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify({ ...status, lifecycleState }, null, 2));
+  } else {
+    console.log("[service-lasso demo] watchdog healthy");
+    printDemoStatus({ ...status, lifecycleState });
+    console.log(`- lifecyclePhase: ${lifecycleState.phase}`);
+  }
+} else {
+  const runtime = await startDemoRuntime(options);
+  const recoveredStatus = await getDemoStatus({
+    ...options,
+    runtimeUrl: runtime.apiServer.url,
+  });
+  const lifecycleState = await writeDemoLifecycleState(recoveredStatus, {
+    phase: "watchdog_recovered",
+  });
+
+  console.log("[service-lasso demo] watchdog recovered runtime");
+  console.log(`- api: ${runtime.apiServer.url}`);
+  console.log(`- servicesRoot: ${runtime.serviceRoot.servicesRoot}`);
+  console.log(`- workspaceRoot: ${runtime.serviceRoot.workspaceRoot}`);
+  console.log(`- lifecycleState: ${lifecycleState.paths.lifecycleStatePath}`);
+  console.log("- stop: Ctrl+C");
+
+  const shutdown = async () => {
+    await runtime.apiServer.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -158,6 +158,86 @@ test("demo start exits cleanly and persists lifecycle state when canonical endpo
   }
 });
 
+test("demo watchdog exits cleanly through core lifecycle state when canonical endpoints are already healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-watchdog-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-watchdog.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const status = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(status.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(status.ok, true);
+    assert.equal(status.classification, "healthy");
+    assert.equal(status.lifecycleState.phase, "watchdog_healthy");
+    assert.equal(persisted.phase, "watchdog_healthy");
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo recycle exits cleanly through core lifecycle state when canonical endpoints are already healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-recycle-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-recycle.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const status = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(status.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(status.ok, true);
+    assert.equal(status.classification, "healthy");
+    assert.equal(status.lifecycleState.phase, "recycle_verified_existing");
+    assert.equal(persisted.phase, "recycle_verified_existing");
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
 test("demo verify canonical exits non-zero when a canonical endpoint is down", async () => {
   const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-verify-"));
   const runtime = await startFixtureServer((request, response) => {


### PR DESCRIPTION
## Summary
- Restore `demo:watchdog` and `demo:recycle` npm entry points expected by the canonical demo recovery workflow.
- Implement both commands as thin JS callers around the current core demo status/lifecycle helpers, avoiding the old child-process recovery spawn path.
- Add fixture-backed tests proving both commands exit cleanly and persist lifecycle state when canonical endpoints are already healthy.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 --test-name-pattern "demo (watchdog|recycle) exits cleanly" tests/demo-instance.test.js`
- `npm run demo:recycle -- --port=17883 --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/`
- `npm run demo:verify-canonical -- --port=17883 --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --json`

## Notes
The full `tests/demo-instance.test.js` run still hits an unrelated dirty-worktree fixture problem because `services/@secretsbroker/` exists locally without `service.json`. The new watchdog/recycle tests passed when targeted.

Closes #763 once reviewed and accepted.
