### PR TITLE
Fix #755 audit mutation demo proof

### DIFF
--- a/scripts/demo-deploy-canonical.mjs
+++ b/scripts/demo-deploy-canonical.mjs
@@ -423,16 +423,23 @@ function unmanagedOwners(portOwners, options) {
   );
 }
 
+export function buildCanonicalDeployRecycleArgs(options) {
+  return [
+    path.join(repoRoot, "scripts", "demo-recycle.mjs"),
+    `--port=${options.runtimePort}`,
+    `--host=${options.host}`,
+    `--runtime-url=${options.runtimeUrl}`,
+    `--admin-url=${options.serviceAdminUrl}`,
+    `--services-root=${options.servicesRoot}`,
+    `--workspace-root=${options.workspaceRoot}`,
+  ];
+}
+
 async function runRecycle(options, logPath) {
   const stdout = await open(logPath, "a");
   const stderr = await open(logPath, "a");
   const command = process.execPath;
-  const args = [
-    path.join(repoRoot, "scripts", "demo-recycle.mjs"),
-    `--port=${options.runtimePort}`,
-    `--services-root=${options.servicesRoot}`,
-    `--workspace-root=${options.workspaceRoot}`,
-  ];
+  const args = buildCanonicalDeployRecycleArgs(options);
 
   return await new Promise((resolve) => {
     const child = spawn(command, args, {
@@ -442,6 +449,9 @@ async function runRecycle(options, logPath) {
       env: {
         ...process.env,
         SERVICE_LASSO_PORT: String(options.runtimePort),
+        SERVICE_LASSO_HOST: options.host,
+        SERVICE_LASSO_RUNTIME_URL: options.runtimeUrl,
+        SERVICE_LASSO_ADMIN_URL: options.serviceAdminUrl,
       },
     });
     let settled = false;

--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -855,6 +855,7 @@ export async function startDetachedDemoRuntime(options = {}) {
       "--preserve",
       `--port=${port}`,
       `--host=${options.host ?? process.env.SERVICE_LASSO_HOST ?? "127.0.0.1"}`,
+      `--runtime-url=${options.runtimeUrl ?? process.env.SERVICE_LASSO_RUNTIME_URL ?? `http://127.0.0.1:${port}`}`,
       `--services-root=${servicesRoot}`,
       `--workspace-root=${workspaceRoot}`,
       `--admin-url=${options.serviceAdminUrl ?? "http://127.0.0.1:17700/"}`,
@@ -865,6 +866,7 @@ export async function startDetachedDemoRuntime(options = {}) {
         ...process.env,
         SERVICE_LASSO_PORT: String(port),
         SERVICE_LASSO_HOST: options.host ?? process.env.SERVICE_LASSO_HOST ?? "127.0.0.1",
+        SERVICE_LASSO_RUNTIME_URL: options.runtimeUrl ?? process.env.SERVICE_LASSO_RUNTIME_URL ?? `http://127.0.0.1:${port}`,
         SERVICE_LASSO_SERVICES_ROOT: servicesRoot,
         SERVICE_LASSO_WORKSPACE_ROOT: workspaceRoot,
       },
@@ -1287,6 +1289,9 @@ export async function runDemoRecycle(options = {}) {
   const servicesRoot = path.resolve(options.servicesRoot ?? defaultDemoServicesRoot);
   const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
   const port = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
+  const host = options.host ?? process.env.SERVICE_LASSO_HOST ?? "127.0.0.1";
+  const runtimeUrl = options.runtimeUrl ?? `http://127.0.0.1:${port}`;
+  const serviceAdminUrl = (options.serviceAdminUrl ?? "http://127.0.0.1:17700").replace(/\/$/, "");
   const preserve = options.preserve === true;
   const keepAlive = options.keepAlive === true;
   await assertDemoRecycleOwnership({ servicesRoot, workspaceRoot, port });
@@ -1295,12 +1300,12 @@ export async function runDemoRecycle(options = {}) {
   await assertDemoPortsAvailable({ port, workspaceRoot });
   await resetDemoInstance({ servicesRoot, workspaceRoot });
 
-  const runtime = await startDemoRuntime({ servicesRoot, workspaceRoot, port, skipBootstrap: true });
+  const runtime = await startDemoRuntime({ servicesRoot, workspaceRoot, port, host, serviceAdminUrl, skipBootstrap: true });
   let servicesStopped = false;
   let runtimeKeptAlive = false;
 
   try {
-    const apiUrl = runtime.apiServer.url;
+    const apiUrl = runtimeUrl;
     const apiHealth = await getJson(`${apiUrl}/api/health`);
     assertCondition(apiHealth.status === 200 && apiHealth.body.status === "ok", "Expected runtime API health to report ok.");
 
@@ -1339,7 +1344,6 @@ export async function runDemoRecycle(options = {}) {
       serviceStates.push(await waitForServiceState(apiUrl, serviceId, expected));
     }
 
-    const serviceAdminUrl = "http://127.0.0.1:17700";
     const secretsBrokerHealthUrl = "http://127.0.0.1:17890/health";
     const nginxHealthUrl = "http://127.0.0.1:18080/health";
     const traefikHealthUrl = "http://127.0.0.1:19081/ping";

--- a/scripts/demo-recycle.mjs
+++ b/scripts/demo-recycle.mjs
@@ -42,10 +42,13 @@ async function commandOutput(command, args) {
   });
 }
 
-const endpointsFor = (apiUrl = `http://127.0.0.1:${options.port}`) => ({
+const recycleRuntimeUrl = () => options.runtimeUrl ?? `http://127.0.0.1:${options.port}`;
+const recycleServiceAdminUrl = () => (options.serviceAdminUrl ?? "http://127.0.0.1:17700/").replace(/\/$/, "");
+
+const endpointsFor = (apiUrl = recycleRuntimeUrl()) => ({
   runtimeApiHealth: `${apiUrl}/api/health`,
-  serviceAdminRoot: "http://127.0.0.1:17700/",
-  serviceAdminHealth: "http://127.0.0.1:17700/health",
+  serviceAdminRoot: `${recycleServiceAdminUrl()}/`,
+  serviceAdminHealth: `${recycleServiceAdminUrl()}/health`,
   secretsBrokerHealth: "http://127.0.0.1:17890/health",
   echoHealth: "http://127.0.0.1:4011/health",
   runtimeServices: `${apiUrl}/api/services`,
@@ -147,6 +150,8 @@ async function waitForCanonicalPostRecycle({ timeoutMs = 300_000, intervalMs = 5
 
   const verifierOptions = resolveCanonicalVerifierOptions([
     `--port=${options.port}`,
+    `--runtime-url=${recycleRuntimeUrl()}`,
+    `--service-admin-url=${options.serviceAdminUrl ?? "http://127.0.0.1:17700/"}`,
     `--services-root=${options.servicesRoot}`,
     `--workspace-root=${options.workspaceRoot}`,
   ]);
@@ -372,14 +377,7 @@ async function runDetachedRecycle() {
 
   const stdout = await open(path.join(logsRoot, "demo-recycle.out.log"), "a");
   const stderr = await open(path.join(logsRoot, "demo-recycle.err.log"), "a");
-  const args = [
-    path.resolve("scripts", "demo-recycle.mjs"),
-    "--foreground",
-    "--preserve",
-    `--services-root=${options.servicesRoot}`,
-    `--workspace-root=${options.workspaceRoot}`,
-    `--port=${options.port}`,
-  ];
+  const args = buildDetachedRecycleArgs(options);
 
   const child = spawn(process.execPath, args, {
     cwd: process.cwd(),
@@ -389,6 +387,9 @@ async function runDetachedRecycle() {
     env: {
       ...process.env,
       SERVICE_LASSO_PORT: String(options.port),
+      SERVICE_LASSO_HOST: options.host,
+      SERVICE_LASSO_RUNTIME_URL: recycleRuntimeUrl(),
+      SERVICE_LASSO_ADMIN_URL: options.serviceAdminUrl ?? "http://127.0.0.1:17700/",
     },
   });
 
@@ -400,7 +401,7 @@ async function runDetachedRecycle() {
   const childExited = () => shouldStopWaitingForDetachedChild(childExit, isProcessAlive(child.pid));
 
   try {
-    const apiUrl = `http://127.0.0.1:${options.port}`;
+    const apiUrl = recycleRuntimeUrl();
     const endpoints = await waitForLiveDemo();
     const instance = await assertLiveRuntimeOwnedByChild(apiUrl, child.pid, {
       childExited,
@@ -417,7 +418,7 @@ async function runDetachedRecycle() {
     await waitForCanonicalPostRecycle();
     console.log("[service-lasso demo] recycle passed");
     console.log(`- api: ${apiUrl}`);
-    console.log("- serviceAdmin: http://127.0.0.1:17700");
+    console.log(`- serviceAdmin: ${recycleServiceAdminUrl()}`);
     console.log(`- servicesRoot: ${options.servicesRoot}`);
     console.log(`- workspaceRoot: ${options.workspaceRoot}`);
     console.log(`- git: ${git.branch}@${git.commit}`);
@@ -443,6 +444,20 @@ async function runDetachedRecycle() {
     await stdout.close();
     await stderr.close();
   }
+}
+
+export function buildDetachedRecycleArgs(recycleOptions = options) {
+  return [
+    path.resolve("scripts", "demo-recycle.mjs"),
+    "--foreground",
+    "--preserve",
+    `--host=${recycleOptions.host}`,
+    `--runtime-url=${recycleOptions.runtimeUrl ?? `http://127.0.0.1:${recycleOptions.port}`}`,
+    `--admin-url=${recycleOptions.serviceAdminUrl ?? "http://127.0.0.1:17700/"}`,
+    `--services-root=${recycleOptions.servicesRoot}`,
+    `--workspace-root=${recycleOptions.workspaceRoot}`,
+    `--port=${recycleOptions.port}`,
+  ];
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -114,12 +114,21 @@ export interface AuditEvent {
   reason: string | null;
   correlationId: string;
   relatedRevisionId: string | null;
+  metadata?: Record<string, AuditSafeMetadataValue>;
   chainId: string;
   sequence: number;
   previousHash: string | null;
   eventHash: string;
   chainStatus: "valid";
 }
+
+export type AuditSafeMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AuditSafeMetadataValue[]
+  | { [key: string]: AuditSafeMetadataValue };
 
 export interface AuditQuery {
   serviceId?: string;

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -11,7 +11,7 @@ export interface RuntimeApp {
 
 export async function startRuntimeApp(options: ApiServerOptions = {}): Promise<RuntimeApp> {
   const apiPort = options.port ?? Number(process.env.SERVICE_LASSO_PORT ?? 18080);
-  const bindHost = process.env.SERVICE_LASSO_HOST ?? "0.0.0.0";
+  const bindHost = options.host ?? process.env.SERVICE_LASSO_HOST ?? "0.0.0.0";
   const publicHost = bindHost === "0.0.0.0" ? "127.0.0.1" : bindHost;
   process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL = `http://${publicHost}:${apiPort}`;
 
@@ -26,6 +26,7 @@ export async function startRuntimeApp(options: ApiServerOptions = {}): Promise<R
     servicesRoot: serviceRoot.servicesRoot,
     workspaceRoot: serviceRoot.workspaceRoot,
     port: apiPort,
+    host: bindHost,
     version: serviceRoot.version,
   });
 

--- a/src/runtime/audit/store.ts
+++ b/src/runtime/audit/store.ts
@@ -1,7 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
-import type { AuditEvent, AuditEventOutcome, AuditQuery, AuditResponse } from "../../contracts/api.js";
+import type { AuditEvent, AuditEventOutcome, AuditQuery, AuditResponse, AuditSafeMetadataValue } from "../../contracts/api.js";
+import { assertSafeAuditMetadata } from "./events.js";
 
 export interface AppendAuditEventInput {
   workspaceRoot?: string;
@@ -19,6 +20,7 @@ export interface AppendAuditEventInput {
   reason?: string | null;
   correlationId?: string | null;
   relatedRevisionId?: string | null;
+  metadata?: Record<string, AuditSafeMetadataValue>;
 }
 
 export interface ReadAuditEventsInput {
@@ -97,6 +99,10 @@ async function appendAuditLine(filePath: string, event: AuditEvent): Promise<voi
 }
 
 export async function appendAuditEvent(input: AppendAuditEventInput): Promise<AuditEvent> {
+  if (input.metadata) {
+    assertSafeAuditMetadata(input.metadata);
+  }
+
   const timestamp = new Date().toISOString();
   const chainId = input.serviceId ? `service:${input.serviceId}` : "runtime";
   const event: AuditEvent = {
@@ -115,6 +121,7 @@ export async function appendAuditEvent(input: AppendAuditEventInput): Promise<Au
     reason: input.reason ?? null,
     correlationId: input.correlationId ?? randomUUID(),
     relatedRevisionId: input.relatedRevisionId ?? null,
+    metadata: input.metadata,
     chainId,
     sequence: 0,
     previousHash: null,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { once } from "node:events";
-import { timingSafeEqual } from "node:crypto";
-import { cp } from "node:fs/promises";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { cp, readFile } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -417,15 +417,23 @@ function parseAuditQuery(searchParams: URLSearchParams): AuditQuery {
   return query;
 }
 
-function parseServiceMetaPatch(
-  input: unknown,
-): { favorite?: boolean; dependencyGraphPosition?: { x: number; y: number } | null } {
+function parseServiceMetaPatch(input: unknown): {
+  patch: { favorite?: boolean; dependencyGraphPosition?: { x: number; y: number } | null };
+  actor?: string;
+  reason?: string | null;
+} {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new ApiError("invalid_body", 400, "Service meta patch must be a JSON object.");
   }
 
   const candidate = input as Record<string, unknown>;
   const patch: { favorite?: boolean; dependencyGraphPosition?: { x: number; y: number } | null } = {};
+  if (candidate.actor !== undefined && candidate.actor !== null && typeof candidate.actor !== "string") {
+    throw new ApiError("invalid_body", 400, '"actor" must be a string when present.');
+  }
+  if (candidate.reason !== undefined && candidate.reason !== null && typeof candidate.reason !== "string") {
+    throw new ApiError("invalid_body", 400, '"reason" must be a string or null when present.');
+  }
 
   if ("favorite" in candidate) {
     if (typeof candidate.favorite !== "boolean") {
@@ -460,7 +468,11 @@ function parseServiceMetaPatch(
     throw new ApiError("invalid_body", 400, "Service meta patch must include \"favorite\" and/or \"dependencyGraphPosition\".");
   }
 
-  return patch;
+  return {
+    patch,
+    actor: typeof candidate.actor === "string" ? candidate.actor : undefined,
+    reason: typeof candidate.reason === "string" ? candidate.reason : candidate.reason === null ? null : undefined,
+  };
 }
 
 function parseUpdateCheckBody(input: unknown): { serviceId?: string } {
@@ -523,6 +535,18 @@ function parseServiceConfigSaveBody(input: unknown): { content: string; actor?: 
     actor: typeof candidate.actor === "string" ? candidate.actor : undefined,
     reason: typeof candidate.reason === "string" ? candidate.reason : null,
   };
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function hashFileContent(filePath: string): Promise<string | null> {
+  try {
+    return sha256(await readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function parseWorkflowCatalogValidateBody(input: unknown): WorkflowCatalogEntry[] {
@@ -1714,27 +1738,41 @@ async function routeRequest(
     }
 
     if (request.method === "PATCH" && pathParts.length === 4 && pathParts[3] === "meta") {
+      let auditActor = "unknown";
+      let auditReason: string | null = null;
       try {
-        const patch = parseServiceMetaPatch(await readJsonBody(request));
+        const { patch, actor, reason } = parseServiceMetaPatch(await readJsonBody(request));
+        auditActor = actor?.trim() || "unknown";
+        auditReason = reason?.trim() || null;
         const persisted = await writeServiceMeta(service.serviceRoot, patch);
+        const changedFields = [
+          patch.favorite !== undefined ? "favorite" : null,
+          "dependencyGraphPosition" in patch ? "dependencyGraphPosition" : null,
+        ].filter((field): field is string => Boolean(field));
 
         await appendAuditEvent({
           serviceRoot: service.serviceRoot,
           source: "runtime-api",
           action: "service.meta.update",
-          actor: "unknown",
+          actor: auditActor,
           subject: "service-meta",
           serviceId,
           method: "PATCH",
           routeTemplate: "/api/services/:serviceId/meta",
           outcome: "success",
           statusCode: 200,
-          summary: [
-            patch.favorite !== undefined ? "favorite" : null,
-            "dependencyGraphPosition" in patch ? "dependencyGraphPosition" : null,
-          ]
-            .filter(Boolean)
-            .join(", "),
+          summary: changedFields.join(", "),
+          reason: auditReason,
+          metadata: {
+            changedFields,
+            favorite: persisted.favorite,
+            dependencyGraphPosition: persisted.dependencyGraphPosition
+              ? {
+                  x: persisted.dependencyGraphPosition.x,
+                  y: persisted.dependencyGraphPosition.y,
+                }
+              : null,
+          },
         });
         writeJson(
           response,
@@ -1750,7 +1788,7 @@ async function routeRequest(
           serviceRoot: service.serviceRoot,
           source: "runtime-api",
           action: "service.meta.update",
-          actor: "unknown",
+          actor: auditActor,
           subject: "service-meta",
           serviceId,
           method: "PATCH",
@@ -1759,6 +1797,9 @@ async function routeRequest(
           statusCode: getApiErrorStatusCode(error),
           summary: "Failed to update service metadata.",
           reason: getAuditFailureReason(error),
+          metadata: {
+            validationStatus: "invalid",
+          },
         });
         throw error;
       }
@@ -1828,8 +1869,12 @@ async function routeRequest(
     }
 
     if (request.method === "PUT" && pathParts.length === 4 && pathParts[3] === "config") {
-      const body = parseServiceConfigSaveBody(await readJsonBody(request));
+      let requestBody: unknown;
+      let body: { content: string; actor?: string; reason?: string | null } | undefined;
+      const relativeConfigPath = path.relative(service.serviceRoot, service.manifestPath).split(path.sep).join("/");
       try {
+        requestBody = await readJsonBody(request);
+        body = parseServiceConfigSaveBody(requestBody);
         const result = await saveServiceConfigDocument(service, config.workspaceRoot, body);
         await appendAuditEvent({
           serviceRoot: service.serviceRoot,
@@ -1843,15 +1888,28 @@ async function routeRequest(
           outcome: "success",
           statusCode: 200,
           summary: "Saved service config document.",
+          reason: result.backup.reason,
           relatedRevisionId: result.backup.id,
+          metadata: {
+            configPath: result.backup.path,
+            previousHash: result.backup.previousHash,
+            currentHash: result.backup.currentHash,
+            validationStatus: result.backup.validationStatus,
+          },
         });
         writeJson(response, 200, result);
       } catch (error) {
+        const requestRecord =
+          requestBody && typeof requestBody === "object" && !Array.isArray(requestBody)
+            ? (requestBody as Record<string, unknown>)
+            : {};
+        const requestedContent = body?.content ?? requestRecord.content;
+        const requestedReason = body?.reason ?? (typeof requestRecord.reason === "string" ? requestRecord.reason : null);
         await appendAuditEvent({
           serviceRoot: service.serviceRoot,
           source: "runtime-api",
           action: "service.config.save",
-          actor: body.actor ?? "unknown",
+          actor: body?.actor ?? getAuditActor(requestBody),
           subject: "server.json",
           serviceId,
           method: "PUT",
@@ -1860,6 +1918,13 @@ async function routeRequest(
           statusCode: getApiErrorStatusCode(error),
           summary: "Failed to save service config document.",
           reason: getAuditFailureReason(error),
+          metadata: {
+            configPath: relativeConfigPath,
+            previousHash: await hashFileContent(service.manifestPath),
+            currentHash: typeof requestedContent === "string" ? sha256(requestedContent) : null,
+            validationStatus: "invalid",
+            requestedReason: typeof requestedReason === "string" && requestedReason.trim() ? requestedReason.trim() : null,
+          },
         });
         throw error;
       }

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -96,6 +96,34 @@ test("runtime API binds to all interfaces by default while reporting a local URL
   }
 });
 
+test("runtime app host option overrides SERVICE_LASSO_HOST", async () => {
+  const previousHost = process.env.SERVICE_LASSO_HOST;
+  process.env.SERVICE_LASSO_HOST = "0.0.0.0";
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-runtime-host-"));
+  const app = await startRuntimeApp({
+    port: 0,
+    host: "127.0.0.1",
+    servicesRoot: path.resolve("services"),
+    workspaceRoot: tempDir,
+    version: "host-option-test",
+  });
+
+  try {
+    const address = app.apiServer.server.address();
+
+    assert.ok(address && typeof address !== "string");
+    assert.equal(address.address, "127.0.0.1");
+  } finally {
+    await app.apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousHost === undefined) {
+      delete process.env.SERVICE_LASSO_HOST;
+    } else {
+      process.env.SERVICE_LASSO_HOST = previousHost;
+    }
+  }
+});
+
 test("GET /api/services returns discovered services from the tracked services root", async () => {
   const servicesRoot = path.resolve("services");
   await clearPersistedFixtureState(servicesRoot);

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -197,7 +197,12 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.equal(install.status, 200);
     const config = await postJson(`${apiServer.url}/api/services/audit-service/config`);
     assert.equal(config.status, 200);
-    const meta = await patchJson(`${apiServer.url}/api/services/audit-service/meta`, { favorite: true });
+    const meta = await patchJson(`${apiServer.url}/api/services/audit-service/meta`, {
+      actor: "operator-ui",
+      reason: "pin favorite and graph position",
+      favorite: true,
+      dependencyGraphPosition: { x: 12, y: 34 },
+    });
     assert.equal(meta.status, 200);
     const runtime = await postJson(`${apiServer.url}/api/runtime/actions/stopAll`);
     assert.equal(runtime.status, 200);
@@ -246,13 +251,19 @@ test("audit API returns durable safe service and runtime mutation events after r
       content: JSON.stringify(editedConfig, null, 2),
     });
     assert.equal(save.status, 200);
+    const invalidSave = await putJson(`${apiServer.url}/api/services/audit-service/config`, {
+      actor: "operator-ui",
+      reason: "bad config should still audit safely",
+      content: '{"id":"audit-service","env":{"SECRET_TOKEN":"SUPER_SECRET_VALUE"',
+    });
+    assert.equal(invalidSave.status, 400);
 
     await apiServer.stop();
     apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
 
-    const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=10`);
+    const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=20`);
     assert.equal(audit.status, 200);
-    assert.equal(audit.body.pagination.total, 10);
+    assert.equal(audit.body.pagination.total, 11);
     assert.deepEqual(
       audit.body.events.map((event) => event.action).sort(),
       [
@@ -260,6 +271,7 @@ test("audit API returns durable safe service and runtime mutation events after r
         "service.action.run",
         "service.action.run",
         "service.action.run",
+        "service.config.save",
         "service.config.save",
         "service.lifecycle.config",
         "service.lifecycle.install",
@@ -269,13 +281,35 @@ test("audit API returns durable safe service and runtime mutation events after r
       ],
     );
 
-    const configEvent = audit.body.events.find((event) => event.action === "service.config.save");
+    const metaEvent = audit.body.events.find((event) => event.action === "service.meta.update");
+    assert.equal(metaEvent.actor, "operator-ui");
+    assert.equal(metaEvent.reason, "pin favorite and graph position");
+    assert.deepEqual(metaEvent.metadata.changedFields, ["favorite", "dependencyGraphPosition"]);
+    assert.equal(metaEvent.metadata.favorite, true);
+    assert.deepEqual(metaEvent.metadata.dependencyGraphPosition, { x: 12, y: 34 });
+
+    const configEvent = audit.body.events.find((event) => event.action === "service.config.save" && event.outcome === "success");
     assert.equal(configEvent.actor, "operator-ui");
+    assert.equal(configEvent.reason, "metadata-only audit coverage");
     assert.equal(configEvent.relatedRevisionId, save.body.backup.id);
     assert.equal(configEvent.outcome, "success");
     assert.equal(configEvent.chainId, "service:audit-service");
     assert.ok(configEvent.eventHash);
     assert.equal(configEvent.chainStatus, "valid");
+    assert.equal(configEvent.metadata.configPath, "service.json");
+    assert.equal(configEvent.metadata.previousHash, save.body.backup.previousHash);
+    assert.equal(configEvent.metadata.currentHash, save.body.backup.currentHash);
+    assert.equal(configEvent.metadata.validationStatus, "valid");
+
+    const configFailure = audit.body.events.find((event) => event.action === "service.config.save" && event.outcome === "failure");
+    assert.equal(configFailure.actor, "operator-ui");
+    assert.match(configFailure.reason, /valid JSON object string/u);
+    assert.equal(configFailure.relatedRevisionId, null);
+    assert.equal(configFailure.metadata.configPath, "service.json");
+    assert.equal(configFailure.metadata.validationStatus, "invalid");
+    assert.equal(configFailure.metadata.requestedReason, "bad config should still audit safely");
+    assert.equal(typeof configFailure.metadata.previousHash, "string");
+    assert.equal(typeof configFailure.metadata.currentHash, "string");
 
     const setupEvent = audit.body.events.find((event) => event.action === "service.setup.run");
     assert.equal(setupEvent.subject, "write-audit-proof");
@@ -322,6 +356,7 @@ test("audit API returns durable safe service and runtime mutation events after r
     const workflowParamSearch = await getJson(`${apiServer.url}/api/audit?query=WORKFLOW_SECRET_PARAM`);
     assert.equal(workflowParamSearch.status, 200);
     assert.equal(workflowParamSearch.body.pagination.total, 0);
+    assert.equal(JSON.stringify(audit.body).includes("SUPER_SECRET_VALUE"), false);
 
     const serviceAuditFile = path.join(serviceRoot, ".state", "audit", "events.jsonl");
     const runtimeAuditFile = path.join(workspaceRoot, ".service-lasso", "audit", "runtime", `${new Date().toISOString().slice(0, 10)}.jsonl`);

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -12,6 +12,7 @@ import {
   assertDemoRecycleOwnership,
   demoProviderServiceIds,
   demoRequiredServiceIds,
+  resolveDemoOptions,
   stopDemoManagedProcesses,
 } from "../scripts/demo-instance-lib.mjs";
 import {
@@ -24,11 +25,13 @@ import {
 } from "../scripts/demo-watchdog.mjs";
 import {
   shouldAcquireDetachedRecycleLock,
+  buildDetachedRecycleArgs,
   shouldStopWaitingForDetachedChild,
   waitForLiveServices,
 } from "../scripts/demo-recycle.mjs";
 import {
   hasJsonPath,
+  buildCanonicalDeployRecycleArgs,
   parseEndpointExpectations,
   resolveCanonicalDeployOptions,
   runCanonicalDeploy,
@@ -216,6 +219,48 @@ test("canonical deploy accepts npm-forwarded positional deploy args", () => {
       statusExpectations: [{ path: "/api/log-shipping", expectedStatus: 200 }],
       jsonExpectations: [{ path: "/api/telemetry", jsonPath: "telemetry.apiRequests" }],
     },
+  );
+});
+
+test("canonical deploy and recycle propagate LAN runtime URLs to child scripts", () => {
+  const deployOptions = resolveCanonicalDeployOptions([
+    "--ref=HEAD",
+    "--host=0.0.0.0",
+    "--runtime-url=http://192.168.1.53:17883",
+    "--service-admin-url=http://192.168.1.53:17700/",
+    "--services-root=C:/tmp/service-lasso/services",
+    "--workspace-root=C:/tmp/service-lasso/workspace",
+  ]);
+
+  assert.deepEqual(
+    buildCanonicalDeployRecycleArgs(deployOptions).filter((arg) =>
+      arg.startsWith("--host=") || arg.startsWith("--runtime-url=") || arg.startsWith("--admin-url=")
+    ),
+    [
+      "--host=0.0.0.0",
+      "--runtime-url=http://192.168.1.53:17883",
+      "--admin-url=http://192.168.1.53:17700/",
+    ],
+  );
+
+  const recycleOptions = resolveDemoOptions([
+    "--port=17883",
+    "--host=0.0.0.0",
+    "--runtime-url=http://192.168.1.53:17883",
+    "--admin-url=http://192.168.1.53:17700/",
+    "--services-root=C:/tmp/service-lasso/services",
+    "--workspace-root=C:/tmp/service-lasso/workspace",
+  ]);
+
+  assert.deepEqual(
+    buildDetachedRecycleArgs(recycleOptions).filter((arg) =>
+      arg.startsWith("--host=") || arg.startsWith("--runtime-url=") || arg.startsWith("--admin-url=")
+    ),
+    [
+      "--host=0.0.0.0",
+      "--runtime-url=http://192.168.1.53:17883",
+      "--admin-url=http://192.168.1.53:17700/",
+    ],
   );
 });
 


### PR DESCRIPTION
Fixes #755.

## What changed
- Keeps the audit mutation work from `6c821ab`.
- Fixes canonical demo recycle argument propagation for LAN runtime/Admin URLs.
- Makes runtime app startup honor explicit `host` options before `SERVICE_LASSO_HOST`.
- Adds regression coverage for canonical deploy/recycle LAN arg propagation and runtime host precedence.

## Validation
- `npm run build` passed.
- `node --test --test-concurrency=1 --test-name-pattern "runtime API binds|runtime app host option|canonical deploy and recycle propagate" tests/api-spine.test.js tests/demo-instance.test.js` passed: 3 pass / 0 fail.
- Full focused `tests/api-spine.test.js tests/demo-instance.test.js` reached 44 pass / 1 fail; the remaining `demo smoke script validates the bounded demo instance end to end` failure was external GitHub release metadata rate limiting: `403 rate limit exceeded` for `service-lasso/lasso-echoservice`.
- Direct canonical deploy passed for `7d2eef8f98cb2ea4327826b7b36b71bc9def0533` with runtime `http://192.168.1.53:17883` and Service Admin `http://192.168.1.53:17700/`.
- `node scripts/demo-verify-canonical.mjs --runtime-url=http://192.168.1.53:17883 --service-admin-url=http://192.168.1.53:17700/ --services-root=C:\projects\service-lasso\service-lasso-issue-755\workspace\canonical-services-root --workspace-root=C:\projects\service-lasso\service-lasso-issue-755\workspace\demo-instance` passed.
- `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --admin-url=http://192.168.1.53:17700/ --services-root=C:\projects\service-lasso\service-lasso-issue-755\workspace\canonical-services-root --workspace-root=C:\projects\service-lasso\service-lasso-issue-755\workspace\demo-instance` passed: gate `healthy`.
- Direct endpoint checks passed: runtime `/api/health` -> 200 `ok`; Service Admin `/` -> 200; live `/api/audit` -> 200.

Evidence root: `C:\projects\service-lasso\.work-agent\logs\issue-755-main-fix-20260715-0245`.
