### PR TITLE
feat: validate scheduled service action declarations

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -189,18 +189,24 @@ Numeric service location classification value.
 
 ## `actions`
 
-`actions` is where the service defines or overrides named lifecycle actions.
+`actions` is where the service defines or overrides named lifecycle and operator actions.
 
 Current intended rule:
 - actions correspond to known Service Lasso lifecycle/action names
 - service config can override how a named action behaves for that service
 - if a service does not override a supported action, Lasso default behavior applies
+- scheduled operations stay attached to the action they trigger
 
 Current sample actions:
 - `install`
 - `config`
 - `start`
 - `stop`
+- `backup`
+- `restart`
+- `validate`
+- `export`
+- `update-check`
 
 ### Current action examples
 
@@ -221,6 +227,62 @@ Current sample actions:
 }
 ```
 
+### Scheduled actions
+
+A scheduled operation is still a service action. Cron is only one trigger attached to that action.
+
+Backup, restart, validate, export, update-check, and similar operations should be modeled as actions. If an action needs automation, declare one or more schedules under `actions.<actionId>.schedules`.
+
+Do not create a separate top-level cron or schedules list that points back at an action. Service Lasso keeps the action definition, service context, cwd/env resolution, permissions, logs, and audit under the service action.
+
+```json
+"actions": {
+  "backup": {
+    "label": "Backup",
+    "description": "Create a verified service backup.",
+    "mode": "workflow",
+    "requiredState": "running",
+    "requiresConfirmation": true,
+    "manualOnly": false,
+    "timeoutSeconds": 900,
+    "schedules": {
+      "nightly": {
+        "label": "Nightly backup",
+        "enabled": true,
+        "cron": "15 2 * * *",
+        "timezone": "Australia/Sydney",
+        "concurrencyPolicy": "skip-if-running",
+        "failurePolicy": "record",
+        "parameters": {
+          "retainDays": 7
+        }
+      }
+    }
+  }
+}
+```
+
+Action fields currently validated by discovery:
+- `label` and `description`
+- `mode`: `built-in`, `command`, `workflow`, or `handler`
+- `command`, `commandline`, and `args` for command-backed actions
+- `cwd` and `env`, resolved in the service context
+- `timeoutSeconds`
+- `requiredState`: `any`, `running`, or `stopped`
+- `requiresConfirmation` and `manualOnly`
+- `permissions`
+- `schedules`
+
+Schedule fields currently validated by discovery:
+- schedule id from the `schedules` map key
+- `label`
+- `enabled`
+- `cron`: 5- or 6-field cron expression
+- `timezone`, omitted to inherit the app timezone
+- `concurrencyPolicy`: `skip-if-running` or `allow-parallel`
+- `failurePolicy`: `record`, `retry`, or `disable-schedule`
+- `parameters`
+
 ### Current action semantics direction
 - `install`
   - prepare/install payload and required local setup
@@ -231,7 +293,7 @@ Current sample actions:
 - `stop`
   - stop the service gracefully
 
-Additional action names may exist later, but this first-pass template should stay small and lifecycle-focused.
+Finite lifecycle actions continue to use their existing bounded runtime behavior. Scheduled actions add contract metadata for later workflow/scheduler consumers; they do not turn cron into a separate service-level action list.
 
 ## `execconfig`
 

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -68,6 +68,42 @@ export interface ServiceLifecycleHooks {
 
 export type ServiceSetupRerunPolicy = "manual" | "ifMissing" | "always";
 
+export type ServiceActionMode = "built-in" | "command" | "workflow" | "handler";
+export type ServiceActionRequiredState = "any" | "running" | "stopped";
+export type ServiceActionConcurrencyPolicy = "skip-if-running" | "allow-parallel";
+export type ServiceActionFailurePolicy = "record" | "retry" | "disable-schedule";
+
+export interface ServiceActionSchedule {
+  label?: string;
+  enabled?: boolean;
+  cron: string;
+  timezone?: string;
+  concurrencyPolicy?: ServiceActionConcurrencyPolicy;
+  failurePolicy?: ServiceActionFailurePolicy;
+  parameters?: Record<string, unknown>;
+}
+
+export interface ServiceActionDefinition {
+  label?: string;
+  description?: string;
+  mode?: ServiceActionMode;
+  command?: string;
+  commandline?: Record<string, string>;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutSeconds?: number;
+  requiredState?: ServiceActionRequiredState;
+  requiresConfirmation?: boolean;
+  manualOnly?: boolean;
+  permissions?: string[];
+  schedules?: Record<string, ServiceActionSchedule>;
+}
+
+export interface ServiceActionPolicy {
+  [actionId: string]: ServiceActionDefinition;
+}
+
 export interface ServiceSetupStep {
   description?: string;
   depend_on?: string[];
@@ -150,6 +186,7 @@ export interface ServiceManifest {
   restartPolicy?: ServiceRestartPolicy;
   doctor?: ServiceDoctorPolicy;
   hooks?: ServiceLifecycleHooks;
+  actions?: ServiceActionPolicy;
   setup?: ServiceSetupPolicy;
   updates?: ServiceUpdatePolicy;
   artifact?: ServiceArchiveArtifact;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1,6 +1,10 @@
 import type {
   ServiceHookFailurePolicy,
   ServiceHookStep,
+  ServiceActionConcurrencyPolicy,
+  ServiceActionFailurePolicy,
+  ServiceActionMode,
+  ServiceActionRequiredState,
   ServiceManifest,
   ServiceSetupRerunPolicy,
   ServiceUpdateInstallWindow,
@@ -17,6 +21,10 @@ const updateRunningServicePolicies = new Set(["skip", "require-stopped", "stop-s
 const updateWindowDays = new Set(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 const serviceRoles = new Set(["service", "provider"]);
 const setupRerunPolicies = new Set(["manual", "ifMissing", "always"]);
+const actionModes = new Set(["built-in", "command", "workflow", "handler"]);
+const actionRequiredStates = new Set(["any", "running", "stopped"]);
+const actionConcurrencyPolicies = new Set(["skip-if-running", "allow-parallel"]);
+const actionFailurePolicies = new Set(["record", "retry", "disable-schedule"]);
 
 function expectNonEmptyString(value: unknown, field: string, manifestPath: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -343,6 +351,196 @@ function readSetupPolicy(value: unknown, manifestPath: string): ServiceManifest[
   return { steps };
 }
 
+function readStringArray(value: unknown, field: string, manifestPath: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an array of non-empty strings.`);
+  }
+
+  return value.map((entry) => entry.trim());
+}
+
+function readJsonObject(value: unknown, field: string, manifestPath: string): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function expectOptionalEnum<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: Set<string>,
+  allowedLabel: string,
+  manifestPath: string,
+): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string" || !allowed.has(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be one of ${allowedLabel}.`);
+  }
+
+  return value as T;
+}
+
+function validateCronExpression(value: unknown, field: string, manifestPath: string): string {
+  const cron = expectNonEmptyString(value, field, manifestPath);
+  const parts = cron.split(/\s+/);
+
+  if (parts.length !== 5 && parts.length !== 6) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "${field}" to be a 5- or 6-field cron expression.`,
+    );
+  }
+
+  if (parts.some((part) => part.length === 0)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to contain populated cron fields.`);
+  }
+
+  return cron;
+}
+
+function readActionSchedules(
+  value: unknown,
+  actionField: string,
+  manifestPath: string,
+): NonNullable<ServiceManifest["actions"]>[string]["schedules"] {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${actionField}.schedules" to be an object.`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([scheduleId, candidate]) => {
+      const normalizedScheduleId = scheduleId.trim();
+      const scheduleField = `${actionField}.schedules.${normalizedScheduleId}`;
+
+      if (normalizedScheduleId.length === 0) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: action schedule ids must be non-empty.`);
+      }
+
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: expected "${scheduleField}" to be an object.`);
+      }
+
+      const schedule = candidate as Record<string, unknown>;
+      if (schedule.action !== undefined || schedule.actionId !== undefined) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: "${scheduleField}" must not declare action references; schedules stay attached under their action.`,
+        );
+      }
+
+      return [
+        normalizedScheduleId,
+        {
+          label: typeof schedule.label === "string" ? schedule.label.trim() : undefined,
+          enabled: expectOptionalBoolean(schedule.enabled, `${scheduleField}.enabled`, manifestPath),
+          cron: validateCronExpression(schedule.cron, `${scheduleField}.cron`, manifestPath),
+          timezone: typeof schedule.timezone === "string" ? schedule.timezone.trim() : undefined,
+          concurrencyPolicy: expectOptionalEnum<ServiceActionConcurrencyPolicy>(
+            schedule.concurrencyPolicy,
+            `${scheduleField}.concurrencyPolicy`,
+            actionConcurrencyPolicies,
+            '"skip-if-running" or "allow-parallel"',
+            manifestPath,
+          ),
+          failurePolicy: expectOptionalEnum<ServiceActionFailurePolicy>(
+            schedule.failurePolicy,
+            `${scheduleField}.failurePolicy`,
+            actionFailurePolicies,
+            '"record", "retry", or "disable-schedule"',
+            manifestPath,
+          ),
+          parameters: readJsonObject(schedule.parameters, `${scheduleField}.parameters`, manifestPath),
+        },
+      ];
+    }),
+  );
+}
+
+function readActionPolicy(value: unknown, manifestPath: string): ServiceManifest["actions"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "actions" to be an object.`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([actionId, candidate]) => {
+      const normalizedActionId = actionId.trim();
+      const actionField = `actions.${normalizedActionId}`;
+
+      if (normalizedActionId.length === 0) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: action ids must be non-empty.`);
+      }
+
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: expected "${actionField}" to be an object.`);
+      }
+
+      const action = candidate as Record<string, unknown>;
+      const commandline = readStringMap(action.commandline, `${actionField}.commandline`, manifestPath);
+      const command = typeof action.command === "string" ? action.command.trim() : undefined;
+      if (action.command !== undefined && (!command || command.length === 0)) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: expected "${actionField}.command" to be a non-empty string.`);
+      }
+
+      if (action.mode === "command" && command === undefined && commandline === undefined) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: command-backed action "${normalizedActionId}" requires "command" or "commandline".`,
+        );
+      }
+
+      return [
+        normalizedActionId,
+        {
+          label: typeof action.label === "string" ? action.label.trim() : undefined,
+          description: typeof action.description === "string" ? action.description.trim() : undefined,
+          mode: expectOptionalEnum<ServiceActionMode>(
+            action.mode,
+            `${actionField}.mode`,
+            actionModes,
+            '"built-in", "command", "workflow", or "handler"',
+            manifestPath,
+          ),
+          command,
+          commandline,
+          args: readStringArray(action.args, `${actionField}.args`, manifestPath),
+          cwd: typeof action.cwd === "string" ? action.cwd.trim() : undefined,
+          env: readStringMap(action.env, `${actionField}.env`, manifestPath),
+          timeoutSeconds: expectOptionalWholeNumber(action.timeoutSeconds, `${actionField}.timeoutSeconds`, manifestPath, 1),
+          requiredState: expectOptionalEnum<ServiceActionRequiredState>(
+            action.requiredState,
+            `${actionField}.requiredState`,
+            actionRequiredStates,
+            '"any", "running", or "stopped"',
+            manifestPath,
+          ),
+          requiresConfirmation: expectOptionalBoolean(action.requiresConfirmation, `${actionField}.requiresConfirmation`, manifestPath),
+          manualOnly: expectOptionalBoolean(action.manualOnly, `${actionField}.manualOnly`, manifestPath),
+          permissions: readStringArray(action.permissions, `${actionField}.permissions`, manifestPath),
+          schedules: readActionSchedules(action.schedules, actionField, manifestPath),
+        },
+      ];
+    }),
+  );
+}
+
 function expectTimeOfDay(value: unknown, field: string, manifestPath: string): string {
   const candidate = expectNonEmptyString(value, field, manifestPath);
   if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(candidate)) {
@@ -602,6 +800,12 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
 
   const record = input as Record<string, unknown>;
 
+  if (record.schedules !== undefined) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: top-level "schedules" are not supported; define schedules under "actions.<actionId>.schedules".`,
+    );
+  }
+
   const dependOn = record.depend_on;
   if (
     dependOn !== undefined &&
@@ -753,6 +957,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const restartPolicy = readRestartPolicy(record.restartPolicy, manifestPath);
   const doctor = readDoctorPolicy(record.doctor, manifestPath);
   const hooks = readLifecycleHooks(record.hooks, manifestPath);
+  const actions = readActionPolicy(record.actions, manifestPath);
   const setup = readSetupPolicy(record.setup, manifestPath);
   const updates = readUpdatePolicy(record.updates, artifact, manifestPath);
 
@@ -790,6 +995,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     restartPolicy,
     doctor,
     hooks,
+    actions,
     setup,
     updates,
     artifact,

--- a/tests/scheduled-actions-discovery.test.js
+++ b/tests/scheduled-actions-discovery.test.js
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rm } from "node:fs/promises";
+import { loadServiceManifest } from "../dist/runtime/discovery/loadManifest.js";
+import { makeTempServicesRoot, writeManifest } from "./test-helpers.js";
+
+async function withManifest(body, recipe) {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-scheduled-actions-");
+  const serviceRoot = await writeManifest(servicesRoot, body.id ?? "scheduled-service", body);
+  const manifestPath = path.join(serviceRoot, "service.json");
+
+  try {
+    return await recipe(manifestPath);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function baseManifest(overrides = {}) {
+  return {
+    id: "scheduled-service",
+    name: "Scheduled Service",
+    description: "Fixture for scheduled action discovery.",
+    executable: process.execPath,
+    args: ["--version"],
+    healthcheck: { type: "process" },
+    ...overrides,
+  };
+}
+
+test("service discovery accepts schedules attached to action definitions", async () => {
+  await withManifest(
+    baseManifest({
+      actions: {
+        backup: {
+          label: "Backup",
+          description: "Create a service backup.",
+          mode: "workflow",
+          requiredState: "running",
+          manualOnly: false,
+          requiresConfirmation: true,
+          timeoutSeconds: 900,
+          env: {
+            BACKUP_MODE: "snapshot",
+          },
+          schedules: {
+            nightly: {
+              label: "Nightly backup",
+              enabled: true,
+              cron: "15 2 * * *",
+              timezone: "Australia/Sydney",
+              concurrencyPolicy: "skip-if-running",
+              failurePolicy: "record",
+              parameters: {
+                retainDays: 7,
+              },
+            },
+          },
+        },
+      },
+    }),
+    async (manifestPath) => {
+      const manifest = await loadServiceManifest(manifestPath);
+
+      assert.equal(manifest.actions.backup.mode, "workflow");
+      assert.equal(manifest.actions.backup.requiredState, "running");
+      assert.equal(manifest.actions.backup.schedules.nightly.cron, "15 2 * * *");
+      assert.equal(manifest.actions.backup.schedules.nightly.timezone, "Australia/Sydney");
+      assert.deepEqual(manifest.actions.backup.schedules.nightly.parameters, { retainDays: 7 });
+    },
+  );
+});
+
+test("service discovery rejects free-floating schedules outside actions", async () => {
+  await withManifest(
+    baseManifest({
+      schedules: {
+        nightly: {
+          action: "backup",
+          cron: "15 2 * * *",
+        },
+      },
+    }),
+    async (manifestPath) => {
+      await assert.rejects(
+        () => loadServiceManifest(manifestPath),
+        /top-level "schedules" are not supported.*actions\.<actionId>\.schedules/i,
+      );
+    },
+  );
+});
+
+test("service discovery rejects invalid action schedule cron expressions", async () => {
+  await withManifest(
+    baseManifest({
+      actions: {
+        backup: {
+          mode: "workflow",
+          schedules: {
+            broken: {
+              cron: "nightly",
+            },
+          },
+        },
+      },
+    }),
+    async (manifestPath) => {
+      await assert.rejects(
+        () => loadServiceManifest(manifestPath),
+        /actions\.backup\.schedules\.broken\.cron.*5- or 6-field cron expression/i,
+      );
+    },
+  );
+});
+
+test("service discovery rejects action references inside schedule declarations", async () => {
+  await withManifest(
+    baseManifest({
+      actions: {
+        backup: {
+          mode: "workflow",
+          schedules: {
+            nightly: {
+              action: "restart",
+              cron: "15 2 * * *",
+            },
+          },
+        },
+      },
+    }),
+    async (manifestPath) => {
+      await assert.rejects(
+        () => loadServiceManifest(manifestPath),
+        /schedules\.nightly.*must not declare action references/i,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- adds typed `actions` contract support for scheduled service actions in `ServiceManifest`
- validates action schedules during service discovery, including cron shape, schedule nesting, and schedule-level action reference rejection
- documents backup/restart/etc. as actions and cron as an action schedule trigger

## Evidence
- Startup gate healthy: `C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260708T232939+1000\demo-gate.stdout.log`
- `npm run build`
- `node --test --test-concurrency=1 tests/scheduled-actions-discovery.test.js tests/lifecycle-actions.test.js`
- Post-change canonical demo verify healthy: `npm run demo:verify-canonical -- -- --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`

Closes #782
