### PR TITLE
feat(#799): add generic action payloads

### DIFF
--- a/docs/reference/service-action-inputs.md
+++ b/docs/reference/service-action-inputs.md
@@ -1,0 +1,119 @@
+# Service Action Inputs
+
+_Status: first runtime contract for generic action payloads._
+
+Service actions can opt in to typed payloads for manual API calls and workflow engines.
+The action declaration owns the payload policy. A run request can then provide an
+inline payload, a reference to a stored payload, or both when the action explicitly
+allows mixed values.
+
+## Manifest Policy
+
+Declare payload support under `actions.<actionId>.payload`:
+
+```json
+{
+  "actions": {
+    "backup": {
+      "mode": "command",
+      "command": "node",
+      "args": ["runtime/backup.mjs"],
+      "payload": {
+        "inline": true,
+        "references": true,
+        "allowMixed": true,
+        "required": true,
+        "schema": {
+          "type": "object",
+          "required": ["retainDays"],
+          "additionalProperties": false,
+          "properties": {
+            "retainDays": { "type": "integer" },
+            "mode": { "type": "string" }
+          }
+        },
+        "recordInlineFields": ["retainDays", "mode"]
+      }
+    }
+  }
+}
+```
+
+Fields:
+
+- `inline`: permits request body `payload` values.
+- `references`: permits request body `payloadRef` values.
+- `allowMixed`: permits both `payload` and `payloadRef` in one run. Inline values override referenced values.
+- `required`: rejects runs without either payload source.
+- `schema`: JSON-schema-style object validation for the resolved payload.
+- `recordInlineFields`: whitelist of inline payload fields that may be recorded in action history.
+
+## Run Requests
+
+Inline payload:
+
+```json
+{
+  "source": "manual",
+  "payload": {
+    "retainDays": 7,
+    "mode": "full"
+  }
+}
+```
+
+Stored payload reference:
+
+```json
+{
+  "source": "dagu",
+  "workflowId": "minecraft.backup.nightly",
+  "scheduleId": "nightly",
+  "payloadRef": "nightly-backup"
+}
+```
+
+Mixed payload:
+
+```json
+{
+  "payloadRef": "nightly-backup",
+  "payload": {
+    "mode": "incremental"
+  }
+}
+```
+
+Stored payload references resolve from:
+
+```text
+<service-root>/.state/action-payloads/<payloadRef>.json
+```
+
+Reference ids may contain letters, numbers, dot, dash, and underscore.
+
+## Runtime Environment
+
+Action processes receive:
+
+- `SERVICE_LASSO_ACTION_PAYLOAD`: resolved payload JSON object.
+- `SERVICE_LASSO_ACTION_PAYLOAD_REF`: stored reference id, or empty string.
+- `SERVICE_LASSO_ACTION_PAYLOAD_SOURCE`: `none`, `inline`, `reference`, or `mixed`.
+- `SERVICE_LASSO_ACTION_INLINE_METADATA`: whitelisted inline metadata JSON object.
+
+## History
+
+Action history records `run.metadata.payload`:
+
+```json
+{
+  "source": "mixed",
+  "referenceId": "nightly-backup",
+  "inline": {
+    "mode": "incremental"
+  }
+}
+```
+
+The full resolved payload is not stored in history. Only the stored reference id
+and whitelisted inline fields are retained.

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -271,7 +271,15 @@ Action fields currently validated by discovery:
 - `requiredState`: `any`, `running`, or `stopped`
 - `requiresConfirmation` and `manualOnly`
 - `permissions`
+- `payload`: opt-in inline/reference action payload policy
 - `schedules`
+
+Action payloads are documented in `docs/reference/service-action-inputs.md`.
+An action can allow inline request payloads, stored payload references, or both.
+The runtime resolves references from `.state/action-payloads/<payloadRef>.json`,
+checks the resolved payload against the action schema, exposes it to the action
+process as `SERVICE_LASSO_ACTION_PAYLOAD`, and stores only the payload reference
+id plus whitelisted inline fields in action history.
 
 Schedule fields currently validated by discovery:
 - schedule id from the `schedules` map key

--- a/schemas/service-action-inputs.schema.json
+++ b/schemas/service-action-inputs.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://service-lasso.dev/schemas/service-action-inputs.schema.json",
+  "title": "Service Lasso service action payload policy",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "inline": {
+      "type": "boolean",
+      "description": "Allows POST action run bodies to include an inline payload object."
+    },
+    "references": {
+      "type": "boolean",
+      "description": "Allows POST action run bodies to include a stored payloadRef id."
+    },
+    "allowMixed": {
+      "type": "boolean",
+      "description": "Allows payload and payloadRef in the same run request."
+    },
+    "required": {
+      "type": "boolean",
+      "description": "Requires each run request to include payload or payloadRef."
+    },
+    "schema": {
+      "$ref": "#/$defs/payloadSchema"
+    },
+    "recordInlineFields": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "jsonType": {
+      "enum": ["string", "number", "integer", "boolean", "object", "array", "null"]
+    },
+    "payloadSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/jsonType"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/jsonType"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          ]
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/payloadSchema"
+          }
+        },
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -72,6 +72,23 @@ export type ServiceActionMode = "built-in" | "command" | "workflow" | "handler";
 export type ServiceActionRequiredState = "any" | "running" | "stopped";
 export type ServiceActionConcurrencyPolicy = "skip-if-running" | "allow-parallel";
 export type ServiceActionFailurePolicy = "record" | "retry" | "disable-schedule";
+export type ServiceActionPayloadJsonType = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+
+export interface ServiceActionPayloadSchema {
+  type?: ServiceActionPayloadJsonType | ServiceActionPayloadJsonType[];
+  required?: string[];
+  properties?: Record<string, ServiceActionPayloadSchema>;
+  additionalProperties?: boolean;
+}
+
+export interface ServiceActionPayloadPolicy {
+  inline?: boolean;
+  references?: boolean;
+  allowMixed?: boolean;
+  required?: boolean;
+  schema?: ServiceActionPayloadSchema;
+  recordInlineFields?: string[];
+}
 
 export interface ServiceActionSchedule {
   label?: string;
@@ -97,6 +114,7 @@ export interface ServiceActionDefinition {
   requiresConfirmation?: boolean;
   manualOnly?: boolean;
   permissions?: string[];
+  payload?: ServiceActionPayloadPolicy;
   schedules?: Record<string, ServiceActionSchedule>;
 }
 

--- a/src/runtime/actions/runs.ts
+++ b/src/runtime/actions/runs.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { DiscoveredService, ServiceActionDefinition } from "../../contracts/service.js";
+import type { DiscoveredService, ServiceActionDefinition, ServiceActionPayloadSchema } from "../../contracts/service.js";
 import { ApiError, LifecycleStateError } from "../../server/errors.js";
 import { parseCommandlineArgs, selectPlatformCommandline } from "../execution/commandline.js";
 import { getLifecycleState } from "../lifecycle/store.js";
@@ -24,6 +24,13 @@ export interface ServiceActionRunMetadata {
   parentActionId: string | null;
   actor: string | null;
   params: Record<string, unknown>;
+  payload: ServiceActionRunPayloadMetadata;
+}
+
+export interface ServiceActionRunPayloadMetadata {
+  source: "none" | "inline" | "reference" | "mixed";
+  referenceId: string | null;
+  inline: Record<string, unknown>;
 }
 
 export interface ServiceActionRunState {
@@ -54,6 +61,8 @@ export interface ServiceActionRunRequest {
   parentActionId?: string;
   actor?: string;
   params?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  payloadRef?: string;
   confirm?: boolean;
 }
 
@@ -74,6 +83,10 @@ function getActionRunLogPaths(serviceRoot: string, actionId: string, runId: stri
 
 function getActionRunsStatePath(service: DiscoveredService): string {
   return path.join(getServiceStatePaths(service.serviceRoot).stateRoot, "action-runs.json");
+}
+
+function getActionPayloadReferencePath(service: DiscoveredService, payloadRef: string): string {
+  return path.join(getServiceStatePaths(service.serviceRoot).stateRoot, "action-payloads", `${payloadRef}.json`);
 }
 
 async function closeWriteStream(stream: WriteStream): Promise<void> {
@@ -155,6 +168,10 @@ export function parseServiceActionRunRequest(input: unknown): ServiceActionRunRe
     throw new ApiError("invalid_body", 400, "\"params\" must be a JSON object when present.");
   }
 
+  if (input.payload !== undefined && !isRecord(input.payload)) {
+    throw new ApiError("invalid_body", 400, "\"payload\" must be a JSON object when present.");
+  }
+
   if (input.confirm !== undefined && typeof input.confirm !== "boolean") {
     throw new ApiError("invalid_body", 400, "\"confirm\" must be a boolean when present.");
   }
@@ -167,11 +184,16 @@ export function parseServiceActionRunRequest(input: unknown): ServiceActionRunRe
     parentActionId: expectOptionalString(input, "parentActionId") ?? undefined,
     actor: expectOptionalString(input, "actor") ?? undefined,
     params: (input.params as Record<string, unknown> | undefined) ?? {},
+    payload: input.payload as Record<string, unknown> | undefined,
+    payloadRef: expectOptionalString(input, "payloadRef") ?? undefined,
     confirm: input.confirm,
   };
 }
 
-function buildRunMetadata(request: ServiceActionRunRequest): ServiceActionRunMetadata {
+function buildRunMetadata(
+  request: ServiceActionRunRequest,
+  payload: ServiceActionRunPayloadMetadata,
+): ServiceActionRunMetadata {
   return {
     source: request.source ?? "manual",
     workflowId: request.workflowId ?? null,
@@ -180,6 +202,7 @@ function buildRunMetadata(request: ServiceActionRunRequest): ServiceActionRunMet
     parentActionId: request.parentActionId ?? null,
     actor: request.actor ?? null,
     params: request.params ?? {},
+    payload,
   };
 }
 
@@ -250,6 +273,145 @@ function assertActionAllowed(service: DiscoveredService, actionId: string, actio
   if (action.requiredState === "stopped" && lifecycle.running) {
     throw new LifecycleStateError(`Cannot run action "${actionId}" for service "${service.manifest.id}" unless the service is stopped.`);
   }
+}
+
+function getJsonType(value: unknown): "string" | "number" | "integer" | "boolean" | "object" | "array" | "null" {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number" && Number.isInteger(value)) return "integer";
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "string") return "string";
+  return "object";
+}
+
+function matchesSchemaType(value: unknown, expected: ServiceActionPayloadSchema["type"]): boolean {
+  if (!expected) {
+    return true;
+  }
+
+  const allowed = Array.isArray(expected) ? expected : [expected];
+  const actual = getJsonType(value);
+  return allowed.some((type) => type === actual || (type === "number" && actual === "integer"));
+}
+
+function validatePayloadSchema(value: unknown, schema: ServiceActionPayloadSchema | undefined, field = "payload"): void {
+  if (!schema) {
+    return;
+  }
+
+  if (!matchesSchemaType(value, schema.type)) {
+    const allowed = Array.isArray(schema.type) ? schema.type.join(", ") : schema.type;
+    throw new ApiError("invalid_action_payload", 400, `"${field}" must match payload schema type ${allowed}.`);
+  }
+
+  const hasObjectRules = !!schema.properties || !!schema.required || schema.additionalProperties === false;
+  if (!hasObjectRules) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    throw new ApiError("invalid_action_payload", 400, `"${field}" must be an object.`);
+  }
+
+  for (const required of schema.required ?? []) {
+    if (value[required] === undefined) {
+      throw new ApiError("invalid_action_payload", 400, `"${field}.${required}" is required by the action payload schema.`);
+    }
+  }
+
+  for (const [property, propertySchema] of Object.entries(schema.properties ?? {})) {
+    if (value[property] !== undefined) {
+      validatePayloadSchema(value[property], propertySchema, `${field}.${property}`);
+    }
+  }
+
+  if (schema.additionalProperties === false) {
+    const allowedProperties = new Set(Object.keys(schema.properties ?? {}));
+    const extra = Object.keys(value).find((property) => !allowedProperties.has(property));
+    if (extra) {
+      throw new ApiError("invalid_action_payload", 400, `"${field}.${extra}" is not allowed by the action payload schema.`);
+    }
+  }
+}
+
+function pickInlinePayloadMetadata(
+  inlinePayload: Record<string, unknown> | undefined,
+  fields: string[] | undefined,
+): Record<string, unknown> {
+  if (!inlinePayload || !fields || fields.length === 0) {
+    return {};
+  }
+
+  return Object.fromEntries(fields.filter((field) => inlinePayload[field] !== undefined).map((field) => [field, inlinePayload[field]]));
+}
+
+async function readStoredActionPayload(service: DiscoveredService, payloadRef: string): Promise<Record<string, unknown>> {
+  if (!/^[A-Za-z0-9_.-]+$/.test(payloadRef)) {
+    throw new ApiError("invalid_action_payload_ref", 400, "\"payloadRef\" may only contain letters, numbers, dot, dash, and underscore.");
+  }
+
+  try {
+    const parsed = JSON.parse(await readFile(getActionPayloadReferencePath(service, payloadRef), "utf8")) as unknown;
+    if (!isRecord(parsed)) {
+      throw new ApiError("invalid_action_payload_ref", 400, `Stored action payload "${payloadRef}" must contain a JSON object.`);
+    }
+    return parsed;
+  } catch (error: unknown) {
+    if (isRecord(error) && error.code === "ENOENT") {
+      throw new ApiError("unknown_action_payload_ref", 404, `Stored action payload "${payloadRef}" was not found.`);
+    }
+    throw error;
+  }
+}
+
+async function resolveActionPayload(
+  service: DiscoveredService,
+  actionId: string,
+  action: ServiceActionDefinition,
+  request: ServiceActionRunRequest,
+): Promise<{ value: Record<string, unknown>; metadata: ServiceActionRunPayloadMetadata }> {
+  const inlinePayload = request.payload;
+  const payloadRef = request.payloadRef;
+  const hasInline = inlinePayload !== undefined;
+  const hasReference = payloadRef !== undefined;
+  const policy = action.payload;
+
+  if (!hasInline && !hasReference) {
+    if (policy?.required) {
+      throw new ApiError("action_payload_required", 400, `Action "${actionId}" requires a payload.`);
+    }
+    return { value: {}, metadata: { source: "none", referenceId: null, inline: {} } };
+  }
+
+  if (!policy) {
+    throw new ApiError("action_payload_not_allowed", 400, `Action "${actionId}" does not accept payloads.`);
+  }
+
+  if (hasInline && policy.inline !== true) {
+    throw new ApiError("inline_action_payload_not_allowed", 400, `Action "${actionId}" does not accept inline payload values.`);
+  }
+
+  if (hasReference && policy.references !== true) {
+    throw new ApiError("referenced_action_payload_not_allowed", 400, `Action "${actionId}" does not accept stored payload references.`);
+  }
+
+  if (hasInline && hasReference && policy.allowMixed !== true) {
+    throw new ApiError("mixed_action_payload_not_allowed", 400, `Action "${actionId}" does not allow mixed inline and referenced payload values.`);
+  }
+
+  const referencePayload = payloadRef ? await readStoredActionPayload(service, payloadRef) : {};
+  const resolvedPayload = { ...referencePayload, ...(inlinePayload ?? {}) };
+  validatePayloadSchema(resolvedPayload, policy.schema);
+
+  return {
+    value: resolvedPayload,
+    metadata: {
+      source: hasInline && hasReference ? "mixed" : hasInline ? "inline" : "reference",
+      referenceId: payloadRef ?? null,
+      inline: pickInlinePayloadMetadata(inlinePayload, policy.recordInlineFields),
+    },
+  };
 }
 
 function buildActionService(
@@ -362,6 +524,7 @@ function buildProcessEnvironment(
   executionPlan: ProviderExecutionPlan,
   action: ServiceActionDefinition,
   metadata: ServiceActionRunMetadata,
+  payloadValue: Record<string, unknown>,
   sharedGlobalEnv: Record<string, string>,
   resolvedPorts: Record<string, number>,
 ): NodeJS.ProcessEnv {
@@ -385,6 +548,10 @@ function buildProcessEnvironment(
     SERVICE_LASSO_STEP_ID: metadata.stepId ?? "",
     SERVICE_LASSO_PARENT_ACTION_ID: metadata.parentActionId ?? "",
     SERVICE_LASSO_ACTION_PARAMS: JSON.stringify(metadata.params),
+    SERVICE_LASSO_ACTION_PAYLOAD: JSON.stringify(payloadValue),
+    SERVICE_LASSO_ACTION_PAYLOAD_REF: metadata.payload.referenceId ?? "",
+    SERVICE_LASSO_ACTION_PAYLOAD_SOURCE: metadata.payload.source,
+    SERVICE_LASSO_ACTION_INLINE_METADATA: JSON.stringify(metadata.payload.inline),
   };
 }
 
@@ -428,13 +595,14 @@ export async function runServiceAction(
   }
 
   assertActionAllowed(service, actionId, action, request);
+  const payload = await resolveActionPayload(service, actionId, action, request);
 
   const runKey = `${service.manifest.id}:${actionId}`;
   if (action.schedules && Object.values(action.schedules).some((schedule) => schedule.concurrencyPolicy === "skip-if-running") && activeRuns.has(runKey)) {
     throw new ApiError("action_already_running", 409, `Action "${actionId}" for service "${service.manifest.id}" is already running.`);
   }
 
-  const metadata = buildRunMetadata(request);
+  const metadata = buildRunMetadata(request, payload.metadata);
   const lifecycle = getLifecycleState(service.manifest.id);
   const sharedGlobalEnv = collectRuntimeGlobalEnv(registry.list());
   const resolvedPorts = Object.keys(lifecycle.runtime.ports).length > 0 ? lifecycle.runtime.ports : service.manifest.ports ?? {};
@@ -454,7 +622,7 @@ export async function runServiceAction(
     const stderr = createWriteStream(logs.stderrPath, { flags: "w" });
     const child = spawn(executable, args, {
       cwd: resolveWorkingDirectory(service, action, executionPlan, executable, sharedGlobalEnv, resolvedPorts),
-      env: buildProcessEnvironment(service, actionId, executionPlan, action, metadata, sharedGlobalEnv, resolvedPorts),
+      env: buildProcessEnvironment(service, actionId, executionPlan, action, metadata, payload.value, sharedGlobalEnv, resolvedPorts),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -4,6 +4,8 @@ import type {
   ServiceActionConcurrencyPolicy,
   ServiceActionFailurePolicy,
   ServiceActionMode,
+  ServiceActionPayloadJsonType,
+  ServiceActionPayloadSchema,
   ServiceActionRequiredState,
   ServiceManifest,
   ServiceSetupRerunPolicy,
@@ -25,6 +27,7 @@ const actionModes = new Set(["built-in", "command", "workflow", "handler"]);
 const actionRequiredStates = new Set(["any", "running", "stopped"]);
 const actionConcurrencyPolicies = new Set(["skip-if-running", "allow-parallel"]);
 const actionFailurePolicies = new Set(["record", "retry", "disable-schedule"]);
+const actionPayloadJsonTypes = new Set(["string", "number", "integer", "boolean", "object", "array", "null"]);
 
 function expectNonEmptyString(value: unknown, field: string, manifestPath: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -375,6 +378,91 @@ function readJsonObject(value: unknown, field: string, manifestPath: string): Re
   return value as Record<string, unknown>;
 }
 
+function readActionPayloadSchema(
+  value: unknown,
+  field: string,
+  manifestPath: string,
+): ServiceActionPayloadSchema | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawType = record.type;
+  let type: ServiceActionPayloadJsonType | ServiceActionPayloadJsonType[] | undefined;
+
+  if (rawType !== undefined) {
+    const values = Array.isArray(rawType) ? rawType : [rawType];
+    if (values.some((entry) => typeof entry !== "string" || !actionPayloadJsonTypes.has(entry))) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: expected "${field}.type" to use JSON schema primitive type names.`,
+      );
+    }
+    type = Array.isArray(rawType)
+      ? values.map((entry) => entry as ServiceActionPayloadJsonType)
+      : (rawType as ServiceActionPayloadJsonType);
+  }
+
+  const required = readStringArray(record.required, `${field}.required`, manifestPath);
+  const rawProperties = record.properties;
+  let properties: Record<string, ServiceActionPayloadSchema> | undefined;
+
+  if (rawProperties !== undefined) {
+    if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}.properties" to be an object.`);
+    }
+
+    properties = Object.fromEntries(
+      Object.entries(rawProperties as Record<string, unknown>).map(([propertyName, propertySchema]) => {
+        const normalizedProperty = propertyName.trim();
+        const parsedSchema = readActionPayloadSchema(propertySchema, `${field}.properties.${normalizedProperty}`, manifestPath);
+        if (!parsedSchema) {
+          throw new Error(
+            `Invalid service manifest at ${manifestPath}: expected "${field}.properties.${normalizedProperty}" to be an object.`,
+          );
+        }
+        return [normalizedProperty, parsedSchema];
+      }),
+    );
+  }
+
+  return {
+    type,
+    required,
+    properties,
+    additionalProperties: expectOptionalBoolean(record.additionalProperties, `${field}.additionalProperties`, manifestPath),
+  };
+}
+
+function readActionPayloadPolicy(
+  value: unknown,
+  actionField: string,
+  manifestPath: string,
+): NonNullable<ServiceManifest["actions"]>[string]["payload"] {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const field = `${actionField}.payload`;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    inline: expectOptionalBoolean(record.inline, `${field}.inline`, manifestPath),
+    references: expectOptionalBoolean(record.references, `${field}.references`, manifestPath),
+    allowMixed: expectOptionalBoolean(record.allowMixed, `${field}.allowMixed`, manifestPath),
+    required: expectOptionalBoolean(record.required, `${field}.required`, manifestPath),
+    schema: readActionPayloadSchema(record.schema, `${field}.schema`, manifestPath),
+    recordInlineFields: readStringArray(record.recordInlineFields, `${field}.recordInlineFields`, manifestPath),
+  };
+}
+
 function expectOptionalEnum<T extends string>(
   value: unknown,
   field: string,
@@ -534,6 +622,7 @@ function readActionPolicy(value: unknown, manifestPath: string): ServiceManifest
           requiresConfirmation: expectOptionalBoolean(action.requiresConfirmation, `${actionField}.requiresConfirmation`, manifestPath),
           manualOnly: expectOptionalBoolean(action.manualOnly, `${actionField}.manualOnly`, manifestPath),
           permissions: readStringArray(action.permissions, `${actionField}.permissions`, manifestPath),
+          payload: readActionPayloadPolicy(action.payload, actionField, manifestPath),
           schedules: readActionSchedules(action.schedules, actionField, manifestPath),
         },
       ];

--- a/tests/service-action-runs.test.js
+++ b/tests/service-action-runs.test.js
@@ -47,6 +47,10 @@ async function writeActionScript(serviceRoot) {
       "  stepId: process.env.SERVICE_LASSO_STEP_ID,",
       "  parentActionId: process.env.SERVICE_LASSO_PARENT_ACTION_ID,",
       "  params: JSON.parse(process.env.SERVICE_LASSO_ACTION_PARAMS ?? '{}'),",
+      "  payload: JSON.parse(process.env.SERVICE_LASSO_ACTION_PAYLOAD ?? '{}'),",
+      "  payloadRef: process.env.SERVICE_LASSO_ACTION_PAYLOAD_REF,",
+      "  payloadSource: process.env.SERVICE_LASSO_ACTION_PAYLOAD_SOURCE,",
+      "  inlineMetadata: JSON.parse(process.env.SERVICE_LASSO_ACTION_INLINE_METADATA ?? '{}'),",
       "  actionValue: process.env.ACTION_VALUE",
       "}, null, 2));",
       "console.log('action writer complete');",
@@ -81,6 +85,23 @@ test("service action run API executes command actions and exposes persisted hist
         env: {
           ACTION_VALUE: "configured-${SERVICE_ID}",
         },
+        payload: {
+          inline: true,
+          references: true,
+          allowMixed: true,
+          required: true,
+          schema: {
+            type: "object",
+            required: ["retainDays"],
+            additionalProperties: false,
+            properties: {
+              retainDays: { type: "integer" },
+              mode: { type: "string" },
+              storedOnly: { type: "boolean" },
+            },
+          },
+          recordInlineFields: ["retainDays", "mode"],
+        },
         timeoutSeconds: 5,
       },
       unscheduled: {
@@ -108,9 +129,25 @@ test("service action run API executes command actions and exposes persisted hist
       workflow: {
         mode: "workflow",
       },
+      strictPayload: {
+        mode: "command",
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        payload: {
+          inline: true,
+          references: true,
+          allowMixed: false,
+        },
+      },
     },
   });
   await writeActionScript(serviceRoot);
+  await mkdir(path.join(serviceRoot, ".state", "action-payloads"), { recursive: true });
+  await writeFile(
+    path.join(serviceRoot, ".state", "action-payloads", "stored-backup.json"),
+    JSON.stringify({ retainDays: 14, storedOnly: true }, null, 2),
+    "utf8",
+  );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
   try {
@@ -123,6 +160,10 @@ test("service action run API executes command actions and exposes persisted hist
       params: {
         retainDays: 7,
       },
+      payload: {
+        retainDays: 7,
+        mode: "full",
+      },
     });
 
     assert.equal(run.status, 200);
@@ -134,6 +175,14 @@ test("service action run API executes command actions and exposes persisted hist
     assert.equal(run.body.run.metadata.stepId, "backup");
     assert.equal(run.body.run.metadata.parentActionId, "nightly-backup");
     assert.deepEqual(run.body.run.metadata.params, { retainDays: 7 });
+    assert.deepEqual(run.body.run.metadata.payload, {
+      source: "inline",
+      referenceId: null,
+      inline: {
+        retainDays: 7,
+        mode: "full",
+      },
+    });
 
     const output = JSON.parse(await readFile(path.join(serviceRoot, "runtime", "action-output.json"), "utf8"));
     assert.equal(output.serviceId, "action-service");
@@ -144,20 +193,84 @@ test("service action run API executes command actions and exposes persisted hist
     assert.equal(output.stepId, "backup");
     assert.equal(output.parentActionId, "nightly-backup");
     assert.deepEqual(output.params, { retainDays: 7 });
+    assert.deepEqual(output.payload, { retainDays: 7, mode: "full" });
+    assert.equal(output.payloadRef, "");
+    assert.equal(output.payloadSource, "inline");
+    assert.deepEqual(output.inlineMetadata, { retainDays: 7, mode: "full" });
     assert.equal(output.actionValue, "configured-action-service");
+
+    const mixedPayload = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
+      source: "dagu",
+      workflowId: "minecraft.backup.nightly",
+      scheduleId: "nightly",
+      payloadRef: "stored-backup",
+      payload: {
+        mode: "incremental",
+      },
+    });
+    assert.equal(mixedPayload.status, 200);
+    assert.equal(mixedPayload.body.ok, true);
+    assert.deepEqual(mixedPayload.body.run.metadata.payload, {
+      source: "mixed",
+      referenceId: "stored-backup",
+      inline: {
+        mode: "incremental",
+      },
+    });
+
+    const mixedOutput = JSON.parse(await readFile(path.join(serviceRoot, "runtime", "action-output.json"), "utf8"));
+    assert.deepEqual(mixedOutput.payload, { retainDays: 14, storedOnly: true, mode: "incremental" });
+    assert.equal(mixedOutput.payloadRef, "stored-backup");
+    assert.equal(mixedOutput.payloadSource, "mixed");
+    assert.deepEqual(mixedOutput.inlineMetadata, { mode: "incremental" });
 
     const history = await getJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`);
     assert.equal(history.status, 200);
     assert.equal(history.body.serviceId, "action-service");
     assert.equal(history.body.actionId, "backup");
-    assert.equal(history.body.runs.length, 1);
+    assert.equal(history.body.runs.length, 2);
     assert.equal(history.body.runs[0].runId, run.body.run.runId);
     assert.match(await readFile(history.body.runs[0].logs.stdoutPath, "utf8"), /action writer complete/);
     assert.match(await readFile(history.body.runs[0].logs.stderrPath, "utf8"), /action writer stderr/);
 
     const allHistory = await getJson(`${apiServer.url}/api/services/action-service/actions`);
     assert.equal(allHistory.status, 200);
-    assert.equal(allHistory.body.runs.length, 1);
+    assert.equal(allHistory.body.runs.length, 2);
+
+    const missingPayload = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`);
+    assert.equal(missingPayload.status, 400);
+    assert.equal(missingPayload.body.error, "action_payload_required");
+
+    const invalidPayload = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
+      payload: {
+        retainDays: "seven",
+      },
+    });
+    assert.equal(invalidPayload.status, 400);
+    assert.equal(invalidPayload.body.error, "invalid_action_payload");
+
+    const unknownPayloadRef = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
+      payloadRef: "missing-payload",
+    });
+    assert.equal(unknownPayloadRef.status, 404);
+    assert.equal(unknownPayloadRef.body.error, "unknown_action_payload_ref");
+
+    const payloadNotAllowed = await postJson(`${apiServer.url}/api/services/action-service/actions/unscheduled/runs`, {
+      payload: {
+        retainDays: 1,
+      },
+    });
+    assert.equal(payloadNotAllowed.status, 400);
+    assert.equal(payloadNotAllowed.body.error, "action_payload_not_allowed");
+
+    const mixedNotAllowed = await postJson(`${apiServer.url}/api/services/action-service/actions/strictPayload/runs`, {
+      payloadRef: "stored-backup",
+      payload: {
+        mode: "full",
+      },
+    });
+    assert.equal(mixedNotAllowed.status, 400);
+    assert.equal(mixedNotAllowed.body.error, "mixed_action_payload_not_allowed");
 
     const scheduledWithoutWorkflow = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
       source: "dagu",


### PR DESCRIPTION
## Summary
- adds manifest-level action payload policy for inline payloads, stored payload references, mixed payloads, required payloads, schema checks, and whitelisted inline history metadata
- resolves stored payload references from `.state/action-payloads/<payloadRef>.json` before action execution and exposes resolved payload details through action environment variables
- records payload source/reference/allowed inline metadata in action history without storing the full resolved payload
- adds the missing `docs/reference/service-action-inputs.md` and `schemas/service-action-inputs.schema.json`

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/service-action-runs.test.js`
- `node --test --test-concurrency=1 tests/api-spine.test.js tests/setup-lifecycle.test.js tests/service-action-runs.test.js`
- `npm test`
- post-change demo gate healthy: `npm run demo:gate -- -- --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`

Evidence: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260709-042606`

Stacked on #841 / `dev/issue-784-action-run-api` because #799 extends the action-run API added for #784.

Refs #799
