### PR TITLE
fix(demo): stop registry-owned processes during recycle

### DIFF
--- a/scripts/demo-instance-lib.mjs
+++ b/scripts/demo-instance-lib.mjs
@@ -378,6 +378,14 @@ function commandLooksServiceOwned(command, serviceRoot) {
   return typeof command === "string" && command.includes(path.resolve(serviceRoot));
 }
 
+function pathLooksServiceOwned(filePath, serviceRoot) {
+  if (typeof filePath !== "string" || !filePath.trim()) {
+    return false;
+  }
+  const relativePath = path.relative(path.resolve(serviceRoot), path.resolve(filePath));
+  return Boolean(relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
 async function stopRuntimeServices(runtimeInstance) {
   const apiUrl = runtimeInstance?.apiUrl ?? (
     Number.isInteger(runtimeInstance?.apiPort)
@@ -409,11 +417,15 @@ export async function stopDemoManagedProcesses(options = {}) {
   const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultDemoWorkspaceRoot);
   const stopped = [];
   const skipped = [];
+  const handledPids = new Set();
   const runtimeInstance = await readJsonIfPresent(path.join(workspaceRoot, ".service-lasso", "runtime-instance.json"));
 
   if (runtimeInstanceMatchesDemoRoots(runtimeInstance, { servicesRoot, workspaceRoot })) {
     stopped.push(await stopRuntimeServices(runtimeInstance));
     stopped.push(await terminateProcessTree(runtimeInstance.pid, "runtime-api"));
+    if (Number.isInteger(runtimeInstance.pid)) {
+      handledPids.add(runtimeInstance.pid);
+    }
   }
 
   for (const serviceId of demoServiceIds) {
@@ -433,6 +445,48 @@ export async function stopDemoManagedProcesses(options = {}) {
     }
 
     stopped.push(await terminateProcessTree(runtimeState.pid, serviceId));
+    handledPids.add(runtimeState.pid);
+  }
+
+  const processRegistry = await readJsonIfPresent(path.join(workspaceRoot, ".service-lasso", "processes.json"));
+  for (const entry of processRegistry?.entries ?? []) {
+    if (
+      entry?.ownerType !== "service" ||
+      entry.lifecycleState !== "running" ||
+      entry.identityStatus !== "owned" ||
+      !Number.isInteger(entry.pid) ||
+      handledPids.has(entry.pid)
+    ) {
+      continue;
+    }
+
+    const serviceId = typeof entry.serviceId === "string" && entry.serviceId
+      ? entry.serviceId
+      : entry.ownerId;
+    if (!demoServiceIds.includes(serviceId)) {
+      continue;
+    }
+
+    const serviceRoot = path.join(servicesRoot, serviceId);
+    if (!sameResolvedPath(entry.ownerRoot, serviceRoot) || !processExists(entry.pid)) {
+      continue;
+    }
+
+    const evidence = await getProcessCommandEvidence(entry.pid);
+    if (
+      !commandLooksServiceOwned(evidence.commandLine, serviceRoot) &&
+      !pathLooksServiceOwned(evidence.executablePath, serviceRoot)
+    ) {
+      skipped.push({
+        serviceId,
+        pid: entry.pid,
+        reason: "process_registry_command_not_owned_by_service_root",
+      });
+      continue;
+    }
+
+    stopped.push(await terminateProcessTree(entry.pid, serviceId));
+    handledPids.add(entry.pid);
   }
 
   return { stopped, skipped };

--- a/tests/demo-instance.test.js
+++ b/tests/demo-instance.test.js
@@ -615,6 +615,81 @@ test("demo recycle asks the previous managed runtime to stop services before rep
   }
 });
 
+test("demo recycle stops service processes recorded only in the process registry", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-registry-cleanup-"));
+  const servicesRoot = path.join(tempDir, "services");
+  const workspaceRoot = path.join(tempDir, "workspace", "demo-instance");
+  const serviceRoot = path.join(servicesRoot, "@nginx");
+  const runtimeStateDir = path.join(workspaceRoot, ".service-lasso");
+  const keepAliveScript = path.join(serviceRoot, "keep-alive.mjs");
+  let child = null;
+
+  const processIsAlive = (pid) => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  try {
+    await mkdir(serviceRoot, { recursive: true });
+    await mkdir(runtimeStateDir, { recursive: true });
+    await writeFile(keepAliveScript, "setInterval(() => {}, 1000);\n");
+    child = spawn(process.execPath, [keepAliveScript], {
+      cwd: serviceRoot,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+
+    await writeFile(
+      path.join(runtimeStateDir, "processes.json"),
+      `${JSON.stringify({
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        entries: [
+          {
+            ownerType: "service",
+            ownerId: "@nginx",
+            serviceId: "@nginx",
+            workspaceId: "test",
+            runtimeInstanceId: null,
+            pid: child.pid,
+            identity: null,
+            ownerRoot: serviceRoot,
+            processGroup: { kind: "none", id: null },
+            allocation: { revision: null, ports: { http: 18080 }, endpoints: [] },
+            lifecycleState: "running",
+            identityStatus: "owned",
+            source: "spawn",
+            recordedAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        ],
+      }, null, 2)}\n`,
+    );
+
+    const result = await stopDemoManagedProcesses({ servicesRoot, workspaceRoot });
+
+    assert.ok(
+      result.stopped.some((entry) => entry.label === "@nginx" && entry.pid === child.pid && entry.stopped === true),
+      "Expected recycle cleanup to stop the registry-owned service process.",
+    );
+    assert.equal(processIsAlive(child.pid), false);
+  } finally {
+    if (child && processIsAlive(child.pid)) {
+      child.kill("SIGKILL");
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("demo recycle uses the canonical baseline service set", () => {
   assert.deepEqual(demoRequiredServiceIds, [...DEFAULT_BASELINE_SERVICE_IDS]);
   assert.equal(demoProviderServiceIds.has("@archive"), true);


### PR DESCRIPTION
## Summary
- stop recycle-owned service processes from `.service-lasso/processes.json` when legacy `.state/runtime.json` is missing or mismatched
- keep the existing service-root command/evidence guard before terminating anything
- add a regression test for registry-only service cleanup

## Validation
- `npm run build`
- `node --test tests\\demo-instance.test.js` (25/25)
- canonical recovery evidence from primary demo checkout:
  - `C:\projects\service-lasso\.work-agent\logs\main-764-recovery-20260725-2055\demo-recycle-after-patch.log`
  - `C:\projects\service-lasso\.work-agent\logs\main-764-recovery-20260725-2055\demo-gate-after-patch.log`
  - `C:\projects\service-lasso\.work-agent\logs\main-764-recovery-20260725-2055\demo-verify-canonical-after-patch.log`

Fixes #764