### PR TITLE
feat(audit): persist operator audit events

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -130,6 +130,53 @@ export interface RuntimeSummaryResponse {
   };
 }
 
+export type AuditEventOutcome = "success" | "failure";
+
+export interface AuditEvent {
+  id: string;
+  timestamp: string;
+  source: string;
+  action: string;
+  actor: string;
+  subject?: string;
+  serviceId?: string;
+  method?: string;
+  routeTemplate?: string;
+  outcome: AuditEventOutcome;
+  statusCode: number;
+  summary: string;
+  reason: string | null;
+  correlationId: string;
+  relatedRevisionId: string | null;
+  chainId: string;
+  sequence: number;
+  previousHash: string | null;
+  eventHash: string;
+  chainStatus: "valid";
+}
+
+export interface AuditQuery {
+  serviceId?: string;
+  actor?: string;
+  action?: string;
+  outcome?: AuditEventOutcome;
+  source?: string;
+  since?: string;
+  until?: string;
+  query?: string;
+  limit?: string;
+  cursor?: string;
+}
+
+export interface AuditResponse {
+  events: AuditEvent[];
+  pagination: {
+    limit: number;
+    nextCursor: string | null;
+    total: number;
+  };
+}
+
 export interface ManagedWorkflowRegistryStep {
   id: string;
   type: "service-lasso-action";

--- a/src/runtime/audit/store.ts
+++ b/src/runtime/audit/store.ts
@@ -1,0 +1,222 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import type { AuditEvent, AuditEventOutcome, AuditQuery, AuditResponse } from "../../contracts/api.js";
+
+export interface AppendAuditEventInput {
+  workspaceRoot?: string;
+  serviceRoot?: string;
+  source: string;
+  action: string;
+  actor?: string;
+  subject?: string;
+  serviceId?: string;
+  method?: string;
+  routeTemplate?: string;
+  outcome: AuditEventOutcome;
+  statusCode: number;
+  summary: string;
+  reason?: string | null;
+  correlationId?: string | null;
+  relatedRevisionId?: string | null;
+}
+
+export interface ReadAuditEventsInput {
+  workspaceRoot?: string;
+  serviceRoots?: string[];
+  query?: AuditQuery;
+}
+
+const defaultLimit = 100;
+const maxLimit = 500;
+
+function auditDateSegment(timestamp: string): string {
+  return timestamp.slice(0, 10);
+}
+
+function getRuntimeAuditPath(workspaceRoot: string, timestamp: string): string {
+  return path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${auditDateSegment(timestamp)}.jsonl`);
+}
+
+function getRuntimeAuditDir(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".service-lasso", "audit", "runtime");
+}
+
+function getServiceAuditPath(serviceRoot: string): string {
+  return path.join(serviceRoot, ".state", "audit", "events.jsonl");
+}
+
+function stableHash(input: unknown): string {
+  return createHash("sha256").update(JSON.stringify(input), "utf8").digest("hex");
+}
+
+function parseJsonl(content: string): AuditEvent[] {
+  return content
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as AuditEvent];
+      } catch {
+        return [];
+      }
+    });
+}
+
+async function readAuditFile(filePath: string): Promise<AuditEvent[]> {
+  const content = await readFile(filePath, "utf8").catch((error: unknown) => {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  });
+
+  return parseJsonl(content);
+}
+
+async function appendAuditLine(filePath: string, event: AuditEvent): Promise<void> {
+  const existing = await readAuditFile(filePath);
+  const previous = existing.at(-1);
+  const sequence = previous ? previous.sequence + 1 : 1;
+  const previousHash = previous?.eventHash ?? null;
+  const eventWithoutHash = {
+    ...event,
+    sequence,
+    previousHash,
+    eventHash: "",
+  };
+  const eventHash = stableHash(eventWithoutHash);
+  const nextEvent: AuditEvent = {
+    ...eventWithoutHash,
+    eventHash,
+  };
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${existing.map((entry) => JSON.stringify(entry)).join("\n")}${existing.length > 0 ? "\n" : ""}${JSON.stringify(nextEvent)}\n`);
+}
+
+export async function appendAuditEvent(input: AppendAuditEventInput): Promise<AuditEvent> {
+  const timestamp = new Date().toISOString();
+  const chainId = input.serviceId ? `service:${input.serviceId}` : "runtime";
+  const event: AuditEvent = {
+    id: randomUUID(),
+    timestamp,
+    source: input.source,
+    action: input.action,
+    actor: input.actor?.trim() || "unknown",
+    subject: input.subject,
+    serviceId: input.serviceId,
+    method: input.method,
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary: input.summary,
+    reason: input.reason ?? null,
+    correlationId: input.correlationId ?? randomUUID(),
+    relatedRevisionId: input.relatedRevisionId ?? null,
+    chainId,
+    sequence: 0,
+    previousHash: null,
+    eventHash: "",
+    chainStatus: "valid",
+  };
+  const filePath =
+    input.serviceRoot && input.serviceId
+      ? getServiceAuditPath(input.serviceRoot)
+      : input.workspaceRoot
+        ? getRuntimeAuditPath(input.workspaceRoot, timestamp)
+        : null;
+
+  if (!filePath) {
+    return event;
+  }
+
+  await appendAuditLine(filePath, event);
+  const [persisted] = (await readAuditFile(filePath)).slice(-1);
+  return persisted ?? event;
+}
+
+function normalizeLimit(value: string | undefined): number {
+  const parsed = value ? Number(value) : defaultLimit;
+  if (!Number.isFinite(parsed) || parsed < 1) return defaultLimit;
+  return Math.min(Math.trunc(parsed), maxLimit);
+}
+
+function normalizeCursor(value: string | undefined): number {
+  const parsed = value ? Number(value) : 0;
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.trunc(parsed);
+}
+
+function matchesQuery(event: AuditEvent, query: AuditQuery): boolean {
+  if (query.serviceId && event.serviceId !== query.serviceId) return false;
+  if (query.actor && event.actor !== query.actor) return false;
+  if (query.action && event.action !== query.action) return false;
+  if (query.outcome && event.outcome !== query.outcome) return false;
+  if (query.source && event.source !== query.source) return false;
+  if (query.since && event.timestamp < query.since) return false;
+  if (query.until && event.timestamp > query.until) return false;
+
+  if (query.query) {
+    const needle = query.query.toLowerCase();
+    const haystack = [
+      event.id,
+      event.source,
+      event.action,
+      event.actor,
+      event.subject,
+      event.serviceId,
+      event.method,
+      event.routeTemplate,
+      event.summary,
+      event.reason,
+      event.relatedRevisionId,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(needle);
+  }
+
+  return true;
+}
+
+export async function readAuditEvents(input: ReadAuditEventsInput): Promise<AuditResponse> {
+  const query = input.query ?? {};
+  const limit = normalizeLimit(query.limit);
+  const cursor = normalizeCursor(query.cursor);
+  const files: string[] = [];
+
+  if (input.workspaceRoot) {
+    const runtimeAuditDir = getRuntimeAuditDir(input.workspaceRoot);
+    const entries = await readdir(runtimeAuditDir, { withFileTypes: true }).catch(() => []);
+    files.push(
+      ...entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .map((entry) => path.join(runtimeAuditDir, entry.name)),
+    );
+  }
+
+  for (const serviceRoot of input.serviceRoots ?? []) {
+    files.push(getServiceAuditPath(serviceRoot));
+  }
+
+  const events = (
+    await Promise.all(files.map(async (filePath) => readAuditFile(filePath)))
+  )
+    .flat()
+    .filter((event) => matchesQuery(event, query))
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp));
+  const page = events.slice(cursor, cursor + limit);
+  const nextCursor = cursor + page.length < events.length ? String(cursor + page.length) : null;
+
+  return {
+    events: page,
+    pagination: {
+      limit,
+      nextCursor,
+      total: events.length,
+    },
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -44,6 +44,7 @@ import { buildDashboardService, buildDashboardSummary } from "../runtime/operato
 import { buildServiceMetrics } from "../runtime/operator/metrics.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
+import { appendAuditEvent, readAuditEvents } from "../runtime/audit/store.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
 import { rehydrateDiscoveredServices } from "../runtime/state/rehydrate.js";
@@ -69,6 +70,7 @@ import type {
   RuntimeOrchestrationResponse,
   ServiceActionRunResponse,
   ServiceActionRunsResponse,
+  AuditQuery,
   ServiceDetailResponse,
   ServicesMetaResponse,
   ServiceSummary,
@@ -213,6 +215,40 @@ function parseUpdateInstallBody(input: unknown): { force?: boolean } {
   return {
     force: typeof candidate.force === "boolean" ? candidate.force : undefined,
   };
+}
+
+function parseAuditQuery(searchParams: URLSearchParams): AuditQuery {
+  const query: AuditQuery = {};
+
+  for (const key of ["serviceId", "actor", "action", "source", "since", "until", "query", "limit", "cursor"] as const) {
+    const value = searchParams.get(key);
+    if (value !== null && value.trim()) {
+      query[key] = value.trim();
+    }
+  }
+
+  const outcome = searchParams.get("outcome");
+  if (outcome === "success" || outcome === "failure") {
+    query.outcome = outcome;
+  }
+
+  return query;
+}
+
+function getApiErrorStatusCode(error: unknown): number {
+  if (error && typeof error === "object" && "statusCode" in error && typeof error.statusCode === "number") {
+    return error.statusCode;
+  }
+
+  return 500;
+}
+
+function getAuditFailureReason(error: unknown): string {
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+    return error.message;
+  }
+
+  return "Request failed.";
 }
 
 async function loadRuntimeModel(servicesRoot: string) {
@@ -513,6 +549,20 @@ async function routeRequest(
     return;
   }
 
+  if (request.method === "GET" && url.pathname === "/api/audit") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(
+      response,
+      200,
+      await readAuditEvents({
+        workspaceRoot: config.workspaceRoot,
+        serviceRoots: runtimeModel.registry.list().map((service) => service.serviceRoot),
+        query: parseAuditQuery(url.searchParams),
+      }),
+    );
+    return;
+  }
+
   if (request.method === "GET" && url.pathname === "/api/setup") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, {
@@ -652,23 +702,92 @@ async function routeRequest(
     }
 
     if (request.method === "PUT" && pathParts.length === 4 && pathParts[3] === "config") {
-      writeJson(response, 200, await saveServiceConfigDocument(service, await readJsonBody(request)));
+      try {
+        const result = await saveServiceConfigDocument(service, await readJsonBody(request));
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.config.save",
+          actor: result.backup.actor,
+          subject: "server.json",
+          serviceId,
+          method: "PUT",
+          routeTemplate: "/api/services/:serviceId/config",
+          outcome: "success",
+          statusCode: 200,
+          summary: "Saved service config document.",
+          relatedRevisionId: result.backup.id,
+        });
+        writeJson(response, 200, result);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.config.save",
+          actor: "unknown",
+          subject: "server.json",
+          serviceId,
+          method: "PUT",
+          routeTemplate: "/api/services/:serviceId/config",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to save service config document.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
     if (request.method === "PATCH" && pathParts.length === 4 && pathParts[3] === "meta") {
-      const patch = parseServiceMetaPatch(await readJsonBody(request));
-      const persisted = await writeServiceMeta(service.serviceRoot, patch);
+      try {
+        const patch = parseServiceMetaPatch(await readJsonBody(request));
+        const persisted = await writeServiceMeta(service.serviceRoot, patch);
 
-      writeJson(
-        response,
-        200,
-        createServiceMetaResponse(serviceId, {
-          id: serviceId,
-          favorite: persisted.favorite,
-          dependencyGraphPosition: persisted.dependencyGraphPosition,
-        }),
-      );
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.meta.update",
+          actor: "unknown",
+          subject: "service-meta",
+          serviceId,
+          method: "PATCH",
+          routeTemplate: "/api/services/:serviceId/meta",
+          outcome: "success",
+          statusCode: 200,
+          summary: [
+            patch.favorite !== undefined ? "favorite" : null,
+            "dependencyGraphPosition" in patch ? "dependencyGraphPosition" : null,
+          ]
+            .filter(Boolean)
+            .join(", "),
+        });
+        writeJson(
+          response,
+          200,
+          createServiceMetaResponse(serviceId, {
+            id: serviceId,
+            favorite: persisted.favorite,
+            dependencyGraphPosition: persisted.dependencyGraphPosition,
+          }),
+        );
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.meta.update",
+          actor: "unknown",
+          subject: "service-meta",
+          serviceId,
+          method: "PATCH",
+          routeTemplate: "/api/services/:serviceId/meta",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to update service metadata.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
@@ -809,7 +928,39 @@ async function routeRequest(
 
     if (request.method === "POST" && pathParts.length === 4) {
       const action = pathParts[3];
-      writeJson(response, 200, await executeLifecycleAction(action, service, runtimeModel.registry));
+      try {
+        const result = await executeLifecycleAction(action, service, runtimeModel.registry);
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: `service.lifecycle.${action}`,
+          actor: "unknown",
+          subject: "service-lifecycle",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/:action",
+          outcome: result.ok ? "success" : "failure",
+          statusCode: 200,
+          summary: result.message,
+        });
+        writeJson(response, 200, result);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: `service.lifecycle.${action}`,
+          actor: "unknown",
+          subject: "service-lifecycle",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/:action",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to run service lifecycle action.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
   }
@@ -849,7 +1000,37 @@ async function routeRequest(
     }
 
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    writeJson(response, 200, await executeRuntimeOrchestrationAction(action, runtimeModel));
+    try {
+      const result = await executeRuntimeOrchestrationAction(action, runtimeModel);
+      await appendAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        source: "runtime-api",
+        action: `runtime.${action}`,
+        actor: "unknown",
+        subject: "runtime",
+        method: "POST",
+        routeTemplate: "/api/runtime/actions/:action",
+        outcome: result.ok ? "success" : "failure",
+        statusCode: 200,
+        summary: `Runtime action ${action} completed for ${result.results.length} service result(s).`,
+      });
+      writeJson(response, 200, result);
+    } catch (error) {
+      await appendAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        source: "runtime-api",
+        action: `runtime.${action}`,
+        actor: "unknown",
+        subject: "runtime",
+        method: "POST",
+        routeTemplate: "/api/runtime/actions/:action",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        summary: `Runtime action ${action} failed.`,
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -141,6 +141,15 @@ async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   }
 }
 
+function getAuditActor(input: unknown): string {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return "unknown";
+  }
+
+  const actor = (input as Record<string, unknown>).actor;
+  return typeof actor === "string" && actor.trim().length > 0 ? actor.trim() : "unknown";
+}
+
 function parseServiceMetaPatch(
   input: unknown,
 ): { favorite?: boolean; dependencyGraphPosition?: { x: number; y: number } | null } {
@@ -899,18 +908,20 @@ async function routeRequest(
 
     if (request.method === "POST" && pathParts.length === 6 && pathParts[3] === "actions" && pathParts[5] === "runs") {
       const actionId = decodeURIComponent(pathParts[4] ?? "");
+      const requestBody = await readJsonBody(request);
+      const auditActor = getAuditActor(requestBody);
       try {
         const payload: ServiceActionRunResponse = await runServiceAction(
           service,
           runtimeModel.registry,
           actionId,
-          parseServiceActionRunRequest(await readJsonBody(request)),
+          parseServiceActionRunRequest(requestBody),
         );
         await appendAuditEvent({
           serviceRoot: service.serviceRoot,
           source: "runtime-api",
           action: "service.action.run",
-          actor: "unknown",
+          actor: auditActor,
           subject: actionId,
           serviceId,
           method: "POST",
@@ -926,7 +937,7 @@ async function routeRequest(
           serviceRoot: service.serviceRoot,
           source: "runtime-api",
           action: "service.action.run",
-          actor: "unknown",
+          actor: auditActor,
           subject: actionId,
           serviceId,
           method: "POST",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -877,41 +877,203 @@ async function routeRequest(
 
     if (request.method === "POST" && pathParts.length === 6 && pathParts[3] === "actions" && pathParts[5] === "runs") {
       const actionId = decodeURIComponent(pathParts[4] ?? "");
-      const payload: ServiceActionRunResponse = await runServiceAction(
-        service,
-        runtimeModel.registry,
-        actionId,
-        parseServiceActionRunRequest(await readJsonBody(request)),
-      );
-      writeJson(response, 200, payload);
+      try {
+        const payload: ServiceActionRunResponse = await runServiceAction(
+          service,
+          runtimeModel.registry,
+          actionId,
+          parseServiceActionRunRequest(await readJsonBody(request)),
+        );
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.action.run",
+          actor: "unknown",
+          subject: actionId,
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/actions/:actionId/runs",
+          outcome: payload.ok ? "success" : "failure",
+          statusCode: 200,
+          summary: `Service action ${actionId} completed from ${payload.run.metadata.source}.`,
+          relatedRevisionId: payload.run.runId,
+        });
+        writeJson(response, 200, payload);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.action.run",
+          actor: "unknown",
+          subject: actionId,
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/actions/:actionId/runs",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: `Failed to run service action ${actionId}.`,
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
     if (request.method === "POST" && pathParts.length >= 5 && pathParts[3] === "setup" && pathParts[4] === "run") {
       const stepId = pathParts.length === 6 ? decodeURIComponent(pathParts[5] ?? "") : undefined;
-      const result = await runServiceSetup(service, runtimeModel.registry, { stepId, includeManual: stepId !== undefined });
-      await writeServiceState(service, result.state);
-      writeJson(response, 200, result);
+      try {
+        const result = await runServiceSetup(service, runtimeModel.registry, { stepId, includeManual: stepId !== undefined });
+        await writeServiceState(service, result.state);
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.setup.run",
+          actor: "unknown",
+          subject: stepId ?? "all",
+          serviceId,
+          method: "POST",
+          routeTemplate: stepId ? "/api/services/:serviceId/setup/run/:stepId" : "/api/services/:serviceId/setup/run",
+          outcome: result.ok ? "success" : "failure",
+          statusCode: 200,
+          summary: `Setup run completed for ${result.runs.length} step(s), ${result.skipped.length} skipped.`,
+          relatedRevisionId: result.runs[0]?.runId ?? null,
+        });
+        writeJson(response, 200, result);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.setup.run",
+          actor: "unknown",
+          subject: stepId ?? "all",
+          serviceId,
+          method: "POST",
+          routeTemplate: stepId ? "/api/services/:serviceId/setup/run/:stepId" : "/api/services/:serviceId/setup/run",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to run service setup.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
     if (request.method === "POST" && pathParts.length === 5 && pathParts[3] === "recovery" && pathParts[4] === "doctor") {
-      writeJson(response, 200, {
-        serviceId,
-        doctor: await runAndRecordDoctorPreflight(service),
-        recovery: await readServiceRecoveryHistory(service),
-      });
+      try {
+        const doctor = await runAndRecordDoctorPreflight(service);
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.recovery.doctor",
+          actor: "unknown",
+          subject: "doctor",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/recovery/doctor",
+          outcome: doctor.ok ? "success" : "failure",
+          statusCode: 200,
+          summary: `Recovery doctor completed with ${doctor.steps.length} step(s).`,
+        });
+        writeJson(response, 200, {
+          serviceId,
+          doctor,
+          recovery: await readServiceRecoveryHistory(service),
+        });
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.recovery.doctor",
+          actor: "unknown",
+          subject: "doctor",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/recovery/doctor",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to run recovery doctor.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
     if (request.method === "POST" && pathParts.length === 5 && pathParts[3] === "update" && pathParts[4] === "download") {
-      writeJson(response, 200, await downloadServiceUpdateCandidate(service));
+      try {
+        const result = await downloadServiceUpdateCandidate(service);
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.update.download",
+          actor: "unknown",
+          subject: "update-candidate",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/update/download",
+          outcome: "success",
+          statusCode: 200,
+          summary: `Downloaded update candidate with status ${result.result.status}.`,
+          relatedRevisionId: result.update.available?.tag ?? null,
+        });
+        writeJson(response, 200, result);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.update.download",
+          actor: "unknown",
+          subject: "update-candidate",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/update/download",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to download update candidate.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 
     if (request.method === "POST" && pathParts.length === 5 && pathParts[3] === "update" && pathParts[4] === "install") {
-      const body = parseUpdateInstallBody(await readJsonBody(request));
-      writeJson(response, 200, await installServiceUpdateCandidate(service, { force: body.force, registry: runtimeModel.registry }));
+      try {
+        const body = parseUpdateInstallBody(await readJsonBody(request));
+        const result = await installServiceUpdateCandidate(service, { force: body.force, registry: runtimeModel.registry });
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.update.install",
+          actor: "unknown",
+          subject: "update-candidate",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/update/install",
+          outcome: "success",
+          statusCode: 200,
+          summary: `Installed update candidate with force=${result.forced}.`,
+          relatedRevisionId: result.state.installArtifacts.artifact?.tag ?? null,
+        });
+        writeJson(response, 200, result);
+      } catch (error) {
+        await appendAuditEvent({
+          serviceRoot: service.serviceRoot,
+          source: "runtime-api",
+          action: "service.update.install",
+          actor: "unknown",
+          subject: "update-candidate",
+          serviceId,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/update/install",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          summary: "Failed to install update candidate.",
+          reason: getAuditFailureReason(error),
+        });
+        throw error;
+      }
       return;
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -581,7 +581,29 @@ async function routeRequest(
   if (request.method === "POST" && url.pathname === "/api/updates/check") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     const body = parseUpdateCheckBody(await readJsonBody(request));
-    writeJson(response, 200, await checkServiceUpdatesForCli(runtimeModel.registry.list(), body.serviceId));
+    const result = await checkServiceUpdatesForCli(runtimeModel.registry.list(), body.serviceId);
+    await Promise.all(result.services.map(async (checked) => {
+      const service = runtimeModel.registry.getById(checked.serviceId);
+      if (!service) {
+        return;
+      }
+
+      await appendAuditEvent({
+        serviceRoot: service.serviceRoot,
+        source: "runtime-api",
+        action: "service.update.check",
+        actor: "unknown",
+        subject: "update-check",
+        serviceId: checked.serviceId,
+        method: "POST",
+        routeTemplate: "/api/updates/check",
+        outcome: checked.result.status === "check_failed" || checked.result.status === "unavailable" ? "failure" : "success",
+        statusCode: 200,
+        summary: `Update check returned ${checked.result.status}; recommended action ${checked.recommendedAction}.`,
+        relatedRevisionId: checked.result.available?.tag ?? null,
+      });
+    }));
+    writeJson(response, 200, result);
     return;
   }
 

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
@@ -14,8 +14,14 @@ async function getJson(url) {
   };
 }
 
-async function postJson(url) {
-  const response = await fetch(url, { method: "POST" });
+async function postJson(url, body = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
   return {
     status: response.status,
     body: await response.json(),
@@ -50,13 +56,55 @@ async function putJson(url, body) {
   };
 }
 
+async function writeAuditScript(serviceRoot) {
+  const runtimeRoot = path.join(serviceRoot, "runtime");
+  await mkdir(runtimeRoot, { recursive: true });
+  await writeFile(
+    path.join(runtimeRoot, "audit-writer.mjs"),
+    [
+      "console.log('AUDIT_SECRET_OUTPUT');",
+      "console.error('AUDIT_SECRET_STDERR');",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 test("audit API returns durable safe service and runtime mutation events after restart", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-");
   const workspaceRoot = path.join(tempRoot, "workspace");
   const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "audit-service", {
     healthcheck: { type: "process" },
+    doctor: {
+      enabled: true,
+      failurePolicy: "block",
+      steps: [
+        {
+          name: "doctor-pass",
+          command: process.execPath,
+          args: ["-e", "process.exit(0)"],
+        },
+      ],
+    },
+    setup: {
+      steps: {
+        "write-audit-proof": {
+          executable: process.execPath,
+          args: ["runtime/audit-writer.mjs"],
+          timeoutSeconds: 5,
+        },
+      },
+    },
+    actions: {
+      "write-audit-proof": {
+        mode: "command",
+        command: process.execPath,
+        args: ["runtime/audit-writer.mjs"],
+        timeoutSeconds: 5,
+      },
+    },
   });
+  await writeAuditScript(serviceRoot);
   let apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
 
   try {
@@ -66,10 +114,20 @@ test("audit API returns durable safe service and runtime mutation events after r
 
     const install = await postJson(`${apiServer.url}/api/services/audit-service/install`);
     assert.equal(install.status, 200);
+    const config = await postJson(`${apiServer.url}/api/services/audit-service/config`);
+    assert.equal(config.status, 200);
     const meta = await patchJson(`${apiServer.url}/api/services/audit-service/meta`, { favorite: true });
     assert.equal(meta.status, 200);
     const runtime = await postJson(`${apiServer.url}/api/runtime/actions/stopAll`);
     assert.equal(runtime.status, 200);
+    const setup = await postJson(`${apiServer.url}/api/services/audit-service/setup/run/write-audit-proof`);
+    assert.equal(setup.status, 200);
+    const recovery = await postJson(`${apiServer.url}/api/services/audit-service/recovery/doctor`);
+    assert.equal(recovery.status, 200);
+    const action = await postJson(`${apiServer.url}/api/services/audit-service/actions/write-audit-proof/runs`, {
+      source: "manual",
+    });
+    assert.equal(action.status, 200);
 
     const currentConfig = await getJson(`${apiServer.url}/api/services/audit-service/config`);
     assert.equal(currentConfig.status, 200);
@@ -91,10 +149,18 @@ test("audit API returns durable safe service and runtime mutation events after r
 
     const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=10`);
     assert.equal(audit.status, 200);
-    assert.equal(audit.body.pagination.total, 3);
+    assert.equal(audit.body.pagination.total, 7);
     assert.deepEqual(
       audit.body.events.map((event) => event.action).sort(),
-      ["service.config.save", "service.lifecycle.install", "service.meta.update"],
+      [
+        "service.action.run",
+        "service.config.save",
+        "service.lifecycle.config",
+        "service.lifecycle.install",
+        "service.meta.update",
+        "service.recovery.doctor",
+        "service.setup.run",
+      ],
     );
 
     const configEvent = audit.body.events.find((event) => event.action === "service.config.save");
@@ -105,6 +171,20 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.ok(configEvent.eventHash);
     assert.equal(configEvent.chainStatus, "valid");
 
+    const setupEvent = audit.body.events.find((event) => event.action === "service.setup.run");
+    assert.equal(setupEvent.subject, "write-audit-proof");
+    assert.equal(setupEvent.outcome, "success");
+    assert.equal(setupEvent.relatedRevisionId, setup.body.runs[0].runId);
+
+    const recoveryEvent = audit.body.events.find((event) => event.action === "service.recovery.doctor");
+    assert.equal(recoveryEvent.subject, "doctor");
+    assert.equal(recoveryEvent.outcome, "success");
+
+    const actionEvent = audit.body.events.find((event) => event.action === "service.action.run");
+    assert.equal(actionEvent.subject, "write-audit-proof");
+    assert.equal(actionEvent.outcome, "success");
+    assert.equal(actionEvent.relatedRevisionId, action.body.run.runId);
+
     const runtimeAudit = await getJson(`${apiServer.url}/api/audit?action=runtime.stopAll`);
     assert.equal(runtimeAudit.status, 200);
     assert.equal(runtimeAudit.body.events.length, 1);
@@ -113,10 +193,14 @@ test("audit API returns durable safe service and runtime mutation events after r
     const secretSearch = await getJson(`${apiServer.url}/api/audit?query=SUPER_SECRET_VALUE`);
     assert.equal(secretSearch.status, 200);
     assert.equal(secretSearch.body.pagination.total, 0);
+    const setupOutputSearch = await getJson(`${apiServer.url}/api/audit?query=AUDIT_SECRET_OUTPUT`);
+    assert.equal(setupOutputSearch.status, 200);
+    assert.equal(setupOutputSearch.body.pagination.total, 0);
 
     const serviceAuditFile = path.join(serviceRoot, ".state", "audit", "events.jsonl");
     const runtimeAuditFile = path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${new Date().toISOString().slice(0, 10)}.jsonl`);
     assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
+    assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /AUDIT_SECRET_OUTPUT/u);
     assert.doesNotMatch(await readFile(runtimeAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
   } finally {
     await apiServer.stop().catch(() => undefined);

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -167,6 +167,12 @@ test("audit API returns durable safe service and runtime mutation events after r
         args: ["runtime/audit-writer.mjs"],
         timeoutSeconds: 5,
       },
+      "dangerous-audit-proof": {
+        mode: "command",
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        requiresConfirmation: true,
+      },
     },
   });
   await writeAuditScript(serviceRoot);
@@ -193,6 +199,16 @@ test("audit API returns durable safe service and runtime mutation events after r
       source: "manual",
     });
     assert.equal(action.status, 200);
+    const missingConfirmation = await postJson(`${apiServer.url}/api/services/audit-service/actions/dangerous-audit-proof/runs`, {
+      actor: "operator-ui",
+    });
+    assert.equal(missingConfirmation.status, 409);
+    assert.equal(missingConfirmation.body.error, "confirmation_required");
+    const confirmedAction = await postJson(`${apiServer.url}/api/services/audit-service/actions/dangerous-audit-proof/runs`, {
+      actor: "operator-ui",
+      confirm: true,
+    });
+    assert.equal(confirmedAction.status, 200);
 
     const currentConfig = await getJson(`${apiServer.url}/api/services/audit-service/config`);
     assert.equal(currentConfig.status, 200);
@@ -214,10 +230,12 @@ test("audit API returns durable safe service and runtime mutation events after r
 
     const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=10`);
     assert.equal(audit.status, 200);
-    assert.equal(audit.body.pagination.total, 7);
+    assert.equal(audit.body.pagination.total, 9);
     assert.deepEqual(
       audit.body.events.map((event) => event.action).sort(),
       [
+        "service.action.run",
+        "service.action.run",
         "service.action.run",
         "service.config.save",
         "service.lifecycle.config",
@@ -245,10 +263,21 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.equal(recoveryEvent.subject, "doctor");
     assert.equal(recoveryEvent.outcome, "success");
 
-    const actionEvent = audit.body.events.find((event) => event.action === "service.action.run");
+    const actionEvent = audit.body.events.find(
+      (event) => event.action === "service.action.run" && event.subject === "write-audit-proof",
+    );
     assert.equal(actionEvent.subject, "write-audit-proof");
     assert.equal(actionEvent.outcome, "success");
     assert.equal(actionEvent.relatedRevisionId, action.body.run.runId);
+
+    const confirmationEvents = audit.body.events.filter((event) => event.subject === "dangerous-audit-proof");
+    assert.equal(confirmationEvents.length, 2);
+    assert.deepEqual(confirmationEvents.map((event) => event.actor), ["operator-ui", "operator-ui"]);
+    assert.deepEqual(confirmationEvents.map((event) => event.outcome).sort(), ["failure", "success"]);
+    const confirmationFailure = confirmationEvents.find((event) => event.outcome === "failure");
+    assert.match(confirmationFailure.reason, /requires explicit confirmation/u);
+    const confirmationSuccess = confirmationEvents.find((event) => event.outcome === "success");
+    assert.equal(confirmationSuccess.relatedRevisionId, confirmedAction.body.run.runId);
 
     const runtimeAudit = await getJson(`${apiServer.url}/api/audit?action=runtime.stopAll`);
     assert.equal(runtimeAudit.status, 200);

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { createServer } from "node:http";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
-import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+import { makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 async function getJson(url) {
   const response = await fetch(url);
@@ -67,6 +68,70 @@ async function writeAuditScript(serviceRoot) {
     ].join("\n"),
     "utf8",
   );
+}
+
+async function startAuditReleaseServer() {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/repos/service-lasso/audit-update-fixture/releases/latest") {
+      const baseUrl = `http://127.0.0.1:${server.address().port}`;
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify({
+        tag_name: "2026.4.24-new",
+        name: "2026.4.24-new",
+        html_url: `${baseUrl}/releases/2026.4.24-new`,
+        published_at: "2026-04-24T00:00:00Z",
+        assets: [
+          {
+            name: "audit-update-fixture.zip",
+            browser_download_url: `${baseUrl}/downloads/audit-update-fixture.zip`,
+          },
+        ],
+      }));
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end();
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+    stop: async () => {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+function createAuditUpdateManifest(releaseServer) {
+  return {
+    id: "audit-update-service",
+    name: "Audit Update Service",
+    description: "Release-backed fixture for audit update checks.",
+    version: "2026.4.20-old",
+    artifact: {
+      kind: "archive",
+      source: {
+        type: "github-release",
+        repo: "service-lasso/audit-update-fixture",
+        tag: "2026.4.20-old",
+        api_base_url: releaseServer.baseUrl,
+      },
+      platforms: {
+        default: {
+          assetName: "audit-update-fixture.zip",
+          archiveType: "zip",
+          command: "node",
+          args: ["runtime/audit-update-fixture.mjs"],
+        },
+      },
+    },
+    updates: {
+      mode: "notify",
+      track: "latest",
+    },
+  };
 }
 
 test("audit API returns durable safe service and runtime mutation events after restart", async () => {
@@ -204,6 +269,37 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.doesNotMatch(await readFile(runtimeAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
   } finally {
     await apiServer.stop().catch(() => undefined);
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("audit API records update checks that mutate durable update state", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-update-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const releaseServer = await startAuditReleaseServer();
+  await writeManifest(servicesRoot, "audit-update-service", createAuditUpdateManifest(releaseServer));
+  let apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const check = await postJson(`${apiServer.url}/api/updates/check`, { serviceId: "audit-update-service" });
+    assert.equal(check.status, 200);
+    assert.equal(check.body.services[0].result.status, "update_available");
+
+    await apiServer.stop();
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+    const audit = await getJson(`${apiServer.url}/api/audit?action=service.update.check`);
+    assert.equal(audit.status, 200);
+    assert.equal(audit.body.pagination.total, 1);
+    assert.equal(audit.body.events[0].serviceId, "audit-update-service");
+    assert.equal(audit.body.events[0].outcome, "success");
+    assert.equal(audit.body.events[0].relatedRevisionId, "2026.4.24-new");
+    assert.match(audit.body.events[0].summary, /update_available/u);
+  } finally {
+    await apiServer.stop().catch(() => undefined);
+    await releaseServer.stop();
     await rm(tempRoot, { recursive: true, force: true });
     resetLifecycleState();
   }

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -173,6 +173,16 @@ test("audit API returns durable safe service and runtime mutation events after r
         args: ["-e", "process.exit(0)"],
         requiresConfirmation: true,
       },
+      "scheduled-audit-proof": {
+        mode: "command",
+        command: process.execPath,
+        args: ["runtime/audit-writer.mjs"],
+        schedules: {
+          nightly: {
+            cron: "15 2 * * *",
+          },
+        },
+      },
     },
   });
   await writeAuditScript(serviceRoot);
@@ -209,6 +219,18 @@ test("audit API returns durable safe service and runtime mutation events after r
       confirm: true,
     });
     assert.equal(confirmedAction.status, 200);
+    const scheduledAction = await postJson(`${apiServer.url}/api/services/audit-service/actions/scheduled-audit-proof/runs`, {
+      source: "dagu",
+      workflowId: "audit.workflow.nightly",
+      scheduleId: "nightly",
+      stepId: "run-audit-proof",
+      parentActionId: "audit-parent",
+      actor: "workflow-engine",
+      params: {
+        unsafe: "WORKFLOW_SECRET_PARAM",
+      },
+    });
+    assert.equal(scheduledAction.status, 200);
 
     const currentConfig = await getJson(`${apiServer.url}/api/services/audit-service/config`);
     assert.equal(currentConfig.status, 200);
@@ -230,10 +252,11 @@ test("audit API returns durable safe service and runtime mutation events after r
 
     const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=10`);
     assert.equal(audit.status, 200);
-    assert.equal(audit.body.pagination.total, 9);
+    assert.equal(audit.body.pagination.total, 10);
     assert.deepEqual(
       audit.body.events.map((event) => event.action).sort(),
       [
+        "service.action.run",
         "service.action.run",
         "service.action.run",
         "service.action.run",
@@ -279,6 +302,12 @@ test("audit API returns durable safe service and runtime mutation events after r
     const confirmationSuccess = confirmationEvents.find((event) => event.outcome === "success");
     assert.equal(confirmationSuccess.relatedRevisionId, confirmedAction.body.run.runId);
 
+    const scheduledEvent = audit.body.events.find((event) => event.subject === "scheduled-audit-proof");
+    assert.equal(scheduledEvent.actor, "workflow-engine");
+    assert.equal(scheduledEvent.outcome, "success");
+    assert.equal(scheduledEvent.relatedRevisionId, scheduledAction.body.run.runId);
+    assert.match(scheduledEvent.summary, /dagu/u);
+
     const runtimeAudit = await getJson(`${apiServer.url}/api/audit?action=runtime.stopAll`);
     assert.equal(runtimeAudit.status, 200);
     assert.equal(runtimeAudit.body.events.length, 1);
@@ -290,11 +319,15 @@ test("audit API returns durable safe service and runtime mutation events after r
     const setupOutputSearch = await getJson(`${apiServer.url}/api/audit?query=AUDIT_SECRET_OUTPUT`);
     assert.equal(setupOutputSearch.status, 200);
     assert.equal(setupOutputSearch.body.pagination.total, 0);
+    const workflowParamSearch = await getJson(`${apiServer.url}/api/audit?query=WORKFLOW_SECRET_PARAM`);
+    assert.equal(workflowParamSearch.status, 200);
+    assert.equal(workflowParamSearch.body.pagination.total, 0);
 
     const serviceAuditFile = path.join(serviceRoot, ".state", "audit", "events.jsonl");
     const runtimeAuditFile = path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${new Date().toISOString().slice(0, 10)}.jsonl`);
     assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
     assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /AUDIT_SECRET_OUTPUT/u);
+    assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /WORKFLOW_SECRET_PARAM/u);
     assert.doesNotMatch(await readFile(runtimeAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
   } finally {
     await apiServer.stop().catch(() => undefined);

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function postJson(url) {
+  const response = await fetch(url, { method: "POST" });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function patchJson(url, body) {
+  const response = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function putJson(url, body) {
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+test("audit API returns durable safe service and runtime mutation events after restart", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "audit-service", {
+    healthcheck: { type: "process" },
+  });
+  let apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const initial = await getJson(`${apiServer.url}/api/audit`);
+    assert.equal(initial.status, 200);
+    assert.deepEqual(initial.body.events, []);
+
+    const install = await postJson(`${apiServer.url}/api/services/audit-service/install`);
+    assert.equal(install.status, 200);
+    const meta = await patchJson(`${apiServer.url}/api/services/audit-service/meta`, { favorite: true });
+    assert.equal(meta.status, 200);
+    const runtime = await postJson(`${apiServer.url}/api/runtime/actions/stopAll`);
+    assert.equal(runtime.status, 200);
+
+    const currentConfig = await getJson(`${apiServer.url}/api/services/audit-service/config`);
+    assert.equal(currentConfig.status, 200);
+    const editedConfig = {
+      ...JSON.parse(currentConfig.body.content),
+      env: {
+        SECRET_TOKEN: "SUPER_SECRET_VALUE",
+      },
+    };
+    const save = await putJson(`${apiServer.url}/api/services/audit-service/config`, {
+      actor: "operator-ui",
+      reason: "metadata-only audit coverage",
+      content: JSON.stringify(editedConfig, null, 2),
+    });
+    assert.equal(save.status, 200);
+
+    await apiServer.stop();
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+    const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=10`);
+    assert.equal(audit.status, 200);
+    assert.equal(audit.body.pagination.total, 3);
+    assert.deepEqual(
+      audit.body.events.map((event) => event.action).sort(),
+      ["service.config.save", "service.lifecycle.install", "service.meta.update"],
+    );
+
+    const configEvent = audit.body.events.find((event) => event.action === "service.config.save");
+    assert.equal(configEvent.actor, "operator-ui");
+    assert.equal(configEvent.relatedRevisionId, save.body.backup.id);
+    assert.equal(configEvent.outcome, "success");
+    assert.equal(configEvent.chainId, "service:audit-service");
+    assert.ok(configEvent.eventHash);
+    assert.equal(configEvent.chainStatus, "valid");
+
+    const runtimeAudit = await getJson(`${apiServer.url}/api/audit?action=runtime.stopAll`);
+    assert.equal(runtimeAudit.status, 200);
+    assert.equal(runtimeAudit.body.events.length, 1);
+    assert.equal(runtimeAudit.body.events[0].chainId, "runtime");
+
+    const secretSearch = await getJson(`${apiServer.url}/api/audit?query=SUPER_SECRET_VALUE`);
+    assert.equal(secretSearch.status, 200);
+    assert.equal(secretSearch.body.pagination.total, 0);
+
+    const serviceAuditFile = path.join(serviceRoot, ".state", "audit", "events.jsonl");
+    const runtimeAuditFile = path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
+    assert.doesNotMatch(await readFile(runtimeAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
+  } finally {
+    await apiServer.stop().catch(() => undefined);
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -75,6 +75,7 @@ export async function writeExecutableFixtureService(
     install = undefined,
     config = undefined,
     setup = undefined,
+    actions = undefined,
     role = undefined,
     broker = undefined,
   } = options;
@@ -198,6 +199,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     install,
     config,
     setup,
+    actions,
     healthcheck: healthcheck === null ? undefined : healthcheck,
   });
 


### PR DESCRIPTION
## Summary
- Add a durable runtime audit contract and JSONL-backed audit store.
- Expose `GET /api/audit` with service/action/outcome/source/actor/time/query filters and cursor pagination.
- Append safe metadata-only audit events for service lifecycle actions, runtime orchestration actions, service meta updates, service config saves, service action runs, setup runs, recovery doctor writes, update download/install actions, and update checks.
- Cover confirmation-required action failures, confirmed action execution, and workflow-origin scheduled action runs without storing request payload/output material.

## Scope Reconciliation
- Current core runtime mutation routes are audited: `/api/updates/check`, `/api/services/:serviceId/config`, `/api/services/:serviceId/meta`, `/api/services/:serviceId/actions/:actionId/runs`, `/api/services/:serviceId/setup/run`, `/api/services/:serviceId/recovery/doctor`, `/api/services/:serviceId/update/download`, `/api/services/:serviceId/update/install`, `/api/services/:serviceId/:action`, and `/api/runtime/actions/:action`.
- Workflow facade mutation coverage is represented by workflow-origin service action runs; the current runtime exposes workflow registry reads but no workflow start/cancel/retry or repo activate/rollback mutation routes.
- Operator action queue and terminal/stdin mutation routes are not present in this core runtime repo. Terminal/stdin follow-up remains tracked in `service-lasso/lasso-serviceadmin#275` if that surface becomes supported.
- Future live Secrets Broker actions remain separate cross-repo work and are tracked by `service-lasso/lasso-serviceadmin#305`.

## Validation
- `npm run build`
- `node --test tests/audit.test.js`
- `node --test tests/api-updates.test.js`
- `node --test tests/service-action-runs.test.js tests/api-recovery.test.js tests/setup-lifecycle.test.js tests/api-updates.test.js`
- `npm test`
- Canonical demo startup gate before latest review: `npm run build`, then `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`

## Latest Evidence
- Latest run logs: `C:\projects\service-lasso\.work-agent\logs\run-20260711-223906-dev-cron\`.
- Focused audit regression: `node-test-audit.stdout.log`, exit 0.
- Full repo test: `npm-test.stdout.log`, exit 0.
- Startup demo gate: `demo-gate.json`, exit 0.
- Project status helper confirmed issue #746 is `In progress`; Project hygiene helper timed out, so this PR does not claim project-board hygiene counts are clean.

Closes #746.
