### PR TITLE
#885 Support organisation-scoped WSL runner groups

### DIFF
--- a/.governance/specs/SPEC-004-isolated-wsl-runner-pool.md
+++ b/.governance/specs/SPEC-004-isolated-wsl-runner-pool.md
@@ -88,8 +88,18 @@ declared installer behavior, the PowerShell parser proves script syntax, and
 a distribution. A live runner may be provisioned separately after merge with
 an operator-supplied SecureString password.
 
+## Organisation runner groups
+
+The installer must keep repository scope as its default and may register new
+runners into an organisation-scoped runner group with selected-repository
+access. Repository grants must be additive, public repositories require an
+explicit opt-in, and existing repository-scoped runners must not be silently
+converted.
+
 ## Change Notes
 
 - 2026-07-20: Issue `#873` created for the first isolated Service Lasso WSL
   runner-pool installer. One distribution per runner was selected to make
   storage ownership, failure isolation, and disposal explicit.
+- 2026-07-23: Issue `#885` added selected-repository organisation runner-group
+  provisioning while preserving repository scope as the default.

--- a/docs/operations/self-hosted-wsl-runner.md
+++ b/docs/operations/self-hosted-wsl-runner.md
@@ -5,6 +5,9 @@ GitHub Actions runner. Every member has its own bounded VHDX, Docker daemon,
 Linux account, workspace, cleanup timer, registration, and Windows autostart
 task.
 
+Repository scope remains the default. Organisation scope can place new runners
+in a runner group limited to selected repositories.
+
 The installer does not alter workflow `runs-on` selectors. Provision and verify
 capacity before selecting the new labels in a separate reviewed change.
 
@@ -99,6 +102,30 @@ Unregister-ScheduledTask -TaskName "WSL Runner Autostart - service-lasso-03" -Co
 
 `wsl --unregister` permanently deletes that distribution and its VHDX. Never
 run it against a general-purpose distro.
+
+## Create an organisation runner group
+
+GitHub CLI needs organisation runner administration permission (`gh auth
+refresh --hostname github.com --scopes admin:org` when needed). This creates or
+reuses `service-lasso-wsl` and grants selected repositories additive access:
+
+```powershell
+$password = Read-Host "Linux runner password" -AsSecureString
+.\scripts\github-actions-runner\install-wsl-runner.ps1 `
+  -LinuxPassword $password `
+  -DistroName service-lasso-org-02 `
+  -InstallLocation C:\WSL\service-lasso-org-02 `
+  -LinuxUser service-lasso-org-02 `
+  -RunnerName "$($env:COMPUTERNAME.ToLowerInvariant())-service-lasso-org-02" `
+  -RunnerScope Organization `
+  -Organization service-lasso `
+  -RunnerGroupName service-lasso-wsl `
+  -RunnerGroupRepositories service-lasso/another-trusted-repository
+```
+
+Service Lasso is always included. Public repositories require the explicit
+`-AllowPublicRepositories` switch. Existing configured runners are not silently
+converted to organisation scope.
 
 ## Reclaim Windows VHDX space
 

--- a/scripts/github-actions-runner/install-wsl-runner.ps1
+++ b/scripts/github-actions-runner/install-wsl-runner.ps1
@@ -33,6 +33,18 @@ param(
     [ValidateRange(1, 16)]
     [int]$RunnerCount = 1,
 
+    [Alias("Scope")]
+    [ValidateSet("Repository", "Organization")]
+    [string]$RunnerScope = "Repository",
+
+    [ValidatePattern('^$|^[A-Za-z0-9_.-]+$')]
+    [string]$Organization = "",
+
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9 ._-]{0,99}$')]
+    [string]$RunnerGroupName = "service-lasso-wsl",
+
+    [string[]]$RunnerGroupRepositories = @(),
+
     [ValidatePattern('^[1-9][0-9]*(MB|GB|TB)$')]
     [string]$VhdSize = "60GB",
 
@@ -67,6 +79,7 @@ param(
 
     [switch]$ForceRecreate,
     [switch]$AllowLowDiskSpace,
+    [switch]$AllowPublicRepositories,
     [switch]$SkipAutostart
 )
 
@@ -163,13 +176,150 @@ function Invoke-WslBootstrap {
     if ($LASTEXITCODE -ne 0) { throw ("{0} (exit code {1})" -f $FailureMessage, $LASTEXITCODE) }
 }
 
-function Get-GhRunnerRegistrationToken {
+function Get-GitHubRepositorySlug {
     param([Parameter(Mandatory = $true)][string]$RepoUrl)
-    $repoSlug = ([Uri]$RepoUrl).AbsolutePath.Trim('/')
-    Write-Step "Requesting a fresh runner registration token with GitHub CLI"
-    $output = & gh.exe api --method POST "repos/$repoSlug/actions/runners/registration-token" --jq .token
-    if ($LASTEXITCODE -ne 0) { throw "GitHub CLI could not create a runner token for $repoSlug." }
-    $value = ([string]($output | Select-Object -First 1)).Trim()
+    $repoSlug = ([Uri]$RepoUrl).AbsolutePath.Trim('/').TrimEnd('/')
+    if ($repoSlug.EndsWith('.git', [StringComparison]::OrdinalIgnoreCase)) {
+        $repoSlug = $repoSlug.Substring(0, $repoSlug.Length - 4)
+    }
+    if ($repoSlug.Split('/').Count -ne 2) { throw "Could not derive owner/repository from '$RepoUrl'." }
+    return $repoSlug
+}
+
+function Invoke-GhApiJson {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments, [Parameter(Mandatory = $true)][string]$FailureMessage)
+    $output = & gh.exe api -H "Accept: application/vnd.github+json" `
+        -H "X-GitHub-Api-Version: 2022-11-28" @Arguments
+    if ($LASTEXITCODE -ne 0) { throw $FailureMessage }
+    $json = ([string[]]$output) -join [Environment]::NewLine
+    if ([string]::IsNullOrWhiteSpace($json)) { return $null }
+    return ($json | ConvertFrom-Json)
+}
+
+function Invoke-GhApiNoContent {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments, [Parameter(Mandatory = $true)][string]$FailureMessage)
+    & gh.exe api -H "Accept: application/vnd.github+json" `
+        -H "X-GitHub-Api-Version: 2022-11-28" @Arguments | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw $FailureMessage }
+}
+
+function Resolve-RunnerGroupRepositorySlugs {
+    param(
+        [Parameter(Mandatory = $true)][string]$OrganizationName,
+        [Parameter(Mandatory = $true)][string]$DefaultRepositorySlug,
+        [string[]]$AdditionalRepositories = @()
+    )
+    $slugs = @($DefaultRepositorySlug)
+    foreach ($repository in $AdditionalRepositories) {
+        if ([string]::IsNullOrWhiteSpace($repository)) { continue }
+        $value = $repository.Trim()
+        if ($value -match '^https://github\.com/') {
+            $value = Get-GitHubRepositorySlug -RepoUrl $value
+        } elseif ($value -notmatch '/') {
+            $value = "{0}/{1}" -f $OrganizationName, $value
+        }
+        if ($value -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+            throw "Runner group repository '$repository' must be a repository name, owner/repository slug, or GitHub repository URL."
+        }
+        if (-not $value.Split('/')[0].Equals($OrganizationName, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Runner group repository '$value' is not owned by organisation '$OrganizationName'."
+        }
+        $slugs += $value
+    }
+    return @($slugs | Sort-Object -Unique)
+}
+
+function Ensure-GhOrganizationRunnerGroup {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Medium")]
+    param(
+        [Parameter(Mandatory = $true)][string]$OrganizationName,
+        [Parameter(Mandatory = $true)][string]$GroupName,
+        [Parameter(Mandatory = $true)][string[]]$RepositorySlugs,
+        [switch]$AllowPublic
+    )
+    Write-Step "Inspecting GitHub organisation runner group '$GroupName'"
+    $groupsResponse = Invoke-GhApiJson -Arguments @(
+        "orgs/$OrganizationName/actions/runner-groups?per_page=100"
+    ) -FailureMessage "GitHub CLI could not list runner groups for '$OrganizationName'."
+    $group = @($groupsResponse.runner_groups) | Where-Object { $_.name -eq $GroupName } | Select-Object -First 1
+    $repositoryMetadata = @()
+    foreach ($slug in $RepositorySlugs) {
+        $repository = Invoke-GhApiJson -Arguments @("repos/$slug") `
+            -FailureMessage "GitHub CLI could not inspect repository '$slug'."
+        if ($repository.owner.login -ne $OrganizationName) {
+            throw "Repository '$slug' is not owned by organisation '$OrganizationName'."
+        }
+        if ($repository.visibility -eq "public" -and -not $AllowPublic) {
+            throw "Repository '$slug' is public. Re-run with -AllowPublicRepositories only after reviewing the self-hosted runner security risk."
+        }
+        $repositoryMetadata += $repository
+    }
+    if ($null -eq $group) {
+        if ($PSCmdlet.ShouldProcess(
+                "$OrganizationName/$GroupName",
+                "Create organisation runner group with selected-repository access")) {
+            $group = Invoke-GhApiJson -Arguments @(
+                "--method", "POST",
+                "orgs/$OrganizationName/actions/runner-groups",
+                "-f", "name=$GroupName",
+                "-f", "visibility=selected",
+                "-F", ("allows_public_repositories={0}" -f $AllowPublic.IsPresent.ToString().ToLowerInvariant())
+            ) -FailureMessage "GitHub CLI could not create runner group '$GroupName' in '$OrganizationName'."
+        } else {
+            foreach ($repository in $repositoryMetadata) {
+                $null = $PSCmdlet.ShouldProcess($repository.full_name, "Grant repository access to planned runner group '$GroupName'")
+            }
+            return
+        }
+    }
+    if ($group.visibility -ne "selected") {
+        throw "Runner group '$GroupName' already exists with '$($group.visibility)' repository visibility. The installer will not narrow an existing group's access automatically."
+    }
+    if ($AllowPublic -and -not $group.allows_public_repositories) {
+        if ($PSCmdlet.ShouldProcess("$OrganizationName/$GroupName", "Allow selected public repositories to use the runner group")) {
+            Invoke-GhApiNoContent -Arguments @(
+                "--method", "PATCH",
+                "orgs/$OrganizationName/actions/runner-groups/$($group.id)",
+                "-F", "allows_public_repositories=true"
+            ) -FailureMessage "GitHub CLI could not enable public-repository access for runner group '$GroupName'."
+        }
+    }
+    $accessResponse = Invoke-GhApiJson -Arguments @(
+        "orgs/$OrganizationName/actions/runner-groups/$($group.id)/repositories?per_page=100"
+    ) -FailureMessage "GitHub CLI could not inspect repository access for runner group '$GroupName'."
+    $currentRepositoryIds = @($accessResponse.repositories | ForEach-Object { [Int64]$_.id })
+    foreach ($repository in $repositoryMetadata) {
+        if ($currentRepositoryIds -contains [Int64]$repository.id) { continue }
+        if ($PSCmdlet.ShouldProcess($repository.full_name, "Grant repository access to runner group '$GroupName'")) {
+            Invoke-GhApiNoContent -Arguments @(
+                "--method", "PUT",
+                "orgs/$OrganizationName/actions/runner-groups/$($group.id)/repositories/$($repository.id)"
+            ) -FailureMessage "GitHub CLI could not grant '$($repository.full_name)' access to runner group '$GroupName'."
+        }
+    }
+}
+
+function Get-GhRunnerRegistrationToken {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet("Repository", "Organization")][string]$Scope,
+        [Parameter(Mandatory = $true)][string]$RepoUrl,
+        [string]$OrganizationName = ""
+    )
+    if ($Scope -eq "Organization") {
+        if ([string]::IsNullOrWhiteSpace($OrganizationName)) {
+            throw "OrganizationName is required for an organisation runner registration token."
+        }
+        $tokenEndpoint = "orgs/$OrganizationName/actions/runners/registration-token"
+        $targetDescription = $OrganizationName
+    } else {
+        $repoSlug = Get-GitHubRepositorySlug -RepoUrl $RepoUrl
+        $tokenEndpoint = "repos/$repoSlug/actions/runners/registration-token"
+        $targetDescription = $repoSlug
+    }
+    Write-Step "Requesting a fresh $($Scope.ToLowerInvariant()) runner registration token with GitHub CLI"
+    $tokenResponse = Invoke-GhApiJson -Arguments @("--method", "POST", $tokenEndpoint) `
+        -FailureMessage "GitHub CLI could not create a runner token for $targetDescription."
+    $value = ([string]$tokenResponse.token).Trim()
     if ([string]::IsNullOrWhiteSpace($value)) { throw "GitHub CLI returned an empty runner token." }
     return $value
 }
@@ -250,11 +400,43 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubTokenFile)) {
         throw "GitHubTokenFile must not be empty."
     }
 }
+$repositorySlug = Get-GitHubRepositorySlug -RepoUrl $RepositoryUrl
+$repositoryOwner = $repositorySlug.Split('/')[0]
+$resolvedOrganization = ""
+$runnerRegistrationUrl = $RepositoryUrl.TrimEnd('/')
+$runnerGroupRepositorySlugs = @()
+if ($RunnerScope -eq "Organization") {
+    $resolvedOrganization = if ([string]::IsNullOrWhiteSpace($Organization)) { $repositoryOwner } else { $Organization }
+    if (-not $repositoryOwner.Equals($resolvedOrganization, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "RepositoryUrl owner '$repositoryOwner' does not match organisation '$resolvedOrganization'."
+    }
+    $runnerRegistrationUrl = "https://github.com/$resolvedOrganization"
+    $runnerGroupRepositorySlugs = Resolve-RunnerGroupRepositorySlugs `
+        -OrganizationName $resolvedOrganization `
+        -DefaultRepositorySlug $repositorySlug `
+        -AdditionalRepositories $RunnerGroupRepositories
+} elseif (
+    $PSBoundParameters.ContainsKey("Organization") -or
+    $PSBoundParameters.ContainsKey("RunnerGroupName") -or
+    $PSBoundParameters.ContainsKey("RunnerGroupRepositories") -or
+    $AllowPublicRepositories
+) {
+    throw "Organization, RunnerGroupName, RunnerGroupRepositories, and AllowPublicRepositories require -RunnerScope Organization."
+}
 $useGitHubCli = -not $GitHubToken -and [string]::IsNullOrWhiteSpace($GitHubTokenFile)
-if ($useGitHubCli) {
-    if (-not (Get-Command gh.exe -ErrorAction SilentlyContinue)) { throw "gh.exe is required when no token is supplied." }
+$requiresGitHubCli = $useGitHubCli -or $RunnerScope -eq "Organization"
+if ($requiresGitHubCli) {
+    if (-not (Get-Command gh.exe -ErrorAction SilentlyContinue)) { throw "gh.exe is required when no token is supplied or organisation runner scope is requested." }
     & gh.exe auth status --hostname github.com *> $null
     if ($LASTEXITCODE -ne 0) { throw "GitHub CLI is not authenticated. Run 'gh auth login'." }
+}
+if ($RunnerScope -eq "Organization" -and $WhatIfPreference) {
+    Ensure-GhOrganizationRunnerGroup `
+        -OrganizationName $resolvedOrganization `
+        -GroupName $RunnerGroupName `
+        -RepositorySlugs $runnerGroupRepositorySlugs `
+        -AllowPublic:$AllowPublicRepositories `
+        -WhatIf
 }
 if (-not $LinuxPassword) {
     $LinuxPassword = Read-Host ("Password for WSL user '{0}'" -f $LinuxUser) -AsSecureString
@@ -284,6 +466,9 @@ if ($RunnerCount -gt 1) {
         $configured = $false
         if ($exists -and -not $ForceRecreate) {
             $configured = Test-WslRunnerConfigured -Distribution $memberDistroName
+            if ($configured -and $RunnerScope -eq "Organization") {
+                Write-Warning ("{0} is already configured. It will be left unchanged; this installer does not silently convert an existing repository-scoped registration to organisation scope." -f $memberDistroName)
+            }
         }
         $members += [pscustomobject]@{
             Index = $index; DistroName = $memberDistroName
@@ -306,16 +491,22 @@ if ($RunnerCount -gt 1) {
         $child = @{
             DistroName = $member.DistroName; InstallLocation = $member.InstallLocation
             RunnerCount = 1; VhdSize = $VhdSize; LinuxUser = $member.LinuxUser
-            LinuxPassword = $LinuxPassword; RepositoryUrl = $RepositoryUrl
+            LinuxPassword = $LinuxPassword; RepositoryUrl = $RepositoryUrl; RunnerScope = $RunnerScope
             RunnerName = $member.RunnerName; RunnerLabels = $member.RunnerLabels
             RunnerVersion = $RunnerVersion; PowerShellVersion = $PowerShellVersion
             RunnerSha256 = $RunnerSha256; PruneUntil = $PruneUntil
             PruneIntervalSeconds = $PruneIntervalSeconds
         }
+        if ($RunnerScope -eq "Organization") {
+            $child.Organization = $resolvedOrganization
+            $child.RunnerGroupName = $RunnerGroupName
+            $child.RunnerGroupRepositories = $RunnerGroupRepositories
+        }
         if ($GitHubToken) { $child.GitHubToken = $GitHubToken }
         elseif ($GitHubTokenFile) { $child.GitHubTokenFile = $GitHubTokenFile }
         if ($ForceRecreate) { $child.ForceRecreate = $true }
         if ($AllowLowDiskSpace) { $child.AllowLowDiskSpace = $true }
+        if ($AllowPublicRepositories) { $child.AllowPublicRepositories = $true }
         if ($SkipAutostart) { $child.SkipAutostart = $true }
         if ($WhatIfPreference) { $child.WhatIf = $true }
         if ($PSBoundParameters.ContainsKey('Confirm')) { $child.Confirm = $PSBoundParameters['Confirm'] }
@@ -327,6 +518,10 @@ if ($RunnerCount -gt 1) {
 }
 
 $distroExists = (Get-WslDistributionNames) -contains $DistroName
+if ($distroExists -and -not $ForceRecreate -and $RunnerScope -eq "Organization" -and
+    (Test-WslRunnerConfigured -Distribution $DistroName)) {
+    throw "$DistroName is already configured; this installer does not silently convert an existing repository-scoped registration to organisation scope. Use a new distro/name or deliberately use -ForceRecreate after confirming the runner is idle."
+}
 $resolvedInstallLocation = [IO.Path]::GetFullPath($InstallLocation)
 if ($distroExists -and $ForceRecreate) {
     if ($PSCmdlet.ShouldProcess($DistroName, "Permanently unregister and delete the WSL distribution")) {
@@ -427,9 +622,22 @@ rm -rf /var/lib/apt/lists/*
     Start-Sleep -Seconds 2
     Invoke-NativeChecked wsl.exe @("--distribution", $DistroName, "--user", "root", "--exec", "systemctl", "start", "docker.service") "Docker did not start"
 
+    if ($RunnerScope -eq "Organization") {
+        Ensure-GhOrganizationRunnerGroup `
+            -OrganizationName $resolvedOrganization `
+            -GroupName $RunnerGroupName `
+            -RepositorySlugs $runnerGroupRepositorySlugs `
+            -AllowPublic:$AllowPublicRepositories
+    }
+
     if ($GitHubToken) { $plainToken = ConvertFrom-SecureValue $GitHubToken }
     elseif ($GitHubTokenFile) { $plainToken = [IO.File]::ReadAllText((Resolve-Path $GitHubTokenFile).Path).Trim() }
-    else { $plainToken = Get-GhRunnerRegistrationToken -RepoUrl $RepositoryUrl }
+    else {
+        $plainToken = Get-GhRunnerRegistrationToken `
+            -Scope $RunnerScope `
+            -RepoUrl $RepositoryUrl `
+            -OrganizationName $resolvedOrganization
+    }
     if ([string]::IsNullOrWhiteSpace($plainToken)) { throw "The runner registration token is empty." }
     $tokenTemp = New-RestrictedTemporaryFile $plainToken
     $plainToken = ""
@@ -437,9 +645,24 @@ rm -rf /var/lib/apt/lists/*
 
     $runnerBootstrap = @'
 set -Eeuo pipefail
-linux_user="$1"; token_source_file="$2"; repo_url="$3"; runner_name="$4"; runner_labels="$5"
+linux_user="$1"; token_source_file="$2"; registration_url="$3"; runner_name="$4"; runner_labels="$5"
 runner_version="$6"; runner_sha256="$7"; prune_until="$8"; prune_interval_seconds="$9"
+runner_scope="${10}"; runner_group="${11}"
 [[ "${runner_sha256}" == "-" ]] && runner_sha256=""
+[[ "${runner_group}" == "-" ]] && runner_group=""
+case "${runner_scope}" in
+  Repository)
+    [[ "${registration_url}" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/?$ ]] \
+      || { echo "Invalid repository registration URL" >&2; exit 2; }
+    [[ -z "${runner_group}" ]] || { echo "Repository runners cannot specify a runner group" >&2; exit 2; }
+    ;;
+  Organization)
+    [[ "${registration_url}" =~ ^https://github\.com/[A-Za-z0-9_.-]+/?$ ]] \
+      || { echo "Invalid organisation registration URL" >&2; exit 2; }
+    [[ -n "${runner_group}" ]] || { echo "Organisation runner group is required" >&2; exit 2; }
+    ;;
+  *) echo "Invalid runner scope: ${runner_scope}" >&2; exit 2 ;;
+esac
 runner_home="/home/${linux_user}/actions-runner"
 work_root="${runner_home}/_work"
 runtime_dir="/run/service-lasso-runner"
@@ -448,7 +671,7 @@ install -o "${linux_user}" -g "${linux_user}" -m 0400 /dev/null "${token_file}"
 tr -d '\r\n' < "${token_source_file}" > "${token_file}"
 trap 'rm -f "${token_file}"' EXIT
 registration_token="$(cat "${token_file}")"
-payload="$(jq -nc --arg url "${repo_url}" '{url: $url, runner_event: "registration"}')"
+payload="$(jq -nc --arg url "${registration_url}" '{url: $url, runner_event: "registration"}')"
 status="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 15 --max-time 30 \
   --request POST --header "Authorization: RemoteAuth ${registration_token}" \
   --header 'Content-Type: application/json' --data "${payload}" \
@@ -521,8 +744,10 @@ chmod 0755 /usr/local/libexec/service-lasso-runner-*
 sudo -u "${linux_user}" bash -Eeuo pipefail -c '
   cd "$1"
   token_value="$(tr -d "\r\n" < "$3")"
-  ./config.sh --unattended --url "$2" --token "${token_value}" --name "$4" --labels "$5" --work _work --replace
-' _ "${runner_home}" "${repo_url}" "${token_file}" "${runner_name}" "${runner_labels}"
+  config_args=(--unattended --url "$2" --token "${token_value}" --name "$4" --labels "$5" --work _work --replace)
+  if [[ -n "$6" ]]; then config_args+=(--runnergroup "$6"); fi
+  ./config.sh "${config_args[@]}"
+' _ "${runner_home}" "${registration_url}" "${token_file}" "${runner_name}" "${runner_labels}" "${runner_group}"
 [[ -x "${runner_home}/svc.sh" ]] || { echo "Runner configuration did not create svc.sh" >&2; exit 6; }
 cd "${runner_home}"
 ./svc.sh install "${linux_user}"
@@ -575,10 +800,11 @@ systemctl daemon-reload
 systemctl enable --now docker.service service-lasso-runner-reaper.timer "${runner_service}"
 '@
     $sha = if ($RunnerSha256) { $RunnerSha256 } else { "-" }
+    $runnerGroupArgument = if ($RunnerScope -eq "Organization") { $RunnerGroupName } else { "-" }
     Invoke-WslBootstrap $DistroName $runnerBootstrap @(
-        $LinuxUser, $tokenWslPath, $RepositoryUrl.TrimEnd('/'), $RunnerName,
+        $LinuxUser, $tokenWslPath, $runnerRegistrationUrl, $RunnerName,
         $RunnerLabels, $RunnerVersion, $sha, $PruneUntil,
-        [string]$PruneIntervalSeconds
+        [string]$PruneIntervalSeconds, $RunnerScope, $runnerGroupArgument
     ) "GitHub runner provisioning failed"
 } finally {
     $plainPassword = ""
@@ -590,5 +816,10 @@ systemctl enable --now docker.service service-lasso-runner-reaper.timer "${runne
 if (-not $SkipAutostart) { Register-WslAutostartTask -Distribution $DistroName }
 Write-Host "Dedicated Service Lasso WSL runner installed." -ForegroundColor Green
 Write-Host ("Distribution: {0}`nRunner: {1}`nLocation: {2}" -f $DistroName, $RunnerName, $resolvedInstallLocation)
+Write-Host ("Scope: {0}" -f $RunnerScope)
+if ($RunnerScope -eq "Organization") {
+    Write-Host ("Runner group: {0}/{1}" -f $resolvedOrganization, $RunnerGroupName)
+    Write-Host ("Repositories: {0}" -f ($runnerGroupRepositorySlugs -join ", "))
+}
 Write-Host ("Verify: wsl -d {0} -- systemctl status 'actions.runner.*'" -f $DistroName)
 Write-Host ("Cleanup: wsl -d {0} -- systemctl list-timers service-lasso-runner-reaper.timer" -f $DistroName)

--- a/tests/wsl-runner-installer.test.js
+++ b/tests/wsl-runner-installer.test.js
@@ -30,7 +30,7 @@ test("issue #873 defines an isolated Service Lasso WSL runner pool", () => {
   assert.match(installer, /function Test-WslRunnerConfigured/);
   assert.match(installer, /service-lasso-runner-\{1:D2\}/);
   assert.match(installer, /a supplied GitHub runner registration token can only be used once/);
-  assert.match(installer, /Get-GhRunnerRegistrationToken -RepoUrl \$RepositoryUrl/);
+  assert.match(installer, /Get-GhRunnerRegistrationToken[\s\S]*?-Scope \$RunnerScope[\s\S]*?-RepoUrl \$RepositoryUrl/);
   assert.match(installer, /Runner\.Worker/);
   assert.match(installer, /docker volume prune --all --force/);
   assert.match(installer, /fstrim \//);
@@ -42,4 +42,26 @@ test("issue #873 defines an isolated Service Lasso WSL runner pool", () => {
   assert.match(docs, /C:\\WSL\\service-lasso-03/);
   assert.match(docs, /wsl --unregister/);
   assert.match(docs, /fstrim/);
+});
+
+test("issue #885 supports selected-repository organisation runner groups", () => {
+  const installer = readRequired(installerRelative);
+  const docs = readRequired(docsRelative);
+  const spec = readRequired(".governance/specs/SPEC-004-isolated-wsl-runner-pool.md");
+
+  assert.match(installer, /\[ValidateSet\("Repository", "Organization"\)\]/);
+  assert.match(installer, /\[string\]\$RunnerScope = "Repository"/);
+  assert.match(installer, /\[string\]\$RunnerGroupName = "service-lasso-wsl"/);
+  assert.match(installer, /\[string\[\]\]\$RunnerGroupRepositories = @\(\)/);
+  assert.match(installer, /\[switch\]\$AllowPublicRepositories/);
+  assert.match(installer, /orgs\/\$OrganizationName\/actions\/runner-groups/);
+  assert.match(installer, /visibility=selected/);
+  assert.match(installer, /repositories\/\$\(\$repository\.id\)/);
+  assert.match(installer, /orgs\/\$OrganizationName\/actions\/runners\/registration-token/);
+  assert.match(installer, /--runnergroup/);
+  assert.doesNotMatch(installer, /\$\{repo_url\}/);
+  assert.match(installer, /does not silently convert an existing repository-scoped registration/i);
+  assert.match(docs, /organisation runner group/i);
+  assert.match(docs, /selected repositories/i);
+  assert.match(spec, /organisation-scoped runner group/i);
 });


### PR DESCRIPTION
## Summary

- keep repository-scoped Service Lasso WSL runners as the default
- add optional organisation registration through a selected-repositories runner group
- create or reuse `service-lasso-wsl`, preserve existing access, and add requested repositories
- require explicit public-repository opt-in and refuse silent conversion of existing runners
- document permissions, commands, and migration safeguards

Closes #885

## Verification

- test-first contract: new issue #885 assertion failed before implementation, then passed
- `node --test tests/wsl-runner-installer.test.js` — 2 passed
- Windows PowerShell 5.1 and PowerShell 7 AST parse — passed
- embedded runner Bash `bash -n` — passed
- repository-scope `-WhatIf` — passed without creating WSL state
- mocked organisation-group `-WhatIf` — planned group creation, Service Lasso access, additional repository access, and WSL creation without mutation
- `git diff --check` — passed

## Operational scope

No live GitHub runner group, runner registration, or WSL distribution was created or replaced. The unrelated dirty primary Service Lasso checkout was not modified.