### PR TITLE
fix(audit): bucket service audit events by date

### DIFF
--- a/src/runtime/audit/store.ts
+++ b/src/runtime/audit/store.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
 import type { AuditEvent, AuditEventOutcome, AuditQuery, AuditResponse } from "../../contracts/api.js";
 
 export interface AppendAuditEventInput {
@@ -42,8 +42,12 @@ function getRuntimeAuditDir(workspaceRoot: string): string {
   return path.join(workspaceRoot, ".service-lasso", "audit", "runtime");
 }
 
-function getServiceAuditPath(serviceRoot: string): string {
-  return path.join(serviceRoot, ".state", "audit", "events.jsonl");
+function getServiceAuditDir(serviceRoot: string): string {
+  return path.join(serviceRoot, ".state", "audit");
+}
+
+function getServiceAuditPath(serviceRoot: string, timestamp: string): string {
+  return path.join(getServiceAuditDir(serviceRoot), `${auditDateSegment(timestamp)}.jsonl`);
 }
 
 function stableHash(input: unknown): string {
@@ -75,8 +79,21 @@ async function readAuditFile(filePath: string): Promise<AuditEvent[]> {
   return parseJsonl(content);
 }
 
-async function appendAuditLine(filePath: string, event: AuditEvent): Promise<void> {
-  const existing = await readAuditFile(filePath);
+async function listAuditFiles(auditDir: string): Promise<string[]> {
+  const entries = await readdir(auditDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => path.join(auditDir, entry.name))
+    .sort();
+}
+
+async function readAuditDir(auditDir: string): Promise<AuditEvent[]> {
+  const files = await listAuditFiles(auditDir);
+  return (await Promise.all(files.map(async (filePath) => readAuditFile(filePath)))).flat();
+}
+
+async function appendAuditLine(filePath: string, auditDir: string, event: AuditEvent): Promise<void> {
+  const existing = await readAuditDir(auditDir);
   const previous = existing.at(-1);
   const sequence = previous ? previous.sequence + 1 : 1;
   const previousHash = previous?.eventHash ?? null;
@@ -93,7 +110,7 @@ async function appendAuditLine(filePath: string, event: AuditEvent): Promise<voi
   };
 
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${existing.map((entry) => JSON.stringify(entry)).join("\n")}${existing.length > 0 ? "\n" : ""}${JSON.stringify(nextEvent)}\n`);
+  await appendFile(filePath, `${JSON.stringify(nextEvent)}\n`, "utf8");
 }
 
 export async function appendAuditEvent(input: AppendAuditEventInput): Promise<AuditEvent> {
@@ -121,19 +138,25 @@ export async function appendAuditEvent(input: AppendAuditEventInput): Promise<Au
     eventHash: "",
     chainStatus: "valid",
   };
-  const filePath =
+  const target =
     input.serviceRoot && input.serviceId
-      ? getServiceAuditPath(input.serviceRoot)
+      ? {
+          auditDir: getServiceAuditDir(input.serviceRoot),
+          filePath: getServiceAuditPath(input.serviceRoot, timestamp),
+        }
       : input.workspaceRoot
-        ? getRuntimeAuditPath(input.workspaceRoot, timestamp)
+        ? {
+            auditDir: getRuntimeAuditDir(input.workspaceRoot),
+            filePath: getRuntimeAuditPath(input.workspaceRoot, timestamp),
+          }
         : null;
 
-  if (!filePath) {
+  if (!target) {
     return event;
   }
 
-  await appendAuditLine(filePath, event);
-  const [persisted] = (await readAuditFile(filePath)).slice(-1);
+  await appendAuditLine(target.filePath, target.auditDir, event);
+  const [persisted] = (await readAuditFile(target.filePath)).slice(-1);
   return persisted ?? event;
 }
 
@@ -190,16 +213,11 @@ export async function readAuditEvents(input: ReadAuditEventsInput): Promise<Audi
 
   if (input.workspaceRoot) {
     const runtimeAuditDir = getRuntimeAuditDir(input.workspaceRoot);
-    const entries = await readdir(runtimeAuditDir, { withFileTypes: true }).catch(() => []);
-    files.push(
-      ...entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-        .map((entry) => path.join(runtimeAuditDir, entry.name)),
-    );
+    files.push(...await listAuditFiles(runtimeAuditDir));
   }
 
   for (const serviceRoot of input.serviceRoots ?? []) {
-    files.push(getServiceAuditPath(serviceRoot));
+    files.push(...await listAuditFiles(getServiceAuditDir(serviceRoot)));
   }
 
   const events = (

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -2,9 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { createServer } from "node:http";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { appendAuditEvent, readAuditEvents } from "../dist/runtime/audit/store.js";
 import { makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 async function getJson(url) {
@@ -131,6 +132,18 @@ function createAuditUpdateManifest(releaseServer) {
       mode: "notify",
       track: "latest",
     },
+  };
+}
+
+function createAuditInput(overrides = {}) {
+  return {
+    source: "runtime",
+    action: "runtime.test",
+    actor: "operator:test",
+    outcome: "success",
+    statusCode: 200,
+    summary: "Runtime test completed",
+    ...overrides,
   };
 }
 
@@ -323,7 +336,7 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.equal(workflowParamSearch.status, 200);
     assert.equal(workflowParamSearch.body.pagination.total, 0);
 
-    const serviceAuditFile = path.join(serviceRoot, ".state", "audit", "events.jsonl");
+    const serviceAuditFile = path.join(serviceRoot, ".state", "audit", `${new Date().toISOString().slice(0, 10)}.jsonl`);
     const runtimeAuditFile = path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${new Date().toISOString().slice(0, 10)}.jsonl`);
     assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /SUPER_SECRET_VALUE/u);
     assert.doesNotMatch(await readFile(serviceAuditFile, "utf8"), /AUDIT_SECRET_OUTPUT/u);
@@ -333,6 +346,72 @@ test("audit API returns durable safe service and runtime mutation events after r
     await apiServer.stop().catch(() => undefined);
     await rm(tempRoot, { recursive: true, force: true });
     resetLifecycleState();
+  }
+});
+
+test("audit store keeps service events in portable date-bucket JSONL files", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-portable-");
+  const serviceRoot = path.join(servicesRoot, "portable-service");
+
+  try {
+    await mkdir(serviceRoot, { recursive: true });
+    const event = await appendAuditEvent(createAuditInput({
+      serviceRoot,
+      serviceId: "portable-service",
+      source: "service",
+      action: "service.lifecycle.install",
+      summary: "Service portable-service installed",
+    }));
+    const auditFile = path.join(serviceRoot, ".state", "audit", `${event.timestamp.slice(0, 10)}.jsonl`);
+    const raw = await readFile(auditFile, "utf8");
+
+    assert.equal(raw.trim().split(/\r?\n/u).length, 1);
+    assert.match(raw, /service\.lifecycle\.install/u);
+
+    const movedRoot = path.join(servicesRoot, "portable-service-copy");
+    await rename(serviceRoot, movedRoot);
+    const result = await readAuditEvents({
+      serviceRoots: [movedRoot],
+      query: { serviceId: "portable-service" },
+    });
+
+    assert.equal(result.pagination.total, 1);
+    assert.equal(result.events[0].id, event.id);
+    assert.equal(result.events[0].serviceId, "portable-service");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("audit reader ignores corrupt JSONL rows and returns valid events newest first", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-corrupt-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const serviceRoot = path.join(servicesRoot, "corrupt-service");
+
+  try {
+    await mkdir(serviceRoot, { recursive: true });
+    const runtimeEvent = await appendAuditEvent(createAuditInput({
+      workspaceRoot,
+      action: "runtime.old",
+      summary: "Old runtime event",
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const serviceEvent = await appendAuditEvent(createAuditInput({
+      serviceRoot,
+      serviceId: "corrupt-service",
+      source: "service",
+      action: "service.new",
+      summary: "New service event",
+    }));
+    const serviceAuditFile = path.join(serviceRoot, ".state", "audit", `${serviceEvent.timestamp.slice(0, 10)}.jsonl`);
+    await writeFile(serviceAuditFile, `${await readFile(serviceAuditFile, "utf8")}{not-json}\n`, "utf8");
+
+    const result = await readAuditEvents({ workspaceRoot, serviceRoots: [serviceRoot] });
+
+    assert.equal(result.pagination.total, 2);
+    assert.deepEqual(result.events.map((event) => event.id), [serviceEvent.id, runtimeEvent.id]);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Rebases #751 onto current `origin/main` with a focused audit-store patch instead of merging the stale branch.
- Stores service-scoped audit JSONL under `<serviceRoot>/.state/audit/YYYY-MM-DD.jsonl` so state remains portable with the service root.
- Reads all runtime/service audit bucket files, appends one JSON object per line, and preserves corrupt-line tolerance.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/audit.test.js`
- `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`
- `node scripts/demo-verify-canonical.mjs --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json`

Evidence logs: `C:\projects\service-lasso\.work-agent\logs\issue-751-current-base-20260714T154259`

Closes #751