### PR TITLE
feat(#706): add broker generated secret startup plan

### DIFF
--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -195,6 +195,55 @@ export interface ServiceArchiveArtifact {
 
 export type ServiceRole = "service" | "provider";
 
+export type ServiceBrokerBucketKind = "service" | "app" | "shared" | "global";
+
+export interface ServiceBrokerBucket {
+  namespace: string;
+  kind?: ServiceBrokerBucketKind;
+  description?: string;
+}
+
+export interface ServiceBrokerImport {
+  namespace: string;
+  ref: string;
+  as?: string;
+  required?: boolean;
+}
+
+export type ServiceBrokerWritebackOperation = "create" | "update" | "rotate" | "delete";
+
+export interface ServiceBrokerWritebackCapture {
+  ref: string;
+  source: string;
+  operation?: ServiceBrokerWritebackOperation;
+  required?: boolean;
+}
+
+export interface ServiceBrokerExport {
+  namespace: string;
+  ref: string;
+  source: string;
+  required?: boolean;
+}
+
+export interface ServiceBrokerWritebackPolicy {
+  allowedNamespaces?: string[];
+  allowedOperations?: ServiceBrokerWritebackOperation[];
+  allowedRefs?: string[];
+  allowOverwrite?: boolean;
+  auditReason?: string;
+  generatedSecrets?: ServiceBrokerWritebackCapture[];
+}
+
+export interface ServiceBrokerPolicy {
+  enabled?: boolean;
+  namespace?: string;
+  buckets?: ServiceBrokerBucket[];
+  imports?: ServiceBrokerImport[];
+  exports?: ServiceBrokerExport[];
+  writeback?: ServiceBrokerWritebackPolicy;
+}
+
 export interface ServiceManifest {
   id: string;
   name: string;
@@ -207,6 +256,7 @@ export interface ServiceManifest {
   healthcheck?: ServiceHealthcheck;
   env?: Record<string, string>;
   globalenv?: Record<string, string>;
+  broker?: ServiceBrokerPolicy;
   ports?: ServicePortDeclaration;
   portmapping?: ServicePortMappingDeclaration;
   urls?: ServiceEndpoint[];

--- a/src/runtime/broker/launch-resolution.ts
+++ b/src/runtime/broker/launch-resolution.ts
@@ -1,0 +1,379 @@
+import type {
+  DiscoveredService,
+  ServiceBrokerBucket,
+  ServiceBrokerImport,
+  ServiceBrokerWritebackOperation,
+} from "../../contracts/service.js";
+import {
+  compileCachedServiceSelectorPlan,
+  type ServiceSelectorPlan,
+  type ServiceVariableResolutionOptions,
+} from "../operator/variables.js";
+
+export type BrokerLaunchLookupStatus =
+  | "resolved"
+  | "missing"
+  | "locked"
+  | "auth-required"
+  | "policy-denied"
+  | "source-unavailable"
+  | "degraded";
+
+export interface BrokerLaunchLookupDecision {
+  ref: string;
+  status: BrokerLaunchLookupStatus;
+  value?: string;
+}
+
+export interface BrokerLaunchLookupRequest {
+  service: DiscoveredService;
+  refs: string[];
+}
+
+export type BrokerLaunchLookup = (
+  request: BrokerLaunchLookupRequest,
+) => Promise<BrokerLaunchLookupDecision[]> | BrokerLaunchLookupDecision[];
+
+export interface ServiceStartupBrokerPlan {
+  serviceId: string;
+  selectorPlan: ServiceSelectorPlan;
+  brokerRefs: string[];
+  buckets: Array<{
+    namespace: string;
+    kind: ServiceBrokerBucket["kind"] | null;
+  }>;
+  imports: Array<{
+    namespace: string;
+    ref: string;
+    as: string | null;
+    required: boolean;
+  }>;
+  writeback: {
+    allowedNamespaces: string[];
+    allowedOperations: ServiceBrokerWritebackOperation[];
+    allowedRefs: string[];
+    allowOverwrite: boolean;
+    auditReason: string | null;
+    generatedSecrets: ServiceStartupBrokerGeneratedSecretPlan[];
+  };
+}
+
+export type ServiceStartupBrokerGeneratedSecretKind =
+  | "password"
+  | "api-token"
+  | "session-secret"
+  | "token"
+  | "secret";
+
+export interface ServiceStartupBrokerGeneratedSecretPlan {
+  namespace: string | null;
+  ref: string;
+  operation: ServiceBrokerWritebackOperation;
+  required: boolean;
+  sourceRefs: string[];
+  valuePolicy: {
+    kind: ServiceStartupBrokerGeneratedSecretKind;
+    bytes: number;
+    encoding: "base64url";
+    minEntropyBits: number;
+  };
+  overwrite: "allow" | "deny";
+  auditReason: string | null;
+}
+
+export interface ServiceStartupBrokerFailure {
+  ref: string;
+  status: Exclude<BrokerLaunchLookupStatus, "resolved">;
+  required: boolean;
+  as: string | null;
+}
+
+export interface ServiceStartupBrokerResolution {
+  serviceId: string;
+  plan: ServiceStartupBrokerPlan;
+  variableResolution: ServiceVariableResolutionOptions;
+  decisions: Array<Omit<BrokerLaunchLookupDecision, "value">>;
+  failures: ServiceStartupBrokerFailure[];
+}
+
+function normalizeImport(entry: ServiceBrokerImport) {
+  return {
+    namespace: entry.namespace,
+    ref: entry.ref,
+    as: entry.as ?? null,
+    required: entry.required === true,
+  };
+}
+
+function normalizeBucket(entry: ServiceBrokerBucket) {
+  return {
+    namespace: entry.namespace,
+    kind: entry.kind ?? null,
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function inferGeneratedSecretKind(
+  ref: string,
+  source: string,
+): ServiceStartupBrokerGeneratedSecretKind {
+  const subject = `${ref} ${source}`.toLowerCase();
+  if (subject.includes("password") || /\bpass\b/.test(subject)) {
+    return "password";
+  }
+  if (subject.includes("session")) {
+    return "session-secret";
+  }
+  if (subject.includes("api") && subject.includes("token")) {
+    return "api-token";
+  }
+  if (subject.includes("token")) {
+    return "token";
+  }
+  return "secret";
+}
+
+function generatedSecretPolicy(
+  ref: string,
+  source: string,
+): ServiceStartupBrokerGeneratedSecretPlan["valuePolicy"] {
+  const kind = inferGeneratedSecretKind(ref, source);
+  const bytes = 32;
+  return {
+    kind,
+    bytes,
+    encoding: "base64url",
+    minEntropyBits: bytes * 8,
+  };
+}
+
+function setToArray(values: Set<string>): string[] | undefined {
+  return values.size > 0 ? [...values] : undefined;
+}
+
+function mergeRecords(
+  left: Record<string, string> | undefined,
+  right: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+  return { ...(left ?? {}), ...(right ?? {}) };
+}
+
+function mergeLists(
+  left: Set<string> | string[] | undefined,
+  right: string[] | undefined,
+): string[] | undefined {
+  const merged = new Set<string>();
+  if (Array.isArray(left)) {
+    for (const value of left) merged.add(value);
+  } else if (left) {
+    for (const value of left) merged.add(value);
+  }
+  for (const value of right ?? []) merged.add(value);
+  return merged.size > 0 ? [...merged] : undefined;
+}
+
+export function mergeServiceVariableResolutionOptions(
+  base: ServiceVariableResolutionOptions = {},
+  launch: ServiceVariableResolutionOptions = {},
+): ServiceVariableResolutionOptions {
+  return {
+    ...base,
+    ...launch,
+    brokerValues: mergeRecords(base.brokerValues, launch.brokerValues),
+    deniedBrokerRefs: mergeLists(
+      base.deniedBrokerRefs,
+      launch.deniedBrokerRefs as string[] | undefined,
+    ),
+    lockedBrokerRefs: mergeLists(
+      base.lockedBrokerRefs,
+      launch.lockedBrokerRefs as string[] | undefined,
+    ),
+    sourceAuthRequiredBrokerRefs: mergeLists(
+      base.sourceAuthRequiredBrokerRefs,
+      launch.sourceAuthRequiredBrokerRefs as string[] | undefined,
+    ),
+    sourceUnavailableBrokerRefs: mergeLists(
+      base.sourceUnavailableBrokerRefs,
+      launch.sourceUnavailableBrokerRefs as string[] | undefined,
+    ),
+    degradedBrokerRefs: mergeLists(
+      base.degradedBrokerRefs,
+      launch.degradedBrokerRefs as string[] | undefined,
+    ),
+    diagnostics: base.diagnostics ?? launch.diagnostics,
+  };
+}
+
+export function compileServiceStartupBrokerPlan(
+  service: DiscoveredService,
+): ServiceStartupBrokerPlan {
+  const broker = service.manifest.broker;
+  const imports = (service.manifest.broker?.imports ?? []).map(normalizeImport);
+  const importTemplates = imports.map((entry) => `\${${entry.ref}}`);
+  const exportsByRef = new Map(
+    (broker?.exports ?? []).map((entry) => [entry.ref, entry]),
+  );
+  const writeback = broker?.writeback;
+  const generatedSecrets: ServiceStartupBrokerGeneratedSecretPlan[] = (
+    writeback?.generatedSecrets ?? []
+  ).map((entry) => {
+    const exportEntry = exportsByRef.get(entry.ref);
+    const sourcePlan = compileCachedServiceSelectorPlan(
+      `service:${service.manifestPath}:${service.manifest.id}:startup-broker:writeback:${entry.ref}`,
+      [entry.source],
+    );
+    return {
+      namespace: exportEntry?.namespace ?? null,
+      ref: entry.ref,
+      operation: entry.operation ?? "create",
+      required: entry.required === true || exportEntry?.required === true,
+      sourceRefs: unique(sourcePlan.selectors.map((selector) => selector.selector)),
+      valuePolicy: generatedSecretPolicy(entry.ref, entry.source),
+      overwrite: writeback?.allowOverwrite === true ? "allow" : "deny",
+      auditReason: writeback?.auditReason ?? null,
+    };
+  });
+  const selectorPlan = compileCachedServiceSelectorPlan(
+    `service:${service.manifestPath}:${service.manifest.id}:startup-broker`,
+    {
+      env: JSON.stringify(service.manifest.env ?? {}),
+      imports: JSON.stringify(imports),
+      importTemplates: importTemplates.join("\n"),
+      generatedSecrets: JSON.stringify(
+        generatedSecrets.map((entry) => ({
+          namespace: entry.namespace,
+          ref: entry.ref,
+          operation: entry.operation,
+          required: entry.required,
+          sourceRefs: entry.sourceRefs,
+        })),
+      ),
+    },
+  );
+
+  return {
+    serviceId: service.manifest.id,
+    selectorPlan,
+    brokerRefs: unique([
+      ...selectorPlan.brokerRefs,
+      ...imports.map((entry) => entry.ref),
+    ]),
+    buckets: (broker?.buckets ?? []).map(normalizeBucket),
+    imports,
+    writeback: {
+      allowedNamespaces: [...(writeback?.allowedNamespaces ?? [])],
+      allowedOperations: [
+        ...(writeback?.allowedOperations ?? [
+          "create",
+          "update",
+          "rotate",
+          "delete",
+        ]),
+      ],
+      allowedRefs: [...(writeback?.allowedRefs ?? [])],
+      allowOverwrite: writeback?.allowOverwrite === true,
+      auditReason: writeback?.auditReason ?? null,
+      generatedSecrets,
+    },
+  };
+}
+
+function importByRef(
+  imports: ServiceStartupBrokerPlan["imports"],
+): Map<string, ServiceStartupBrokerPlan["imports"][number]> {
+  const result = new Map<string, ServiceStartupBrokerPlan["imports"][number]>();
+  for (const entry of imports) {
+    result.set(entry.ref, entry);
+  }
+  return result;
+}
+
+export async function resolveServiceStartupBrokerResolution(
+  service: DiscoveredService,
+  lookup: BrokerLaunchLookup,
+  baseResolution: ServiceVariableResolutionOptions = {},
+): Promise<ServiceStartupBrokerResolution> {
+  const plan = compileServiceStartupBrokerPlan(service);
+  const decisions = await lookup({ service, refs: plan.brokerRefs });
+  const expectedRefs = new Set(plan.brokerRefs);
+  const importMap = importByRef(plan.imports);
+  const brokerValues: Record<string, string> = {};
+  const denied = new Set<string>();
+  const locked = new Set<string>();
+  const authRequired = new Set<string>();
+  const sourceUnavailable = new Set<string>();
+  const degraded = new Set<string>();
+  const seen = new Set<string>();
+  const failures: ServiceStartupBrokerFailure[] = [];
+
+  const addFailure = (
+    ref: string,
+    status: ServiceStartupBrokerFailure["status"],
+  ) => {
+    const imported = importMap.get(ref);
+    failures.push({
+      ref,
+      status,
+      required: imported?.required === true,
+      as: imported?.as ?? null,
+    });
+  };
+
+  for (const decision of decisions) {
+    if (!expectedRefs.has(decision.ref) || seen.has(decision.ref)) {
+      continue;
+    }
+    seen.add(decision.ref);
+
+    if (decision.status === "resolved" && decision.value !== undefined) {
+      brokerValues[decision.ref] = decision.value;
+      continue;
+    }
+
+    if (decision.status === "policy-denied") denied.add(decision.ref);
+    if (decision.status === "locked") locked.add(decision.ref);
+    if (decision.status === "auth-required") authRequired.add(decision.ref);
+    if (decision.status === "source-unavailable")
+      sourceUnavailable.add(decision.ref);
+    if (decision.status === "degraded") degraded.add(decision.ref);
+    addFailure(
+      decision.ref,
+      decision.status === "resolved" ? "missing" : decision.status,
+    );
+  }
+
+  for (const ref of plan.brokerRefs) {
+    if (!seen.has(ref)) {
+      addFailure(ref, "missing");
+    }
+  }
+
+  return {
+    serviceId: service.manifest.id,
+    plan,
+    variableResolution: mergeServiceVariableResolutionOptions(baseResolution, {
+      brokerValues,
+      deniedBrokerRefs: setToArray(denied),
+      lockedBrokerRefs: setToArray(locked),
+      sourceAuthRequiredBrokerRefs: setToArray(authRequired),
+      sourceUnavailableBrokerRefs: setToArray(sourceUnavailable),
+      degradedBrokerRefs: setToArray(degraded),
+    }),
+    decisions: decisions
+      .filter((decision) => expectedRefs.has(decision.ref))
+      .map((decision) => ({ ref: decision.ref, status: decision.status })),
+    failures,
+  };
+}
+
+export function summarizeRequiredStartupBrokerFailures(
+  resolution: ServiceStartupBrokerResolution,
+): ServiceStartupBrokerFailure[] {
+  return resolution.failures.filter((failure) => failure.required);
+}

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -162,6 +162,18 @@ function readStringMap(value: unknown, field: string, manifestPath: string): Rec
   return Object.fromEntries(Object.entries(value as Record<string, string>).map(([key, entry]) => [key.trim(), entry]));
 }
 
+function readBrokerPolicy(value: unknown, manifestPath: string): ServiceManifest["broker"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "broker" to be an object.`);
+  }
+
+  return value as ServiceManifest["broker"];
+}
+
 function readHookSteps(value: unknown, field: string, manifestPath: string): ServiceHookStep[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -1096,6 +1108,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const actions = readActionPolicy(record.actions, manifestPath);
   const setup = readSetupPolicy(record.setup, manifestPath);
   const updates = readUpdatePolicy(record.updates, artifact, manifestPath);
+  const broker = readBrokerPolicy(record.broker, manifestPath);
 
   return {
     id: expectNonEmptyString(record.id, "id", manifestPath),
@@ -1111,6 +1124,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     globalenv: rawGlobalEnv
       ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
       : undefined,
+    broker,
     ports: rawPorts
       ? Object.fromEntries(Object.entries(rawPorts as Record<string, number>).map(([key, value]) => [key.trim(), value]))
       : undefined,

--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -4,7 +4,7 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { resolveExecutionArgs } from "./commandline.js";
-import { buildServiceVariables } from "../operator/variables.js";
+import { buildServiceVariables, type ServiceVariableResolutionOptions } from "../operator/variables.js";
 import { archiveRuntimeLogs, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
 
@@ -40,6 +40,7 @@ interface StartProcessOptions {
   executionPlan: ProviderExecutionPlan;
   sharedGlobalEnv?: Record<string, string>;
   resolvedPorts?: Record<string, number>;
+  variableResolution?: ServiceVariableResolutionOptions;
   onExit?: (payload: {
     service: DiscoveredService;
     exitCode: number | null;
@@ -163,9 +164,13 @@ function buildProcessEnvironment(
   executionPlan: ProviderExecutionPlan,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = {},
+  variableResolution: ServiceVariableResolutionOptions = {},
 ): NodeJS.ProcessEnv {
   const serviceVariables = Object.fromEntries(
-    buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
+    buildServiceVariables(service, sharedGlobalEnv, resolvedPorts, variableResolution).variables.map((entry) => [
+      entry.key,
+      entry.value,
+    ]),
   );
 
   return {
@@ -180,7 +185,7 @@ export function hasManagedProcess(serviceId: string): boolean {
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
-  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, onExit } = options;
+  const { service, executionPlan, sharedGlobalEnv, resolvedPorts, variableResolution, onExit } = options;
   const serviceId = service.manifest.id;
 
   const priorFinalizer = managedProcessFinalizers.get(serviceId);
@@ -201,7 +206,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
 
   const child = spawn(executable, args, {
     cwd: workingDirectory,
-    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts),
+    env: buildProcessEnvironment(service, executionPlan, sharedGlobalEnv, resolvedPorts, variableResolution),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
   });

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -4,7 +4,7 @@ import { startManagedProcess, stopManagedProcess } from "../execution/supervisor
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
-import { collectRuntimeGlobalEnv } from "../operator/variables.js";
+import { collectRuntimeGlobalEnv, type ServiceVariableResolutionOptions } from "../operator/variables.js";
 import { negotiateServicePorts } from "../ports/negotiate.js";
 import { createDirectExecutionPlan } from "../providers/direct.js";
 import { resolveProviderExecution } from "../providers/resolveProvider.js";
@@ -16,6 +16,10 @@ import { writeServiceState } from "../state/writeState.js";
 import { isProviderRole } from "../roles.js";
 import { getLifecycleState, setLifecycleState } from "./store.js";
 import type { LifecycleAction, LifecycleActionResult, ServiceLifecycleState } from "./types.js";
+
+export interface StartServiceOptions {
+  variableResolution?: ServiceVariableResolutionOptions;
+}
 
 function calculateRunDurationMs(startedAt: string | null, finishedAt: string): number | null {
   if (!startedAt) {
@@ -203,6 +207,7 @@ export async function configService(
 export async function startService(
   service: DiscoveredService,
   registry?: ServiceRegistry,
+  options: StartServiceOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
   const current = getLifecycleState(serviceId);
@@ -268,6 +273,7 @@ export async function startService(
     executionPlan,
     sharedGlobalEnv,
     resolvedPorts,
+    variableResolution: options.variableResolution,
     onExit: async ({ exitCode, wasStopping }) => {
       if (wasStopping) {
         return;

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -9,9 +9,47 @@ export interface ServiceVariableEntry {
   scope: "manifest" | "derived" | "global";
 }
 
+export interface ServiceSelectorRef {
+  selector: string;
+  kind: "local" | "broker";
+  key: string;
+}
+
+export interface ServiceSelectorPlan {
+  selectors: ServiceSelectorRef[];
+  localRefs: string[];
+  brokerRefs: string[];
+}
+
+export interface ServiceSelectorDiagnostic {
+  selector: string;
+  kind: "local" | "broker";
+  reason:
+    | "unresolved-local"
+    | "missing-broker"
+    | "locked-broker"
+    | "denied-broker"
+    | "source-auth-required"
+    | "source-unavailable"
+    | "degraded-broker";
+}
+
+export interface ServiceVariableResolutionOptions {
+  brokerValues?: Record<string, string>;
+  diagnostics?: ServiceSelectorDiagnostic[];
+  allowedBrokerRefs?: Set<string> | string[];
+  deniedBrokerRefs?: Set<string> | string[];
+  lockedBrokerRefs?: Set<string> | string[];
+  sourceAuthRequiredBrokerRefs?: Set<string> | string[];
+  sourceUnavailableBrokerRefs?: Set<string> | string[];
+  degradedBrokerRefs?: Set<string> | string[];
+}
+
 export interface ServiceVariablesPayload {
   serviceId: string;
   variables: ServiceVariableEntry[];
+  selectorPlan: ServiceSelectorPlan;
+  diagnostics: ServiceSelectorDiagnostic[];
 }
 
 function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVariableEntry[] {
@@ -37,18 +75,100 @@ function buildPortVariables(resolvedPorts: Record<string, number>): ServiceVaria
   return entries;
 }
 
-function replaceVariableSelectors(value: string, variables: ServiceVariableEntry[]): string {
+function hasRef(refs: Set<string> | string[] | undefined, ref: string): boolean {
+  return Array.isArray(refs) ? refs.includes(ref) : refs?.has(ref) === true;
+}
+
+function replaceVariableSelectors(
+  value: string,
+  variables: ServiceVariableEntry[],
+  options: ServiceVariableResolutionOptions = {},
+): string {
   return value.replace(/\$\{([^}]+)\}/g, (match, key) => {
     const normalizedKey = normalizeVariableSelector(key);
     const entry = variables.find((candidate) => candidate.key === normalizedKey);
-    return entry ? entry.value : match;
+    if (entry) {
+      return entry.value;
+    }
+    if (options.deniedBrokerRefs && hasRef(options.deniedBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "denied-broker" });
+      return match;
+    }
+    if (options.lockedBrokerRefs && hasRef(options.lockedBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "locked-broker" });
+      return match;
+    }
+    if (options.sourceAuthRequiredBrokerRefs && hasRef(options.sourceAuthRequiredBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "source-auth-required" });
+      return match;
+    }
+    if (options.sourceUnavailableBrokerRefs && hasRef(options.sourceUnavailableBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "source-unavailable" });
+      return match;
+    }
+    if (options.degradedBrokerRefs && hasRef(options.degradedBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "degraded-broker" });
+      return match;
+    }
+    if (Object.hasOwn(options.brokerValues ?? {}, normalizedKey)) {
+      return options.brokerValues?.[normalizedKey] ?? match;
+    }
+    if (options.allowedBrokerRefs && hasRef(options.allowedBrokerRefs, normalizedKey)) {
+      options.diagnostics?.push({ selector: normalizedKey, kind: "broker", reason: "missing-broker" });
+    }
+    return match;
   });
+}
+
+const selectorPlanCache = new Map<string, { fingerprint: string; plan: ServiceSelectorPlan }>();
+
+function fingerprintSelectorValues(values: string[] | Record<string, string>): string {
+  return JSON.stringify(Array.isArray(values) ? values : Object.entries(values).sort());
+}
+
+export function compileCachedServiceSelectorPlan(
+  cacheKey: string,
+  values: string[] | Record<string, string>,
+): ServiceSelectorPlan {
+  const fingerprint = fingerprintSelectorValues(values);
+  const cached = selectorPlanCache.get(cacheKey);
+  if (cached?.fingerprint === fingerprint) {
+    return cached.plan;
+  }
+  const plan = compileServiceSelectorPlan(values);
+  selectorPlanCache.set(cacheKey, { fingerprint, plan });
+  return plan;
+}
+
+export function compileServiceSelectorPlan(values: string[] | Record<string, string>): ServiceSelectorPlan {
+  const texts = Array.isArray(values) ? values : Object.values(values);
+  const selectors = new Map<string, ServiceSelectorRef>();
+
+  for (const text of texts) {
+    for (const match of String(text).matchAll(/\$\{([^}]+)\}/g)) {
+      const selector = normalizeVariableSelector(match[1] ?? "");
+      if (!selector) continue;
+      selectors.set(selector, {
+        selector,
+        kind: "local",
+        key: selector,
+      });
+    }
+  }
+
+  const orderedSelectors = [...selectors.values()];
+  return {
+    selectors: orderedSelectors,
+    localRefs: orderedSelectors.filter((selector) => selector.kind === "local").map((selector) => selector.key),
+    brokerRefs: orderedSelectors.filter((selector) => selector.kind === "broker").map((selector) => selector.selector),
+  };
 }
 
 export function buildServiceVariables(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
+  options: ServiceVariableResolutionOptions = {},
 ): ServiceVariablesPayload {
   const statePaths = getServiceStatePaths(service.serviceRoot);
   const installArtifact = getLifecycleState(service.manifest.id).installArtifacts.artifact;
@@ -112,14 +232,30 @@ export function buildServiceVariables(
     ...buildPortVariables(resolvedPorts),
   ];
 
+  const diagnostics: ServiceSelectorDiagnostic[] = [];
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
+  const resolutionOptions: ServiceVariableResolutionOptions = {
+    ...options,
+    allowedBrokerRefs: options.allowedBrokerRefs ?? declaredBrokerRefs,
+    diagnostics,
+  };
   const manifestVariables = rawManifestVariables.map((entry) => ({
     ...entry,
-    value: replaceVariableSelectors(entry.value, [...rawManifestVariables, ...globalVariables, ...derivedVariables]),
+    value: replaceVariableSelectors(
+      entry.value,
+      [...rawManifestVariables, ...globalVariables, ...derivedVariables],
+      resolutionOptions,
+    ),
   }));
 
   return {
     serviceId: service.manifest.id,
     variables: [...manifestVariables, ...globalVariables, ...derivedVariables],
+    selectorPlan: compileCachedServiceSelectorPlan(
+      `service:${service.manifestPath}:${service.manifest.id}:env`,
+      service.manifest.env ?? {},
+    ),
+    diagnostics,
   };
 }
 
@@ -147,8 +283,14 @@ export function resolveServiceText(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
   resolvedPorts: Record<string, number> = service.manifest.ports ?? {},
+  options: ServiceVariableResolutionOptions = {},
 ): string {
-  return replaceVariableSelectors(value, buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables);
+  const variablesPayload = buildServiceVariables(service, sharedGlobalEnv, resolvedPorts, options);
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map((entry) => entry.ref);
+  return replaceVariableSelectors(value, variablesPayload.variables, {
+    ...options,
+    allowedBrokerRefs: options.allowedBrokerRefs ?? declaredBrokerRefs,
+  });
 }
 
 export function collectRuntimeGlobalEnv(services: DiscoveredService[]): Record<string, string> {

--- a/tests/broker-consumption-fixtures.test.js
+++ b/tests/broker-consumption-fixtures.test.js
@@ -1,0 +1,265 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
+import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
+import { installService, configService, startService, stopService } from "../dist/runtime/lifecycle/actions.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { buildServiceVariables, resolveServiceText } from "../dist/runtime/operator/variables.js";
+import { compileServiceStartupBrokerPlan } from "../dist/runtime/broker/launch-resolution.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function waitFor(predicate, timeoutMs = 1_500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function prepareRegistry(servicesRoot) {
+  const discovered = await discoverServices(servicesRoot);
+  const registry = createServiceRegistry(discovered);
+  return { discovered, registry };
+}
+
+test("startup broker plan includes generated writeback metadata without raw values", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-generated-plan-");
+  const rawSeed = "raw-session-seed-must-not-leak";
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "generated-broker-secret", {
+      env: {
+        SESSION_SEED: rawSeed,
+      },
+      broker: {
+        enabled: true,
+        namespace: "services/generated-broker-secret",
+        buckets: [
+          { namespace: "services/generated-broker-secret", kind: "service" },
+        ],
+        accessPolicy: {
+          serviceId: "generated-broker-secret",
+          workspace: "test",
+          grants: [
+            {
+              namespace: "services/generated-broker-secret",
+              scope: "service",
+              refs: ["sample.SESSION_SECRET"],
+              operations: ["create"],
+              purpose: "create generated session secret metadata",
+            },
+          ],
+        },
+        writeback: {
+          allowedNamespaces: ["services/generated-broker-secret"],
+          allowedOperations: ["create"],
+          allowedRefs: ["sample.SESSION_SECRET"],
+          allowOverwrite: false,
+          auditReason: "test generated secret provisioning",
+          generatedSecrets: [
+            {
+              ref: "sample.SESSION_SECRET",
+              source: "${SESSION_SEED}",
+              operation: "create",
+              required: true,
+            },
+          ],
+        },
+        exports: [
+          {
+            namespace: "services/generated-broker-secret",
+            ref: "sample.SESSION_SECRET",
+            source: "${SESSION_SEED}",
+            required: true,
+          },
+        ],
+      },
+    });
+    const { registry } = await prepareRegistry(servicesRoot);
+    const service = registry.getById("generated-broker-secret");
+    assert.ok(service);
+
+    const plan = compileServiceStartupBrokerPlan(service);
+    assert.deepEqual(plan.buckets, [
+      { namespace: "services/generated-broker-secret", kind: "service" },
+    ]);
+    assert.deepEqual(plan.writeback.allowedNamespaces, ["services/generated-broker-secret"]);
+    assert.deepEqual(plan.writeback.allowedOperations, ["create"]);
+    assert.deepEqual(plan.writeback.allowedRefs, ["sample.SESSION_SECRET"]);
+    assert.equal(plan.writeback.allowOverwrite, false);
+    assert.equal(plan.writeback.auditReason, "test generated secret provisioning");
+    assert.deepEqual(plan.writeback.generatedSecrets, [
+      {
+        namespace: "services/generated-broker-secret",
+        ref: "sample.SESSION_SECRET",
+        operation: "create",
+        required: true,
+        sourceRefs: ["SESSION_SEED"],
+        valuePolicy: {
+          kind: "session-secret",
+          bytes: 32,
+          encoding: "base64url",
+          minEntropyBits: 256,
+        },
+        overwrite: "deny",
+        auditReason: "test generated secret provisioning",
+      },
+    ]);
+    assert.equal(JSON.stringify(plan).includes(rawSeed), false);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("ordinary service consumes Secrets Broker imports through resolved env without logging raw values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-env-e2e-");
+  const rawSecret = "ordinary-service-db-password";
+
+  try {
+    const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "ordinary-broker-env-consumer", {
+      readyFileAfterMs: 10,
+      captureEnvKeys: ["DB_PASSWORD", "API_TOKEN", "BROKER_BACKED_URL"],
+      stdoutLines: ["ordinary broker env consumer started"],
+      stderrLines: ["ordinary broker env consumer diagnostics are scrubbed"],
+      env: {
+        DB_PASSWORD: "${database.PASSWORD}",
+        API_TOKEN: "${services.API_TOKEN}",
+        BROKER_BACKED_URL: "postgres://service:${database.PASSWORD}@localhost/app",
+      },
+      broker: {
+        enabled: true,
+        namespace: "services/ordinary-broker-env-consumer",
+        buckets: [
+          { namespace: "services/ordinary-broker-env-consumer", kind: "service" },
+          { namespace: "shared/database", kind: "shared" },
+        ],
+        imports: [
+          { namespace: "shared/database", ref: "database.PASSWORD", as: "DB_PASSWORD", required: true },
+          { namespace: "services/ordinary-broker-env-consumer", ref: "services.API_TOKEN", as: "API_TOKEN", required: true },
+        ],
+      },
+    });
+    const { registry } = await prepareRegistry(servicesRoot);
+    const service = registry.getById("ordinary-broker-env-consumer");
+    assert.ok(service);
+
+    await installService(service, registry);
+    await configService(service, registry);
+    const started = await startService(service, registry, {
+      variableResolution: {
+        brokerValues: {
+          "database.PASSWORD": rawSecret,
+          "services.API_TOKEN": "ordinary-service-api-token",
+        },
+      },
+    });
+
+    try {
+      const snapshotPath = path.join(serviceRoot, "runtime", "env.json");
+      await waitFor(async () => {
+        try {
+          await readFile(snapshotPath, "utf8");
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const snapshot = JSON.parse(await readFile(snapshotPath, "utf8"));
+      assert.equal(snapshot.DB_PASSWORD, rawSecret);
+      assert.equal(snapshot.API_TOKEN, "ordinary-service-api-token");
+      assert.equal(snapshot.BROKER_BACKED_URL, `postgres://service:${rawSecret}@localhost/app`);
+    } finally {
+      await stopService(service);
+    }
+
+    const stdout = await readFile(started.state.runtime.logs.stdoutPath, "utf8");
+    const stderr = await readFile(started.state.runtime.logs.stderrPath, "utf8");
+    const combined = await readFile(started.state.runtime.logs.logPath, "utf8");
+    assert.equal(stdout.includes(rawSecret), false);
+    assert.equal(stderr.includes(rawSecret), false);
+    assert.equal(combined.includes(rawSecret), false);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI-style broker resolution fixture reports missing denied and source-auth refs without leaking values", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-broker-cli-fixture-");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "ordinary-broker-cli-consumer", {
+      env: {
+        CLI_TOKEN: "${cli.TOKEN}",
+        LOCAL_ONLY: "local-value",
+        MISSING_REF: "${cli.MISSING}",
+        DENIED_REF: "${cli.DENIED}",
+        SOURCE_REF: "${source.NEEDS_AUTH}",
+      },
+      broker: {
+        enabled: true,
+        namespace: "services/ordinary-broker-cli-consumer",
+        imports: [
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.TOKEN", as: "CLI_TOKEN", required: true },
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.MISSING", as: "MISSING_REF" },
+          { namespace: "services/ordinary-broker-cli-consumer", ref: "cli.DENIED", as: "DENIED_REF" },
+          { namespace: "external/source", ref: "source.NEEDS_AUTH", as: "SOURCE_REF" },
+        ],
+      },
+    });
+    const { registry } = await prepareRegistry(servicesRoot);
+    const service = registry.getById("ordinary-broker-cli-consumer");
+    assert.ok(service);
+
+    const diagnostics = [];
+    const resolved = resolveServiceText(
+      "secretsbroker-resolve cli.TOKEN -> ${cli.TOKEN}; local=${LOCAL_ONLY}; denied=${cli.DENIED}; source=${source.NEEDS_AUTH}",
+      service,
+      {},
+      {},
+      {
+        brokerValues: {
+          "cli.TOKEN": "cli-token-value",
+          "cli.DENIED": "must-not-leak-denied",
+          "source.NEEDS_AUTH": "must-not-leak-source",
+        },
+        deniedBrokerRefs: ["cli.DENIED"],
+        sourceAuthRequiredBrokerRefs: ["source.NEEDS_AUTH"],
+        diagnostics,
+      },
+    );
+
+    assert.equal(resolved, "secretsbroker-resolve cli.TOKEN -> cli-token-value; local=local-value; denied=${cli.DENIED}; source=${source.NEEDS_AUTH}");
+    assert.equal(resolved.includes("must-not-leak-denied"), false);
+    assert.equal(resolved.includes("must-not-leak-source"), false);
+    assert.deepEqual(diagnostics, [
+      { selector: "cli.DENIED", kind: "broker", reason: "denied-broker" },
+      { selector: "source.NEEDS_AUTH", kind: "broker", reason: "source-auth-required" },
+    ]);
+
+    const payload = buildServiceVariables(service, {}, {}, {
+      brokerValues: { "cli.TOKEN": "cli-token-value", "cli.DENIED": "must-not-leak-denied" },
+      deniedBrokerRefs: ["cli.DENIED"],
+      sourceAuthRequiredBrokerRefs: ["source.NEEDS_AUTH"],
+    });
+    const serialized = JSON.stringify(payload);
+    assert.equal(serialized.includes("must-not-leak-denied"), false);
+    assert.equal(serialized.includes("must-not-leak-source"), false);
+    assert.deepEqual(payload.diagnostics.map((entry) => entry.reason), [
+      "missing-broker",
+      "denied-broker",
+      "source-auth-required",
+    ]);
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -76,6 +76,7 @@ export async function writeExecutableFixtureService(
     config = undefined,
     setup = undefined,
     role = undefined,
+    broker = undefined,
   } = options;
 
   const serviceRoot = path.join(servicesRoot, serviceId);
@@ -186,6 +187,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
         : {}),
     },
     globalenv,
+    broker,
     autostart,
     monitoring,
     restartPolicy,


### PR DESCRIPTION
## Summary\n- adds broker manifest contract fields and preserves broker policy through service discovery\n- adds startup broker planning for buckets, imports, writeback policy, and generated secret metadata without raw values\n- threads broker variable-resolution options through service start so broker-backed env can resolve without leaking denied/source-auth values\n\n## Validation\n- npm run build\n- node --test --test-concurrency=1 tests/broker-consumption-fixtures.test.js\n- node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json now runs, but blocks on service_admin_api_non_json because Service Admin /api/dashboard and /api/services return HTML instead of runtime JSON\n\nRefs #706