### PR TITLE
fix(demo): refresh Service Admin canonical gate

### DIFF
--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -233,6 +233,30 @@ function createExpectedServiceStateCheck(serviceAdminServicesProbe) {
     return null;
   }
 
+  const actualById = new Map(serviceAdminServicesProbe.body.services.map((service) => [service.id, toServiceState(service)]));
+  const actualServiceAdmin = actualById.get("@serviceadmin");
+  const managedServiceAdmin =
+    actualServiceAdmin?.installed === true
+    && actualServiceAdmin?.configured === true
+    && actualServiceAdmin?.running === true
+    && actualServiceAdmin?.healthy === true;
+  const serviceAdminExpected = managedServiceAdmin
+    ? {
+        id: "@serviceadmin",
+        installed: true,
+        configured: true,
+        running: true,
+        healthy: true,
+        expectedMode: "managed_serviceadmin_owns_17700",
+      }
+    : {
+        id: "@serviceadmin",
+        installed: false,
+        configured: false,
+        running: false,
+        healthy: false,
+        expectedMode: "source_admin_owns_17700",
+      };
   const expected = [
     { id: "@java", installed: true, configured: true, running: false, healthy: true, expectedMode: "provider_ready" },
     { id: "@localcert", installed: true, configured: true, running: false, healthy: true, expectedMode: "provider_ready" },
@@ -240,14 +264,7 @@ function createExpectedServiceStateCheck(serviceAdminServicesProbe) {
     { id: "@traefik", installed: true, configured: true, running: true, healthy: true, expectedMode: "managed_running" },
     { id: "@node", installed: true, configured: true, running: false, healthy: true, expectedMode: "provider_ready" },
     { id: "echo-service", installed: true, configured: true, running: true, healthy: true, expectedMode: "managed_running" },
-    {
-      id: "@serviceadmin",
-      installed: false,
-      configured: false,
-      running: false,
-      healthy: false,
-      expectedMode: "source_admin_owns_17700",
-    },
+    serviceAdminExpected,
     {
       id: "node-sample-service",
       installed: false,
@@ -257,7 +274,6 @@ function createExpectedServiceStateCheck(serviceAdminServicesProbe) {
       expectedMode: "manifest_only_sample",
     },
   ];
-  const actualById = new Map(serviceAdminServicesProbe.body.services.map((service) => [service.id, toServiceState(service)]));
   const actual = expected
     .map(({ id, expectedMode }) => {
       const state = actualById.get(id);
@@ -281,8 +297,10 @@ function createExpectedServiceStateCheck(serviceAdminServicesProbe) {
 
   return {
     ok: mismatches.length === 0,
-    mode: "source_admin_on_17700",
-    acceptedWarningReason: "Source Service Admin owns port 17700; the managed @serviceadmin manifest is intentionally present but not installed or started.",
+    mode: managedServiceAdmin ? "managed_serviceadmin_on_17700" : "source_admin_on_17700",
+    acceptedWarningReason: managedServiceAdmin
+      ? null
+      : "Source Service Admin owns port 17700; the managed @serviceadmin manifest is intentionally present but not installed or started.",
     expected,
     actual,
     mismatches,

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -8,6 +8,12 @@
   "ports": {
     "ui": 17700
   },
+  "env": {
+    "SERVICE_HOST": "0.0.0.0",
+    "SERVICE_PORT": "${UI_PORT}",
+    "SERVICE_LASSO_API_BASE_URL": "http://127.0.0.1:17883",
+    "SERVICE_LASSO_RUNTIME_API_BASE_URL": "http://127.0.0.1:17883"
+  },
   "urls": [
     {
       "label": "ui",
@@ -20,7 +26,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.4.18-170a1af"
+      "tag": "2026.7.9-97b4660"
     },
     "platforms": {
       "win32": {

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -653,7 +653,7 @@ test("demo verify canonical exits non-zero when Service Admin returns HTML for t
   }
 });
 
-test("demo verify canonical exits non-zero when canonical service state does not match source Admin mode", async () => {
+test("demo verify canonical accepts managed Service Admin ownership of port 17700", async () => {
   const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-demo-verify-service-state-"));
   const runtime = await startFixtureServer((request, response) => {
     if (request.url === "/api/health") {
@@ -693,19 +693,15 @@ test("demo verify canonical exits non-zero when canonical service state does not
       "--json",
     ]);
 
-    assert.equal(result.code, 1);
+    assert.equal(result.code, 0);
     const status = JSON.parse(result.stdout);
 
-    assert.equal(status.ok, false);
-    assert.equal(status.classification, "canonical_service_state_mismatch");
-    assert.equal(status.endpoints.serviceAdmin.serviceState.ok, false);
-    assert.equal(status.endpoints.serviceAdmin.serviceState.mode, "source_admin_on_17700");
-    assert.deepEqual(
-      status.endpoints.serviceAdmin.serviceState.mismatches
-        .filter((mismatch) => mismatch.id === "@serviceadmin")
-        .map((mismatch) => mismatch.field),
-      ["installed", "configured", "running", "healthy"],
-    );
+    assert.equal(status.ok, true);
+    assert.equal(status.classification, "healthy");
+    assert.equal(status.endpoints.serviceAdmin.serviceState.ok, true);
+    assert.equal(status.endpoints.serviceAdmin.serviceState.mode, "managed_serviceadmin_on_17700");
+    assert.equal(status.endpoints.serviceAdmin.serviceState.acceptedWarningReason, null);
+    assert.deepEqual(status.endpoints.serviceAdmin.serviceState.mismatches, []);
   } finally {
     await admin.close();
     await runtime.close();


### PR DESCRIPTION
Closes #846.\n\nValidation:\n- npm run build\n- node --test --test-concurrency=1 tests/demo-instance.test.js\n- node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --timeout-ms=30000 --json\n- node scripts/demo-verify-canonical.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --timeout-ms=30000 --json\n- git diff --check