### PR TITLE
Implement service.json stop action override contract

### DIFF
--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -249,6 +249,19 @@ export function hasManagedProcess(serviceId: string): boolean {
   return managedProcesses.has(serviceId);
 }
 
+export async function beginManagedProcessStop(serviceId: string): Promise<boolean> {
+  const record = managedProcesses.get(serviceId);
+  if (!record) {
+    return false;
+  }
+
+  record.stopping = true;
+  if (record.workspaceRoot) {
+    await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopping", undefined, record.child.pid);
+  }
+  return true;
+}
+
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
   const {
     service,
@@ -441,11 +454,7 @@ export async function stopManagedProcess(
     return null;
   }
 
-  record.stopping = true;
-
-  if (record.workspaceRoot) {
-    await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopping", undefined, record.child.pid);
-  }
+  await beginManagedProcessStop(serviceId);
 
   if (!record.child.killed) {
     record.child.kill();
@@ -465,6 +474,49 @@ export async function stopManagedProcess(
   if (timeout) {
     clearTimeout(timeout);
   }
+  const finalizer = managedProcessFinalizers.get(serviceId);
+  if (finalizer) {
+    await finalizer;
+  }
+  if (record.workspaceRoot) {
+    await transitionProcessOwnership(
+      record.workspaceRoot,
+      "service",
+      serviceId,
+      "stopped",
+      "not_running",
+      record.child.pid,
+    );
+  }
+
+  return result;
+}
+
+export async function waitForManagedProcessExit(
+  serviceId: string,
+  timeoutMs = 5_000,
+): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null } | null> {
+  const record = managedProcesses.get(serviceId);
+  if (!record) {
+    return null;
+  }
+
+  await beginManagedProcessStop(serviceId);
+
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeout = setTimeout(() => resolve(null), timeoutMs);
+    timeout.unref?.();
+  });
+
+  const result = await Promise.race([record.exitPromise, timeoutPromise]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  if (!result) {
+    return null;
+  }
+
   const finalizer = managedProcessFinalizers.get(serviceId);
   if (finalizer) {
     await finalizer;

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,11 +1,18 @@
-import type { DiscoveredService } from "../../contracts/service.js";
+import type { DiscoveredService, ServiceActionDefinition } from "../../contracts/service.js";
 import path from "node:path";
+import { spawn } from "node:child_process";
 import { LifecycleStateError } from "../../server/errors.js";
 import {
+  beginManagedProcessStop,
   hasManagedProcess,
   startManagedProcess,
   stopManagedProcess,
+  waitForManagedProcessExit,
 } from "../execution/supervisor.js";
+import {
+  parseCommandlineArgs,
+  selectPlatformCommandline,
+} from "../execution/commandline.js";
 import {
   issueScopedBrokerIdentity,
   revokeServiceScopedBrokerIdentities,
@@ -21,8 +28,10 @@ import { waitForServiceReadiness } from "../health/waitForReadiness.js";
 import { DependencyGraph } from "../manager/DependencyGraph.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
 import {
+  buildServiceVariables,
   compileServiceSelectorPlan,
   collectRuntimeGlobalEnv,
+  resolveServiceText,
   type ServiceVariableResolutionOptions,
 } from "../operator/variables.js";
 import { resolveServiceEndpoints } from "../operator/endpoints.js";
@@ -55,6 +64,7 @@ const SECRETSBROKER_SERVICE_ID = "@secretsbroker";
 const LAUNCH_LEASE_COMMAND_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND";
 const LAUNCH_LEASE_ARGS_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON";
 const WORKSPACE_ID_ENV = "SERVICE_LASSO_WORKSPACE_ID";
+const DEFAULT_STOP_ACTION_TIMEOUT_SECONDS = 30;
 const SECRET_LIKE_VALUE_PATTERN =
   /(BEGIN PRIVATE KEY|access_token\s*[:=]\s*[^\s,;}]+|refresh_token\s*[:=]\s*[^\s,;}]+|id_token\s*[:=]\s*[^\s,;}]+|session_cookie\s*[:=]\s*[^\s,;}]+|client_secret\s*[:=]\s*[^\s,;}]+|provider_credential\s*[:=]\s*[^\s,;}]+|raw_secret\s*[:=]\s*[^\s,;}]+|password\s*[:=]\s*[^\s,;}]+|token\s*[:=]\s*[^\s,;}]+|Bearer\s+[A-Za-z0-9._~+/-]{12,})/gi;
 const SECRET_LIKE_KEY_PATTERN = /(secret|token|password|credential|private|cookie|key)/i;
@@ -490,6 +500,175 @@ function resolveExecutionPlanForLifecycle(
   );
 }
 
+function getLifecycleStopOverride(service: DiscoveredService): ServiceActionDefinition | null {
+  const action = service.manifest.actions?.stop;
+  if (!action) {
+    return null;
+  }
+
+  if (selectPlatformCommandline(action.commandline) || action.command) {
+    return action;
+  }
+
+  return null;
+}
+
+function resolveStopOverrideCommand(
+  service: DiscoveredService,
+  action: ServiceActionDefinition,
+  resolvedPorts: Record<string, number>,
+): { executable: string; args: string[] } | null {
+  const commandline = selectPlatformCommandline(action.commandline);
+  if (commandline) {
+    const [executable, ...args] = parseCommandlineArgs(resolveServiceText(commandline, service, {}, resolvedPorts));
+    if (!executable) {
+      throw new LifecycleStateError(
+        `Cannot stop service "${service.manifest.id}" because actions.stop.commandline did not resolve to an executable.`,
+      );
+    }
+    return { executable, args };
+  }
+
+  if (!action.command) {
+    return null;
+  }
+
+  return {
+    executable: resolveServiceText(action.command, service, {}, resolvedPorts),
+    args: (action.args ?? []).map((arg) => resolveServiceText(arg, service, {}, resolvedPorts)),
+  };
+}
+
+function resolveStopOverrideCwd(
+  service: DiscoveredService,
+  action: ServiceActionDefinition,
+  resolvedPorts: Record<string, number>,
+): string {
+  if (!action.cwd) {
+    return service.serviceRoot;
+  }
+
+  const cwd = resolveServiceText(action.cwd, service, {}, resolvedPorts);
+  return path.isAbsolute(cwd) ? cwd : path.resolve(service.serviceRoot, cwd);
+}
+
+function buildStopOverrideEnvironment(
+  service: DiscoveredService,
+  action: ServiceActionDefinition,
+  resolvedPorts: Record<string, number>,
+): NodeJS.ProcessEnv {
+  const serviceVariables = Object.fromEntries(
+    buildServiceVariables(service, {}, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
+  );
+  const actionEnv = Object.fromEntries(
+    Object.entries(action.env ?? {}).map(([key, value]) => [key, resolveServiceText(value, service, {}, resolvedPorts)]),
+  );
+
+  return {
+    ...process.env,
+    ...serviceVariables,
+    ...actionEnv,
+    SERVICE_LASSO_ACTION_ID: "stop",
+    SERVICE_LASSO_TARGET_ACTION_ID: "stop",
+    SERVICE_LASSO_RUN_SOURCE: "lifecycle",
+  };
+}
+
+async function runStopOverrideCommand(
+  service: DiscoveredService,
+  action: ServiceActionDefinition,
+  resolvedPorts: Record<string, number>,
+): Promise<{ ok: boolean; timedOut: boolean; exitCode: number | null; signal: NodeJS.Signals | null }> {
+  const command = resolveStopOverrideCommand(service, action, resolvedPorts);
+  if (!command) {
+    return { ok: false, timedOut: false, exitCode: null, signal: null };
+  }
+
+  const timeoutMs = (action.timeoutSeconds ?? DEFAULT_STOP_ACTION_TIMEOUT_SECONDS) * 1000;
+  await beginManagedProcessStop(service.manifest.id);
+
+  const child = spawn(command.executable, command.args, {
+    cwd: resolveStopOverrideCwd(service, action, resolvedPorts),
+    env: buildStopOverrideEnvironment(service, action, resolvedPorts),
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  let timedOut = false;
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<{ exitCode: null; signal: "SIGKILL" }>((resolve) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      resolve({ exitCode: null, signal: "SIGKILL" });
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  const exitPromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => resolve({ exitCode, signal }));
+  });
+
+  try {
+    const exit = await Promise.race([exitPromise, timeoutPromise]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    return {
+      ok: !timedOut && exit.exitCode === 0,
+      timedOut,
+      exitCode: exit.exitCode,
+      signal: exit.signal,
+    };
+  } catch {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    return {
+      ok: false,
+      timedOut: false,
+      exitCode: null,
+      signal: null,
+    };
+  }
+}
+
+async function stopManagedProcessWithOverride(
+  service: DiscoveredService,
+  current: ServiceLifecycleState,
+): Promise<{ exitCode: number | null; message: string }> {
+  const serviceId = service.manifest.id;
+  const override = getLifecycleStopOverride(service);
+  if (!override) {
+    const stopped = await stopManagedProcess(serviceId);
+    return {
+      exitCode: stopped?.exitCode ?? current.runtime.exitCode ?? 0,
+      message: "Stop completed.",
+    };
+  }
+
+  const overrideResult = await runStopOverrideCommand(service, override, current.runtime.ports);
+  if (overrideResult.ok) {
+    const settled = await waitForManagedProcessExit(serviceId, 5_000);
+    if (settled || !hasManagedProcess(serviceId)) {
+      return {
+        exitCode: settled?.exitCode ?? overrideResult.exitCode ?? current.runtime.exitCode ?? 0,
+        message: "Stop completed with actions.stop override.",
+      };
+    }
+  }
+
+  const stopped = await stopManagedProcess(serviceId);
+  const reason = overrideResult.timedOut
+    ? "timed out"
+    : `failed with exit code ${overrideResult.exitCode ?? "unknown"}`;
+  return {
+    exitCode: stopped?.exitCode ?? current.runtime.exitCode ?? 0,
+    message: `Stop override ${reason}; fallback stop completed.`,
+  };
+}
+
 export async function installService(
   service: DiscoveredService,
   registry?: ServiceRegistry,
@@ -892,7 +1071,7 @@ export async function stopService(
     );
   }
 
-  const stopped = await stopManagedProcess(serviceId);
+  const stopped = await stopManagedProcessWithOverride(service, current);
   const finishedAt = new Date().toISOString();
   const revokedIdentities = revokeServiceScopedBrokerIdentities(serviceId, {
     now: new Date(finishedAt),
@@ -908,13 +1087,13 @@ export async function stopService(
         ...state.runtime,
         pid: null,
         finishedAt,
-        exitCode: stopped?.exitCode ?? state.runtime.exitCode ?? 0,
+        exitCode: stopped.exitCode,
         lastTermination: "stopped",
         metrics: applyRunCompletionMetrics(state, finishedAt, "stopped"),
         brokerIdentity: revokedIdentity,
       },
     },
-    message: "Stop completed.",
+    message: stopped.message,
   }));
 }
 

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -1,13 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer as startRuntimeApiServer } from "../dist/server/index.js";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 import {
   installService,
   configService,
   startService,
+  stopService,
 } from "../dist/runtime/lifecycle/actions.js";
 import {
   hasManagedProcess,
@@ -587,6 +588,120 @@ test("managed process stop escalates after timeout and clears supervisor state",
     }
   } finally {
     await stopManagedProcess("stubborn-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("stop uses manifest actions.stop.commandline override before managed fallback", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-stop-override-",
+  );
+  const serviceRoot = path.join(servicesRoot, "graceful-stop-service");
+  const runtimeRoot = path.join(serviceRoot, "runtime");
+  await mkdir(runtimeRoot, { recursive: true });
+  await writeFile(
+    path.join(runtimeRoot, "server.mjs"),
+    `
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+const stopFile = path.resolve(process.cwd(), "runtime", "stop-requested.txt");
+const heartbeat = setInterval(async () => {
+  try {
+    await access(stopFile);
+    clearInterval(heartbeat);
+    process.exit(0);
+  } catch {
+  }
+}, 25);
+`.trim(),
+  );
+  await writeFile(
+    path.join(runtimeRoot, "stop.mjs"),
+    `
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
+await writeFile(path.resolve(process.cwd(), "runtime", "stop-requested.txt"), "stop");
+await writeFile(path.resolve(process.cwd(), "runtime", "override-ran.txt"), "ran");
+`.trim(),
+  );
+  await writeManifest(servicesRoot, "graceful-stop-service", {
+    id: "graceful-stop-service",
+    name: "Graceful Stop Service",
+    description: "Fixture with manifest stop override.",
+    executable: process.execPath,
+    args: ["runtime/server.mjs"],
+    healthcheck: { type: "process" },
+    actions: {
+      stop: {
+        commandline: {
+          default: `${JSON.stringify(process.execPath)} runtime/stop.mjs`,
+        },
+        timeoutSeconds: 2,
+      },
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+
+    await installService(service);
+    await configService(service);
+    const start = await startService(service);
+    assert.equal(start.state.running, true);
+    assert.equal(hasManagedProcess("graceful-stop-service"), true);
+
+    const stop = await stopService(service);
+
+    assert.equal(stop.ok, true);
+    assert.equal(stop.state.running, false);
+    assert.equal(stop.state.runtime.pid, null);
+    assert.match(stop.message, /actions\.stop override/i);
+    assert.equal(await readFile(path.join(runtimeRoot, "override-ran.txt"), "utf8"), "ran");
+    assert.equal(hasManagedProcess("graceful-stop-service"), false);
+  } finally {
+    await stopManagedProcess("graceful-stop-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("stop falls back to managed process stop when manifest override fails", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-stop-override-fallback-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "fallback-stop-service", {
+    actions: {
+      stop: {
+        commandline: {
+          default: `${JSON.stringify(process.execPath)} -e "process.exit(7)"`,
+        },
+        timeoutSeconds: 1,
+      },
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+
+    await installService(service);
+    await configService(service);
+    await startService(service);
+    assert.equal(hasManagedProcess("fallback-stop-service"), true);
+
+    const stop = await stopService(service);
+
+    assert.equal(stop.ok, true);
+    assert.equal(stop.state.running, false);
+    assert.equal(stop.state.runtime.pid, null);
+    assert.match(stop.message, /fallback stop completed/i);
+    assert.equal(hasManagedProcess("fallback-stop-service"), false);
+  } finally {
+    await stopManagedProcess("fallback-stop-service", 100).catch(() => null);
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Issue
Closes #777

## Summary
- Added lifecycle stop support for manifest `actions.stop.commandline` / command overrides.
- Added supervisor helpers to mark a managed process as intentionally stopping and wait for a graceful external stop before falling back.
- Added lifecycle tests for graceful override success and managed-stop fallback on override failure.

## Scope
- In scope: `stop` lifecycle action override and fallback behavior.
- Out of scope: NGINX manifest update in `service-lasso/lasso-nginx`; issue #777 tracks that as a related follow-up.

## Spec / contract / fixture impact
- Updated: TypeScript runtime behavior now matches the existing `service.json` reference for `actions.stop.commandline`.
- Not required because: docs already describe the action commandline fields and the issue acceptance criteria targeted runtime implementation.

## Service Lasso invariant impact
- Invariant: services without `actions.stop` keep the existing managed-process stop path.
- Preservation proof: targeted lifecycle tests include default stop behavior and fallback from failed override.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\20260726-232824\issue-777-npm-build-final.log`
- PASS `node --test tests/lifecycle-actions.test.js tests/manifest-discovery.test.js` — `C:\projects\service-lasso\.work-agent\logs\20260726-232824\issue-777-targeted-tests.log`

## Approval trail
- Required: no special approval expected beyond repository checks.
- Evidence: focused runtime lifecycle implementation with tests.

## Cleanup
- Branch cleanup after merge; developer will return local checkout to `develop` when completion gates pass.