### PR TITLE
Pin Service Admin release 2026.7.24-db583d4

### DIFF
--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -11,8 +11,8 @@
   "env": {
     "SERVICE_HOST": "0.0.0.0",
     "SERVICE_PORT": "${UI_PORT}",
-    "SERVICE_LASSO_API_BASE_URL": "http://127.0.0.1:17883",
-    "SERVICE_LASSO_RUNTIME_API_BASE_URL": "http://127.0.0.1:17883"
+    "SERVICE_LASSO_API_BASE_URL": "http://192.168.1.53:17883",
+    "SERVICE_LASSO_RUNTIME_API_BASE_URL": "http://192.168.1.53:17883"
   },
   "urls": [
     {
@@ -26,7 +26,7 @@
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-serviceadmin",
-      "tag": "2026.7.9-97b4660"
+      "tag": "2026.7.24-db583d4"
     },
     "platforms": {
       "win32": {
@@ -49,7 +49,10 @@
       }
     }
   },
-  "healthcheck": {
-    "type": "process"
-  }
+  "healthchecks": [
+    {
+      "id": "process-ready",
+      "type": "process"
+    }
+  ]
 }

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -271,7 +271,7 @@ test("core services root declares the clean-clone baseline inventory", async () 
   });
   assert.equal(byId.get("echo-service")?.artifact?.source.repo, "service-lasso/lasso-echoservice");
   assert.equal(byId.get("@serviceadmin")?.artifact?.source.repo, "service-lasso/lasso-serviceadmin");
-  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.7.9-97b4660");
+  assert.equal(byId.get("@serviceadmin")?.artifact?.source.tag, "2026.7.24-db583d4");
   assert.equal(byId.get("@serviceadmin")?.name, "Core Service Admin");
   assert.match(byId.get("@serviceadmin")?.description ?? "", /Core operator\/admin UI service/);
   assert.deepEqual(byId.get("@serviceadmin")?.env, {


### PR DESCRIPTION
## Summary
- Pin canonical @serviceadmin to lasso-serviceadmin release 2026.7.24-db583d4, built from merged develop commit db583d436be3fb89aaca191346cdddc9b957819b covering lasso-serviceadmin PRs #457 and #460.
- Preserve the current LAN runtime API env and healthchecks[] manifest contract.
- Update manifest discovery coverage for the pinned release tag.

## Validation
- npm run build
- node --test tests/manifest-discovery.test.js

## Demo follow-up
Main will recycle the canonical demo and post evidence back to lasso-serviceadmin #372/#374 after merge.
