### PR TITLE
Define service Files workspace registry

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -42,6 +42,7 @@ This reference tracks each runtime-facing field as:
 | Field | Status | TypeScript contract | Runtime/lifecycle behavior |
 | --- | --- | --- | --- |
 | `actions` | implemented | `ServiceManifest.actions?: ServiceActionPolicy` with action definitions, payload policy, workflow steps, and schedule maps | Validated during manifest discovery, used by service action run APIs, used by lifecycle stop overrides, and published through `GET /api/workflows/registry` for enabled scheduled actions. Closed alignment issue: [#777](https://github.com/service-lasso/service-lasso/issues/777). |
+| `files` | implemented | `ServiceManifest.files?: ServiceFilesPolicy` with service-root-relative workspace roots | Validated during manifest discovery and published through `GET /api/files/workspaces` as the `service-lasso-workspaces` registry for file-manager consumers. |
 | `serviceorder` | implemented | `ServiceManifest.serviceorder?: number` | Validated as a top-level whole number and used by dependency graph ordering for otherwise-independent services. Closed alignment issue: [#778](https://github.com/service-lasso/service-lasso/issues/778). |
 | `execconfig.serviceorder` | compatibility | `ServiceManifest.execconfig?: ServiceExecutionConfig` with `serviceorder?: number` | Accepted for legacy manifests and normalized behind top-level `serviceorder`; top-level `serviceorder` takes precedence when both are present. Closed alignment issue: [#778](https://github.com/service-lasso/service-lasso/issues/778). |
 
@@ -878,6 +879,47 @@ Sample:
 ```
 
 ## Other important manifest aspects
+
+### Files workspace roots
+
+`files` declares service-owned workspace roots that may be exposed to a file-manager consumer such as `lasso-files`.
+This stays separate from Config/Definition editing: `service.json` remains the service definition, while `files.roots[]`
+describes bounded runtime/workspace file surfaces.
+
+```json
+"files": {
+  "enabled": true,
+  "roots": [
+    {
+      "id": "workspace",
+      "label": "Workspace",
+      "path": ".",
+      "mode": "read-write"
+    },
+    {
+      "id": "logs",
+      "label": "Logs",
+      "path": "./logs",
+      "mode": "read-only"
+    },
+    {
+      "id": "state",
+      "label": "Runtime State",
+      "path": "./.state",
+      "mode": "read-only",
+      "protected": true
+    }
+  ]
+}
+```
+
+Runtime rules:
+
+- `files.enabled` must be `true` before roots are published.
+- `files.roots[].path` must be relative to the service root and cannot escape it with traversal or absolute paths.
+- `mode` is `read-only` or `read-write`; protected roots are exposed as non-writable even when a manifest accidentally marks them read-write.
+- Hidden and protected roots are preserved as registry safety metadata.
+- `GET /api/files/workspaces` returns source `service-lasso-workspaces`, service id/name, root id/label, relative path, resolved path, mode, access, and safety metadata for each declared root.
 
 ### Setup lifecycle steps
 

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -10,6 +10,7 @@ import type { RuntimeLogShippingPreview } from "../runtime/operator/log-shipping
 import type { RuntimeTelemetryPreview, ServiceTelemetryPreview, TelemetryExportTestResult } from "../runtime/operator/telemetry.js";
 import type { ServiceCatalogProvenance } from "./service.js";
 import type { ServiceActionRunState } from "../runtime/actions/runs.js";
+import type { ServiceWorkspaceRegistry } from "../runtime/files/workspace-registry.js";
 
 export interface HealthResponse {
   service: "service-lasso";
@@ -195,6 +196,10 @@ export interface ManagedWorkflowRegistryResponse {
   workflows: ManagedWorkflowRegistryEntry[];
 }
 
+export interface ServiceWorkspaceRegistryResponse {
+  registry: ServiceWorkspaceRegistry;
+}
+
 export interface ServiceDetailResponse {
   service: ServiceSummary;
 }
@@ -325,6 +330,7 @@ export interface RuntimeFeatureFlags {
   operatorLogShipping: boolean;
   operatorLogs: boolean;
   operatorMcp: boolean;
+  serviceFiles: boolean;
   providerConnections: boolean;
   workflowFacade: boolean;
   localRouteGeneration: boolean;

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -56,6 +56,22 @@ export interface ServiceActionMaterialization {
   files?: ServiceMaterializedFile[];
 }
 
+export type ServiceFilesRootMode = "read-only" | "read-write";
+
+export interface ServiceFilesRootDeclaration {
+  id: string;
+  label: string;
+  path: string;
+  mode: ServiceFilesRootMode;
+  hidden?: boolean;
+  protected?: boolean;
+}
+
+export interface ServiceFilesPolicy {
+  enabled?: boolean;
+  roots?: ServiceFilesRootDeclaration[];
+}
+
 export type ServiceHookFailurePolicy = "block" | "warn" | "continue";
 
 export interface ServiceHookStep {
@@ -339,6 +355,7 @@ export interface ServiceManifest {
   hooks?: ServiceLifecycleHooks;
   actions?: ServiceActionPolicy;
   setup?: ServiceSetupPolicy;
+  files?: ServiceFilesPolicy;
   updates?: ServiceUpdatePolicy;
   artifact?: ServiceArchiveArtifact;
   install?: ServiceActionMaterialization;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type {
   ServiceBrokerAccessOperation,
   ServiceBrokerAccessScope,
@@ -17,6 +18,7 @@ import type {
   ServiceEndpointPortStrategy,
   ServiceEndpointProtocol,
   ServiceEndpointTransport,
+  ServiceFilesRootMode,
   ServiceManifestEndpoint,
   ServiceActionWorkflowStep,
   ServiceManifest,
@@ -50,9 +52,11 @@ const endpointTransports = new Set(["tcp", "udp"]);
 const endpointProtocols = new Set(["http", "https", "tcp", "udp"]);
 const endpointExposures = new Set(["local", "lan", "public"]);
 const endpointPortStrategies = new Set(["automatic", "preferred", "fixed"]);
+const filesRootModes = new Set<ServiceFilesRootMode>(["read-only", "read-write"]);
 const brokerNamespacePattern = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9][A-Za-z0-9_.-]*)*$/;
 const brokerRefPattern = /^[A-Za-z][A-Za-z0-9_-]*\.[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 const endpointIdPattern = /^[A-Za-z][A-Za-z0-9_:-]*$/;
+const filesRootIdPattern = /^[A-Za-z][A-Za-z0-9_:-]*$/;
 
 function expectNonEmptyString(value: unknown, field: string, manifestPath: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -405,6 +409,80 @@ function readSetupPolicy(value: unknown, manifestPath: string): ServiceManifest[
   );
 
   return { steps };
+}
+
+function assertServiceRootRelativePath(value: string, field: string, manifestPath: string): string {
+  const declaredPath = value.trim();
+  if (declaredPath.length === 0) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be a non-empty service-root-relative path.`);
+  }
+
+  if (path.isAbsolute(declaredPath)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be relative to the service root.`);
+  }
+
+  if (declaredPath.split(/[\\/]+/).includes("..")) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to stay inside the service root.`);
+  }
+
+  return declaredPath;
+}
+
+function readFilesPolicy(value: unknown, manifestPath: string): ServiceManifest["files"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "files" to be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const enabled = expectOptionalBoolean(record.enabled, "files.enabled", manifestPath);
+  if (record.roots === undefined) {
+    return { enabled };
+  }
+
+  if (!Array.isArray(record.roots)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "files.roots" to be an array.`);
+  }
+
+  const seenRootIds = new Set<string>();
+  const roots = record.roots.map((entry, index) => {
+    const field = `files.roots[${index}]`;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}" to be an object.`);
+    }
+
+    const root = entry as Record<string, unknown>;
+    const id = expectNonEmptyString(root.id, `${field}.id`, manifestPath);
+    if (!filesRootIdPattern.test(id)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "${field}.id" to be a stable root id.`);
+    }
+    if (seenRootIds.has(id)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: duplicate files root id "${id}".`);
+    }
+    seenRootIds.add(id);
+
+    const mode = expectOptionalEnum<ServiceFilesRootMode>(
+      root.mode,
+      `${field}.mode`,
+      filesRootModes,
+      '"read-only" or "read-write"',
+      manifestPath,
+    ) ?? "read-only";
+
+    return {
+      id,
+      label: expectNonEmptyString(root.label, `${field}.label`, manifestPath),
+      path: assertServiceRootRelativePath(expectNonEmptyString(root.path, `${field}.path`, manifestPath), `${field}.path`, manifestPath),
+      mode,
+      hidden: expectOptionalBoolean(root.hidden, `${field}.hidden`, manifestPath),
+      protected: expectOptionalBoolean(root.protected, `${field}.protected`, manifestPath),
+    };
+  });
+
+  return { enabled, roots };
 }
 
 function readStringArray(value: unknown, field: string, manifestPath: string): string[] | undefined {
@@ -1687,6 +1765,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const hooks = readLifecycleHooks(record.hooks, manifestPath);
   const actions = readActionPolicy(record.actions, manifestPath);
   const setup = readSetupPolicy(record.setup, manifestPath);
+  const files = readFilesPolicy(record.files, manifestPath);
   const updates = readUpdatePolicy(record.updates, artifact, manifestPath);
   return {
     id: serviceId,
@@ -1726,6 +1805,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     hooks,
     actions,
     setup,
+    files,
     updates,
     artifact,
     install,

--- a/src/runtime/files/workspace-registry.ts
+++ b/src/runtime/files/workspace-registry.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+import type { DiscoveredService, ServiceFilesRootDeclaration } from "../../contracts/service.js";
+
+export interface ServiceWorkspaceRegistryEntry {
+  id: string;
+  source: "service-lasso-workspaces";
+  serviceId: string;
+  serviceName: string;
+  rootId: string;
+  label: string;
+  mode: ServiceFilesRootDeclaration["mode"];
+  relativePath: string;
+  resolvedPath: string;
+  hidden: boolean;
+  protected: boolean;
+  access: {
+    read: true;
+    write: boolean;
+  };
+  safety: {
+    scope: "service-root";
+    withinServiceRoot: true;
+    pathPolicy: "service-root-relative-only";
+    serviceRoot: string;
+    manifestPath: string;
+  };
+}
+
+export interface ServiceWorkspaceRegistry {
+  source: "service-lasso-workspaces";
+  registryVersion: 1;
+  generatedAt: string;
+  workspaces: ServiceWorkspaceRegistryEntry[];
+}
+
+function toPortablePath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function toRegistryRoot(service: DiscoveredService, root: ServiceFilesRootDeclaration): ServiceWorkspaceRegistryEntry {
+  const resolvedServiceRoot = path.resolve(service.serviceRoot);
+  const resolvedPath = path.resolve(resolvedServiceRoot, root.path);
+  const relativePath = toPortablePath(path.relative(resolvedServiceRoot, resolvedPath)) || ".";
+
+  return {
+    id: `${service.manifest.id}:${root.id}`,
+    source: "service-lasso-workspaces",
+    serviceId: service.manifest.id,
+    serviceName: service.manifest.name,
+    rootId: root.id,
+    label: root.label,
+    mode: root.mode,
+    relativePath,
+    resolvedPath,
+    hidden: root.hidden === true,
+    protected: root.protected === true,
+    access: {
+      read: true,
+      write: root.mode === "read-write" && root.protected !== true,
+    },
+    safety: {
+      scope: "service-root",
+      withinServiceRoot: true,
+      pathPolicy: "service-root-relative-only",
+      serviceRoot: resolvedServiceRoot,
+      manifestPath: service.manifestPath,
+    },
+  };
+}
+
+export function buildServiceWorkspaceRegistry(services: DiscoveredService[]): ServiceWorkspaceRegistry {
+  return {
+    source: "service-lasso-workspaces",
+    registryVersion: 1,
+    generatedAt: new Date().toISOString(),
+    workspaces: services
+      .filter((service) => service.manifest.enabled !== false && service.manifest.files?.enabled === true)
+      .flatMap((service) => (service.manifest.files?.roots ?? []).map((root) => toRegistryRoot(service, root)))
+      .sort((left, right) => left.serviceId.localeCompare(right.serviceId) || left.rootId.localeCompare(right.rootId)),
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,6 +23,7 @@ import { createServiceNetworkResponse } from "./routes/network.js";
 import { createGlobalEnvResponse } from "./routes/globalenv.js";
 import { createServiceMetaResponse, createServicesMetaResponse } from "./routes/service-meta.js";
 import { createManagedWorkflowRegistryResponse } from "./routes/workflows.js";
+import { createServiceWorkspaceRegistryResponse } from "./routes/files.js";
 import {
   createDashboardServiceDetailResponse,
   createDashboardServicesResponse,
@@ -140,6 +141,7 @@ import { readServiceRecoveryHistory } from "../runtime/recovery/history.js";
 import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
 import { listServiceActionRuns, parseServiceActionRunRequest, runServiceAction } from "../runtime/actions/runs.js";
 import { buildManagedWorkflowRegistry } from "../runtime/workflows/registry.js";
+import { buildServiceWorkspaceRegistry } from "../runtime/files/workspace-registry.js";
 import { createRuntimeServiceMonitor, type RuntimeServiceMonitor } from "../runtime/recovery/monitor.js";
 import { readServiceUpdateState } from "../runtime/updates/state.js";
 import { createRuntimeUpdateScheduler, type RuntimeUpdateScheduler } from "../runtime/updates/scheduler.js";
@@ -1653,6 +1655,12 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/workflows/registry") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, createManagedWorkflowRegistryResponse(buildManagedWorkflowRegistry(runtimeModel.discovered)));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/files/workspaces") {
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    writeJson(response, 200, createServiceWorkspaceRegistryResponse(buildServiceWorkspaceRegistry(runtimeModel.discovered)));
     return;
   }
 

--- a/src/server/routes/files.ts
+++ b/src/server/routes/files.ts
@@ -1,0 +1,8 @@
+import type { ServiceWorkspaceRegistryResponse } from "../../contracts/api.js";
+import type { ServiceWorkspaceRegistry } from "../../runtime/files/workspace-registry.js";
+
+export function createServiceWorkspaceRegistryResponse(registry: ServiceWorkspaceRegistry): ServiceWorkspaceRegistryResponse {
+  return {
+    registry,
+  };
+}

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -104,6 +104,13 @@ const endpointGroups: RuntimeEndpointGroupResponse[] = [
     pathPrefix: "/api/mcp",
     mutating: false,
   },
+  {
+    id: "service-files",
+    label: "Service Files registry",
+    methods: ["GET"],
+    pathPrefix: "/api/files",
+    mutating: false,
+  },
 ];
 
 function createDefaultFeatureFlags(
@@ -126,6 +133,7 @@ function createDefaultFeatureFlags(
     operatorLogShipping: true,
     operatorLogs: true,
     operatorMcp: true,
+    serviceFiles: true,
     providerConnections: false,
     workflowFacade: false,
     localRouteGeneration: true,
@@ -175,6 +183,7 @@ export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInpu
             "dependencies",
             "updates",
             "recovery",
+            "service-files",
             "telemetry",
             "log-shipping",
           ],

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -147,6 +147,77 @@ test("GET /api/services returns discovered services from the tracked services ro
   }
 });
 
+test("GET /api/files/workspaces returns the service-root scoped Files registry", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-files-registry-");
+
+  await writeManifest(servicesRoot, "alpha-service", {
+    id: "alpha-service",
+    name: "Alpha Service",
+    description: "Service with workspace file roots.",
+    files: {
+      enabled: true,
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: ".",
+          mode: "read-write",
+        },
+        {
+          id: "logs",
+          label: "Logs",
+          path: "./logs",
+          mode: "read-only",
+          hidden: true,
+        },
+        {
+          id: "state",
+          label: "Runtime State",
+          path: "./.state",
+          mode: "read-write",
+          protected: true,
+        },
+      ],
+    },
+  });
+  await writeManifest(servicesRoot, "bravo-service", {
+    id: "bravo-service",
+    name: "Bravo Service",
+    description: "Service without Files enabled.",
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const result = await getJson(`${apiServer.url}/api/files/workspaces`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.registry.source, "service-lasso-workspaces");
+    assert.equal(result.body.registry.registryVersion, 1);
+    assert.deepEqual(
+      result.body.registry.workspaces.map((entry) => entry.id),
+      ["alpha-service:logs", "alpha-service:state", "alpha-service:workspace"],
+    );
+
+    const byRootId = new Map(result.body.registry.workspaces.map((entry) => [entry.rootId, entry]));
+    assert.equal(byRootId.get("workspace").serviceId, "alpha-service");
+    assert.equal(byRootId.get("workspace").mode, "read-write");
+    assert.equal(byRootId.get("workspace").access.write, true);
+    assert.equal(byRootId.get("workspace").relativePath, ".");
+    assert.equal(byRootId.get("workspace").resolvedPath, path.join(servicesRoot, "alpha-service"));
+    assert.equal(byRootId.get("workspace").safety.withinServiceRoot, true);
+    assert.equal(byRootId.get("workspace").safety.pathPolicy, "service-root-relative-only");
+
+    assert.equal(byRootId.get("logs").hidden, true);
+    assert.equal(byRootId.get("logs").access.write, false);
+    assert.equal(byRootId.get("state").protected, true);
+    assert.equal(byRootId.get("state").access.write, false);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/diagnostics/dependencies reports start blockers and safe next actions", async () => {
   resetLifecycleState();
   const occupiedPortServer = net.createServer();
@@ -626,9 +697,11 @@ test("GET /api/runtime/capabilities returns versioned runtime capability metadat
     assert.equal(result.body.capabilities.api.contractVersion, "service-lasso.runtime-capabilities.v1");
     assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "runtime"));
     assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "operator-mcp" && group.mutating === false));
+    assert.ok(result.body.capabilities.api.endpointGroups.some((group) => group.id === "service-files" && group.pathPrefix === "/api/files" && group.mutating === false));
     assert.equal(result.body.capabilities.features.lifecycleActions, true);
     assert.equal(result.body.capabilities.features.dashboardAdapter, true);
     assert.equal(result.body.capabilities.features.operatorMcp, true);
+    assert.equal(result.body.capabilities.features.serviceFiles, true);
     assert.equal(result.body.capabilities.features.providerConnections, false);
     assert.equal(result.body.capabilities.features.workflowFacade, false);
     assert.equal(result.body.capabilities.features.autostart, false);

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -581,6 +581,132 @@ test("loadServiceManifest accepts bounded broker manifest policy", async () => {
   }
 });
 
+test("loadServiceManifest accepts bounded service files workspace roots", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "files-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "files-service",
+        name: "Files Service",
+        description: "Service with bounded workspace file roots.",
+        files: {
+          enabled: true,
+          roots: [
+            {
+              id: "workspace",
+              label: "Workspace",
+              path: ".",
+              mode: "read-write",
+            },
+            {
+              id: "logs",
+              label: "Logs",
+              path: "./logs",
+              mode: "read-only",
+              hidden: true,
+            },
+            {
+              id: "state",
+              label: "Runtime State",
+              path: "./.state",
+              mode: "read-write",
+              protected: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.files, {
+      enabled: true,
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: ".",
+          mode: "read-write",
+          hidden: undefined,
+          protected: undefined,
+        },
+        {
+          id: "logs",
+          label: "Logs",
+          path: "./logs",
+          mode: "read-only",
+          hidden: true,
+          protected: undefined,
+        },
+        {
+          id: "state",
+          label: "Runtime State",
+          path: "./.state",
+          mode: "read-write",
+          hidden: undefined,
+          protected: true,
+        },
+      ],
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects files roots outside the service root", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "absolute-root-service", {
+      id: "absolute-root-service",
+      name: "Absolute Root Service",
+      description: "Invalid absolute files root.",
+      files: {
+        enabled: true,
+        roots: [
+          {
+            id: "host",
+            label: "Host",
+            path: path.resolve(os.tmpdir()),
+            mode: "read-only",
+          },
+        ],
+      },
+    });
+    await writeManifest(servicesRoot, "traversal-root-service", {
+      id: "traversal-root-service",
+      name: "Traversal Root Service",
+      description: "Invalid traversal files root.",
+      files: {
+        enabled: true,
+        roots: [
+          {
+            id: "escape",
+            label: "Escape",
+            path: "../outside",
+            mode: "read-only",
+          },
+        ],
+      },
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "absolute-root-service", "service.json")),
+      /files\.roots\[0\]\.path.*relative to the service root/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "traversal-root-service", "service.json")),
+      /files\.roots\[0\]\.path.*inside the service root/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest rejects malformed broker manifest policy", async () => {
   const servicesRoot = await makeTempServicesRoot();
 


### PR DESCRIPTION
## Issue
Closes #780

## Summary
- Adds a manifest-side iles contract for service-root scoped workspace roots.
- Publishes GET /api/files/workspaces as the service-lasso-workspaces registry for file-manager consumers.
- Documents the Files contract and advertises the read-only registry through runtime capabilities.

## Scope
- In scope: manifest validation, registry response, runtime API route, docs, targeted tests.
- Out of scope: mutating file operations and lasso-files UI/provider implementation.

## Spec / contract / fixture impact
- Updated: docs/reference/service-json-reference.md, src/contracts/service.ts, src/contracts/api.ts.

## Service Lasso invariant impact
- Invariant: service Files roots cannot expose arbitrary host paths.
- Preservation proof: validator rejects absolute paths and .. traversal, registry roots are service-root scoped, protected roots are non-writable.

## Validation
- PASS 
pm run build - see .work-agent/logs/cron-9e9b19ce-20260727T022907/issue-780-npm-build-v5.stdout.log
- PASS 
ode --test --test-concurrency=1 tests/manifest-discovery.test.js - see .work-agent/logs/cron-9e9b19ce-20260727T022907/issue-780-manifest-discovery-test-v5.stdout.log
- PASS 
ode --test --test-concurrency=1 --test-name-pattern "Files registry|runtime/capabilities" tests/api-spine.test.js - see .work-agent/logs/cron-9e9b19ce-20260727T022907/issue-780-api-spine-focused-v5.stdout.log

## Approval trail
- Required: no special approval identified; normal branch checks/review apply.

## Cleanup
- Branch will be merged into develop and local checkout returned to clean develop when DEV completion gates allow.
