### PR TITLE
Add service config document API

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -58,6 +58,43 @@ export interface ServiceDetailResponse {
   service: ServiceSummary;
 }
 
+export interface ServiceConfigRevisionResponse {
+  id: string;
+  createdAt: string;
+  actor: string;
+  reason: string | null;
+  path: string;
+  previousHash: string;
+  currentHash: string;
+  validationStatus: "valid";
+  content: string;
+}
+
+export interface ServiceConfigDocumentResponse {
+  serviceId: string;
+  fileName: "server.json";
+  path: string;
+  content: string;
+  hash: string;
+  updatedAt: string;
+  backupCount: number;
+  revisions: ServiceConfigRevisionResponse[];
+  safety: {
+    rawSecretValuesLoaded: false;
+    omittedSensitiveFields: string[];
+  };
+}
+
+export interface ServiceConfigSaveResponse {
+  serviceId: string;
+  fileName: "server.json";
+  path: string;
+  hash: string;
+  savedAt: string;
+  backup: ServiceConfigRevisionResponse;
+  validationStatus: "valid";
+}
+
 export interface ServiceMetaResponse {
   serviceId: string;
   meta: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { createServiceVariablesResponse } from "./routes/variables.js";
 import { createServiceNetworkResponse } from "./routes/network.js";
 import { createGlobalEnvResponse } from "./routes/globalenv.js";
 import { createServiceMetaResponse, createServicesMetaResponse } from "./routes/service-meta.js";
+import { createServiceConfigDocumentResponse, saveServiceConfigDocument } from "./routes/service-config.js";
 import {
   createDashboardServiceDetailResponse,
   createDashboardServicesResponse,
@@ -631,6 +632,16 @@ async function routeRequest(
 
     if (!service) {
       notFound(response);
+      return;
+    }
+
+    if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "config") {
+      writeJson(response, 200, await createServiceConfigDocumentResponse(service));
+      return;
+    }
+
+    if (request.method === "PUT" && pathParts.length === 4 && pathParts[3] === "config") {
+      writeJson(response, 200, await saveServiceConfigDocument(service, await readJsonBody(request)));
       return;
     }
 

--- a/src/server/routes/service-config.ts
+++ b/src/server/routes/service-config.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { getServiceStatePaths } from "../../runtime/state/paths.js";
+import { ApiError } from "../errors.js";
+import type { ServiceConfigDocumentResponse, ServiceConfigSaveResponse } from "../../contracts/api.js";
+
+interface ServiceConfigRevisionFile {
+  id: string;
+  createdAt: string;
+  actor: string;
+  reason: string | null;
+  path: string;
+  previousHash: string;
+  currentHash: string;
+  validationStatus: "valid";
+  content: string;
+}
+
+interface ServiceConfigSaveBody {
+  content: string;
+  actor: string;
+  reason: string | null;
+}
+
+const serviceConfigBackupDirName = "service-config";
+
+function hashContent(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function toRevisionId(createdAt: string): string {
+  return createdAt.replaceAll(/[^0-9A-Za-z]+/g, "-").replaceAll(/^-|-$/g, "");
+}
+
+function parseServiceConfigSaveBody(input: unknown): ServiceConfigSaveBody {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Service config save body must be a JSON object.");
+  }
+
+  const candidate = input as Record<string, unknown>;
+  if (typeof candidate.content !== "string") {
+    throw new ApiError("invalid_body", 400, "\"content\" must be a string.");
+  }
+
+  if (candidate.actor !== undefined && typeof candidate.actor !== "string") {
+    throw new ApiError("invalid_body", 400, "\"actor\" must be a string when present.");
+  }
+
+  if (candidate.reason !== undefined && candidate.reason !== null && typeof candidate.reason !== "string") {
+    throw new ApiError("invalid_body", 400, "\"reason\" must be a string or null when present.");
+  }
+
+  return {
+    content: candidate.content,
+    actor: typeof candidate.actor === "string" && candidate.actor.trim() ? candidate.actor.trim() : "unknown",
+    reason: typeof candidate.reason === "string" && candidate.reason.trim() ? candidate.reason.trim() : null,
+  };
+}
+
+function parseServiceJson(content: string, serviceId: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content) as unknown;
+  } catch {
+    throw new ApiError("invalid_json", 400, "Service config content must be valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ApiError("invalid_json", 400, "Service config content must be a JSON object.");
+  }
+
+  const id = (parsed as Record<string, unknown>).id;
+  if (id !== serviceId) {
+    throw new ApiError("invalid_json", 400, `Service config id must remain "${serviceId}".`);
+  }
+
+  return parsed;
+}
+
+async function getConfigBackupDir(service: DiscoveredService): Promise<string> {
+  const paths = getServiceStatePaths(service.serviceRoot);
+  const backupDir = path.join(paths.backups, serviceConfigBackupDirName);
+  await mkdir(backupDir, { recursive: true });
+  return backupDir;
+}
+
+async function readRevisions(service: DiscoveredService): Promise<ServiceConfigRevisionFile[]> {
+  const backupDir = await getConfigBackupDir(service);
+  const entries = await readdir(backupDir, { withFileTypes: true }).catch(() => []);
+  const revisions = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map(async (entry) => {
+        const content = await readFile(path.join(backupDir, entry.name), "utf8");
+        const parsed = JSON.parse(content) as ServiceConfigRevisionFile;
+        return parsed;
+      }),
+  );
+
+  return revisions.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function createServiceConfigDocumentResponse(
+  service: DiscoveredService,
+): Promise<ServiceConfigDocumentResponse> {
+  const content = await readFile(service.manifestPath, "utf8");
+  const manifestStats = await stat(service.manifestPath);
+  const revisions = await readRevisions(service);
+
+  return {
+    serviceId: service.manifest.id,
+    fileName: "server.json",
+    path: service.manifestPath,
+    content,
+    hash: hashContent(content),
+    updatedAt: manifestStats.mtime.toISOString(),
+    backupCount: revisions.length,
+    revisions,
+    safety: {
+      rawSecretValuesLoaded: false,
+      omittedSensitiveFields: [],
+    },
+  };
+}
+
+export async function saveServiceConfigDocument(
+  service: DiscoveredService,
+  input: unknown,
+): Promise<ServiceConfigSaveResponse> {
+  const body = parseServiceConfigSaveBody(input);
+  parseServiceJson(body.content, service.manifest.id);
+
+  const previousContent = await readFile(service.manifestPath, "utf8");
+  const previousHash = hashContent(previousContent);
+  const nextHash = hashContent(body.content);
+  const createdAt = new Date().toISOString();
+  const backupDir = await getConfigBackupDir(service);
+  const backup: ServiceConfigRevisionFile = {
+    id: toRevisionId(createdAt),
+    createdAt,
+    actor: body.actor,
+    reason: body.reason,
+    path: service.manifestPath,
+    previousHash,
+    currentHash: nextHash,
+    validationStatus: "valid",
+    content: previousContent,
+  };
+
+  await writeFile(path.join(backupDir, `${backup.id}.json`), JSON.stringify(backup, null, 2));
+  await writeFile(service.manifestPath, body.content.endsWith("\n") ? body.content : `${body.content}\n`);
+
+  return {
+    serviceId: service.manifest.id,
+    fileName: "server.json",
+    path: service.manifestPath,
+    hash: nextHash,
+    savedAt: createdAt,
+    backup,
+    validationStatus: "valid",
+  };
+}

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { startRuntimeApp } from "../dist/runtime/app.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
@@ -23,6 +23,20 @@ async function getJson(url) {
 
 async function postJson(url) {
   const response = await fetch(url, { method: "POST" });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function putJson(url, body) {
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
   return {
     status: response.status,
     body: await response.json(),
@@ -183,6 +197,107 @@ test("dashboard adapter routes expose bounded admin-facing service and summary s
   } finally {
     await apiServer.stop();
     resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service config document API loads and saves runtime-backed service.json with backup history", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-document-");
+  const serviceRoot = await writeManifest(servicesRoot, "node-sample-service", {
+    id: "node-sample-service",
+    name: "Node Sample Service",
+    description: "Config document fixture.",
+    enabled: true,
+    executable: process.execPath,
+    args: ["runtime/server.mjs"],
+    healthcheck: {
+      type: "process",
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const initial = await getJson(`${apiServer.url}/api/services/node-sample-service/config`);
+    assert.equal(initial.status, 200);
+    assert.equal(initial.body.serviceId, "node-sample-service");
+    assert.equal(initial.body.fileName, "server.json");
+    assert.equal(initial.body.path, path.join(serviceRoot, "service.json"));
+    assert.equal(initial.body.backupCount, 0);
+    assert.equal(initial.body.safety.rawSecretValuesLoaded, false);
+    assert.match(initial.body.content, /Node Sample Service/);
+
+    const nextContent = JSON.stringify(
+      {
+        id: "node-sample-service",
+        name: "Node Sample Service",
+        description: "Edited through the config document API.",
+        enabled: true,
+        executable: process.execPath,
+        args: ["runtime/server.mjs"],
+        healthcheck: {
+          type: "process",
+        },
+      },
+      null,
+      2,
+    );
+    const save = await putJson(`${apiServer.url}/api/services/node-sample-service/config`, {
+      content: nextContent,
+      actor: "service-admin-web",
+      reason: "prove config editor save path",
+    });
+
+    assert.equal(save.status, 200);
+    assert.equal(save.body.serviceId, "node-sample-service");
+    assert.equal(save.body.validationStatus, "valid");
+    assert.equal(save.body.backup.actor, "service-admin-web");
+    assert.equal(save.body.backup.reason, "prove config editor save path");
+    assert.match(save.body.backup.content, /Config document fixture/);
+
+    const savedManifest = await readFile(path.join(serviceRoot, "service.json"), "utf8");
+    assert.match(savedManifest, /Edited through the config document API/);
+
+    const reloaded = await getJson(`${apiServer.url}/api/services/node-sample-service/config`);
+    assert.equal(reloaded.status, 200);
+    assert.equal(reloaded.body.backupCount, 1);
+    assert.equal(reloaded.body.revisions.length, 1);
+    assert.equal(reloaded.body.revisions[0].id, save.body.backup.id);
+    assert.match(reloaded.body.content, /Edited through the config document API/);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service config document API rejects invalid or wrong-service JSON saves", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-document-invalid-");
+  await writeManifest(servicesRoot, "node-sample-service", {
+    id: "node-sample-service",
+    name: "Node Sample Service",
+    description: "Config document fixture.",
+    enabled: true,
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const invalidJson = await putJson(`${apiServer.url}/api/services/node-sample-service/config`, {
+      content: "",
+      actor: "service-admin-web",
+      reason: "invalid save",
+    });
+    assert.equal(invalidJson.status, 400);
+    assert.equal(invalidJson.body.error, "invalid_json");
+
+    const wrongService = await putJson(`${apiServer.url}/api/services/node-sample-service/config`, {
+      content: JSON.stringify({ id: "other-service", name: "Other service" }),
+      actor: "service-admin-web",
+      reason: "wrong service",
+    });
+    assert.equal(wrongService.status, 400);
+    assert.equal(wrongService.body.error, "invalid_json");
+    assert.match(wrongService.body.message, /must remain "node-sample-service"/);
+  } finally {
+    await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes #773.

## Summary
- Add GET/PUT `/api/services/{serviceId}/config` for the Service Admin config editor.
- Read the runtime-backed `service.json` document and validate saves as JSON objects for the same service id.
- Record the previous `service.json` as an audited backup revision before writing.

## Validation
- `npm run build`
- `node --test --test-name-pattern "service config document API" tests/api-spine.test.js`
- `node --test --test-concurrency=1 tests/api-spine.test.js` reached the new config tests and they passed; unrelated existing local fixture failures remain from untracked `services/@secretsbroker` without `service.json`.