### PR TITLE
feat(#783): expose scheduled workflow registry

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -245,6 +245,12 @@ Do not create a separate top-level cron or schedules list that points back at an
     "requiresConfirmation": true,
     "manualOnly": false,
     "timeoutSeconds": 900,
+    "steps": [
+      { "id": "stop", "type": "service-lasso-action", "actionId": "stop" },
+      { "id": "backup", "type": "service-lasso-action", "actionId": "backup" },
+      { "id": "verify", "type": "service-lasso-action", "actionId": "verify-backup" },
+      { "id": "start", "type": "service-lasso-action", "actionId": "start", "run": "always", "condition": "was-running-before-workflow" }
+    ],
     "schedules": {
       "nightly": {
         "label": "Nightly backup",
@@ -271,7 +277,16 @@ Action fields currently validated by discovery:
 - `requiredState`: `any`, `running`, or `stopped`
 - `requiresConfirmation` and `manualOnly`
 - `permissions`
+- `steps` for workflow-backed actions
 - `schedules`
+
+Workflow step fields currently validated by discovery:
+- `id`
+- `type`: currently `service-lasso-action`
+- `actionId`: action invoked for this workflow step
+- `run`: `on-success` or `always`
+- `condition`
+- `parameters`
 
 Schedule fields currently validated by discovery:
 - schedule id from the `schedules` map key
@@ -294,6 +309,8 @@ Schedule fields currently validated by discovery:
   - stop the service gracefully
 
 Finite lifecycle actions continue to use their existing bounded runtime behavior. Scheduled actions add contract metadata for later workflow/scheduler consumers; they do not turn cron into a separate service-level action list.
+
+The runtime publishes scheduled action workflows through `GET /api/workflows/registry`. The registry is generated from validated service manifests, hides disabled services and disabled schedules, and includes stable workflow ids, service/action/schedule metadata, tags, workflow steps, and per-entry checksums for Dagu drift detection.
 
 ## `execconfig`
 

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -129,6 +129,49 @@ export interface RuntimeSummaryResponse {
   };
 }
 
+export interface ManagedWorkflowRegistryStep {
+  id: string;
+  type: "service-lasso-action";
+  actionId: string;
+  endpoint: string;
+  run?: "always" | "on-success";
+  condition?: string;
+  parameters?: Record<string, unknown>;
+}
+
+export interface ManagedWorkflowRegistryEntry {
+  id: string;
+  managedBy: "service-lasso";
+  registryVersion: number;
+  serviceId: string;
+  serviceName: string;
+  serviceVersion?: string;
+  actionId: string;
+  actionLabel?: string;
+  scheduleId: string;
+  scheduleLabel?: string;
+  cron: string;
+  timezone?: string;
+  enabled: true;
+  tags: string[];
+  checksum: string;
+  concurrencyPolicy?: "skip-if-running" | "allow-parallel";
+  failurePolicy?: "record" | "retry" | "disable-schedule";
+  parameters?: Record<string, unknown>;
+  steps: ManagedWorkflowRegistryStep[];
+  source: {
+    manifestPath: string;
+    serviceRoot: string;
+  };
+}
+
+export interface ManagedWorkflowRegistryResponse {
+  managedBy: "service-lasso";
+  registryVersion: number;
+  generatedAt: string;
+  workflows: ManagedWorkflowRegistryEntry[];
+}
+
 export interface DashboardLinkResponse {
   label: string;
   url: string;

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -83,6 +83,15 @@ export interface ServiceActionSchedule {
   parameters?: Record<string, unknown>;
 }
 
+export interface ServiceActionWorkflowStep {
+  id: string;
+  type?: "service-lasso-action";
+  actionId: string;
+  run?: "always" | "on-success";
+  condition?: string;
+  parameters?: Record<string, unknown>;
+}
+
 export interface ServiceActionDefinition {
   label?: string;
   description?: string;
@@ -97,6 +106,7 @@ export interface ServiceActionDefinition {
   requiresConfirmation?: boolean;
   manualOnly?: boolean;
   permissions?: string[];
+  steps?: ServiceActionWorkflowStep[];
   schedules?: Record<string, ServiceActionSchedule>;
 }
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -5,6 +5,7 @@ import type {
   ServiceActionFailurePolicy,
   ServiceActionMode,
   ServiceActionRequiredState,
+  ServiceActionWorkflowStep,
   ServiceManifest,
   ServiceSetupRerunPolicy,
   ServiceUpdateInstallWindow,
@@ -471,6 +472,51 @@ function readActionSchedules(
   );
 }
 
+function readActionWorkflowSteps(
+  value: unknown,
+  actionField: string,
+  manifestPath: string,
+): ServiceActionWorkflowStep[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${actionField}.steps" to be an array.`);
+  }
+
+  return value.map((candidate, index) => {
+    const stepField = `${actionField}.steps[${index}]`;
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "${stepField}" to be an object.`);
+    }
+
+    const step = candidate as Record<string, unknown>;
+    const type = step.type;
+    if (type !== undefined && type !== "service-lasso-action") {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: expected "${stepField}.type" to be "service-lasso-action" when present.`,
+      );
+    }
+
+    const run = step.run;
+    if (run !== undefined && run !== "always" && run !== "on-success") {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: expected "${stepField}.run" to be "always" or "on-success" when present.`,
+      );
+    }
+
+    return {
+      id: expectNonEmptyString(step.id, `${stepField}.id`, manifestPath),
+      type: "service-lasso-action",
+      actionId: expectNonEmptyString(step.actionId, `${stepField}.actionId`, manifestPath),
+      run: run as ServiceActionWorkflowStep["run"],
+      condition: typeof step.condition === "string" ? step.condition.trim() : undefined,
+      parameters: readJsonObject(step.parameters, `${stepField}.parameters`, manifestPath),
+    };
+  });
+}
+
 function readActionPolicy(value: unknown, manifestPath: string): ServiceManifest["actions"] | undefined {
   if (value === undefined) {
     return undefined;
@@ -534,6 +580,7 @@ function readActionPolicy(value: unknown, manifestPath: string): ServiceManifest
           requiresConfirmation: expectOptionalBoolean(action.requiresConfirmation, `${actionField}.requiresConfirmation`, manifestPath),
           manualOnly: expectOptionalBoolean(action.manualOnly, `${actionField}.manualOnly`, manifestPath),
           permissions: readStringArray(action.permissions, `${actionField}.permissions`, manifestPath),
+          steps: readActionWorkflowSteps(action.steps, actionField, manifestPath),
           schedules: readActionSchedules(action.schedules, actionField, manifestPath),
         },
       ];

--- a/src/runtime/workflows/registry.ts
+++ b/src/runtime/workflows/registry.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+import type {
+  ManagedWorkflowRegistryEntry,
+  ManagedWorkflowRegistryResponse,
+  ManagedWorkflowRegistryStep,
+} from "../../contracts/api.js";
+import type { DiscoveredService, ServiceActionDefinition } from "../../contracts/service.js";
+
+const registryVersion = 1;
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .filter((key) => record[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function checksumWorkflowEntry(entry: Omit<ManagedWorkflowRegistryEntry, "checksum">): string {
+  return createHash("sha256").update(stableJson(entry)).digest("hex");
+}
+
+function buildWorkflowSteps(
+  serviceId: string,
+  actionId: string,
+  action: ServiceActionDefinition,
+): ManagedWorkflowRegistryStep[] {
+  const steps = action.steps?.length
+    ? action.steps
+    : [
+        {
+          id: actionId,
+          type: "service-lasso-action" as const,
+          actionId,
+        },
+      ];
+
+  return steps.map((step) => ({
+    id: step.id,
+    type: "service-lasso-action",
+    actionId: step.actionId,
+    endpoint: `/api/services/${encodeURIComponent(serviceId)}/actions/${encodeURIComponent(step.actionId)}/runs`,
+    run: step.run,
+    condition: step.condition,
+    parameters: step.parameters,
+  }));
+}
+
+export function buildManagedWorkflowRegistry(services: DiscoveredService[]): ManagedWorkflowRegistryResponse {
+  const workflows = services
+    .filter((service) => service.manifest.enabled !== false)
+    .flatMap((service) =>
+      Object.entries(service.manifest.actions ?? {}).flatMap(([actionId, action]) =>
+        Object.entries(action.schedules ?? {})
+          .filter(([, schedule]) => schedule.enabled !== false)
+          .map(([scheduleId, schedule]) => {
+            const entry = {
+              id: `${service.manifest.id}.${actionId}.${scheduleId}`,
+              managedBy: "service-lasso" as const,
+              registryVersion,
+              serviceId: service.manifest.id,
+              serviceName: service.manifest.name,
+              serviceVersion: service.manifest.version,
+              actionId,
+              actionLabel: action.label,
+              scheduleId,
+              scheduleLabel: schedule.label,
+              cron: schedule.cron,
+              timezone: schedule.timezone,
+              enabled: true as const,
+              tags: ["service-lasso", `service:${service.manifest.id}`, `action:${actionId}`],
+              concurrencyPolicy: schedule.concurrencyPolicy,
+              failurePolicy: schedule.failurePolicy,
+              parameters: schedule.parameters,
+              steps: buildWorkflowSteps(service.manifest.id, actionId, action),
+              source: {
+                manifestPath: service.manifestPath,
+                serviceRoot: service.serviceRoot,
+              },
+            };
+
+            return {
+              ...entry,
+              checksum: checksumWorkflowEntry(entry),
+            };
+          }),
+      ),
+    )
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    managedBy: "service-lasso",
+    registryVersion,
+    generatedAt: new Date().toISOString(),
+    workflows,
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import { createHealthResponse } from "./routes/health.js";
 import { createServicesResponse } from "./routes/services.js";
 import { createDependenciesResponse } from "./routes/dependencies.js";
 import { createRuntimeSummaryResponse } from "./routes/runtime.js";
+import { createManagedWorkflowRegistryResponse } from "./routes/workflows.js";
 import { createServiceHealthResponse } from "./routes/service-health.js";
 import { createServiceLogsResponse } from "./routes/logs.js";
 import { createServiceLogChunkResponse, createServiceLogInfoResponse } from "./routes/log-reader.js";
@@ -59,6 +60,7 @@ import {
   installServiceUpdateCandidate,
   listServiceUpdateStates,
 } from "../runtime/updates/actions.js";
+import { buildManagedWorkflowRegistry } from "../runtime/workflows/registry.js";
 import { ApiError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
@@ -487,6 +489,12 @@ async function routeRequest(
       action: "list",
       services: await listServiceUpdateStates(runtimeModel.registry.list()),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/workflows/registry") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, createManagedWorkflowRegistryResponse(buildManagedWorkflowRegistry(runtimeModel.discovered)));
     return;
   }
 

--- a/src/server/routes/workflows.ts
+++ b/src/server/routes/workflows.ts
@@ -1,0 +1,7 @@
+import type { ManagedWorkflowRegistryResponse } from "../../contracts/api.js";
+
+export function createManagedWorkflowRegistryResponse(
+  registry: ManagedWorkflowRegistryResponse,
+): ManagedWorkflowRegistryResponse {
+  return registry;
+}

--- a/tests/workflow-registry.test.js
+++ b/tests/workflow-registry.test.js
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { buildManagedWorkflowRegistry } from "../dist/runtime/workflows/registry.js";
+import { startApiServer } from "../dist/server/index.js";
+import { makeTempServicesRoot, writeManifest } from "./test-helpers.js";
+
+async function readRegistry(servicesRoot) {
+  return buildManagedWorkflowRegistry(await discoverServices(servicesRoot));
+}
+
+function scheduledManifest(overrides = {}) {
+  return {
+    id: "minecraft",
+    name: "Minecraft",
+    description: "Scheduled workflow registry fixture.",
+    version: "1.2.3",
+    executable: process.execPath,
+    args: ["--version"],
+    healthcheck: { type: "process" },
+    actions: {
+      backup: {
+        label: "Backup",
+        description: "Create a service backup.",
+        mode: "workflow",
+        requiredState: "running",
+        steps: [
+          { id: "stop", actionId: "stop" },
+          { id: "backup", actionId: "backup" },
+          { id: "verify", actionId: "verify-backup" },
+          {
+            id: "start",
+            actionId: "start",
+            run: "always",
+            condition: "was-running-before-workflow",
+          },
+        ],
+        schedules: {
+          nightly: {
+            label: "Nightly backup",
+            enabled: true,
+            cron: "15 2 * * *",
+            timezone: "Australia/Sydney",
+            concurrencyPolicy: "skip-if-running",
+            failurePolicy: "record",
+            parameters: {
+              retainDays: 7,
+            },
+          },
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+test("managed workflow registry exposes scheduled service action workflows", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-registry-");
+
+  try {
+    await writeManifest(servicesRoot, "minecraft", scheduledManifest());
+
+    const registry = await readRegistry(servicesRoot);
+
+    assert.equal(registry.managedBy, "service-lasso");
+    assert.equal(registry.registryVersion, 1);
+    assert.equal(registry.workflows.length, 1);
+
+    const [workflow] = registry.workflows;
+    assert.equal(workflow.id, "minecraft.backup.nightly");
+    assert.equal(workflow.managedBy, "service-lasso");
+    assert.equal(workflow.serviceId, "minecraft");
+    assert.equal(workflow.serviceVersion, "1.2.3");
+    assert.equal(workflow.actionId, "backup");
+    assert.equal(workflow.scheduleId, "nightly");
+    assert.equal(workflow.cron, "15 2 * * *");
+    assert.equal(workflow.timezone, "Australia/Sydney");
+    assert.equal(workflow.enabled, true);
+    assert.deepEqual(workflow.tags, ["service-lasso", "service:minecraft", "action:backup"]);
+    assert.equal(workflow.checksum.length, 64);
+    assert.deepEqual(
+      workflow.steps.map((step) => `${step.id}:${step.actionId}:${step.type}`),
+      [
+        "stop:stop:service-lasso-action",
+        "backup:backup:service-lasso-action",
+        "verify:verify-backup:service-lasso-action",
+        "start:start:service-lasso-action",
+      ],
+    );
+    assert.equal(workflow.steps[3].run, "always");
+    assert.equal(workflow.steps[3].condition, "was-running-before-workflow");
+    assert.equal(workflow.steps[0].endpoint, "/api/services/minecraft/actions/stop/runs");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("managed workflow registry reflects add update remove and disable schedule changes", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-registry-changes-");
+
+  try {
+    await writeManifest(servicesRoot, "minecraft", scheduledManifest());
+    const initial = await readRegistry(servicesRoot);
+    const initialWorkflow = initial.workflows[0];
+
+    await writeManifest(
+      servicesRoot,
+      "minecraft",
+      scheduledManifest({
+        actions: {
+          backup: {
+            mode: "workflow",
+            schedules: {
+              nightly: {
+                cron: "30 3 * * *",
+                enabled: true,
+              },
+              weekly: {
+                cron: "0 4 * * 0",
+                enabled: true,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const updated = await readRegistry(servicesRoot);
+    assert.deepEqual(
+      updated.workflows.map((workflow) => workflow.id),
+      ["minecraft.backup.nightly", "minecraft.backup.weekly"],
+    );
+    assert.equal(updated.workflows[0].cron, "30 3 * * *");
+    assert.notEqual(updated.workflows[0].checksum, initialWorkflow.checksum);
+
+    await writeManifest(
+      servicesRoot,
+      "minecraft",
+      scheduledManifest({
+        actions: {
+          backup: {
+            mode: "workflow",
+            schedules: {
+              weekly: {
+                cron: "0 4 * * 0",
+                enabled: false,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const removedAndDisabled = await readRegistry(servicesRoot);
+    assert.deepEqual(removedAndDisabled.workflows, []);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/workflows/registry returns managed workflow registry", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-registry-api-");
+  await writeManifest(servicesRoot, "minecraft", scheduledManifest());
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/workflows/registry`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.managedBy, "service-lasso");
+    assert.equal(body.workflows.length, 1);
+    assert.equal(body.workflows[0].id, "minecraft.backup.nightly");
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds validated workflow steps to service action definitions.
- Builds a managed Service Lasso workflow registry from `actions.<actionId>.schedules`.
- Exposes the registry at `GET /api/workflows/registry` with stable ids, metadata, steps, tags, and checksums.
- Documents the scheduled workflow registry contract and adds focused registry/API tests.

## Validation

- `npm run build`
- `node --test --test-concurrency=1 tests/scheduled-actions-discovery.test.js tests/workflow-registry.test.js`
- `npm test`
- Canonical demo refreshed after code update: stopped stale port 17883 listener, then `npm run demo:gate -- -- --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json` recovered a fresh runtime.
- `npm run demo:verify-canonical -- -- --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`
- Demo endpoint probe: `GET http://127.0.0.1:17883/api/workflows/registry` returned HTTP 200 with registry version 1.

Evidence logs: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260709T012553+1000`.

Closes #783