### PR TITLE
Add canonical demo gate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Use these commands when operating or checking the demo:
 | Command | Meaning |
 | --- | --- |
 | `npm run demo:start -- --port=17883` | Build, ensure the demo runtime is available on the canonical runtime port, and exit cleanly when the canonical endpoints are already healthy. |
+| `npm run demo:gate -- --port=17883` | Return one worker-safe gate result with endpoint health, listener state, lifecycle ownership, recovery lock path, and next safe action. |
 | `npm run demo:status -- --port=17883` | Print a non-mutating status report for runtime health, Service Admin reachability, workspace root, lifecycle state path, and demo log path. |
 | `npm run demo:verify-canonical -- --port=17883` | Verify the canonical runtime health endpoint and Service Admin URL. Exits non-zero when either surface is not reachable. |
 | `npm run demo:reset` | Clear the default demo workspace and managed demo service state. |
@@ -89,7 +90,7 @@ Canonical LAN checks used by the unattended worker are:
 | `http://192.168.1.53:17883/api/health` | Service Lasso runtime health |
 | `http://192.168.1.53:17700/` | Service Admin UI |
 
-Start, status, and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, and `--json` for automation. `demo:start` writes the latest canonical demo ownership/status record to `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when it finds or starts a healthy demo. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
+Start, gate, status, and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, `--demo-log-root=...`, and `--json` for automation. `demo:start` writes the latest canonical demo ownership/status record to `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when it finds or starts a healthy demo. `demo:gate` also writes that lifecycle state and exits non-zero with a structured classification such as `runtime_port_owner_conflict`, `wrong_workspace_owner`, `stale_recovery_lock`, or `service_admin_down` when the worker should stop and hand off a blocker. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
 
 On npm/PowerShell combinations that do not pass script flags after the first separator, add a second separator before the script flags:
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "demo:start": "npm run build && node scripts/demo-start.mjs",
     "demo:watchdog": "npm run build && node scripts/demo-watchdog.mjs",
     "demo:recycle": "npm run build && node scripts/demo-recycle.mjs",
+    "demo:gate": "npm run build && node scripts/demo-gate.mjs",
     "demo:status": "node scripts/demo-status.mjs",
     "demo:verify-canonical": "node scripts/demo-verify-canonical.mjs",
     "demo:reset": "npm run build && node scripts/demo-reset.mjs",

--- a/scripts/demo-gate.mjs
+++ b/scripts/demo-gate.mjs
@@ -1,0 +1,14 @@
+import { getDemoGateReport, printDemoGateReport, resolveDemoOptions } from "./demo-instance-lib.mjs";
+
+const options = resolveDemoOptions();
+const report = await getDemoGateReport(options);
+
+if (options.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  printDemoGateReport(report);
+}
+
+if (!report.ok) {
+  process.exitCode = 1;
+}

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createConnection } from "node:net";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 export const repoRoot = path.resolve(scriptDir, "..");
@@ -32,6 +33,7 @@ export function resolveDemoOptions(args = process.argv.slice(2)) {
     port,
     runtimeUrl: parseOption(args, "runtime-url") ?? process.env.SERVICE_LASSO_RUNTIME_URL ?? `http://127.0.0.1:${port}`,
     serviceAdminUrl: parseOption(args, "admin-url") ?? process.env.SERVICE_LASSO_ADMIN_URL ?? "http://127.0.0.1:17700/",
+    demoLogRoot: path.resolve(parseOption(args, "demo-log-root") ?? defaultDemoLogRoot),
     timeoutMs: Number(parseOption(args, "timeout-ms") ?? process.env.SERVICE_LASSO_DEMO_TIMEOUT_MS ?? 5_000),
     json: args.includes("--json") || parseNpmConfig("json") === "true",
     preserve: args.includes("--preserve"),
@@ -164,15 +166,131 @@ function classifyDemoStatus(runtimeProbe, serviceAdminProbe) {
   return runtimeHealthy ? "service_admin_down" : "runtime_down";
 }
 
+async function probeTcpListener(targetUrl, timeoutMs) {
+  let parsedUrl;
+
+  try {
+    parsedUrl = new URL(targetUrl);
+  } catch (error) {
+    return {
+      ok: false,
+      host: null,
+      port: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const port = Number(parsedUrl.port || (parsedUrl.protocol === "https:" ? 443 : 80));
+  const host = parsedUrl.hostname;
+
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      resolve({ ok: false, host, port, error: "connect timeout" });
+    }, timeoutMs);
+
+    socket.once("connect", () => {
+      clearTimeout(timeout);
+      socket.end();
+      resolve({ ok: true, host, port, error: null });
+    });
+
+    socket.once("error", (error) => {
+      clearTimeout(timeout);
+      resolve({
+        ok: false,
+        host,
+        port,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+}
+
+function readLockUpdatedAt(recoveryLock) {
+  if (!recoveryLock || typeof recoveryLock !== "object") {
+    return null;
+  }
+
+  for (const key of ["updatedAt", "startedAt", "createdAt", "checkedAt"]) {
+    const value = recoveryLock[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const timestamp = Date.parse(value);
+    if (Number.isFinite(timestamp)) {
+      return timestamp;
+    }
+  }
+
+  return null;
+}
+
+function hasWrongWorkspaceOwner(status) {
+  const ownerWorkspaceRoot = status.lifecycleState?.owner?.workspaceRoot;
+  return typeof ownerWorkspaceRoot === "string" && path.resolve(ownerWorkspaceRoot) !== status.paths.workspaceRoot;
+}
+
+function classifyDemoGate(status, runtimeListener, staleRecoveryLockMs) {
+  if (status.ok) {
+    return "healthy";
+  }
+
+  if (hasWrongWorkspaceOwner(status)) {
+    return "wrong_workspace_owner";
+  }
+
+  if (status.recoveryLock) {
+    const lockUpdatedAt = readLockUpdatedAt(status.recoveryLock);
+    if (lockUpdatedAt && Date.now() - lockUpdatedAt > staleRecoveryLockMs) {
+      return "stale_recovery_lock";
+    }
+
+    return "recovery_in_progress";
+  }
+
+  if (!status.endpoints.runtime.ok && runtimeListener.ok) {
+    return "runtime_port_owner_conflict";
+  }
+
+  return status.classification;
+}
+
+function getGateNextSafeAction(classification) {
+  switch (classification) {
+    case "healthy":
+      return "Continue with issue selection or validation.";
+    case "wrong_workspace_owner":
+      return "Inspect lifecycle state owner and reconcile the demo workspace before starting a new runtime.";
+    case "stale_recovery_lock":
+      return "Inspect the recovery lock and demo logs, then remove or refresh stale recovery state only after confirming no recovery process is active.";
+    case "recovery_in_progress":
+      return "Wait for the active recovery owner to finish, or inspect the recovery lock if it is not progressing.";
+    case "runtime_port_owner_conflict":
+      return "Inspect the process listening on the runtime port before recycling the canonical demo.";
+    case "service_admin_down":
+      return "Recover or restart Service Admin, then run demo:gate again.";
+    case "runtime_down":
+      return "Start or recycle the canonical runtime, then run demo:gate again.";
+    case "canonical_endpoints_down":
+      return "Recover the canonical runtime and Service Admin endpoints, then run demo:gate again.";
+    default:
+      return "Inspect the reported endpoint and lifecycle evidence before manual recovery.";
+  }
+}
+
 export async function getDemoStatus(options = {}) {
   const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
   const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
   const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
   const runtimeUrl = options.runtimeUrl ?? `http://127.0.0.1:${port}`;
   const serviceAdminUrl = options.serviceAdminUrl ?? "http://127.0.0.1:17700/";
+  const demoLogRoot = path.resolve(options.demoLogRoot ?? defaultDemoLogRoot);
   const timeoutMs = options.timeoutMs ?? 5_000;
   const { lifecycleRoot, lifecycleStatePath } = getDemoLifecyclePaths(workspaceRoot);
-  const recoveryLockPath = path.join(defaultDemoLogRoot, "demo-watchdog.lock.json");
+  const recoveryLockPath = path.join(demoLogRoot, "demo-watchdog.lock.json");
   const runtimeHealthUrl = joinUrl(runtimeUrl, "/api/health");
   const [runtimeProbe, serviceAdminProbe, lifecycleState, recoveryLock] = await Promise.all([
     fetchStatus(runtimeHealthUrl, timeoutMs, true),
@@ -207,11 +325,56 @@ export async function getDemoStatus(options = {}) {
       workspaceRoot,
       lifecycleRoot,
       lifecycleStatePath,
-      demoLogRoot: defaultDemoLogRoot,
+      demoLogRoot,
       recoveryLockPath,
     },
     lifecycleState,
     recoveryLock,
+  };
+}
+
+export async function getDemoGateReport(options = {}) {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const status = await getDemoStatus(options);
+  const runtimeListener = await probeTcpListener(status.endpoints.runtime.url, timeoutMs);
+  const classification = classifyDemoGate(status, runtimeListener, options.staleRecoveryLockMs ?? 10 * 60 * 1_000);
+  const ok = classification === "healthy";
+  const gate = {
+    ok,
+    classification,
+    sourceClassification: status.classification,
+    checkedAt: new Date().toISOString(),
+    phase: ok ? "gate_healthy" : "gate_blocked",
+    runtimeListener,
+    nextSafeAction: getGateNextSafeAction(classification),
+  };
+  const lifecycleState = await writeDemoLifecycleState(status, {
+    phase: gate.phase,
+    classification,
+    gate,
+  });
+
+  return {
+    ...status,
+    ok,
+    classification,
+    gate,
+    lifecycleState,
+  };
+}
+
+function summarizePreviousLifecycleState(lifecycleState) {
+  if (!lifecycleState || typeof lifecycleState !== "object") {
+    return null;
+  }
+
+  return {
+    schemaVersion: lifecycleState.schemaVersion ?? null,
+    updatedAt: lifecycleState.updatedAt ?? null,
+    phase: lifecycleState.phase ?? null,
+    classification: lifecycleState.classification ?? null,
+    owner: lifecycleState.owner ?? null,
+    gate: lifecycleState.gate ?? null,
   };
 }
 
@@ -232,7 +395,7 @@ export async function writeDemoLifecycleState(status, updates = {}) {
     },
     endpoints: status.endpoints,
     paths: status.paths,
-    previousState: status.lifecycleState ?? null,
+    previousState: summarizePreviousLifecycleState(status.lifecycleState),
     ...updates,
   };
 
@@ -251,6 +414,19 @@ export function printDemoStatus(status) {
   console.log(`- workspaceRoot: ${status.paths.workspaceRoot}`);
   console.log(`- lifecycleState: ${status.paths.lifecycleStatePath}`);
   console.log(`- demoLogs: ${status.paths.demoLogRoot}`);
+}
+
+export function printDemoGateReport(report) {
+  console.log(`[service-lasso demo] gate ${report.classification}`);
+  console.log(`- ok: ${report.ok ? "yes" : "no"}`);
+  console.log(`- runtime: ${report.endpoints.runtime.healthUrl} -> ${report.endpoints.runtime.status ?? report.endpoints.runtime.error}`);
+  console.log(`- runtimeListener: ${report.gate.runtimeListener.host}:${report.gate.runtimeListener.port} -> ${report.gate.runtimeListener.ok ? "open" : report.gate.runtimeListener.error}`);
+  console.log(`- serviceAdmin: ${report.endpoints.serviceAdmin.url} -> ${report.endpoints.serviceAdmin.status ?? report.endpoints.serviceAdmin.error}`);
+  console.log(`- servicesRoot: ${report.paths.servicesRoot}`);
+  console.log(`- workspaceRoot: ${report.paths.workspaceRoot}`);
+  console.log(`- lifecycleState: ${report.paths.lifecycleStatePath}`);
+  console.log(`- recoveryLock: ${report.paths.recoveryLockPath}`);
+  console.log(`- nextSafeAction: ${report.gate.nextSafeAction}`);
 }
 
 export async function startDemoRuntime(options = {}) {

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -158,6 +158,90 @@ test("demo start exits cleanly and persists lifecycle state when canonical endpo
   }
 });
 
+test("demo gate exits cleanly and persists lifecycle state when canonical endpoints are already healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-gate-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-gate.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const report = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(report.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(report.ok, true);
+    assert.equal(report.classification, "healthy");
+    assert.equal(report.gate.phase, "gate_healthy");
+    assert.equal(report.gate.runtimeListener.ok, true);
+    assert.equal(persisted.phase, "gate_healthy");
+    assert.equal(persisted.classification, "healthy");
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo gate reports a runtime port owner conflict when the listener is not Service Lasso health", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-gate-conflict-"));
+  const runtime = await startFixtureServer((request, response) => {
+    if (request.url === "/api/health") {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "not-service-lasso" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const result = await runNodeScript("demo-gate.mjs", [
+      `--runtime-url=${runtime.url}`,
+      `--admin-url=${admin.url}/`,
+      `--workspace-root=${workspaceRoot}`,
+      "--json",
+    ]);
+
+    assert.equal(result.code, 1);
+    const report = JSON.parse(result.stdout);
+    const persisted = JSON.parse(await readFile(report.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(report.ok, false);
+    assert.equal(report.classification, "runtime_port_owner_conflict");
+    assert.equal(report.gate.sourceClassification, "runtime_down");
+    assert.equal(report.gate.runtimeListener.ok, true);
+    assert.equal(persisted.phase, "gate_blocked");
+    assert.equal(persisted.classification, "runtime_port_owner_conflict");
+  } finally {
+    await admin.close();
+    await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
 test("demo watchdog exits cleanly through core lifecycle state when canonical endpoints are already healthy", async () => {
   const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-watchdog-"));
   const runtime = await startFixtureServer((request, response) => {


### PR DESCRIPTION
## Summary
- add JS `demo:gate` command for the scheduled worker startup gate
- classify healthy, wrong workspace owner, recovery lock, runtime listener conflict, and endpoint-down states with a next safe action
- write lifecycle state for gate results and keep previous lifecycle snapshots compact
- document the new command and add targeted demo gate tests

## Validation
- PASS `node --test --test-concurrency=1 --test-name-pattern="demo gate|demo status|demo start|demo verify canonical" tests/demo-instance.test.js`
- PASS `npm run build`
- PASS `npm run demo:gate -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json`

## Demo evidence
- Canonical runtime health: `http://192.168.1.53:17883/api/health` HTTP 200, health `ok`
- Service Admin: `http://192.168.1.53:17700/` HTTP 200
- Gate classification: `healthy`
- Lifecycle state path: `workspace/demo-instance/.service-lasso/demo-lifecycle.json`

Part of service-lasso/service-lasso#764.
