### PR TITLE
Add active demo gate recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Use these commands when operating or checking the demo:
 | Command | Meaning |
 | --- | --- |
 | `npm run demo:start -- --port=17883` | Build, ensure the demo runtime is available on the canonical runtime port, and exit cleanly when the canonical endpoints are already healthy. |
-| `npm run demo:gate -- --port=17883` | Return one worker-safe gate result with endpoint health, listener state, lifecycle ownership, recovery lock path, and next safe action. |
+| `npm run demo:gate -- --port=17883` | Return one worker-safe gate result with endpoint health, listener state, lifecycle ownership, recovery lock path, recovery attempt evidence, and next safe action. |
 | `npm run demo:status -- --port=17883` | Print a non-mutating status report for runtime health, Service Admin reachability, workspace root, lifecycle state path, and demo log path. |
 | `npm run demo:verify-canonical -- --port=17883` | Verify the canonical runtime health endpoint and Service Admin URL. Exits non-zero when either surface is not reachable. |
 | `npm run demo:reset` | Clear the default demo workspace and managed demo service state. |
@@ -90,7 +90,7 @@ Canonical LAN checks used by the unattended worker are:
 | `http://192.168.1.53:17883/api/health` | Service Lasso runtime health |
 | `http://192.168.1.53:17700/` | Service Admin UI |
 
-Start, gate, status, and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, `--demo-log-root=...`, and `--json` for automation. `demo:start` writes the latest canonical demo ownership/status record to `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when it finds or starts a healthy demo. `demo:gate` also writes that lifecycle state and exits non-zero with a structured classification such as `runtime_port_owner_conflict`, `wrong_workspace_owner`, `stale_recovery_lock`, or `service_admin_down` when the worker should stop and hand off a blocker. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
+Start, gate, status, and verification commands accept `--runtime-url=...`, `--admin-url=...`, `--workspace-root=...`, `--services-root=...`, `--timeout-ms=...`, `--demo-log-root=...`, and `--json` for automation. `demo:start` writes the latest canonical demo ownership/status record to `workspace/demo-instance/.service-lasso/demo-lifecycle.json` when it finds or starts a healthy demo. `demo:gate` also writes that lifecycle state. When runtime health is down and there is no wrong-owner, stale-lock, active-recovery, or listener-conflict blocker, the gate starts one detached Service Lasso runtime process, records the runtime log path under `.demo-logs/`, waits for the canonical endpoints, and returns `recovered` if they become healthy. It exits non-zero with a structured classification such as `runtime_port_owner_conflict`, `wrong_workspace_owner`, `stale_recovery_lock`, `service_admin_down`, or `service_startup_failure` when the worker should stop and hand off a blocker. Lifecycle state is reported under `workspace/demo-instance/.service-lasso/`; demo logs are reported under `.demo-logs/`.
 
 On npm/PowerShell combinations that do not pass script flags after the first separator, add a second separator before the script flags:
 

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { closeSync, openSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { createConnection } from "node:net";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -262,6 +264,8 @@ function getGateNextSafeAction(classification) {
   switch (classification) {
     case "healthy":
       return "Continue with issue selection or validation.";
+    case "recovered":
+      return "Continue with issue selection or validation; the gate recovered the canonical runtime.";
     case "wrong_workspace_owner":
       return "Inspect lifecycle state owner and reconcile the demo workspace before starting a new runtime.";
     case "stale_recovery_lock":
@@ -276,8 +280,58 @@ function getGateNextSafeAction(classification) {
       return "Start or recycle the canonical runtime, then run demo:gate again.";
     case "canonical_endpoints_down":
       return "Recover the canonical runtime and Service Admin endpoints, then run demo:gate again.";
+    case "service_startup_failure":
+      return "Inspect the detached runtime log and lifecycle state before retrying demo recovery.";
     default:
       return "Inspect the reported endpoint and lifecycle evidence before manual recovery.";
+  }
+}
+
+function isRecoverableGateClassification(classification) {
+  return classification === "runtime_down" || classification === "canonical_endpoints_down";
+}
+
+function createLogTimestamp(date = new Date()) {
+  return date.toISOString().replaceAll(":", "").replaceAll(".", "-");
+}
+
+export async function startDetachedDemoRuntime(options = {}) {
+  const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
+  const demoLogRoot = path.resolve(options.demoLogRoot ?? defaultDemoLogRoot);
+  const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
+  const runtimeEntry = path.join(repoRoot, "dist", "index.js");
+  const logPath = path.join(demoLogRoot, `demo-runtime-${createLogTimestamp()}.log`);
+
+  await mkdir(demoLogRoot, { recursive: true });
+
+  const outputFd = openSync(logPath, "a");
+  try {
+    const child = spawn(process.execPath, ["--enable-source-maps", runtimeEntry], {
+      cwd: repoRoot,
+      detached: true,
+      env: {
+        ...process.env,
+        SERVICE_LASSO_PORT: String(port),
+        SERVICE_LASSO_SERVICES_ROOT: servicesRoot,
+        SERVICE_LASSO_WORKSPACE_ROOT: workspaceRoot,
+      },
+      stdio: ["ignore", outputFd, outputFd],
+      windowsHide: true,
+    });
+
+    child.unref();
+
+    return {
+      pid: child.pid ?? null,
+      command: `${process.execPath} --enable-source-maps ${runtimeEntry}`,
+      logPath,
+      servicesRoot,
+      workspaceRoot,
+      port,
+    };
+  } finally {
+    closeSync(outputFd);
   }
 }
 
@@ -338,26 +392,83 @@ export async function getDemoGateReport(options = {}) {
   const status = await getDemoStatus(options);
   const runtimeListener = await probeTcpListener(status.endpoints.runtime.url, timeoutMs);
   const classification = classifyDemoGate(status, runtimeListener, options.staleRecoveryLockMs ?? 10 * 60 * 1_000);
-  const ok = classification === "healthy";
+  const shouldRecover = options.recover !== false && isRecoverableGateClassification(classification);
+  const recovery = {
+    attempted: false,
+    startedRuntime: null,
+    error: null,
+  };
+
+  if (shouldRecover) {
+    recovery.attempted = true;
+
+    try {
+      const startRuntime = options.startDetachedRuntime ?? startDetachedDemoRuntime;
+      recovery.startedRuntime = await startRuntime(options);
+      const recoveredStatus = await waitFor(async () => {
+        const nextStatus = await getDemoStatus(options);
+        return nextStatus.ok ? nextStatus : null;
+      }, options.recoveryTimeoutMs ?? Math.max(timeoutMs, 5_000), options.recoveryPollIntervalMs ?? 250);
+      const recoveredListener = await probeTcpListener(recoveredStatus.endpoints.runtime.url, timeoutMs);
+      const gate = {
+        ok: true,
+        classification: "recovered",
+        sourceClassification: status.classification,
+        checkedAt: new Date().toISOString(),
+        phase: "gate_recovered",
+        runtimeListener: recoveredListener,
+        recovery,
+        nextSafeAction: getGateNextSafeAction("recovered"),
+      };
+      const lifecycleState = await writeDemoLifecycleState(recoveredStatus, {
+        phase: gate.phase,
+        classification: "recovered",
+        gate,
+      });
+
+      return {
+        ...recoveredStatus,
+        ok: true,
+        classification: "recovered",
+        gate,
+        lifecycleState,
+      };
+    } catch (error) {
+      recovery.error = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const finalStatus = recovery.attempted ? await getDemoStatus(options) : status;
+  const finalRuntimeListener = recovery.attempted
+    ? await probeTcpListener(finalStatus.endpoints.runtime.url, timeoutMs)
+    : runtimeListener;
+  const finalGateClassification = recovery.attempted
+    ? classifyDemoGate(finalStatus, finalRuntimeListener, options.staleRecoveryLockMs ?? 10 * 60 * 1_000)
+    : classification;
+  const finalClassification = recovery.attempted && isRecoverableGateClassification(finalGateClassification)
+    ? "service_startup_failure"
+    : finalGateClassification;
+  const ok = finalClassification === "healthy";
   const gate = {
     ok,
-    classification,
+    classification: finalClassification,
     sourceClassification: status.classification,
     checkedAt: new Date().toISOString(),
     phase: ok ? "gate_healthy" : "gate_blocked",
-    runtimeListener,
-    nextSafeAction: getGateNextSafeAction(classification),
+    runtimeListener: finalRuntimeListener,
+    recovery,
+    nextSafeAction: getGateNextSafeAction(finalClassification),
   };
-  const lifecycleState = await writeDemoLifecycleState(status, {
+  const lifecycleState = await writeDemoLifecycleState(finalStatus, {
     phase: gate.phase,
-    classification,
+    classification: finalClassification,
     gate,
   });
 
   return {
-    ...status,
+    ...finalStatus,
     ok,
-    classification,
+    classification: finalClassification,
     gate,
     lifecycleState,
   };
@@ -426,6 +537,9 @@ export function printDemoGateReport(report) {
   console.log(`- workspaceRoot: ${report.paths.workspaceRoot}`);
   console.log(`- lifecycleState: ${report.paths.lifecycleStatePath}`);
   console.log(`- recoveryLock: ${report.paths.recoveryLockPath}`);
+  if (report.gate.recovery?.attempted) {
+    console.log(`- recoveryRuntimeLog: ${report.gate.recovery.startedRuntime?.logPath ?? report.gate.recovery.error}`);
+  }
   console.log(`- nextSafeAction: ${report.gate.nextSafeAction}`);
 }
 

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -5,16 +5,25 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { getDemoGateReport } from "../scripts/demo-instance-lib.mjs";
 
-async function startFixtureServer(handler) {
+async function startFixtureServer(handler, options = {}) {
   const server = http.createServer(handler);
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise((resolve) => server.listen(options.port ?? 0, "127.0.0.1", resolve));
   const address = server.address();
 
   return {
     url: `http://127.0.0.1:${address.port}`,
     close: () => new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
   };
+}
+
+async function getFreePort() {
+  const server = http.createServer((request, response) => response.end());
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
 }
 
 async function runNodeScript(script, args = []) {
@@ -238,6 +247,102 @@ test("demo gate reports a runtime port owner conflict when the listener is not S
   } finally {
     await admin.close();
     await runtime.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo gate attempts runtime recovery and reports recovered when endpoints become healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-gate-recovered-"));
+  const runtimePort = await getFreePort();
+  let runtime = null;
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const report = await getDemoGateReport({
+      runtimeUrl: `http://127.0.0.1:${runtimePort}`,
+      serviceAdminUrl: `${admin.url}/`,
+      workspaceRoot,
+      timeoutMs: 250,
+      recoveryTimeoutMs: 2_000,
+      startDetachedRuntime: async () => {
+        runtime = await startFixtureServer((request, response) => {
+          if (request.url === "/api/health") {
+            response.writeHead(200, { "content-type": "application/json" });
+            response.end(JSON.stringify({ status: "ok" }));
+            return;
+          }
+
+          response.writeHead(404);
+          response.end();
+        }, { port: runtimePort });
+
+        return {
+          pid: 12345,
+          command: "fixture-runtime",
+          logPath: path.join(workspaceRoot, "fixture-runtime.log"),
+          servicesRoot: path.resolve("services"),
+          workspaceRoot,
+          port: runtimePort,
+        };
+      },
+    });
+    const persisted = JSON.parse(await readFile(report.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(report.ok, true);
+    assert.equal(report.classification, "recovered");
+    assert.equal(report.gate.phase, "gate_recovered");
+    assert.equal(report.gate.recovery.attempted, true);
+    assert.equal(report.gate.recovery.startedRuntime.pid, 12345);
+    assert.equal(report.gate.sourceClassification, "runtime_down");
+    assert.equal(persisted.phase, "gate_recovered");
+    assert.equal(persisted.classification, "recovered");
+  } finally {
+    if (runtime) {
+      await runtime.close();
+    }
+    await admin.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("demo gate reports service startup failure when recovery does not make endpoints healthy", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-gate-failed-recovery-"));
+  const runtimePort = await getFreePort();
+  const admin = await startFixtureServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service Admin</title>");
+  });
+
+  try {
+    const report = await getDemoGateReport({
+      runtimeUrl: `http://127.0.0.1:${runtimePort}`,
+      serviceAdminUrl: `${admin.url}/`,
+      workspaceRoot,
+      timeoutMs: 100,
+      recoveryTimeoutMs: 250,
+      recoveryPollIntervalMs: 50,
+      startDetachedRuntime: async () => ({
+        pid: 12345,
+        command: "fixture-runtime",
+        logPath: path.join(workspaceRoot, "fixture-runtime.log"),
+        servicesRoot: path.resolve("services"),
+        workspaceRoot,
+        port: runtimePort,
+      }),
+    });
+    const persisted = JSON.parse(await readFile(report.paths.lifecycleStatePath, "utf8"));
+
+    assert.equal(report.ok, false);
+    assert.equal(report.classification, "service_startup_failure");
+    assert.equal(report.gate.recovery.attempted, true);
+    assert.match(report.gate.recovery.error, /Condition not met/);
+    assert.equal(persisted.phase, "gate_blocked");
+    assert.equal(persisted.classification, "service_startup_failure");
+  } finally {
+    await admin.close();
     await rm(workspaceRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- make `demo:gate` attempt one active runtime recovery when runtime health is down and no ownership/lock/listener blocker is present
- start the recovery runtime as a detached Service Lasso process with stdout/stderr logged under `.demo-logs/`
- add recovered and startup-failure gate classifications, lifecycle persistence, README docs, and targeted tests

## Validation
- PASS `node --test --test-concurrency=1 --test-name-pattern="demo gate|demo status|demo start|demo verify canonical|demo recycle" tests/demo-instance.test.js`
- PASS `npm run build`
- PASS `git diff --check`
- PASS `npm run demo:recycle -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json`
- PASS `npm run demo:gate -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json`
- PASS `npm run demo:verify-canonical -- -- --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=services --json`

Runtime health and Service Admin both reported HTTP 200 / healthy on the canonical LAN endpoints.

Closes part of #764.