### PR TITLE
Fix hosted demo smoke reliability

### DIFF
--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -113,35 +113,52 @@ async function runNodeScript(script, args = []) {
 
 test("demo smoke script validates the bounded demo instance end to end", async () => {
   const demoScript = path.resolve("scripts", "demo-smoke.mjs");
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-smoke-"));
+  const servicesRoot = path.join(tempRoot, "services");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const demoLogRoot = path.join(tempRoot, "logs");
 
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [demoScript], {
-      cwd: process.cwd(),
-      stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        SERVICE_LASSO_PORT: "0",
-      },
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [
+          demoScript,
+          `--services-root=${servicesRoot}`,
+          `--workspace-root=${workspaceRoot}`,
+          `--demo-log-root=${demoLogRoot}`,
+        ],
+        {
+          cwd: process.cwd(),
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            SERVICE_LASSO_PORT: "0",
+          },
+        },
+      );
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      child.once("error", reject);
+      child.once("close", (code) => resolve({ code, stdout, stderr }));
     });
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-
-    child.once("error", reject);
-    child.once("close", (code) => resolve({ code, stdout, stderr }));
-  });
-
-  assert.equal(result.code, 0, `Expected demo smoke to pass.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
-  assert.match(result.stdout, /\[service-lasso demo] smoke passed/);
-  assert.match(result.stdout, /@java, @localcert, @nginx, @traefik, @node, echo-service, @serviceadmin, node-sample-service/);
+    assert.equal(result.code, 0, `Expected demo smoke to pass.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+    assert.match(result.stdout, /\[service-lasso demo] smoke passed/);
+    assert.match(result.stdout, /@java, @localcert, @nginx, @traefik, @node, echo-service, @serviceadmin, node-sample-service/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("demo reset seeds documented baseline manifests into a dedicated services root", async () => {


### PR DESCRIPTION
## Summary

- Isolates the demo smoke test with temp `servicesRoot`, `workspaceRoot`, and `demoLogRoot` paths.
- Stops the full suite from mutating the checked-in `services/` tree during hosted release/publish pipeline tests.
- Keeps the existing stdout/stderr assertion diagnostics intact for future demo-smoke failures.

## Validation

- `npm run build`
- `node --test --test-concurrency=1 tests/demo-instance.test.js`
- `npm test` (196/196 passing)

## Related

Fixes #843.
Follow-up evidence for #799/#784 blocker: #842/#841 are already merged on `main`, but hosted Release Artifact / Publish Package reruns failed in demo smoke before closure evidence could be accepted.
