### PR TITLE
Update @node baseline healthchecks

### DIFF
--- a/services/@node/service.json
+++ b/services/@node/service.json
@@ -7,6 +7,14 @@
   "enabled": true,
   "executable": "node",
   "args": ["--version"],
+  "healthchecks": [
+    {
+      "id": "node-version",
+      "type": "process",
+      "retries": 3,
+      "interval": 1000
+    }
+  ],
   "env": {
     "NODE_ENV": "development"
   },


### PR DESCRIPTION
## Summary

- update the checked-in core @node baseline manifest to include the lasso-node healthchecks[] entry
- keep the existing pinned provider artifact tag unchanged
- unblocks stale canonical-demo validation for service-lasso/lasso-node#4 / PR #5

## Validation

- npm run build
- npm run verify:baseline-start

Fixes #883.
Related: service-lasso/lasso-node#4, service-lasso/lasso-node#5, #817.