### PR TITLE
Capture outputvarregex matches in runtime state

### DIFF
--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -7,6 +7,8 @@ import { resolveExecutionArgs, selectPlatformCommandline } from "./commandline.j
 import { buildServiceVariables, type ServiceVariableResolutionOptions } from "../operator/variables.js";
 import { buildServiceNetwork } from "../operator/network.js";
 import { archiveRuntimeLogs, buildServiceRuntimeLogRunId, getServiceRuntimeLogPaths, type ServiceRuntimeLogPaths } from "../operator/logs.js";
+import { getLifecycleState, setLifecycleState } from "../lifecycle/store.js";
+import { writeServiceState } from "../state/writeState.js";
 import {
   recordProcessOwnership,
   reconcileRegisteredProcess,
@@ -37,6 +39,7 @@ interface ManagedProcessRecord {
   };
   stdoutBuffer: string;
   stderrBuffer: string;
+  variableCapturePromise: Promise<void>;
   workspaceRoot: string | null;
   exitPromise: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
   finalizePromise: Promise<void>;
@@ -128,6 +131,63 @@ function writeCombinedLogEntry(stream: WriteStream, level: "stdout" | "stderr", 
   stream.write(`${JSON.stringify({ level, message })}\n`);
 }
 
+function matchOutputVariable(pattern: string, line: string): string | null {
+  const match = new RegExp(pattern).exec(line);
+  return typeof match?.[1] === "string" ? match[1] : null;
+}
+
+async function persistOutputVariableMatches(
+  record: ManagedProcessRecord,
+  source: "stdout" | "stderr",
+  line: string,
+): Promise<void> {
+  const outputVarRegex = record.service.manifest.outputvarregex;
+  if (!outputVarRegex || Object.keys(outputVarRegex).length === 0) {
+    return;
+  }
+
+  const matches = Object.entries(outputVarRegex)
+    .map(([name, pattern]) => [name, matchOutputVariable(pattern, line)] as const)
+    .filter((entry): entry is readonly [string, string] => entry[1] !== null);
+  if (matches.length === 0) {
+    return;
+  }
+
+  const matchedAt = new Date().toISOString();
+  const current = getLifecycleState(record.service.manifest.id);
+  const state = setLifecycleState(record.service.manifest.id, {
+    ...current,
+    runtime: {
+      ...current.runtime,
+      variables: {
+        ...current.runtime.variables,
+        ...Object.fromEntries(
+          matches.map(([name, value]) => [
+            name,
+            {
+              value,
+              source,
+              matchedAt,
+            },
+          ]),
+        ),
+      },
+    },
+  });
+
+  await writeServiceState(record.service, state);
+}
+
+function captureOutputVariableMatches(
+  record: ManagedProcessRecord,
+  source: "stdout" | "stderr",
+  line: string,
+): void {
+  record.variableCapturePromise = record.variableCapturePromise
+    .then(() => persistOutputVariableMatches(record, source, line))
+    .catch(() => undefined);
+}
+
 function attachRuntimeLogCapture(record: ManagedProcessRecord): void {
   const flushBufferedLines = (level: "stdout" | "stderr", flushRemainder = false) => {
     const bufferKey = level === "stdout" ? "stdoutBuffer" : "stderrBuffer";
@@ -139,6 +199,7 @@ function attachRuntimeLogCapture(record: ManagedProcessRecord): void {
     for (const line of parts) {
       outputStream.write(`${line}\n`);
       writeCombinedLogEntry(record.logStreams.combined, level, line);
+      captureOutputVariableMatches(record, level, line);
     }
 
     record[bufferKey] = remainder;
@@ -160,6 +221,7 @@ function attachRuntimeLogCapture(record: ManagedProcessRecord): void {
   record.finalizePromise = record.exitPromise.then(async () => {
     flushBufferedLines("stdout", true);
     flushBufferedLines("stderr", true);
+    await record.variableCapturePromise;
     await closeRuntimeLogStreams(record.logStreams);
   });
 }
@@ -346,6 +408,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
     logStreams,
     stdoutBuffer: "",
     stderrBuffer: "",
+    variableCapturePromise: Promise.resolve(),
     workspaceRoot: workspaceRoot ?? null,
     exitPromise,
     finalizePromise: Promise.resolve(),

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -105,6 +105,7 @@ function createInitialState(): ServiceLifecycleState {
         totalRunDurationMs: 0,
         lastRunDurationMs: null,
       },
+      variables: {},
       brokerIdentity: null,
       startTrace: {
         current: null,
@@ -194,6 +195,12 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
         totalRunDurationMs: current.runtime.metrics.totalRunDurationMs,
         lastRunDurationMs: current.runtime.metrics.lastRunDurationMs,
       },
+      variables: Object.fromEntries(
+        Object.entries(current.runtime.variables).map(([key, variable]) => [
+          key,
+          { ...variable },
+        ]),
+      ),
       brokerIdentity: cloneBrokerIdentity(current.runtime.brokerIdentity),
       startTrace: cloneStartTrace(current.runtime.startTrace),
     },
@@ -274,6 +281,12 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
         totalRunDurationMs: nextState.runtime.metrics.totalRunDurationMs,
         lastRunDurationMs: nextState.runtime.metrics.lastRunDurationMs,
       },
+      variables: Object.fromEntries(
+        Object.entries(nextState.runtime.variables).map(([key, variable]) => [
+          key,
+          { ...variable },
+        ]),
+      ),
       brokerIdentity: cloneBrokerIdentity(nextState.runtime.brokerIdentity),
       startTrace: cloneStartTrace(nextState.runtime.startTrace),
     },

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -108,6 +108,12 @@ export interface ServiceRuntimeMetricsState {
   lastRunDurationMs: number | null;
 }
 
+export interface ServiceRuntimeVariableState {
+  value: string;
+  source: "stdout" | "stderr";
+  matchedAt: string;
+}
+
 export interface ServiceRuntimeState {
   pid: number | null;
   startedAt: string | null;
@@ -126,6 +132,7 @@ export interface ServiceRuntimeState {
     stderrPath: string | null;
   };
   metrics: ServiceRuntimeMetricsState;
+  variables: Record<string, ServiceRuntimeVariableState>;
   brokerIdentity: ScopedBrokerIdentityMetadata | null;
   startTrace: ServiceStartTraceState;
 }

--- a/src/runtime/operator/dashboard.ts
+++ b/src/runtime/operator/dashboard.ts
@@ -172,11 +172,11 @@ function buildDashboardLinks(endpoints: DashboardEndpointResponse[]): DashboardS
     }));
 }
 
-function mapVariableScope(scope: "manifest" | "derived" | "global" | "broker"): "global" | "service" {
+function mapVariableScope(scope: "manifest" | "derived" | "global" | "broker" | "runtime"): "global" | "service" {
   return scope === "global" ? "global" : "service";
 }
 
-function mapVariableSource(scope: "manifest" | "derived" | "global" | "broker"): string {
+function mapVariableSource(scope: "manifest" | "derived" | "global" | "broker" | "runtime"): string {
   if (scope === "manifest") {
     return "service.json";
   }
@@ -187,6 +187,10 @@ function mapVariableSource(scope: "manifest" | "derived" | "global" | "broker"):
 
   if (scope === "broker") {
     return "broker.imports";
+  }
+
+  if (scope === "runtime") {
+    return "process-output";
   }
 
   return "runtime";

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -7,7 +7,7 @@ import { buildEndpointVariables } from "./endpoints.js";
 export interface ServiceVariableEntry {
   key: string;
   value: string;
-  scope: "manifest" | "derived" | "global" | "broker";
+  scope: "manifest" | "derived" | "global" | "broker" | "runtime";
 }
 
 export type ServiceSelectorKind = "local" | "broker";
@@ -551,6 +551,13 @@ export function buildServiceVariables(
       }
       return [{ key: entry.as as string, value: brokerValue, scope: "broker" }];
     });
+  const runtimeVariables = Object.entries(
+    getLifecycleState(service.manifest.id).runtime.variables,
+  ).map(([key, variable]) => ({
+    key,
+    value: variable.value,
+    scope: "runtime" as const,
+  }));
 
   return {
     serviceId: service.manifest.id,
@@ -559,6 +566,7 @@ export function buildServiceVariables(
       ...brokerImportVariables,
       ...globalVariables,
       ...derivedVariables,
+      ...runtimeVariables,
     ],
     selectorPlan: compileCachedServiceSelectorPlan(
       `service:${service.manifestPath}:${service.manifest.id}:env`,

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -87,6 +87,7 @@ interface StoredRuntimeState {
     totalRunDurationMs?: number;
     lastRunDurationMs?: number | null;
   };
+  variables?: unknown;
   brokerIdentity?: ServiceLifecycleState["runtime"]["brokerIdentity"];
   startTrace?: unknown;
   lastAction?: LifecycleAction | null;
@@ -291,6 +292,31 @@ function parseStartTraceState(value: unknown): ServiceLifecycleState["runtime"][
   };
 }
 
+function parseRuntimeVariables(value: unknown): ServiceLifecycleState["runtime"]["variables"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return false;
+        }
+        const variable = entry as { value?: unknown; source?: unknown; matchedAt?: unknown };
+        return (
+          typeof variable.value === "string" &&
+          (variable.source === "stdout" || variable.source === "stderr") &&
+          typeof variable.matchedAt === "string"
+        );
+      })
+      .map(([key, entry]) => [
+        key,
+        { ...(entry as ServiceLifecycleState["runtime"]["variables"][string]) },
+      ]),
+  );
+}
+
 function parseSetupRun(value: unknown): ServiceSetupStepRunState | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -490,6 +516,7 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
         lastRunDurationMs:
           typeof runtime?.metrics?.lastRunDurationMs === "number" ? runtime.metrics.lastRunDurationMs : null,
       },
+      variables: parseRuntimeVariables(runtime?.variables),
       brokerIdentity: parseBrokerIdentity(runtime?.brokerIdentity),
       startTrace: parseStartTraceState(runtime?.startTrace),
     },

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -85,6 +85,7 @@ export async function writeServiceState(
           endpoints: lifecycle.runtime.endpoints,
           logs: lifecycle.runtime.logs,
           metrics: lifecycle.runtime.metrics,
+          variables: lifecycle.runtime.variables,
           brokerIdentity: lifecycle.runtime.brokerIdentity,
           startTrace: lifecycle.runtime.startTrace,
           lastAction: lifecycle.lastAction,

--- a/src/server/routes/variables.ts
+++ b/src/server/routes/variables.ts
@@ -1,7 +1,7 @@
 export interface ServiceVariablesResponse {
   variables: {
     serviceId: string;
-    variables: { key: string; value: string; scope: "manifest" | "derived" | "global" | "broker" }[];
+    variables: { key: string; value: string; scope: "manifest" | "derived" | "global" | "broker" | "runtime" }[];
   };
 }
 

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -16,6 +16,7 @@ import {
   stopManagedProcess,
 } from "../dist/runtime/execution/supervisor.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { resolveServiceVariable } from "../dist/runtime/operator/variables.js";
 import { createServiceRegistry } from "../dist/runtime/manager/DependencyGraph.js";
 import { createDirectExecutionPlan } from "../dist/runtime/providers/direct.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
@@ -588,6 +589,74 @@ test("managed process stop escalates after timeout and clears supervisor state",
     }
   } finally {
     await stopManagedProcess("stubborn-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("managed process captures outputvarregex matches into runtime state", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-outputvarregex-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "outputvar-service",
+    {
+      stdoutLines: ["IGNORED", "PORT=4123", "PORT=4124"],
+      stderrLines: ["TOKEN=stderr-value"],
+      outputvarregex: {
+        CAPTURED_PORT: "PORT=(\\d+)",
+        STDERR_TOKEN: "TOKEN=(\\S+)",
+        NO_MATCH: "NO_MATCH=(\\S+)",
+      },
+    },
+  );
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    const handle = await startManagedProcess({
+      service,
+      executionPlan: createDirectExecutionPlan(service.manifest),
+    });
+
+    assert.equal(handle.pid > 0, true);
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return (
+        stored.runtime?.variables?.CAPTURED_PORT?.value === "4124" &&
+        stored.runtime?.variables?.STDERR_TOKEN?.value === "stderr-value"
+      );
+    });
+
+    const stored = await readStoredState(serviceRoot);
+    assert.deepEqual(stored.runtime.variables.CAPTURED_PORT, {
+      value: "4124",
+      source: "stdout",
+      matchedAt: stored.runtime.variables.CAPTURED_PORT.matchedAt,
+    });
+    assert.equal(typeof stored.runtime.variables.CAPTURED_PORT.matchedAt, "string");
+    assert.deepEqual(stored.runtime.variables.STDERR_TOKEN, {
+      value: "stderr-value",
+      source: "stderr",
+      matchedAt: stored.runtime.variables.STDERR_TOKEN.matchedAt,
+    });
+    assert.equal(stored.runtime.variables.NO_MATCH, undefined);
+
+    const capturedPort = resolveServiceVariable(service, "CAPTURED_PORT");
+    const stderrToken = resolveServiceVariable(service, "STDERR_TOKEN");
+    assert.deepEqual(capturedPort, {
+      key: "CAPTURED_PORT",
+      value: "4124",
+      scope: "runtime",
+    });
+    assert.deepEqual(stderrToken, {
+      key: "STDERR_TOKEN",
+      value: "stderr-value",
+      scope: "runtime",
+    });
+  } finally {
+    await stopManagedProcess("outputvar-service", 100).catch(() => null);
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -84,6 +84,7 @@ export async function writeExecutableFixtureService(
     role = undefined,
     enabled = undefined,
     broker = undefined,
+    outputvarregex = undefined,
     ignoreSignals = false,
   } = options;
 
@@ -197,6 +198,7 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     },
     globalenv,
     broker,
+    outputvarregex,
     autostart,
     monitoring,
     restartPolicy,


### PR DESCRIPTION
## Issue
Closes #786

## Summary
- scan managed process stdout and stderr lines against service manifest `outputvarregex`
- persist first capture-group matches under `runtime.variables` with `value`, `source`, and `matchedAt`
- expose captured runtime variables through service variable/operator surfaces without changing existing log capture

## Scope
- In scope: runtime process log capture, lifecycle runtime state, persisted state rehydration, variable API/dashboard typing, targeted fixture coverage
- Out of scope: changing manifest validation semantics or broker/globalenv writeback behavior

## Spec / contract / fixture impact
- Updated: runtime state now includes `variables` for captured process-output values
- Fixture impact: executable fixture service can define `outputvarregex` for managed process tests

## Service Lasso invariant impact
- Invariant: stdout/stderr log capture remains unchanged while outputvarregex values become queryable runtime metadata
- Preservation proof: targeted lifecycle test verifies log-capture path continues through managed process start/stop while capturing stdout and stderr variables

## Validation
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\dev-20260727T032545Z\issue-786-npm-build-2.log`
- PASS `node --test --test-concurrency=1 tests/lifecycle-actions.test.js` - `C:\projects\service-lasso\.work-agent\logs\dev-20260727T032545Z\issue-786-lifecycle-actions-test.log`
- PASS `npm run build` post-change - `C:\projects\service-lasso\.work-agent\logs\dev-20260727T032545Z\issue-786-postchange-npm-build.log`
- PASS canonical demo gate - `C:\projects\service-lasso\.work-agent\logs\dev-20260727T032545Z\issue-786-postchange-demo-gate.log`
- PASS canonical demo verify - `C:\projects\service-lasso\.work-agent\logs\dev-20260727T032545Z\issue-786-postchange-demo-verify-canonical.log`

## Approval trail
- Required: no explicit approval gate identified for this focused runtime fix
- Evidence: Project #1 selected issue #786 from Ready queue and moved it to In progress

## Cleanup
- Branch: `feature/786-outputvarregex-runtime`
- Target: `develop`
- Post-merge: return local checkout to clean develop where possible
