### PR TITLE
Support runtime stdout/stderr log streams

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -334,14 +334,14 @@ export interface ServiceMetricsResponse {
 
 export interface ServiceLogInfoResponse {
   serviceId: string;
-  type: "default";
+  type: "default" | "stdout" | "stderr";
   path: string;
-  availableTypes: ["default"];
+  availableTypes: Array<"default" | "stdout" | "stderr">;
 }
 
 export interface ServiceLogChunkResponse {
   serviceId: string;
-  type: "default";
+  type: "default" | "stdout" | "stderr";
   path: string;
   totalLines: number;
   start: number;

--- a/src/runtime/operator/logs.ts
+++ b/src/runtime/operator/logs.ts
@@ -23,6 +23,8 @@ export interface ServiceRuntimeLogArchive {
   stderrPath: string;
 }
 
+export type ServiceLogType = "default" | "stdout" | "stderr";
+
 export interface ServiceLogsPayload extends ServiceRuntimeLogPaths {
   serviceId: string;
   entries: ServiceLogEntry[];
@@ -34,14 +36,14 @@ export interface ServiceLogsPayload extends ServiceRuntimeLogPaths {
 
 export interface ServiceLogInfoPayload {
   serviceId: string;
-  type: "default";
+  type: ServiceLogType;
   path: string;
-  availableTypes: ["default"];
+  availableTypes: ServiceLogType[];
 }
 
 export interface ServiceLogChunkPayload {
   serviceId: string;
-  type: "default";
+  type: ServiceLogType;
   path: string;
   totalLines: number;
   start: number;
@@ -191,6 +193,12 @@ function buildSyntheticEntries(serviceId: string, lifecycle: ServiceLifecycleSta
   }));
 }
 
+function getRuntimeLogPathByType(paths: ServiceRuntimeLogPaths, type: ServiceLogType): string {
+  if (type === "stdout") return paths.stdoutPath;
+  if (type === "stderr") return paths.stderrPath;
+  return paths.logPath;
+}
+
 async function readRuntimeLogEntries(logPath: string): Promise<ServiceLogEntry[]> {
   try {
     const content = await readFile(logPath, "utf8");
@@ -248,24 +256,26 @@ export async function buildServiceLogs(
   };
 }
 
-export function buildServiceLogInfo(service: DiscoveredService): ServiceLogInfoPayload {
+export function buildServiceLogInfo(service: DiscoveredService, type: ServiceLogType = "default"): ServiceLogInfoPayload {
   const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
 
   return {
     serviceId: service.manifest.id,
-    type: "default",
-    path: runtimeLogPaths.logPath,
-    availableTypes: ["default"],
+    type,
+    path: getRuntimeLogPathByType(runtimeLogPaths, type),
+    availableTypes: ["default", "stdout", "stderr"],
   };
 }
 
 export async function readServiceLogChunk(
   service: DiscoveredService,
+  type: ServiceLogType = "default",
   before?: number,
   limit = 100,
 ): Promise<ServiceLogChunkPayload> {
   const runtimeLogPaths = getServiceRuntimeLogPaths(service.serviceRoot);
-  const lines = await readRuntimeLogLines(runtimeLogPaths.logPath);
+  const logPath = getRuntimeLogPathByType(runtimeLogPaths, type);
+  const lines = await readRuntimeLogLines(logPath);
   const totalLines = lines.length;
   const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(500, Math.trunc(limit))) : 100;
   const end = typeof before === "number" ? Math.max(0, Math.min(totalLines, before)) : totalLines;
@@ -274,8 +284,8 @@ export async function readServiceLogChunk(
 
   return {
     serviceId: service.manifest.id,
-    type: "default",
-    path: runtimeLogPaths.logPath,
+    type,
+    path: logPath,
     totalLines,
     start,
     end,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,6 +37,7 @@ import {
   buildServiceLogs,
   getServiceRuntimeLogPaths,
   readServiceLogChunk,
+  type ServiceLogType,
 } from "../runtime/operator/logs.js";
 import { buildDashboardService, buildDashboardSummary } from "../runtime/operator/dashboard.js";
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
@@ -78,6 +79,12 @@ export interface ApiServerOptions {
   monitorIntervalMs?: number;
   updateScheduler?: boolean;
   updateSchedulerIntervalMs?: number;
+}
+
+function parseServiceLogType(value: string | null): ServiceLogType {
+  if (value === null || value === "default") return "default";
+  if (value === "stdout" || value === "stderr") return value;
+  throw new ApiError("invalid_request", 400, "Unsupported runtime log type.");
 }
 
 export interface RunningApiServer {
@@ -575,14 +582,10 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/services/log-info") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
-    const type = url.searchParams.get("type") ?? "default";
+    const type = parseServiceLogType(url.searchParams.get("type"));
 
     if (!serviceId) {
       throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
-    }
-
-    if (type !== "default") {
-      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
     }
 
     const service = runtimeModel.registry.getById(serviceId);
@@ -591,23 +594,19 @@ async function routeRequest(
       return;
     }
 
-    writeJson(response, 200, createServiceLogInfoResponse(buildServiceLogInfo(service)));
+    writeJson(response, 200, createServiceLogInfoResponse(buildServiceLogInfo(service, type)));
     return;
   }
 
   if (request.method === "GET" && url.pathname === "/api/logs/read") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const serviceId = url.searchParams.get("service");
-    const type = url.searchParams.get("type") ?? "default";
+    const type = parseServiceLogType(url.searchParams.get("type"));
     const beforeParam = url.searchParams.get("before");
     const limitParam = url.searchParams.get("limit");
 
     if (!serviceId) {
       throw new ApiError("invalid_request", 400, "Missing required \"service\" query parameter.");
-    }
-
-    if (type !== "default") {
-      throw new ApiError("invalid_request", 400, "Only the default runtime log type is currently supported.");
     }
 
     const service = runtimeModel.registry.getById(serviceId);
@@ -619,7 +618,7 @@ async function routeRequest(
     const before = beforeParam === null ? undefined : Number(beforeParam);
     const limit = limitParam === null ? undefined : Number(limitParam);
 
-    writeJson(response, 200, createServiceLogChunkResponse(await readServiceLogChunk(service, before, limit)));
+    writeJson(response, 200, createServiceLogChunkResponse(await readServiceLogChunk(service, type, before, limit)));
     return;
   }
 

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -206,19 +206,19 @@ test("managed stdout/stderr are captured into runtime-owned log files and surfac
 test("live log info and chunk routes expose runtime-owned log files for admin consumers", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-log-reader-");
-  await writeExecutableFixtureService(servicesRoot, "reader-service", {
+  await writeExecutableFixtureService(servicesRoot, "@reader-service", {
     stdoutLines: ["reader stdout"],
     stderrLines: ["reader stderr"],
   });
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
-    await postJson(`${apiServer.url}/api/services/reader-service/install`);
-    await postJson(`${apiServer.url}/api/services/reader-service/config`);
-    await postJson(`${apiServer.url}/api/services/reader-service/start`);
+    await postJson(`${apiServer.url}/api/services/%40reader-service/install`);
+    await postJson(`${apiServer.url}/api/services/%40reader-service/config`);
+    await postJson(`${apiServer.url}/api/services/%40reader-service/start`);
 
     await waitFor(async () => {
-      const response = await fetch(`${apiServer.url}/api/services/reader-service/logs`);
+      const response = await fetch(`${apiServer.url}/api/services/%40reader-service/logs`);
       const body = await response.json();
       if (body.logs.entries.some((entry) => entry.message === "reader stdout")) {
         return body;
@@ -226,27 +226,47 @@ test("live log info and chunk routes expose runtime-owned log files for admin co
       return null;
     });
 
-    const infoResponse = await fetch(`${apiServer.url}/api/services/log-info?service=reader-service&type=default`);
+    const infoResponse = await fetch(`${apiServer.url}/api/services/log-info?service=%40reader-service&type=default`);
     const infoBody = await infoResponse.json();
-    const chunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=reader-service&type=default&limit=50`);
+    const chunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=%40reader-service&type=default&limit=50`);
     const chunkBody = await chunkResponse.json();
+    const stdoutInfoResponse = await fetch(`${apiServer.url}/api/services/log-info?service=%40reader-service&type=stdout`);
+    const stdoutInfoBody = await stdoutInfoResponse.json();
+    const stdoutChunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=%40reader-service&type=stdout&limit=50`);
+    const stdoutChunkBody = await stdoutChunkResponse.json();
+    const stderrChunkResponse = await fetch(`${apiServer.url}/api/logs/read?service=%40reader-service&type=stderr&limit=50`);
+    const stderrChunkBody = await stderrChunkResponse.json();
 
     assert.equal(infoResponse.status, 200);
-    assert.equal(infoBody.serviceId, "reader-service");
+    assert.equal(infoBody.serviceId, "@reader-service");
     assert.equal(infoBody.type, "default");
-    assert.deepEqual(infoBody.availableTypes, ["default"]);
-    assert.equal(infoBody.path.endsWith(path.join("reader-service", "logs", "runtime", "service.log")), true);
+    assert.deepEqual(infoBody.availableTypes, ["default", "stdout", "stderr"]);
+    assert.equal(infoBody.path.endsWith(path.join("@reader-service", "logs", "runtime", "service.log")), true);
 
     assert.equal(chunkResponse.status, 200);
-    assert.equal(chunkBody.serviceId, "reader-service");
+    assert.equal(chunkBody.serviceId, "@reader-service");
     assert.equal(chunkBody.type, "default");
     assert.equal(typeof chunkBody.totalLines, "number");
     assert.equal(chunkBody.lines.length > 0, true);
-    assert.equal(chunkBody.path.endsWith(path.join("reader-service", "logs", "runtime", "service.log")), true);
+    assert.equal(chunkBody.path.endsWith(path.join("@reader-service", "logs", "runtime", "service.log")), true);
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stdout\"")));
     assert.ok(chunkBody.lines.some((line) => line.includes("\"message\":\"reader stderr\"")));
 
-    await postJson(`${apiServer.url}/api/services/reader-service/stop`);
+    assert.equal(stdoutInfoResponse.status, 200);
+    assert.equal(stdoutInfoBody.type, "stdout");
+    assert.equal(stdoutInfoBody.path.endsWith(path.join("@reader-service", "logs", "runtime", "stdout.log")), true);
+
+    assert.equal(stdoutChunkResponse.status, 200);
+    assert.equal(stdoutChunkBody.type, "stdout");
+    assert.equal(stdoutChunkBody.path.endsWith(path.join("@reader-service", "logs", "runtime", "stdout.log")), true);
+    assert.ok(stdoutChunkBody.lines.some((line) => line.includes("reader stdout")));
+
+    assert.equal(stderrChunkResponse.status, 200);
+    assert.equal(stderrChunkBody.type, "stderr");
+    assert.equal(stderrChunkBody.path.endsWith(path.join("@reader-service", "logs", "runtime", "stderr.log")), true);
+    assert.ok(stderrChunkBody.lines.some((line) => line.includes("reader stderr")));
+
+    await postJson(`${apiServer.url}/api/services/%40reader-service/stop`);
   } finally {
     await apiServer.stop();
     resetLifecycleState();


### PR DESCRIPTION
Fixes #775.

## Summary
- allow runtime log reader endpoints to resolve `default`, `stdout`, and `stderr` streams
- return stdout/stderr paths in log info payloads
- cover encoded scoped service IDs such as `%40reader-service` in focused log API tests

## Validation
- `npm run build`
- `node --test --test-name-pattern "live log info" tests/operator-data.test.js`