### PR TITLE
Audit durable operator mutations

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -187,6 +187,7 @@ import { ApiError, LifecycleStateError, toApiErrorBody } from "./errors.js";
 import type {
   DashboardServiceResponse,
   LifecycleActionResponse,
+  OperatorCommandConfirmationAuditEvent,
   OperatorCommandConfirmationExecuteRequest,
   OperatorCommandConfirmationConfirmRequest,
   OperatorCommandConfirmationIssueRequest,
@@ -465,6 +466,78 @@ async function appendOperatorActionQueueAuditEvent(input: {
         : `Operator action queue ${input.action.replace("operator.action.", "")} failed.`,
     reason: safeAuditText(input.reason),
     metadata,
+  });
+}
+
+function getConfirmationRequestActor(input: unknown): string {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return "unknown";
+  }
+
+  const actor = (input as Record<string, unknown>).actor;
+  if (!actor || typeof actor !== "object" || Array.isArray(actor)) {
+    return "unknown";
+  }
+
+  const actorRecord = actor as Record<string, unknown>;
+  if (typeof actorRecord.actorId === "string" && actorRecord.actorId.trim()) {
+    return actorRecord.actorId.trim();
+  }
+  if (typeof actorRecord.source === "string" && typeof actorRecord.senderId === "string") {
+    return `${actorRecord.source}:${actorRecord.senderId}`;
+  }
+  if (typeof actorRecord.senderDisplay === "string" && actorRecord.senderDisplay.trim()) {
+    return actorRecord.senderDisplay.trim();
+  }
+  return "unknown";
+}
+
+async function appendOperatorCommandConfirmationRuntimeAuditEvent(input: {
+  workspaceRoot: string;
+  action: "operator.confirmation.issue" | "operator.confirmation.confirm" | "operator.confirmation.execute";
+  routeTemplate: string;
+  outcome: "success" | "failure";
+  statusCode: number;
+  audit?: OperatorCommandConfirmationAuditEvent | null;
+  confirmationId?: string | null;
+  actor?: string | null;
+  reason?: string | null;
+}): Promise<void> {
+  const audit = input.audit ?? null;
+  const confirmationId = safeAuditText(audit?.confirmationId ?? input.confirmationId);
+  const serviceId = safeAuditText(audit?.targetServiceId);
+  const confirmationEvent = safeAuditText(audit?.event);
+  const command = safeAuditText(audit?.command);
+  const resultStatus = safeAuditText(audit?.resultStatus);
+  const reason = safeAuditText(audit?.errorCode ?? input.reason);
+
+  await appendAuditEvent({
+    workspaceRoot: input.workspaceRoot,
+    source: "runtime-api",
+    action: input.action,
+    actor: safeAuditText(audit?.actorId ?? input.actor, "unknown") ?? "unknown",
+    subject: confirmationId ?? undefined,
+    serviceId: serviceId ?? undefined,
+    method: "POST",
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary:
+      input.outcome === "success"
+        ? `${input.action.replace("operator.confirmation.", "Operator confirmation ")} completed.`
+        : `${input.action.replace("operator.confirmation.", "Operator confirmation ")} failed.`,
+    reason,
+    metadata: {
+      confirmationId,
+      confirmationEvent,
+      resultStatus,
+      command,
+      planId: safeAuditText(audit?.planId),
+      channel: safeAuditText(audit?.channel),
+      chatId: safeAuditText(audit?.chatId),
+      senderId: safeAuditText(audit?.senderId),
+      sourceMessageId: safeAuditText(audit?.sourceMessageId),
+    },
   });
 }
 
@@ -1453,15 +1526,34 @@ async function routeRequest(
 
   if (request.method === "POST" && url.pathname === "/api/operator/confirmations") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
-    writeJson(
-      response,
-      201,
-      await issueOperatorCommandConfirmation(await readJsonBody(request) as OperatorCommandConfirmationIssueRequest, {
+    const requestBody = await readJsonBody(request) as OperatorCommandConfirmationIssueRequest;
+    try {
+      const confirmationResponse = await issueOperatorCommandConfirmation(requestBody, {
         workspaceRoot: config.workspaceRoot,
         registry: runtimeModel.registry,
         trustedChatBridge: isTrustedChatBridgeRequest(request),
-      }),
-    );
+      });
+      await appendOperatorCommandConfirmationRuntimeAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.confirmation.issue",
+        routeTemplate: "/api/operator/confirmations",
+        outcome: "success",
+        statusCode: 201,
+        audit: confirmationResponse.audit,
+      });
+      writeJson(response, 201, confirmationResponse);
+    } catch (error) {
+      await appendOperatorCommandConfirmationRuntimeAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.confirmation.issue",
+        routeTemplate: "/api/operator/confirmations",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        actor: getConfirmationRequestActor(requestBody),
+        reason: toApiErrorBody(error).error,
+      });
+      throw error;
+    }
     return;
   }
 
@@ -1478,28 +1570,75 @@ async function routeRequest(
       trustedChatBridge: isTrustedChatBridgeRequest(request),
     };
     if (pathParts[4] === "confirm") {
-      const confirmationResponse = await confirmOperatorCommandConfirmation(
-        confirmationId,
-        await readJsonBody(request) as OperatorCommandConfirmationConfirmRequest,
-        confirmationModel,
-      );
-      writeJson(response, 200, confirmationResponse);
+      const requestBody = await readJsonBody(request) as OperatorCommandConfirmationConfirmRequest;
+      try {
+        const confirmationResponse = await confirmOperatorCommandConfirmation(
+          confirmationId,
+          requestBody,
+          confirmationModel,
+        );
+        await appendOperatorCommandConfirmationRuntimeAuditEvent({
+          workspaceRoot: config.workspaceRoot,
+          action: "operator.confirmation.confirm",
+          routeTemplate: "/api/operator/confirmations/:id/confirm",
+          outcome: "success",
+          statusCode: 200,
+          audit: confirmationResponse.audit,
+        });
+        writeJson(response, 200, confirmationResponse);
+      } catch (error) {
+        await appendOperatorCommandConfirmationRuntimeAuditEvent({
+          workspaceRoot: config.workspaceRoot,
+          action: "operator.confirmation.confirm",
+          routeTemplate: "/api/operator/confirmations/:id/confirm",
+          outcome: "failure",
+          statusCode: getApiErrorStatusCode(error),
+          confirmationId,
+          actor: getConfirmationRequestActor(requestBody),
+          reason: toApiErrorBody(error).error,
+        });
+        throw error;
+      }
       return;
     }
 
-    const executionResponse = await executeOperatorCommandConfirmation(
-      confirmationId,
-      await readJsonBody(request) as OperatorCommandConfirmationExecuteRequest,
-      confirmationModel,
-      async (record) => {
-        const service = runtimeModel.registry.getById(record.targetServiceId);
-        if (!service) {
-          throw new ApiError("service_not_found", 404, `Unknown service id: ${record.targetServiceId}.`);
-        }
-        return await executeLifecycleAction(record.command, service, runtimeModel.registry, config.workspaceRoot);
-      },
-    );
-    writeJson(response, executionResponse.action.ok ? 200 : 409, executionResponse);
+    const requestBody = await readJsonBody(request) as OperatorCommandConfirmationExecuteRequest;
+    try {
+      const executionResponse = await executeOperatorCommandConfirmation(
+        confirmationId,
+        requestBody,
+        confirmationModel,
+        async (record) => {
+          const service = runtimeModel.registry.getById(record.targetServiceId);
+          if (!service) {
+            throw new ApiError("service_not_found", 404, `Unknown service id: ${record.targetServiceId}.`);
+          }
+          return await executeLifecycleAction(record.command, service, runtimeModel.registry, config.workspaceRoot);
+        },
+      );
+      const statusCode = executionResponse.action.ok ? 200 : 409;
+      await appendOperatorCommandConfirmationRuntimeAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.confirmation.execute",
+        routeTemplate: "/api/operator/confirmations/:id/execute",
+        outcome: executionResponse.action.ok ? "success" : "failure",
+        statusCode,
+        audit: executionResponse.audit,
+      });
+      writeJson(response, statusCode, executionResponse);
+    } catch (error) {
+      await appendOperatorCommandConfirmationRuntimeAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.confirmation.execute",
+        routeTemplate: "/api/operator/confirmations/:id/execute",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        confirmationId,
+        actor: getConfirmationRequestActor(requestBody),
+        reason: toApiErrorBody(error).error,
+      });
+      throw error;
+    }
     return;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -161,6 +161,8 @@ import {
   activateWorkflowRepoSources,
   readWorkflowRepoSyncState,
   rollbackWorkflowRepoActivation,
+  type WorkflowRepoActivationResult,
+  type WorkflowRepoSyncState,
   type WorkflowRepoSource,
 } from "../platform/workflowSyncController.js";
 import {
@@ -584,6 +586,70 @@ async function appendWorkflowFacadeRuntimeAuditEvent(input: {
       facadeRunId,
       engineRunId: safeAuditText(auditEvent?.engineRunId),
       facadeOutcome: safeAuditText(auditEvent?.outcome),
+    },
+  });
+}
+
+async function appendWorkflowRepoRuntimeAuditEvent(input: {
+  config: ApiRouteConfig;
+  action: "workflow.repo.sync" | "workflow.repo.activate" | "workflow.repo.rollback";
+  routeTemplate: string;
+  outcome: "success" | "failure";
+  statusCode: number;
+  actor?: string | null;
+  result?: WorkflowRepoActivationResult | WorkflowRepoSyncState | null;
+  sources?: WorkflowRepoSource[] | null;
+  reason?: string | null;
+}): Promise<void> {
+  const result = input.result ?? null;
+  const state = result && "state" in result ? result.state : result;
+  const active = result && "active" in result ? result.active : state?.active;
+  const diagnostics = result && "diagnostics" in result ? result.diagnostics : state?.failed?.diagnostics ?? [];
+  const sourceIds = (input.sources ?? [])
+    .map((source) => safeAuditText(source.id))
+    .filter((value): value is string => value !== null);
+  const sourceRefs = (input.sources ?? [])
+    .map((source) => safeAuditText(source.ref))
+    .filter((value): value is string => value !== null);
+  const sourceKinds = (input.sources ?? [])
+    .map((source) => safeAuditText(source.source))
+    .filter((value): value is string => value !== null);
+  const activationId = safeAuditText(active?.activationId ?? state?.failed?.activationId);
+  const activeRevision = safeAuditText(active?.revision);
+  const reason = safeAuditText(input.reason ?? state?.failed?.reason);
+
+  await appendAuditEvent({
+    workspaceRoot: input.config.workspaceRoot,
+    source: "runtime-api",
+    action: input.action,
+    actor: safeAuditText(input.actor, "unknown") ?? "unknown",
+    subject: activationId ?? activeRevision ?? input.action,
+    method: "POST",
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary:
+      input.outcome === "success"
+        ? `Workflow repo ${input.action.replace("workflow.repo.", "")} completed.`
+        : `Workflow repo ${input.action.replace("workflow.repo.", "")} failed.`,
+    reason,
+    relatedRevisionId: activeRevision,
+    metadata: {
+      activationId,
+      activeRevision,
+      previousGoodRevision: safeAuditText(state?.previousGood?.revision),
+      sourceCount: input.sources?.length ?? (result && "synced" in result ? result.synced.length : 0),
+      sourceIds,
+      sourceRefs,
+      sourceKinds,
+      packageCount: active?.packages.length ?? 0,
+      diagnostics: diagnostics.map((diagnostic) => ({
+        code: safeAuditText(diagnostic.code),
+        field: safeAuditText(diagnostic.field),
+        packageId: safeAuditText(diagnostic.packageId),
+        severity: safeAuditText(diagnostic.severity),
+      })),
+      historyCount: state?.history.length ?? 0,
     },
   });
 }
@@ -1926,24 +1992,79 @@ async function routeRequest(
     request.method === "POST" &&
     (url.pathname === "/api/platform/workflow-repos/sync" || url.pathname === "/api/platform/workflow-repos/activate")
   ) {
-    const sources = parseWorkflowRepoSourcesBody(await readJsonBody(request));
-    const result = await activateWorkflowRepoSources(sources, {
-      workspaceRoot: workflowRepoWorkspaceRoot(config),
-      statePath: workflowRepoStatePath(config),
-      fetcher: async ({ source, destination }) => {
-        await cp(resolveLocalWorkflowRepo(source.repo), destination, { recursive: true, force: true });
-        return { revision: source.ref, packageRoot: source.path ?? "." };
-      },
-    });
-    writeJson(response, result.ok ? 200 : 400, result);
+    const action = url.pathname.endsWith("/sync") ? "workflow.repo.sync" : "workflow.repo.activate";
+    const routeTemplate = url.pathname.endsWith("/sync")
+      ? "/api/platform/workflow-repos/sync"
+      : "/api/platform/workflow-repos/activate";
+    const actor = firstHeader(request.headers["x-service-lasso-user-id"]);
+    let sources: WorkflowRepoSource[] = [];
+    try {
+      sources = parseWorkflowRepoSourcesBody(await readJsonBody(request));
+      const result = await activateWorkflowRepoSources(sources, {
+        workspaceRoot: workflowRepoWorkspaceRoot(config),
+        statePath: workflowRepoStatePath(config),
+        fetcher: async ({ source, destination }) => {
+          await cp(resolveLocalWorkflowRepo(source.repo), destination, { recursive: true, force: true });
+          return { revision: source.ref, packageRoot: source.path ?? "." };
+        },
+      });
+      await appendWorkflowRepoRuntimeAuditEvent({
+        config,
+        action,
+        routeTemplate,
+        outcome: result.ok ? "success" : "failure",
+        statusCode: result.ok ? 200 : 400,
+        actor,
+        result,
+        sources,
+        reason: result.ok ? null : result.state.failed?.reason ?? result.diagnostics[0]?.code ?? null,
+      });
+      writeJson(response, result.ok ? 200 : 400, result);
+    } catch (error) {
+      await appendWorkflowRepoRuntimeAuditEvent({
+        config,
+        action,
+        routeTemplate,
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        actor,
+        sources,
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 
   if (request.method === "POST" && url.pathname === "/api/platform/workflow-repos/rollback") {
-    writeJson(response, 200, await rollbackWorkflowRepoActivation({
-      workspaceRoot: workflowRepoWorkspaceRoot(config),
-      statePath: workflowRepoStatePath(config),
-    }));
+    const actor = firstHeader(request.headers["x-service-lasso-user-id"]);
+    try {
+      const result = await rollbackWorkflowRepoActivation({
+        workspaceRoot: workflowRepoWorkspaceRoot(config),
+        statePath: workflowRepoStatePath(config),
+      });
+      await appendWorkflowRepoRuntimeAuditEvent({
+        config,
+        action: "workflow.repo.rollback",
+        routeTemplate: "/api/platform/workflow-repos/rollback",
+        outcome: "success",
+        statusCode: 200,
+        actor,
+        result,
+      });
+      writeJson(response, 200, result);
+    } catch (error) {
+      await appendWorkflowRepoRuntimeAuditEvent({
+        config,
+        action: "workflow.repo.rollback",
+        routeTemplate: "/api/platform/workflow-repos/rollback",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        actor,
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -178,6 +178,7 @@ import {
   listWorkflowFacadeDefinitions,
   retryWorkflowFacadeRun,
   startWorkflowFacadeRun,
+  type WorkflowFacadeAuditEvent,
   type WorkflowFacadeErrorCode,
   type WorkflowFacadeRun,
   type WorkflowRunFacadeState,
@@ -537,6 +538,52 @@ async function appendOperatorCommandConfirmationRuntimeAuditEvent(input: {
       chatId: safeAuditText(audit?.chatId),
       senderId: safeAuditText(audit?.senderId),
       sourceMessageId: safeAuditText(audit?.sourceMessageId),
+    },
+  });
+}
+
+async function appendWorkflowFacadeRuntimeAuditEvent(input: {
+  config: ApiRouteConfig;
+  action: WorkflowFacadeAuditEvent["action"];
+  routeTemplate: string;
+  statusCode: number;
+  context: PlatformRequestContext;
+  outcome: "success" | "failure";
+  auditEvent?: WorkflowFacadeAuditEvent | null;
+  workspaceId: string;
+  workflowId?: string | null;
+  facadeRunId?: string | null;
+  reason?: string | null;
+}): Promise<void> {
+  const auditEvent = input.auditEvent ?? null;
+  const facadeRunId = safeAuditText(auditEvent?.facadeRunId ?? input.facadeRunId);
+  const workflowId = safeAuditText(auditEvent?.workflowId ?? input.workflowId);
+  const workspaceId = safeAuditText(auditEvent?.workspaceId ?? input.workspaceId);
+  const reason = safeAuditText(auditEvent?.reason ?? input.reason);
+
+  await appendAuditEvent({
+    workspaceRoot: input.config.workspaceRoot,
+    source: "runtime-api",
+    action: input.action,
+    actor: safeAuditText(auditEvent?.actorUserId ?? input.context.userId, "unknown") ?? "unknown",
+    subject: facadeRunId ?? workflowId ?? undefined,
+    method: "POST",
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary:
+      input.outcome === "success"
+        ? `Workflow ${input.action.replace("workflow.run.", "run ")} accepted.`
+        : `Workflow ${input.action.replace("workflow.run.", "run ")} failed.`,
+    reason,
+    correlationId: safeAuditText(auditEvent?.id),
+    relatedRevisionId: safeAuditText(auditEvent?.engineRunId),
+    metadata: {
+      workspaceId,
+      workflowId,
+      facadeRunId,
+      engineRunId: safeAuditText(auditEvent?.engineRunId),
+      facadeOutcome: safeAuditText(auditEvent?.outcome),
     },
   });
 }
@@ -1192,6 +1239,7 @@ async function routeWorkflowFacadeRequest(
   request: IncomingMessage,
   response: ServerResponse,
   url: URL,
+  config: ApiRouteConfig,
   state: WorkflowRunFacadeState,
 ): Promise<boolean> {
   if (!url.pathname.startsWith("/api/platform/workspaces/")) return false;
@@ -1226,8 +1274,32 @@ async function routeWorkflowFacadeRequest(
     if (request.method === "POST" && pathParts.length === 7 && workflowId && pathParts[6] === "runs") {
       const input = await parseStartWorkflowRunInput(request);
       const result = startWorkflowFacadeRun(context, { workspaceId, workflowId, input }, state);
-      if (!result.ok) throwWorkflowFacadeError(result);
+      if (!result.ok) {
+        await appendWorkflowFacadeRuntimeAuditEvent({
+          config,
+          action: "workflow.run.start",
+          routeTemplate: "/api/platform/workspaces/:workspaceId/workflows/:workflowId/runs",
+          statusCode: workflowFacadeStatusCode(result.error.code),
+          context,
+          outcome: "failure",
+          workspaceId,
+          workflowId,
+          reason: result.error.code,
+        });
+        throwWorkflowFacadeError(result);
+      }
       upsertWorkflowRun(state, result.value);
+      await appendWorkflowFacadeRuntimeAuditEvent({
+        config,
+        action: "workflow.run.start",
+        routeTemplate: "/api/platform/workspaces/:workspaceId/workflows/:workflowId/runs",
+        statusCode: 200,
+        context,
+        outcome: "success",
+        auditEvent: result.auditEvent,
+        workspaceId,
+        workflowId,
+      });
       writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
       return true;
     }
@@ -1246,16 +1318,64 @@ async function routeWorkflowFacadeRequest(
 
     if (request.method === "POST" && pathParts.length === 7 && runId && action === "cancel") {
       const result = cancelWorkflowFacadeRun(context, workspaceId, runId, state);
-      if (!result.ok) throwWorkflowFacadeError(result);
+      if (!result.ok) {
+        await appendWorkflowFacadeRuntimeAuditEvent({
+          config,
+          action: "workflow.run.cancel",
+          routeTemplate: "/api/platform/workspaces/:workspaceId/workflow-runs/:runId/cancel",
+          statusCode: workflowFacadeStatusCode(result.error.code),
+          context,
+          outcome: "failure",
+          workspaceId,
+          facadeRunId: runId,
+          reason: result.error.code,
+        });
+        throwWorkflowFacadeError(result);
+      }
       upsertWorkflowRun(state, result.value);
+      await appendWorkflowFacadeRuntimeAuditEvent({
+        config,
+        action: "workflow.run.cancel",
+        routeTemplate: "/api/platform/workspaces/:workspaceId/workflow-runs/:runId/cancel",
+        statusCode: 200,
+        context,
+        outcome: "success",
+        auditEvent: result.auditEvent,
+        workspaceId,
+        facadeRunId: runId,
+      });
       writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
       return true;
     }
 
     if (request.method === "POST" && pathParts.length === 7 && runId && action === "retry") {
       const result = retryWorkflowFacadeRun(context, workspaceId, runId, state);
-      if (!result.ok) throwWorkflowFacadeError(result);
+      if (!result.ok) {
+        await appendWorkflowFacadeRuntimeAuditEvent({
+          config,
+          action: "workflow.run.retry",
+          routeTemplate: "/api/platform/workspaces/:workspaceId/workflow-runs/:runId/retry",
+          statusCode: workflowFacadeStatusCode(result.error.code),
+          context,
+          outcome: "failure",
+          workspaceId,
+          facadeRunId: runId,
+          reason: result.error.code,
+        });
+        throwWorkflowFacadeError(result);
+      }
       upsertWorkflowRun(state, result.value);
+      await appendWorkflowFacadeRuntimeAuditEvent({
+        config,
+        action: "workflow.run.retry",
+        routeTemplate: "/api/platform/workspaces/:workspaceId/workflow-runs/:runId/retry",
+        statusCode: 200,
+        context,
+        outcome: "success",
+        auditEvent: result.auditEvent,
+        workspaceId,
+        facadeRunId: runId,
+      });
       writeJson(response, 200, { run: result.value, auditEvent: result.auditEvent });
       return true;
     }
@@ -1398,7 +1518,7 @@ async function routeRequest(
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
-  if (await routeWorkflowFacadeRequest(request, response, url, workflowRunFacadeState)) {
+  if (await routeWorkflowFacadeRequest(request, response, url, config, workflowRunFacadeState)) {
     return;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -122,7 +122,9 @@ import {
   readOperatorActionQueue,
   upsertOperatorActionItem,
   type OperatorActionInput,
+  type OperatorActionItem,
   type OperatorActionMutationInput,
+  type OperatorActionQueueState,
 } from "../runtime/operator/action-queue.js";
 import { buildDiagnosticsBundle } from "../runtime/diagnostics/bundle.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
@@ -391,12 +393,79 @@ function getAuditActor(input: unknown): string {
   return typeof actor === "string" && actor.trim().length > 0 ? actor.trim() : "unknown";
 }
 
+function redactAuditText(value: string): string {
+  return value
+    .replace(/([\w.-]*(?:password|passwd|secret|token|key|credential)[\w.-]*\s*[:=]\s*)[^\s,;]+/gi, "$1[redacted]")
+    .replace(/(bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(/(gh[pousr]_[A-Za-z0-9_]+)/g, "[redacted]")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function safeAuditText(value: unknown, fallback: string | null = null): string | null {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const redacted = redactAuditText(value).slice(0, 240);
+  return redacted || fallback;
+}
+
 function getApiErrorStatusCode(error: unknown): number {
   return toApiErrorBody(error).statusCode;
 }
 
 function getAuditFailureReason(error: unknown): string {
-  return toApiErrorBody(error).message;
+  return redactAuditText(toApiErrorBody(error).message);
+}
+
+function getOperatorActionAuditItem(queue: OperatorActionQueueState, itemId?: string | null): OperatorActionItem | null {
+  if (itemId) {
+    return queue.items.find((item) => item.id === itemId) ?? null;
+  }
+  return queue.items[0] ?? null;
+}
+
+async function appendOperatorActionQueueAuditEvent(input: {
+  workspaceRoot: string;
+  action: "operator.action.record" | "operator.action.acknowledge" | "operator.action.defer" | "operator.action.reopen";
+  routeTemplate: string;
+  outcome: "success" | "failure";
+  statusCode: number;
+  item?: OperatorActionItem | null;
+  itemId?: string | null;
+  actor?: string | null;
+  reason?: string | null;
+  mutation?: string | null;
+}): Promise<void> {
+  const item = input.item ?? null;
+  const subject = item?.id ?? safeAuditText(input.itemId);
+  const metadata: Record<string, string | null> = {
+    itemId: subject,
+    queueStatus: item?.status ?? null,
+    severity: item?.severity ?? null,
+    sourceKind: item?.source.kind ?? null,
+    serviceId: item?.source.serviceId ?? null,
+    reference: item?.source.reference ?? null,
+    mutation: input.mutation ?? null,
+  };
+
+  await appendAuditEvent({
+    workspaceRoot: input.workspaceRoot,
+    source: "runtime-api",
+    action: input.action,
+    actor: safeAuditText(input.actor, "unknown") ?? "unknown",
+    subject: subject ?? undefined,
+    method: "POST",
+    routeTemplate: input.routeTemplate,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    summary:
+      input.outcome === "success"
+        ? `Operator action queue ${input.action.replace("operator.action.", "")} completed.`
+        : `Operator action queue ${input.action.replace("operator.action.", "")} failed.`,
+    reason: safeAuditText(input.reason),
+    metadata,
+  });
 }
 
 function parseAuditQuery(searchParams: URLSearchParams): AuditQuery {
@@ -1455,9 +1524,30 @@ async function routeRequest(
   }
 
   if (request.method === "POST" && url.pathname === "/api/operator/actions/record") {
-    writeJson(response, 200, {
-      queue: await upsertOperatorActionItem(config.workspaceRoot, parseOperatorActionRecordBody(await readJsonBody(request))),
-    });
+    try {
+      const queue = await upsertOperatorActionItem(config.workspaceRoot, parseOperatorActionRecordBody(await readJsonBody(request)));
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.record",
+        routeTemplate: "/api/operator/actions/record",
+        outcome: "success",
+        statusCode: 200,
+        item: getOperatorActionAuditItem(queue),
+      });
+      writeJson(response, 200, {
+        queue,
+      });
+    } catch (error) {
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.record",
+        routeTemplate: "/api/operator/actions/record",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 
@@ -1466,11 +1556,55 @@ async function routeRequest(
     const actionId = decodeURIComponent(pathParts[3] ?? "");
     const mutation = pathParts[4];
     if (!actionId || (mutation !== "acknowledge" && mutation !== "defer" && mutation !== "reopen")) {
-      throw new ApiError("invalid_action", 400, "Unknown operator action mutation route.");
+      const error = new ApiError("invalid_action", 400, "Unknown operator action mutation route.");
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: "operator.action.reopen",
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        itemId: actionId,
+        mutation: safeAuditText(mutation),
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
     }
-    writeJson(response, 200, {
-      queue: await mutateOperatorActionItem(config.workspaceRoot, actionId, mutation, parseOperatorActionMutationBody(await readJsonBody(request))),
-    });
+    const auditAction =
+      mutation === "acknowledge"
+        ? "operator.action.acknowledge"
+        : mutation === "defer"
+          ? "operator.action.defer"
+          : "operator.action.reopen";
+    try {
+      const body = parseOperatorActionMutationBody(await readJsonBody(request));
+      const queue = await mutateOperatorActionItem(config.workspaceRoot, actionId, mutation, body);
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: auditAction,
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "success",
+        statusCode: 200,
+        item: getOperatorActionAuditItem(queue, actionId),
+        actor: body.actor,
+        reason: body.reason,
+        mutation,
+      });
+      writeJson(response, 200, {
+        queue,
+      });
+    } catch (error) {
+      await appendOperatorActionQueueAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        action: auditAction,
+        routeTemplate: "/api/operator/actions/:id/:mutation",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        itemId: actionId,
+        mutation,
+        reason: getAuditFailureReason(error),
+      });
+      throw error;
+    }
     return;
   }
 

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -401,3 +401,42 @@ test("audit API records update checks that mutate durable update state", async (
     resetLifecycleState();
   }
 });
+
+test("audit API records update download and install failures without unsafe request material", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-audit-update-failure-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  const releaseServer = await startAuditReleaseServer();
+  await writeManifest(servicesRoot, "audit-update-service", createAuditUpdateManifest(releaseServer));
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const check = await postJson(`${apiServer.url}/api/updates/check`, { serviceId: "audit-update-service" });
+    assert.equal(check.status, 200);
+    assert.equal(check.body.services[0].result.status, "update_available");
+
+    const download = await postJson(`${apiServer.url}/api/services/audit-update-service/update/download`);
+    assert.equal(download.status, 500);
+
+    const install = await postJson(`${apiServer.url}/api/services/audit-update-service/update/install`, {
+      force: "raw-update-secret",
+    });
+    assert.equal(install.status, 400);
+
+    const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-update-service&limit=10`);
+    assert.equal(audit.status, 200);
+    const downloadAudit = audit.body.events.find((event) => event.action === "service.update.download");
+    const installAudit = audit.body.events.find((event) => event.action === "service.update.install");
+    assert.equal(downloadAudit.outcome, "failure");
+    assert.equal(downloadAudit.routeTemplate, "/api/services/:serviceId/update/download");
+    assert.equal(installAudit.outcome, "failure");
+    assert.equal(installAudit.statusCode, 400);
+    assert.equal(installAudit.routeTemplate, "/api/services/:serviceId/update/install");
+    assert.equal(JSON.stringify(audit.body).includes("raw-update-secret"), false);
+  } finally {
+    await apiServer.stop().catch(() => undefined);
+    await releaseServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});

--- a/tests/operator-action-queue.test.js
+++ b/tests/operator-action-queue.test.js
@@ -197,6 +197,21 @@ test("operator action queue is available through API and CLI", async () => {
     assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory.length, 2);
     assert.equal(acknowledgedAgain.body.queue.acknowledgementHistory[0].previousStatus, "acknowledged");
 
+    const deferred = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/defer", {
+      actor: "operator@example.com",
+      reason: "Delay until token=ghp_auditSecret is checked.",
+      deferredUntil: "2026-05-22T18:10:00.000Z",
+    });
+    assert.equal(deferred.status, 200);
+    assert.equal(deferred.body.queue.items[0].status, "deferred");
+
+    const reopened = await postJson(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/reopen", {
+      actor: "operator@example.com",
+      reason: "Resume after credential=hunter2 review.",
+    });
+    assert.equal(reopened.status, 200);
+    assert.equal(reopened.body.queue.items[0].status, "open");
+
     response = await fetch(apiServer.url + "/api/operator/actions/" + encodeURIComponent(actionId) + "/acknowledgements");
     payload = await response.json();
     assert.equal(response.status, 200);
@@ -204,6 +219,17 @@ test("operator action queue is available through API and CLI", async () => {
     assert.equal(payload.acknowledgements.length, 2);
     assert.equal(payload.acknowledgements[1].previousStatus, "open");
     assert.doesNotMatch(JSON.stringify(payload), /ghp_apiSecret/);
+
+    response = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    payload = await response.json();
+    assert.equal(response.status, 200);
+    const auditActions = payload.events.map((event) => event.action);
+    assert.ok(auditActions.includes("operator.action.record"));
+    assert.ok(auditActions.includes("operator.action.acknowledge"));
+    assert.ok(auditActions.includes("operator.action.defer"));
+    assert.ok(auditActions.includes("operator.action.reopen"));
+    assert.equal(payload.events.find((event) => event.action === "operator.action.record").subject, actionId);
+    assert.doesNotMatch(JSON.stringify(payload), /ghp_apiSecret|ghp_auditSecret|hunter2/);
 
     const cliListOut = await runCli([
       "operator",
@@ -216,7 +242,7 @@ test("operator action queue is available through API and CLI", async () => {
       "--json",
     ]);
     const cliList = JSON.parse(cliListOut);
-    assert.equal(cliList.queue.items[0].status, "acknowledged");
+    assert.equal(cliList.queue.items[0].status, "open");
 
     const cliReopenOut = await runCli([
       "operator",

--- a/tests/operator-command-confirmations.test.js
+++ b/tests/operator-command-confirmations.test.js
@@ -119,6 +119,15 @@ test("operator command confirmations issue and confirm with the same trusted cha
     assert.deepEqual(events.map((event) => event.event), ["issued", "confirmed"]);
     assert.equal(events.every((event) => event.actorId === "telegram:42"), true);
     assert.equal(JSON.stringify({ issued, confirmed, events }).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+
+    const runtimeAuditResponse = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    const runtimeAudit = await runtimeAuditResponse.json();
+    assert.equal(runtimeAuditResponse.status, 200);
+    const runtimeActions = runtimeAudit.events.map((event) => event.action);
+    assert.ok(runtimeActions.includes("operator.confirmation.issue"));
+    assert.ok(runtimeActions.includes("operator.confirmation.confirm"));
+    assert.equal(runtimeAudit.events.find((event) => event.action === "operator.confirmation.issue").subject, issued.body.confirmation.id);
+    assert.equal(JSON.stringify(runtimeAudit).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
   });
 });
 
@@ -187,6 +196,19 @@ test("operator command confirmations execute a confirmed mutation once", async (
     const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
     assert.deepEqual(events.map((event) => event.event), ["issued", "confirmed", "executed"]);
     assert.equal(JSON.stringify({ executed, events }).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
+
+    const runtimeAuditResponse = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    const runtimeAudit = await runtimeAuditResponse.json();
+    assert.equal(runtimeAuditResponse.status, 200);
+    const runtimeActions = runtimeAudit.events.map((event) => event.action);
+    assert.ok(runtimeActions.includes("operator.confirmation.issue"));
+    assert.ok(runtimeActions.includes("operator.confirmation.confirm"));
+    assert.ok(runtimeActions.includes("operator.confirmation.execute"));
+    assert.equal(
+      runtimeAudit.events.some((event) => event.action === "operator.confirmation.execute" && event.outcome === "success"),
+      true,
+    );
+    assert.equal(JSON.stringify(runtimeAudit).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
   });
 });
 
@@ -361,6 +383,15 @@ test("operator command confirmations deny actor mismatch and capability drift", 
     const events = auditLog.trim().split("\n").map((line) => JSON.parse(line));
     assert.equal(events.some((event) => event.event === "denied" && event.errorCode === "actor_mismatch"), true);
     assert.equal(events.some((event) => event.event === "denied" && event.errorCode === "capability_drift"), true);
+
+    const runtimeAuditResponse = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    const runtimeAudit = await runtimeAuditResponse.json();
+    assert.equal(runtimeAuditResponse.status, 200);
+    const deniedRuntimeEvents = runtimeAudit.events.filter((event) => event.action === "operator.confirmation.confirm" && event.outcome === "failure");
+    assert.equal(deniedRuntimeEvents.length, 2);
+    assert.equal(deniedRuntimeEvents.some((event) => event.reason === "actor_mismatch"), true);
+    assert.equal(deniedRuntimeEvents.some((event) => event.reason === "capability_drift"), true);
+    assert.equal(JSON.stringify(runtimeAudit).includes("SERVICE_LASSO_TEST_BRIDGE_TOKEN"), false);
   });
 });
 
@@ -387,5 +418,12 @@ test("operator command confirmations reject unsafe plans before audit persistenc
       readFile(path.join(workspaceRoot, ".state", "operator-command-confirmation-audit.jsonl"), "utf8"),
       /ENOENT/,
     );
+
+    const runtimeAuditResponse = await fetch(apiServer.url + "/api/audit?source=runtime-api&limit=20");
+    const runtimeAudit = await runtimeAuditResponse.json();
+    assert.equal(runtimeAuditResponse.status, 200);
+    assert.equal(runtimeAudit.events[0].action, "operator.confirmation.issue");
+    assert.equal(runtimeAudit.events[0].outcome, "failure");
+    assert.equal(JSON.stringify(runtimeAudit).includes("SERVICE_LASSO_FAKE_SECRET_SENTINEL_CONFIRMATION_DO_NOT_USE"), false);
   });
 });

--- a/tests/workflow-platform-api.test.js
+++ b/tests/workflow-platform-api.test.js
@@ -129,6 +129,20 @@ test("workflow platform API exposes repo state activate sync and rollback over H
     assert.equal(rollback.status, 200);
     assert.equal(rollback.body.active.revision, firstActivation.body.active.revision);
     assert.equal(rollback.body.history.at(-1).result, "rolled-back");
+
+    const audit = await readJson(await fetch(`${apiServer.url}/api/audit?source=runtime-api&limit=20`));
+    assert.equal(audit.status, 200);
+    const auditActions = audit.body.events.map((event) => event.action);
+    assert.ok(auditActions.includes("workflow.repo.activate"));
+    assert.ok(auditActions.includes("workflow.repo.sync"));
+    assert.ok(auditActions.includes("workflow.repo.rollback"));
+    const activationAudit = audit.body.events.find((event) => event.action === "workflow.repo.activate");
+    assert.equal(activationAudit.outcome, "success");
+    assert.deepEqual(activationAudit.metadata.sourceIds, [first.id]);
+    assert.deepEqual(activationAudit.metadata.sourceRefs, [first.repository.ref]);
+    assert.equal(activationAudit.metadata.packageCount, 1);
+    assert.equal(JSON.stringify(audit.body).includes(firstRoot), false);
+    assert.equal(JSON.stringify(audit.body).includes(secondRoot), false);
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });
@@ -185,6 +199,25 @@ test("workflow platform API rejects unsafe repo activation inputs before promoti
     }));
     assert.equal(missingDaguDefinition.status, 400);
     assert.equal(missingDaguDefinition.body.diagnostics.some((diagnostic) => /Dagu workflow definition/.test(diagnostic.message)), true);
+
+    const secretBearingRepoUrl = `${pathToFileURL(officialRoot).href}?token=raw-workflow-secret`;
+    const secretBearingActivation = await readJson(await fetch(`${apiServer.url}/api/platform/workflow-repos/activate`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-service-lasso-user-id": "token=raw-workflow-secret",
+      },
+      body: JSON.stringify({ sources: [{ ...sourceFor(officialRoot, official), repo: secretBearingRepoUrl }] }),
+    }));
+    assert.equal(secretBearingActivation.status, 400);
+
+    const audit = await readJson(await fetch(`${apiServer.url}/api/audit?source=runtime-api&action=workflow.repo.activate&outcome=failure&limit=20`));
+    assert.equal(audit.status, 200);
+    assert.ok(audit.body.events.length >= 4);
+    const serializedAudit = JSON.stringify(audit.body);
+    assert.equal(serializedAudit.includes("raw-workflow-secret"), false);
+    assert.equal(serializedAudit.includes(secretBearingRepoUrl), false);
+    assert.ok(audit.body.events.some((event) => event.actor === "token=[redacted]"));
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/workflow-run-facade.test.js
+++ b/tests/workflow-run-facade.test.js
@@ -171,11 +171,11 @@ test("workflow run facade docs cover endpoints status policy and no-secret rende
 });
 
 test("workflow run facade is exposed through runtime HTTP routes", async () => {
-  const { servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-api-");
+  const { servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-workflow-api-");
   const state = clone(exampleWorkflowRunFacadeState);
   state.runs[0].status = "failed";
   state.runs[0].engine.status = "error";
-  const apiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: state });
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, workflowRunFacadeState: state });
   const workspaceId = "wks_local_demo";
   const workflowId = encodeURIComponent("official.core.maintenance/backup-check");
 
@@ -236,10 +236,10 @@ test("workflow run facade is exposed through runtime HTTP routes", async () => {
 });
 
 test("workflow runtime HTTP routes fail closed for policy and request errors", async () => {
-  const { servicesRoot } = await makeTempServicesRoot("service-lasso-workflow-api-denied-");
+  const { servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-workflow-api-denied-");
   const connectionState = clone(exampleWorkflowRunFacadeState);
   connectionState.providerConnections[0].status = "needs-auth";
-  const apiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: connectionState });
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, workflowRunFacadeState: connectionState });
   const workspaceId = "wks_local_demo";
   const workflowId = encodeURIComponent("official.core.maintenance/backup-check");
   const errorBodies = [];
@@ -277,7 +277,7 @@ test("workflow runtime HTTP routes fail closed for policy and request errors", a
 
   const secretState = clone(exampleWorkflowRunFacadeState);
   secretState.workflows[0].secretDependencies[0].status = "missing";
-  const secretApiServer = await startApiServer({ port: 0, servicesRoot, workflowRunFacadeState: secretState });
+  const secretApiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, workflowRunFacadeState: secretState });
 
   try {
     const missingSecret = await postJson(`${secretApiServer.url}/api/platform/workspaces/${workspaceId}/workflows/${workflowId}/runs`);

--- a/tests/workflow-run-facade.test.js
+++ b/tests/workflow-run-facade.test.js
@@ -217,7 +217,15 @@ test("workflow run facade is exposed through runtime HTTP routes", async () => {
     assert.equal(retried.body.run.status, "retrying");
     assert.equal(retried.body.auditEvent.action, "workflow.run.retry");
 
-    const serialized = JSON.stringify([list.body, workflow.body, started.body, fetchedRun.body, logs.body, artifacts.body, cancelled.body, retried.body]);
+    const audit = await getJson(`${apiServer.url}/api/audit?source=runtime-api&limit=20`);
+    assert.equal(audit.status, 200);
+    const auditActions = audit.body.events.map((event) => event.action);
+    assert.ok(auditActions.includes("workflow.run.start"));
+    assert.ok(auditActions.includes("workflow.run.cancel"));
+    assert.ok(auditActions.includes("workflow.run.retry"));
+    assert.equal(audit.body.events.find((event) => event.action === "workflow.run.start").subject, started.body.run.facadeRunId);
+
+    const serialized = JSON.stringify([list.body, workflow.body, started.body, fetchedRun.body, logs.body, artifacts.body, cancelled.body, retried.body, audit.body]);
     assert.equal(serialized.includes("raw-workflow-secret"), false);
     assert.equal(serialized.includes("access-token-value"), false);
     assert.equal(serialized.includes("refresh-token-value"), false);
@@ -257,6 +265,12 @@ test("workflow runtime HTTP routes fail closed for policy and request errors", a
     assert.equal(connectionNotReady.status, 403);
     assert.equal(connectionNotReady.body.error, "connection-not-ready");
     errorBodies.push(connectionNotReady.body);
+
+    const audit = await getJson(`${apiServer.url}/api/audit?source=runtime-api&action=workflow.run.start&outcome=failure&limit=20`);
+    assert.equal(audit.status, 200);
+    assert.equal(audit.body.events.length, 2);
+    assert.equal(audit.body.events.every((event) => event.reason === "missing-entitlement" || event.reason === "connection-not-ready"), true);
+    errorBodies.push(audit.body);
   } finally {
     await apiServer.stop();
   }


### PR DESCRIPTION
Closes service-lasso/service-lasso#756.

## Summary
- Emits runtime audit events for operator action queue record, acknowledge, defer, and reopen mutations.
- Emits runtime audit events for operator confirmation issue, confirm, and execute mutations, including denied/failure outcomes.
- Emits runtime audit events for setup, recovery doctor, update check, update download, and update install mutations.
- Normalizes workflow run facade audit events into the runtime audit surface for start, cancel, retry, and failure outcomes.
- Emits runtime audit events for workflow repo sync, activate, and rollback mutations, including validation failures.
- Keeps unsafe request material, workflow inputs, repo URLs with sentinels, command output, and known secret/token/password sentinels out of persisted/runtime audit responses.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 tests/workflow-platform-api.test.js tests/workflow-run-facade.test.js tests/operator-action-queue.test.js tests/operator-command-confirmations.test.js tests/audit.test.js`
- Canonical demo gate passed against `http://192.168.1.53:17883` and Service Admin `http://192.168.1.53:17700/`.
- Canonical demo verifier passed against the same runtime/admin endpoints.

## Evidence
- Current run logs: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260718-1025`
- Final commit in this run: `dde199d08f93ac7cfb2476b4d259a129a8778296`
