### PR TITLE
feat(config): persist portable service config history

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -647,7 +647,7 @@ async function routeRequest(
     }
 
     if (request.method === "GET" && pathParts.length === 4 && pathParts[3] === "config") {
-      writeJson(response, 200, await createServiceConfigDocumentResponse(service));
+      writeJson(response, 200, await createServiceConfigDocumentResponse(service, config.workspaceRoot));
       return;
     }
 

--- a/src/server/routes/service-config.ts
+++ b/src/server/routes/service-config.ts
@@ -6,15 +6,21 @@ import { getServiceStatePaths } from "../../runtime/state/paths.js";
 import { ApiError } from "../errors.js";
 import type { ServiceConfigDocumentResponse, ServiceConfigSaveResponse } from "../../contracts/api.js";
 
-interface ServiceConfigRevisionFile {
+interface ServiceConfigRevisionMetadata {
   id: string;
   createdAt: string;
   actor: string;
   reason: string | null;
   path: string;
+  serviceId?: string;
+  relativeConfigPath?: string;
   previousHash: string;
   currentHash: string;
   validationStatus: "valid";
+  runtimeVersion?: string | null;
+}
+
+interface ServiceConfigRevisionFile extends ServiceConfigRevisionMetadata {
   content: string;
 }
 
@@ -24,14 +30,17 @@ interface ServiceConfigSaveBody {
   reason: string | null;
 }
 
-const serviceConfigBackupDirName = "service-config";
+const serviceConfigBackupDirName = "config";
+const legacyServiceConfigBackupDirName = "service-config";
+const legacyWorkspaceConfigBackupDirName = "service-config-backups";
 
 function hashContent(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");
 }
 
-function toRevisionId(createdAt: string): string {
-  return createdAt.replaceAll(/[^0-9A-Za-z]+/g, "-").replaceAll(/^-|-$/g, "");
+function toRevisionId(createdAt: string, previousHash: string): string {
+  const timestamp = createdAt.replaceAll(/[^0-9A-Za-z]+/g, "-").replaceAll(/^-|-$/g, "");
+  return `${timestamp}-${previousHash.slice(0, 12)}`;
 }
 
 function parseServiceConfigSaveBody(input: unknown): ServiceConfigSaveBody {
@@ -86,10 +95,39 @@ async function getConfigBackupDir(service: DiscoveredService): Promise<string> {
   return backupDir;
 }
 
-async function readRevisions(service: DiscoveredService): Promise<ServiceConfigRevisionFile[]> {
+function getLegacyServiceConfigBackupDir(service: DiscoveredService): string {
+  const paths = getServiceStatePaths(service.serviceRoot);
+  return path.join(paths.backups, legacyServiceConfigBackupDirName);
+}
+
+function getLegacyWorkspaceConfigBackupDir(workspaceRoot: string, service: DiscoveredService): string {
+  return path.join(workspaceRoot, legacyWorkspaceConfigBackupDirName, service.manifest.id);
+}
+
+async function readPortableRevisions(service: DiscoveredService): Promise<ServiceConfigRevisionFile[]> {
   const backupDir = await getConfigBackupDir(service);
   const entries = await readdir(backupDir, { withFileTypes: true }).catch(() => []);
-  const revisions = await Promise.all(
+  const metadataEntries = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".metadata.json"));
+
+  return Promise.all(
+    metadataEntries.map(async (entry) => {
+      const metadataPath = path.join(backupDir, entry.name);
+      const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as ServiceConfigRevisionMetadata;
+      const contentFileName = entry.name.replace(/\.metadata\.json$/u, ".server.json");
+      const content = await readFile(path.join(backupDir, contentFileName), "utf8");
+
+      return {
+        ...metadata,
+        content,
+      };
+    }),
+  );
+}
+
+async function readLegacyRevisionFiles(backupDir: string): Promise<ServiceConfigRevisionFile[]> {
+  const entries = await readdir(backupDir, { withFileTypes: true }).catch(() => []);
+
+  return Promise.all(
     entries
       .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
       .map(async (entry) => {
@@ -98,16 +136,32 @@ async function readRevisions(service: DiscoveredService): Promise<ServiceConfigR
         return parsed;
       }),
   );
+}
 
-  return revisions.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+async function readRevisions(service: DiscoveredService, workspaceRoot: string): Promise<ServiceConfigRevisionFile[]> {
+  const revisions = [
+    ...(await readPortableRevisions(service)),
+    ...(await readLegacyRevisionFiles(getLegacyServiceConfigBackupDir(service))),
+    ...(await readLegacyRevisionFiles(getLegacyWorkspaceConfigBackupDir(workspaceRoot, service))),
+  ];
+  const uniqueRevisions = new Map<string, ServiceConfigRevisionFile>();
+
+  for (const revision of revisions) {
+    if (!uniqueRevisions.has(revision.id)) {
+      uniqueRevisions.set(revision.id, revision);
+    }
+  }
+
+  return [...uniqueRevisions.values()].sort((left, right) => right.createdAt.localeCompare(left.createdAt));
 }
 
 export async function createServiceConfigDocumentResponse(
   service: DiscoveredService,
+  workspaceRoot: string,
 ): Promise<ServiceConfigDocumentResponse> {
   const content = await readFile(service.manifestPath, "utf8");
   const manifestStats = await stat(service.manifestPath);
-  const revisions = await readRevisions(service);
+  const revisions = await readRevisions(service, workspaceRoot);
 
   return {
     serviceId: service.manifest.id,
@@ -137,19 +191,27 @@ export async function saveServiceConfigDocument(
   const nextHash = hashContent(body.content);
   const createdAt = new Date().toISOString();
   const backupDir = await getConfigBackupDir(service);
-  const backup: ServiceConfigRevisionFile = {
-    id: toRevisionId(createdAt),
+  const revisionId = toRevisionId(createdAt, previousHash);
+  const metadata: ServiceConfigRevisionMetadata = {
+    id: revisionId,
     createdAt,
     actor: body.actor,
     reason: body.reason,
-    path: service.manifestPath,
+    path: path.relative(service.serviceRoot, service.manifestPath).split(path.sep).join("/"),
+    serviceId: service.manifest.id,
+    relativeConfigPath: path.relative(service.serviceRoot, service.manifestPath).split(path.sep).join("/"),
     previousHash,
     currentHash: nextHash,
     validationStatus: "valid",
+    runtimeVersion: null,
+  };
+  const backup: ServiceConfigRevisionFile = {
+    ...metadata,
     content: previousContent,
   };
 
-  await writeFile(path.join(backupDir, `${backup.id}.json`), JSON.stringify(backup, null, 2));
+  await writeFile(path.join(backupDir, `${revisionId}.server.json`), previousContent);
+  await writeFile(path.join(backupDir, `${revisionId}.metadata.json`), JSON.stringify(metadata, null, 2));
   await writeFile(service.manifestPath, body.content.endsWith("\n") ? body.content : `${body.content}\n`);
 
   return {

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
-import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { startRuntimeApp } from "../dist/runtime/app.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
@@ -267,7 +267,13 @@ test("service config document API loads and saves runtime-backed service.json wi
     assert.equal(save.body.validationStatus, "valid");
     assert.equal(save.body.backup.actor, "service-admin-web");
     assert.equal(save.body.backup.reason, "prove config editor save path");
+    assert.equal(save.body.backup.path, "service.json");
     assert.match(save.body.backup.content, /Config document fixture/);
+
+    const backupDir = path.join(serviceRoot, ".state", "backups", "config");
+    const backupFiles = await readdir(backupDir);
+    assert.ok(backupFiles.some((fileName) => fileName.endsWith(".server.json")));
+    assert.ok(backupFiles.some((fileName) => fileName.endsWith(".metadata.json")));
 
     const savedManifest = await readFile(path.join(serviceRoot, "service.json"), "utf8");
     assert.match(savedManifest, /Edited through the config document API/);
@@ -278,6 +284,111 @@ test("service config document API loads and saves runtime-backed service.json wi
     assert.equal(reloaded.body.revisions.length, 1);
     assert.equal(reloaded.body.revisions[0].id, save.body.backup.id);
     assert.match(reloaded.body.content, /Edited through the config document API/);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service config history travels with a copied service root", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-copy-source-");
+  const serviceRoot = await writeManifest(servicesRoot, "node-sample-service", {
+    id: "node-sample-service",
+    name: "Node Sample Service",
+    description: "Portable config history fixture.",
+    enabled: true,
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const nextContent = JSON.stringify(
+      {
+        id: "node-sample-service",
+        name: "Node Sample Service",
+        description: "Copied bundle config.",
+        enabled: true,
+      },
+      null,
+      2,
+    );
+    const save = await putJson(`${apiServer.url}/api/services/node-sample-service/config`, {
+      content: nextContent,
+      actor: "service-admin-web",
+      reason: "prove copied service root history",
+    });
+    assert.equal(save.status, 200);
+  } finally {
+    await apiServer.stop();
+  }
+
+  const restartedApiServer = await startApiServer({ port: 0, servicesRoot });
+  try {
+    const afterRestart = await getJson(`${restartedApiServer.url}/api/services/node-sample-service/config`);
+    assert.equal(afterRestart.status, 200);
+    assert.equal(afterRestart.body.backupCount, 1);
+    assert.match(afterRestart.body.revisions[0].content, /Portable config history fixture/);
+  } finally {
+    await restartedApiServer.stop();
+  }
+
+  const movedTempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-config-copy-target-"));
+  const movedServicesRoot = path.join(movedTempRoot, "services");
+  const movedServiceRoot = path.join(movedServicesRoot, "node-sample-service");
+  await mkdir(movedServicesRoot, { recursive: true });
+  await cp(serviceRoot, movedServiceRoot, { recursive: true });
+  const copiedApiServer = await startApiServer({ port: 0, servicesRoot: movedServicesRoot });
+
+  try {
+    const copied = await getJson(`${copiedApiServer.url}/api/services/node-sample-service/config`);
+    assert.equal(copied.status, 200);
+    assert.equal(copied.body.backupCount, 1);
+    assert.equal(copied.body.revisions.length, 1);
+    assert.match(copied.body.revisions[0].content, /Portable config history fixture/);
+  } finally {
+    await copiedApiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    await rm(movedTempRoot, { recursive: true, force: true });
+  }
+});
+
+test("service config document API reads legacy workspace backup history during fallback", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-config-legacy-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const serviceRoot = await writeManifest(servicesRoot, "node-sample-service", {
+    id: "node-sample-service",
+    name: "Node Sample Service",
+    description: "Legacy workspace history fixture.",
+    enabled: true,
+  });
+  const legacyBackupDir = path.join(workspaceRoot, "service-config-backups", "node-sample-service");
+  await mkdir(legacyBackupDir, { recursive: true });
+  await writeFile(
+    path.join(legacyBackupDir, "legacy-revision.json"),
+    JSON.stringify(
+      {
+        id: "legacy-revision",
+        createdAt: "2026-06-26T09:12:44.123Z",
+        actor: "service-admin-web",
+        reason: "legacy workspace fallback",
+        path: path.join(serviceRoot, "service.json"),
+        previousHash: "previous",
+        currentHash: "current",
+        validationStatus: "valid",
+        content: "{\n  \"id\": \"node-sample-service\",\n  \"description\": \"Legacy workspace history fixture.\"\n}\n",
+      },
+      null,
+      2,
+    ),
+  );
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const response = await getJson(`${apiServer.url}/api/services/node-sample-service/config`);
+    assert.equal(response.status, 200);
+    assert.equal(response.body.backupCount, 1);
+    assert.equal(response.body.revisions[0].id, "legacy-revision");
+    assert.equal(response.body.revisions[0].reason, "legacy workspace fallback");
+    assert.match(response.body.revisions[0].content, /Legacy workspace history fixture/);
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Persist new service config revisions under the portable service bundle at `.state/backups/config`.
- Write each revision as separate `*.server.json` content and `*.metadata.json` metadata files before replacing the live config.
- Keep API responses compatible by reading new portable revisions plus legacy service-root and workspace-level backup JSON files.
- Add API coverage for save layout, restart persistence, copied service-root portability, legacy workspace fallback, and invalid saves.

## Validation
- `npm run build`
- `node --test --test-force-exit --test-concurrency=1 --test-name-pattern "service config" tests/api-spine.test.js`
- `npm run build`
- `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`
- `node scripts/demo-verify-canonical.mjs --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`

Closes #725.
