### PR TITLE
Reinstate outputvarregex manifest contract

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -43,6 +43,7 @@ This reference tracks each runtime-facing field as:
 | --- | --- | --- | --- |
 | `actions` | implemented | `ServiceManifest.actions?: ServiceActionPolicy` with action definitions, payload policy, workflow steps, and schedule maps | Validated during manifest discovery, used by service action run APIs, used by lifecycle stop overrides, and published through `GET /api/workflows/registry` for enabled scheduled actions. Closed alignment issue: [#777](https://github.com/service-lasso/service-lasso/issues/777). |
 | `files` | implemented | `ServiceManifest.files?: ServiceFilesPolicy` with service-root-relative workspace roots | Validated during manifest discovery and published through `GET /api/files/workspaces` as the `service-lasso-workspaces` registry for file-manager consumers. |
+| `outputvarregex` | compatibility | `ServiceManifest.outputvarregex?: Record<string, string>` | Validated during manifest discovery as a legacy-compatible stdout/stderr variable extraction contract for services that use `variable` healthchecks. |
 | `serviceorder` | implemented | `ServiceManifest.serviceorder?: number` | Validated as a top-level whole number and used by dependency graph ordering for otherwise-independent services. Closed alignment issue: [#778](https://github.com/service-lasso/service-lasso/issues/778). |
 | `execconfig.serviceorder` | compatibility | `ServiceManifest.execconfig?: ServiceExecutionConfig` with `serviceorder?: number` | Accepted for legacy manifests and normalized behind top-level `serviceorder`; top-level `serviceorder` takes precedence when both are present. Closed alignment issue: [#778](https://github.com/service-lasso/service-lasso/issues/778). |
 
@@ -868,6 +869,7 @@ Sample:
 Use when:
 
 - a specific resolved/exported variable is the readiness signal
+- a legacy-compatible `outputvarregex` declaration derives that variable from process output
 
 Sample:
 
@@ -877,6 +879,31 @@ Sample:
   "variable": "${SERVICE_URL}"
 }
 ```
+
+### `outputvarregex`
+
+`outputvarregex` declares legacy-compatible variables extracted from managed process output. Each map key is the variable name to set. Each value is a JavaScript regular expression string applied to stdout/stderr lines collected by the managed process runtime.
+
+Example:
+
+```json
+"outputvarregex": {
+  "FILEBEAT_ENABLED_INPUTS": ".*Enabled inputs: (\\d+).*"
+},
+"healthcheck": {
+  "type": "variable",
+  "variable": "FILEBEAT_ENABLED_INPUTS",
+  "retries": 180
+}
+```
+
+Runtime contract:
+
+- `outputvarregex` must be an object whose keys are non-empty variable names and whose values are valid regular expression strings.
+- The first capture group becomes the variable value.
+- If a valid regex has no capture group, the full match becomes the variable value.
+- Existing manifests without `outputvarregex` behave unchanged.
+- This stays separate from `env` and `globalenv`; it is for stdout/stderr-derived runtime variables that can feed `variable` healthchecks.
 
 ## Other important manifest aspects
 

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -342,6 +342,7 @@ export interface ServiceManifest {
   execconfig?: ServiceExecutionConfig;
   depend_on?: string[];
   healthcheck?: ServiceHealthcheck;
+  outputvarregex?: Record<string, string>;
   env?: Record<string, string>;
   globalenv?: Record<string, string>;
   broker?: ServiceBrokerPolicy;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -190,6 +190,35 @@ function readStringMap(value: unknown, field: string, manifestPath: string): Rec
   return Object.fromEntries(Object.entries(value as Record<string, string>).map(([key, entry]) => [key.trim(), entry]));
 }
 
+function readOutputVarRegex(value: unknown, manifestPath: string): Record<string, string> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.values(value).some((entry) => typeof entry !== "string")) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "outputvarregex" to be a string map.`);
+  }
+
+  const variables = new Map<string, string>();
+  for (const [rawName, pattern] of Object.entries(value as Record<string, string>)) {
+    const variableName = rawName.trim();
+    if (variableName.length === 0) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: outputvarregex variable names must be non-empty.`);
+    }
+    if (variables.has(variableName)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: duplicate outputvarregex variable "${variableName}".`);
+    }
+    try {
+      new RegExp(pattern);
+    } catch {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected outputvarregex.${variableName} to be a valid regular expression.`);
+    }
+    variables.set(variableName, pattern);
+  }
+
+  return Object.fromEntries(variables);
+}
+
 function readNonEmptyStringArray(value: unknown, field: string, manifestPath: string): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -1751,6 +1780,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
 
   const broker = readBrokerPolicy(record.broker, manifestPath, serviceId);
   const endpoints = readManifestEndpoints(record.endpoints, manifestPath);
+  const outputvarregex = readOutputVarRegex(record.outputvarregex, manifestPath);
   const env = rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined;
   const globalenv = rawGlobalEnv
     ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
@@ -1779,6 +1809,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     execconfig,
     depend_on: dependOn?.map((dependency) => dependency.trim()),
     healthcheck,
+    outputvarregex,
     env,
     globalenv,
     broker,

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -363,6 +363,98 @@ test("loadServiceManifest accepts bounded variable healthchecks", async () => {
   }
 });
 
+test("loadServiceManifest accepts legacy outputvarregex maps for variable healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "stdout-variable-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "stdout-variable-service",
+        name: "Stdout Variable Service",
+        description: "Service with stdout-derived variable readiness.",
+        outputvarregex: {
+          FILEBEAT_ENABLED_INPUTS: ".*Enabled inputs: (\\d+).*",
+        },
+        healthcheck: {
+          type: "variable",
+          variable: "FILEBEAT_ENABLED_INPUTS",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.outputvarregex, {
+      FILEBEAT_ENABLED_INPUTS: ".*Enabled inputs: (\\d+).*",
+    });
+    assert.deepEqual(manifest.healthcheck, {
+      type: "variable",
+      variable: "FILEBEAT_ENABLED_INPUTS",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects malformed outputvarregex maps", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "bad-outputvarregex-shape", {
+      id: "bad-outputvarregex-shape",
+      name: "Bad Output Regex Shape",
+      description: "Invalid output variable regex shape.",
+      outputvarregex: ["not", "a", "map"],
+    });
+    await writeManifest(servicesRoot, "bad-outputvarregex-value", {
+      id: "bad-outputvarregex-value",
+      name: "Bad Output Regex Value",
+      description: "Invalid output variable regex value.",
+      outputvarregex: {
+        FILEBEAT_ENABLED_INPUTS: 1,
+      },
+    });
+    await writeManifest(servicesRoot, "bad-outputvarregex-name", {
+      id: "bad-outputvarregex-name",
+      name: "Bad Output Regex Name",
+      description: "Invalid output variable regex name.",
+      outputvarregex: {
+        " ": ".*Enabled inputs: (\\d+).*",
+      },
+    });
+    await writeManifest(servicesRoot, "bad-outputvarregex-pattern", {
+      id: "bad-outputvarregex-pattern",
+      name: "Bad Output Regex Pattern",
+      description: "Invalid output variable regex pattern.",
+      outputvarregex: {
+        FILEBEAT_ENABLED_INPUTS: "[",
+      },
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-outputvarregex-shape", "service.json")),
+      /expected "outputvarregex" to be a string map/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-outputvarregex-value", "service.json")),
+      /expected "outputvarregex" to be a string map/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-outputvarregex-name", "service.json")),
+      /outputvarregex variable names must be non-empty/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-outputvarregex-pattern", "service.json")),
+      /expected outputvarregex\.FILEBEAT_ENABLED_INPUTS to be a valid regular expression/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest accepts manifest readiness retry fields", async () => {
   const servicesRoot = await makeTempServicesRoot();
 


### PR DESCRIPTION
## Issue
Refs #785

## Summary
- Adds the top-level `ServiceManifest.outputvarregex?: Record<string, string>` compatibility field.
- Validates `outputvarregex` as a string map with non-empty variable names and compileable JavaScript regex patterns.
- Documents legacy-compatible variable extraction for `variable` healthchecks.
- Adds manifest discovery coverage for valid and invalid `outputvarregex` examples.

## Scope
- In scope: manifest contract, discovery validation, reference docs, focused tests.
- Out of scope: runtime stdout/stderr extraction implementation beyond the manifest contract slice.

## Spec / contract / fixture impact
- Updated: `src/contracts/service.ts`, `src/runtime/discovery/validateManifest.ts`, `docs/reference/service-json-reference.md`, `tests/manifest-discovery.test.js`.

## Service Lasso invariant impact
- Invariant: Existing manifests without `outputvarregex` remain unchanged.
- Preservation proof: Focused manifest discovery suite passes, including existing healthcheck and manifest validation cases.

## Validation
- PASS `npm ci --no-audit --no-fund` after the new worktree initially lacked `node_modules`.
- PASS `npm run build`.
- PASS `node --test tests\manifest-discovery.test.js`.
- PASS post-failure safety check `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json` reported `healthy`.
- BLOCKED updated-code canonical deployment proof: `npm run demo:deploy-canonical -- --ref HEAD --logs-root ... --summary ...` was rejected because a required canonical demo port is owned by a non-managed process. I did not force recovery.

Evidence root: `C:\projects\service-lasso\.work-agent\logs\run-20260727-122910`.

## Approval trail
- Required: yes, after main/operator clears the canonical deploy port ownership blocker and updated-code proof is rerun.

## Cleanup
- Branch is pushed as `issue-785-outputvarregex-contract` targeting `develop`.
- Local issue worktree remains for blocker continuation: `C:\projects\service-lasso\worktrees\service-lasso-issue-785-outputvarregex`.
