### PR TITLE
Draft: audit operator action queue mutations

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -122,7 +122,9 @@ import {
   readOperatorActionQueue,
   upsertOperatorActionItem,
   type OperatorActionInput,
+  type OperatorActionItem,
   type OperatorActionMutationInput,
+  type OperatorActionQueueState,
 } from "../runtime/operator/action-queue.js";
 import { buildDiagnosticsBundle } from "../runtime/diagnostics/bundle.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
@@ -391,12 +393,79 @@ function getAuditActor(input: unknown): string {
   return typeof actor === "string" && actor.trim().length > 0 ? actor.trim() : "unknown";
 }
 
+function redactAuditText(value: string): string {
+  return value
+    .replace(/([\w.-]*(?:password|passwd|secret|token|key|credential)[\w.-]*\s*[:=]\s*)[^\s,;]+/gi, "$1[redacted]")
+    .replace(/(bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(/(gh[pousr]_[A-Za-z0-9_]+)/g, "[redacted]")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function safeAuditText(value: unknown, fallback: string | null = null): string | null {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const redacted = redactAuditText(value).slice(0, 240);
+  return redacted || fallback;
+}
+
 function getApiErrorStatusCode(error: unknown): number {
   return toApiErrorBody(error).statusCode;
 }
 
 function getAuditFailureReason(error: unknown): string {
-  return toApiErrorBody(error).message;
+  return redactAuditText(toApiErrorBody(error).message);
+}
+
+function getOperatorActionAuditItem(queue: OperatorActionQueueState, itemId?: string | null): OperatorActionItem | null {
+  if (itemId) {
+    return queue.items.find((item) => item.id === itemId) ?? null;
+  }
+  return queue.items[0] ?? null;
+}
+
+async function appendOperatorActionQueueAuditEvent(input: {
+  workspaceRoot: string;
+  action: "operator.action.record" | "operator.action.acknowledge" | "operator.action.defer" | "operator.action.reopen";
+  routeTemplate: string;
+  outcome: "success" | "failure";
+  statusCode: number;
+  item?: OperatorActionItem | null;
+  itemId?: string | null;
+  actor?: string | null;
+  reason?: string | null;
+  mutation?: string | null;
+}): Promise<void> {
+  const item = input.item ?? null;
+  const subject = item?.id ?? safeAuditText(input.itemId);
+  const metadata: Record<string, string | null> = {
+    itemId: subject,
+    queueStatus: item?.status ?? null,
+    severity: item?.severity ?? null,
+    sourceKind: item?.source.kind ?? null,
+    serviceId: item?.source.serviceId ?? null,
+    reference: item?.source.reference ?? null,
+    mutation: input.mutation ?? null,
+  };
+
+  await appendAuditEvent({
+    workspaceRoot: input.workspaceRoot,
+    source: "runtime-api",
+    action: input.action,
+    actor: safeAuditText(input.actor, "unknown") ?? "unknown",
+    subject: subject ?? undefined,
+    method: "POST",
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary:
+      input.outcome === "success"
+        ? `Operator action queue ${input.action.replace("operator.action.", "")} completed.`
+        : `Operator action queue ${input.action.replace("operator.action.", "")} failed.`,
+    reason: safeAuditText(input.reason),
+    metadata,
+  });
 }
 
 function parseAuditQuery(searchParams: URLSearchParams): AuditQuery {
@@ -1455,9 +1524,30 @@ async function routeRequest(
   }
 
   if (request.method === "POST" && url.pathname === "/api/operator/actions/record") {
-    writeJson(response, 200, {
-      queue: await upsertOperatorActionItem(config.workspaceRoot, parseOperatorActionRecordBody(await readJsonBody(request))),
-    });
+    try {
+      const queue = await upsertOperatorActionItem(config.workspaceRoot, parseOperatorActionRecordBody(await readJsonBody(request)));
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.record",
+        routeTemplate: "/api/operator/actions/record",
+        outcome: "success",
+        statusCode: 200,
+        item: getOperatorActionAuditItem(queue),
+      });
+      writeJson(response, 200, {
+        queue,
+      });
+    } catch (error) {
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.record",
+        routeTemplate: "/api/operator/actions/record",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 
@@ -1466,11 +1556,55 @@ async function routeRequest(
     const actionId = decodeURIComponent(pathParts[3] ?? "");
     const mutation = pathParts[4];
     if (!actionId || (mutation !== "acknowledge" && mutation !== "defer" && mutation !== "reopen")) {
-      throw new ApiError("invalid_action", 400, "Unknown operator action mutation route.");
+      const error = new ApiError("invalid_action", 400, "Unknown operator action mutation route.");
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.reopen",
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        itemId: actionId,
+        mutation: safeAuditText(mutation),
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
     }
-    writeJson(response, 200, {
-      queue: await mutateOperatorActionItem(config.workspaceRoot, actionId, mutation, parseOperatorActionMutationBody(await readJsonBody(request))),
-    });
+    const auditAction =
+      mutation === "acknowledge"
+        ? "operator.action.acknowledge"
+        : mutation === "defer"
+          ? "operator.action.defer"
+          : "operator.action.reopen";
+    try {
+      const body = parseOperatorActionMutationBody(await readJsonBody(request));
+      const queue = await mutateOperatorActionItem(config.workspaceRoot, actionId, mutation, body);
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: auditAction,
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "success",
+        statusCode: 200,
+        item: getOperatorActionAuditItem(queue, actionId),
+        actor: body.actor,
+        reason: body.reason,
+        mutation,
+      });
+      writeJson(response, 200, {
+        queue,
+      });
+    } catch (error) {
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: auditAction,
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        itemId: actionId,
+        mutation,
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 

--- a/tests/operator-action-queue.test.js
+++ b/tests/operator-action-queue.test.js
@@ -197,6 +197,21 @@ test("operator action queue is available through API and CLI", async () => {
     assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory.length, 2);
     assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory[0].previousStatus, "acknowledged");
 
+    const deferred = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/defer", {
+      actor: "operator@example.com",
+      reason: "Delay until token=ghp_auditSecret is checked.",
+      deferredUntil: "2026-05-22T18:10:00.000Z",
+    });
+    assert.equal(deferred.status, 200);
+    assert.equal(deferred.body.queue.items[0].status, "deferred");
+
+    const reopened = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/reopen", {
+      actor: "operator@example.com",
+      reason: "Resume after credential=hunter2 review.",
+    });
+    assert.equal(reopened.status, 200);
+    assert.equal(reopened.body.queue.items[0].status, "open");
+
     response = await fetch(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledgements");
     payload = await response.json();
     assert.equal(response.status, 200);
@@ -204,6 +219,17 @@ test("operator action queue is available through API and CLI", async () => {
     assert.equal(payload.acknowledgements.length, 2);
     assert.equal(payload.acknowledgements[1].previousStatus, "open");
     assert.doesNotMatch(JSON.stringify(payload), /ghp_apiSecret/);
+
+    response = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    payload = await response.json();
+    assert.equal(response.status, 200);
+    const auditActions = payload.events.map((event) => event.action);
+    assert.ok(auditActions.includes("operator.action.record"));
+    assert.ok(auditActions.includes("operator.action.acknowledge"));
+    assert.ok(auditActions.includes("operator.action.defer"));
+    assert.ok(auditActions.includes("operator.action.reopen"));
+    assert.equal(payload.events.find((event) => event.action === "operator.action.record").subject, actionId);
+    assert.doesNotMatch(JSON.stringify(payload), /ghp_apiSecret|ghp_auditSecret|hunter2/);
 
     const cliListOut = await runCli([
       "operator",
@@ -216,7 +242,7 @@ test("operator action queue is available through API and CLI", async () => {
       "--json",
     ]);
     const cliList = JSON.parse(cliListOut);
-    assert.equal(cliList.queue.items[0].status, "acknowledged");
+    assert.equal(cliList.queue.items[0].status, "open");
 
     const cliReopenOut = await runCli([
       "operator",


### PR DESCRIPTION
Part of service-lasso/service-lasso#756.

This is a partial DEV slice for operator action queue audit coverage:
- Emits runtime audit events for `POST /api/operator/actions/record`.
- Emits runtime audit events for `acknowledge`, `defer`, and `reopen` mutations.
- Redacts known secret/token/password patterns before audit persistence.
- Extends operator action queue API coverage to assert audit actions and secret sentinel exclusion.

Validation:
- `npm run build` passed.
- `node --test tests/operator-action-queue.test.js` passed.
- Updated-code canonical demo gate passed: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260716-222549\issue-756-primary-demo-gate.json`.
- Updated-code canonical demo verify passed: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260716-222549\issue-756-primary-demo-verify.json`.

Remaining #756 scope before ready for final merge:
- Operator confirmations runtime audit normalization.
- Workflow run/repo mutation runtime audit normalization.
- Broader failure/denied coverage across the remaining listed mutation groups.