### PR TITLE
Support canonical TCP healthcheck targets

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -847,7 +847,28 @@ Sample:
 }
 ```
 
-This relies on the configured service host/port.
+Bare `type: "tcp"` uses `127.0.0.1` and infers the port only when the service has exactly one unambiguous declared or resolved port.
+
+Use `address` when a single TCP target string is clearer:
+
+```json
+"healthcheck": {
+  "type": "tcp",
+  "address": "127.0.0.1:${HTTP_PORT}"
+}
+```
+
+Use `host` + `port` when the values should be edited independently:
+
+```json
+"healthcheck": {
+  "type": "tcp",
+  "host": "127.0.0.1",
+  "port": "${HTTP_PORT}"
+}
+```
+
+Multiple-port services must declare `address` or `host` + `port`. Legacy alias names such as `tcphost` and `tcpport` are not supported.
 
 ### `file` healthcheck
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1663,9 +1663,60 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
         ...readinessOptions,
       };
     } else if (healthRecord.type === "tcp") {
+      if (healthRecord.tcphost !== undefined || healthRecord.tcpport !== undefined) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: "tcphost" and "tcpport" are not supported; use "healthcheck.host" + "healthcheck.port" or "healthcheck.address".`,
+        );
+      }
+
+      const hasAddress = healthRecord.address !== undefined;
+      const hasHost = healthRecord.host !== undefined;
+      const hasPort = healthRecord.port !== undefined;
+      const rawPort = healthRecord.port;
+
+      if (hasAddress && (hasHost || hasPort)) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: TCP healthcheck must use either "healthcheck.address" or "healthcheck.host" + "healthcheck.port", not both.`,
+        );
+      }
+
+      if (hasHost !== hasPort) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: TCP healthcheck "host" and "port" must be supplied together.`,
+        );
+      }
+
+      if (
+        hasPort &&
+        typeof rawPort !== "string" &&
+        (typeof rawPort !== "number" ||
+          !Number.isInteger(rawPort) ||
+          rawPort < 1 ||
+          rawPort > 65535)
+      ) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: expected "healthcheck.port" to be a non-empty string selector or an integer port between 1 and 65535.`,
+        );
+      }
+
+      if (typeof rawPort === "string" && rawPort.trim().length === 0) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: expected non-empty string for "healthcheck.port".`);
+      }
+
+      const normalizedPort =
+        rawPort === undefined
+          ? undefined
+          : typeof rawPort === "number"
+            ? rawPort
+            : typeof rawPort === "string"
+              ? rawPort.trim()
+              : undefined;
+
       healthcheck = {
         type: "tcp",
-        address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath),
+        ...(hasAddress ? { address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath) } : {}),
+        ...(hasHost ? { host: expectNonEmptyString(healthRecord.host, "healthcheck.host", manifestPath) } : {}),
+        ...(normalizedPort !== undefined ? { port: normalizedPort } : {}),
         ...readinessOptions,
       };
     } else if (healthRecord.type === "file") {

--- a/src/runtime/health/checkTcp.ts
+++ b/src/runtime/health/checkTcp.ts
@@ -2,30 +2,29 @@ import net from "node:net";
 import type { ServiceHealthResult, TcpHealthcheck } from "./types.js";
 
 export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<ServiceHealthResult> {
-  const address = healthcheck.address.trim();
-  const separator = address.lastIndexOf(":");
+  const target =
+    healthcheck.address !== undefined
+      ? parseTcpAddress(healthcheck.address)
+      : parseTcpHostPort(healthcheck.host, healthcheck.port);
 
-  if (separator <= 0 || separator === address.length - 1) {
+  if (!target) {
     return {
       type: "tcp",
       healthy: false,
-      detail: `TCP healthcheck address is invalid: ${address}`,
+      detail: "TCP healthcheck target is invalid; expected address or host + port.",
     };
   }
 
-  const host = address.slice(0, separator);
-  const port = Number(address.slice(separator + 1));
-
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  if (!Number.isInteger(target.port) || target.port < 1 || target.port > 65535) {
     return {
       type: "tcp",
       healthy: false,
-      detail: `TCP healthcheck port is invalid: ${address}`,
+      detail: `TCP healthcheck port is invalid: ${target.address}`,
     };
   }
 
   return new Promise((resolve) => {
-    const socket = net.createConnection({ host, port });
+    const socket = net.createConnection({ host: target.host, port: target.port });
     let settled = false;
 
     const finish = (payload: ServiceHealthResult) => {
@@ -42,7 +41,7 @@ export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<Servi
       finish({
         type: "tcp",
         healthy: true,
-        detail: `TCP healthcheck connected successfully to ${address}.`,
+        detail: `TCP healthcheck connected successfully to ${target.address}.`,
       });
     });
 
@@ -60,8 +59,47 @@ export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<Servi
       finish({
         type: "tcp",
         healthy: false,
-        detail: `TCP healthcheck timed out: ${address}`,
+        detail: `TCP healthcheck timed out: ${target.address}`,
       });
     });
   });
+}
+
+function parseTcpAddress(address: string): { host: string; port: number; address: string } | undefined {
+  const resolvedAddress = address.trim();
+  const separator = resolvedAddress.lastIndexOf(":");
+
+  if (separator <= 0 || separator === resolvedAddress.length - 1) {
+    return undefined;
+  }
+
+  const host = resolvedAddress.slice(0, separator).trim();
+  const port = Number(resolvedAddress.slice(separator + 1).trim());
+  if (!host) {
+    return undefined;
+  }
+
+  return {
+    host,
+    port,
+    address: `${host}:${Number.isFinite(port) ? port : resolvedAddress.slice(separator + 1).trim()}`,
+  };
+}
+
+function parseTcpHostPort(
+  host: string | undefined,
+  port: string | number | undefined,
+): { host: string; port: number; address: string } | undefined {
+  const resolvedHost = host?.trim();
+  const resolvedPort = typeof port === "number" ? port : Number(port?.trim());
+
+  if (!resolvedHost) {
+    return undefined;
+  }
+
+  return {
+    host: resolvedHost,
+    port: resolvedPort,
+    address: `${resolvedHost}:${Number.isFinite(resolvedPort) ? resolvedPort : String(port ?? "").trim()}`,
+  };
 }

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -10,6 +10,20 @@ import type { ServiceHealthResult } from "./types.js";
 import { isProviderRole } from "../roles.js";
 import { resolveServiceText } from "../operator/variables.js";
 
+function inferSingleTcpPort(resolvedPorts: Record<string, number>): number | string {
+  const validPorts = [...new Set(Object.values(resolvedPorts).filter((port) => Number.isInteger(port) && port > 0 && port <= 65535))];
+
+  if (validPorts.length === 1) {
+    return validPorts[0];
+  }
+
+  if (validPorts.length === 0) {
+    return "TCP healthcheck requires an explicit address or host + port because no resolved service port is available.";
+  }
+
+  return "TCP healthcheck requires an explicit address or host + port because multiple service ports are available.";
+}
+
 export async function evaluateServiceHealth(
   manifest: ServiceManifest,
   lifecycle: ServiceLifecycleState,
@@ -44,11 +58,40 @@ export async function evaluateServiceHealth(
   }
 
   if (healthcheck.type === "tcp") {
+    if (healthcheck.address !== undefined) {
+      return checkTcpHealth({
+        ...healthcheck,
+        address: service
+          ? resolveServiceText(healthcheck.address, service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.address,
+      });
+    }
+
+    if (healthcheck.host !== undefined && healthcheck.port !== undefined) {
+      return checkTcpHealth({
+        ...healthcheck,
+        host: service
+          ? resolveServiceText(healthcheck.host, service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.host,
+        port: service
+          ? resolveServiceText(String(healthcheck.port), service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.port,
+      });
+    }
+
+    const inferredPort = inferSingleTcpPort(resolvedPorts);
+    if (typeof inferredPort === "string") {
+      return {
+        type: "tcp",
+        healthy: false,
+        detail: inferredPort,
+      };
+    }
+
     return checkTcpHealth({
       ...healthcheck,
-      address: service
-        ? resolveServiceText(healthcheck.address, service, sharedGlobalEnv, resolvedPorts)
-        : healthcheck.address,
+      host: "127.0.0.1",
+      port: inferredPort,
     });
   }
 

--- a/src/runtime/health/history.ts
+++ b/src/runtime/health/history.ts
@@ -99,6 +99,11 @@ function portFromAddress(value: string): number | undefined {
   return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined;
 }
 
+function tcpAddressFromHealthDetail(value: string): string | undefined {
+  const match = value.match(/\b(?:to|timed out:)\s+([^\s]+:\d{1,5})\.?$/i)?.[1];
+  return match?.replace(/\.$/, "");
+}
+
 function sanitizeVariable(value: string): string {
   const match = value.trim().match(/^\$\{([A-Z0-9_]+)\}$/i);
   return match ? match[1] : "<expression>";
@@ -126,7 +131,25 @@ function observedTarget(
   }
 
   if (healthcheck?.type === "tcp") {
-    const address = sanitizeAddress(healthcheck.address);
+    const configuredAddress =
+      healthcheck.address ??
+      (healthcheck.host !== undefined && healthcheck.port !== undefined
+        ? `${healthcheck.host}:${String(healthcheck.port)}`
+        : tcpAddressFromHealthDetail(health.detail));
+
+    if (configuredAddress === undefined) {
+      return {
+        type: health.type,
+      };
+    }
+
+    const address = sanitizeAddress(configuredAddress);
+    if (address === "<invalid-address>") {
+      return {
+        type: health.type,
+      };
+    }
+
     return {
       type: health.type,
       address,

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -16,7 +16,9 @@ export interface HttpHealthcheck extends HealthcheckReadinessOptions {
 
 export interface TcpHealthcheck extends HealthcheckReadinessOptions {
   type: "tcp";
-  address: string;
+  address?: string;
+  host?: string;
+  port?: string | number;
 }
 
 export interface FileHealthcheck extends HealthcheckReadinessOptions {

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -327,6 +327,136 @@ test("GET /api/services/:id/health supports bounded TCP healthchecks", async () 
   }
 });
 
+test("TCP healthchecks resolve host and port selectors", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  const tcpServer = net.createServer((socket) => {
+    socket.end("OK");
+  });
+  tcpServer.listen(0, "127.0.0.1");
+  await once(tcpServer, "listening");
+  const tcpAddress = tcpServer.address();
+  if (!tcpAddress || typeof tcpAddress === "string") {
+    throw new Error("TCP probe server failed to bind.");
+  }
+
+  await writeManifest(servicesRoot, "tcp-selector-service", {
+    id: "tcp-selector-service",
+    name: "TCP Selector Service",
+    description: "Temporary service for TCP selector health proof.",
+    ports: {
+      http: tcpAddress.port,
+    },
+    healthcheck: {
+      type: "tcp",
+      host: "127.0.0.1",
+      port: "${HTTP_PORT}",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/tcp-selector-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "tcp-selector-service");
+    assert.equal(body.health.type, "tcp");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /connected successfully/i);
+  } finally {
+    await apiServer.stop();
+    tcpServer.close();
+    await once(tcpServer, "close");
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("bare TCP healthchecks infer the default single service port", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  const tcpServer = net.createServer((socket) => {
+    socket.end("OK");
+  });
+  tcpServer.listen(0, "127.0.0.1");
+  await once(tcpServer, "listening");
+  const tcpAddress = tcpServer.address();
+  if (!tcpAddress || typeof tcpAddress === "string") {
+    throw new Error("TCP probe server failed to bind.");
+  }
+
+  await writeManifest(servicesRoot, "tcp-default-service", {
+    id: "tcp-default-service",
+    name: "TCP Default Service",
+    description: "Temporary service for default TCP health proof.",
+    ports: {
+      service: tcpAddress.port,
+    },
+    healthcheck: {
+      type: "tcp",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/tcp-default-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "tcp-default-service");
+    assert.equal(body.health.type, "tcp");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /127\.0\.0\.1/i);
+  } finally {
+    await apiServer.stop();
+    tcpServer.close();
+    await once(tcpServer, "close");
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("bare TCP healthchecks report ambiguous multi-port services", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  await writeManifest(servicesRoot, "tcp-ambiguous-service", {
+    id: "tcp-ambiguous-service",
+    name: "TCP Ambiguous Service",
+    description: "Temporary service for ambiguous TCP health proof.",
+    ports: {
+      http: 4012,
+      admin: 4013,
+    },
+    healthcheck: {
+      type: "tcp",
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/tcp-ambiguous-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "tcp-ambiguous-service");
+    assert.equal(body.health.type, "tcp");
+    assert.equal(body.health.healthy, false);
+    assert.match(body.health.detail, /multiple service ports/i);
+    assert.match(body.health.detail, /address or host \+ port/i);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("HTTP healthcheck lifecycle actions stay 200 when the probe is unavailable", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -303,6 +303,97 @@ test("loadServiceManifest accepts bounded tcp healthchecks", async () => {
   }
 });
 
+test("loadServiceManifest accepts canonical tcp host and port healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "tcp-host-port-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "tcp-host-port-service",
+        name: "TCP Host Port Service",
+        description: "Service with host and port TCP health.",
+        healthcheck: {
+          type: "tcp",
+          host: "127.0.0.1",
+          port: "${HTTP_PORT}",
+          retries: 30,
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "tcp",
+      host: "127.0.0.1",
+      port: "${HTTP_PORT}",
+      retries: 30,
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest accepts bare tcp healthchecks", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "tcp-default-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "tcp-default-service",
+        name: "TCP Default Service",
+        description: "Service with default TCP health.",
+        healthcheck: {
+          type: "tcp",
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "tcp",
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects legacy tcp healthcheck aliases", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "tcp-alias-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "tcp-alias-service",
+        name: "TCP Alias Service",
+        description: "Service with unsupported TCP health aliases.",
+        healthcheck: {
+          type: "tcp",
+          tcphost: "127.0.0.1",
+          tcpport: "4012",
+        },
+      }),
+    );
+
+    await assert.rejects(
+      () => loadServiceManifest(manifestPath),
+      /tcphost.*tcpport.*healthcheck\.host.*healthcheck\.port.*healthcheck\.address/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest accepts bounded file healthchecks", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const manifestPath = path.join(servicesRoot, "file-service", "service.json");


### PR DESCRIPTION
## Issue
Closes #788

Supersedes #911, which used a non-compliant source branch name and failed the Branch Policy check.

## Summary
- Support canonical TCP healthcheck targets: bare single-port defaults, `address`, and `host` + `port`.
- Resolve TCP `host`, `port`, and `address` selectors before probing.
- Reject unsupported `tcphost` / `tcpport` aliases with an actionable validator error.
- Update health history target reporting and the service.json reference for the new TCP forms.

## Scope
- In scope: singular `healthcheck` TCP runtime/validator behavior requested by #788.
- Out of scope: broad multi-healthcheck array implementation and unrelated lifecycle process-spawn behavior.

## Spec / contract / fixture impact
- Updated: `docs/reference/service-json-reference.md` TCP healthcheck guidance.
- Tests added for address-adjacent host/port selectors, bare single-port inference, ambiguous multi-port failure, and alias rejection.

## Service Lasso invariant impact
- Invariant: service manifests stay clean and canonical without legacy TCP alias compatibility.
- Preservation proof: validation rejects `tcphost` / `tcpport`; multi-port bare TCP returns an actionable unhealthy result instead of guessing.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727-152604\issue-788-npm-run-build-post-history.log`
- PASS `node --test --test-concurrency=1 --test-name-pattern "loadServiceManifest accepts canonical tcp host and port healthchecks|loadServiceManifest accepts bare tcp healthchecks|loadServiceManifest rejects legacy tcp healthcheck aliases|TCP healthchecks resolve host and port selectors|bare TCP healthchecks infer the default single service port|bare TCP healthchecks report ambiguous multi-port services" tests/manifest-discovery.test.js tests/health-state.test.js` — `C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727-152604\issue-788-new-tcp-tests-post-history.log`
- NOTE full `tests/manifest-discovery.test.js tests/health-state.test.js` run reached all new TCP assertions as PASS, then failed an existing short-lived managed process test with `process_not_running` / HTTP 409. Evidence: `C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727-152604\issue-788-targeted-tests-final.log` and rerun body `issue-788-existing-health-state-409-body.log`.
- PASS startup `npm run build` during this drain run — `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260727-160500\startup-npm-build.log`
- PASS startup `demo-gate` classification=`healthy` during this drain run — `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260727-160500\startup-demo-gate.stdout.json`

## Approval trail
- Required: no special product approval identified; standard maintainer/CI gate applies.

## Cleanup
- Branch pushed: `fix/issue-788-tcp-healthcheck-schema`
- Superseded PR #911 should be closed after this PR is created.
- Post-merge: return local checkout/worktree to clean `develop` where possible.