### PR TITLE
Support path-list env arrays

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -493,7 +493,12 @@ Example:
 
 ```json
 "env": {
-  "ECHO_MESSAGE": "hello from service-template"
+  "ECHO_MESSAGE": "hello from service-template",
+  "PATH": [
+    "${PYTHON_HOME}",
+    "${PYTHON_SCRIPTS_PATH}",
+    "${SERVICE_ROOT}/bin"
+  ]
 }
 ```
 
@@ -503,6 +508,8 @@ Current direction:
 - avoid depending on uncontrolled host-machine env leakage
 - use `${VAR}` for local/current-service/derived values and legacy `globalenv` compatibility
 - use `${namespace.KEY}` only for explicit Secrets Broker selectors; unresolved or denied broker refs stay unresolved for diagnostics rather than falling back to a bare local name
+- env and `globalenv` values can be strings or arrays of non-empty strings
+- string arrays resolve selectors per entry and join with the host path delimiter before a process is spawned
 
 ### `broker`
 

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -81,7 +81,7 @@ export interface ServiceHookStep {
   cwd?: string;
   timeoutSeconds?: number;
   failurePolicy?: ServiceHookFailurePolicy;
-  env?: Record<string, string>;
+  env?: ServiceEnvMap;
 }
 
 export interface ServiceMonitoringPolicy {
@@ -166,7 +166,7 @@ export interface ServiceActionDefinition {
   commandline?: Record<string, string>;
   args?: string[];
   cwd?: string;
-  env?: Record<string, string>;
+  env?: ServiceEnvMap;
   timeoutSeconds?: number;
   requiredState?: ServiceActionRequiredState;
   requiresConfirmation?: boolean;
@@ -188,7 +188,7 @@ export interface ServiceSetupStep {
   executable?: string;
   args?: string[];
   commandline?: Record<string, string>;
-  env?: Record<string, string>;
+  env?: ServiceEnvMap;
   timeoutSeconds?: number;
   rerun?: ServiceSetupRerunPolicy;
 }
@@ -200,6 +200,9 @@ export interface ServiceSetupPolicy {
 export interface ServiceExecutionConfig {
   serviceorder?: number;
 }
+
+export type ServiceEnvValue = string | string[];
+export type ServiceEnvMap = Record<string, ServiceEnvValue>;
 
 export type ServiceUpdateMode = "disabled" | "notify" | "download" | "install";
 export type ServiceUpdateRunningServicePolicy = "skip" | "require-stopped" | "stop-start" | "restart";
@@ -343,8 +346,8 @@ export interface ServiceManifest {
   depend_on?: string[];
   healthcheck?: ServiceHealthcheck;
   outputvarregex?: Record<string, string>;
-  env?: Record<string, string>;
-  globalenv?: Record<string, string>;
+  env?: ServiceEnvMap;
+  globalenv?: ServiceEnvMap;
   broker?: ServiceBrokerPolicy;
   endpoints?: ServiceManifestEndpoint[];
   ports?: ServicePortDeclaration;

--- a/src/runtime/actions/runs.ts
+++ b/src/runtime/actions/runs.ts
@@ -7,7 +7,7 @@ import { ApiError, LifecycleStateError } from "../../server/errors.js";
 import { parseCommandlineArgs, selectPlatformCommandline } from "../execution/commandline.js";
 import { getLifecycleState } from "../lifecycle/store.js";
 import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
-import { buildServiceVariables, collectRuntimeGlobalEnv, resolveServiceText } from "../operator/variables.js";
+import { buildServiceVariables, collectRuntimeGlobalEnv, resolveServiceEnvValue, resolveServiceText } from "../operator/variables.js";
 import { createDirectExecutionPlan } from "../providers/direct.js";
 import { resolveProviderExecution } from "../providers/resolveProvider.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
@@ -532,7 +532,10 @@ function buildProcessEnvironment(
     buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
   );
   const actionEnv = Object.fromEntries(
-    Object.entries(action.env ?? {}).map(([key, value]) => [key, resolveServiceText(value, service, sharedGlobalEnv, resolvedPorts)]),
+    Object.entries(action.env ?? {}).map(([key, value]) => [
+      key,
+      resolveServiceEnvValue(value, service, sharedGlobalEnv, resolvedPorts),
+    ]),
   );
 
   return {

--- a/src/runtime/broker/legacy-globalenv-migration.ts
+++ b/src/runtime/broker/legacy-globalenv-migration.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type {
   DiscoveredService,
   ServiceBrokerImport,
+  ServiceEnvValue,
   ServiceManifest,
 } from "../../contracts/service.js";
 
@@ -112,20 +113,27 @@ function normalizeServiceRefPrefix(serviceId: string): string {
   return normalized || "service";
 }
 
-function metadataForValue(value: string): LegacySecretMetadata {
-  const fingerprint = value
-    ? createHash("sha256").update(value).digest("hex").slice(0, 16)
-    : null;
-  return {
-    present: value.length > 0,
-    length: value.length,
-    fingerprint,
-    valueKind:
-      value.length === 0
-        ? "empty"
+function metadataForValue(value: ServiceEnvValue): LegacySecretMetadata {
+  const fingerprintInput = Array.isArray(value) ? JSON.stringify(value) : value;
+  const valueLength = Array.isArray(value) ? value.reduce((total, entry) => total + entry.length, 0) : value.length;
+  const valueKind =
+    valueLength === 0
+      ? "empty"
+      : Array.isArray(value)
+        ? value.every((entry) => /^\$\{[^}]+\}$/.test(entry.trim()))
+          ? "selector"
+          : "literal"
         : /^\$\{[^}]+\}$/.test(value.trim())
           ? "selector"
-          : "literal",
+          : "literal";
+  const fingerprint = fingerprintInput
+    ? createHash("sha256").update(fingerprintInput).digest("hex").slice(0, 16)
+    : null;
+  return {
+    present: valueLength > 0,
+    length: valueLength,
+    fingerprint,
+    valueKind,
   };
 }
 
@@ -221,7 +229,7 @@ function candidateForEntry(
   service: DiscoveredService,
   source: LegacyEnvSource,
   key: string,
-  value: string,
+  value: ServiceEnvValue,
   options: LegacyGlobalEnvMigrationOptions,
 ): LegacyGlobalEnvMigrationCandidate {
   const { classification, reasons } = classifyLegacyEnvKey(key);

--- a/src/runtime/cli/config-snapshot.ts
+++ b/src/runtime/cli/config-snapshot.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import type { ServiceManifest } from "../../contracts/service.js";
+import type { ServiceEnvMap, ServiceManifest } from "../../contracts/service.js";
 import { discoverServices } from "../discovery/discoverServices.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } from "../config.js";
 
@@ -114,7 +114,7 @@ function redactValue(value: unknown, parentKey = ""): unknown {
   return value;
 }
 
-function redactEnvMap(value: Record<string, string> | undefined): Record<string, string> | undefined {
+function redactEnvMap(value: ServiceEnvMap | undefined): Record<string, string> | undefined {
   if (!value) {
     return undefined;
   }

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -21,6 +21,8 @@ import type {
   ServiceFilesRootMode,
   ServiceManifestEndpoint,
   ServiceActionWorkflowStep,
+  ServiceEnvMap,
+  ServiceEnvValue,
   ServiceManifest,
   ServiceSetupRerunPolicy,
   ServiceUpdateInstallWindow,
@@ -190,6 +192,28 @@ function readStringMap(value: unknown, field: string, manifestPath: string): Rec
   return Object.fromEntries(Object.entries(value as Record<string, string>).map(([key, entry]) => [key.trim(), entry]));
 }
 
+function isServiceEnvValue(value: unknown): value is ServiceEnvValue {
+  if (typeof value === "string") {
+    return true;
+  }
+
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string" && entry.trim().length > 0);
+}
+
+function readEnvMap(value: unknown, field: string, manifestPath: string): ServiceEnvMap | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.values(value).some((entry) => !isServiceEnvValue(entry))) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "${field}" to be a map of strings or non-empty string arrays.`,
+    );
+  }
+
+  return Object.fromEntries(Object.entries(value as ServiceEnvMap).map(([key, entry]) => [key.trim(), entry]));
+}
+
 function readOutputVarRegex(value: unknown, manifestPath: string): Record<string, string> | undefined {
   if (value === undefined) {
     return undefined;
@@ -275,7 +299,7 @@ function readHookSteps(value: unknown, field: string, manifestPath: string): Ser
       cwd: typeof record.cwd === "string" ? record.cwd.trim() : undefined,
       timeoutSeconds: expectOptionalWholeNumber(record.timeoutSeconds, `${stepField}.timeoutSeconds`, manifestPath, 1),
       failurePolicy: expectOptionalFailurePolicy(record.failurePolicy, `${stepField}.failurePolicy`, manifestPath),
-      env: readStringMap(record.env, `${stepField}.env`, manifestPath),
+      env: readEnvMap(record.env, `${stepField}.env`, manifestPath),
     };
   });
 }
@@ -424,7 +448,7 @@ function readSetupPolicy(value: unknown, manifestPath: string): ServiceManifest[
           executable: typeof step.executable === "string" ? step.executable.trim() : undefined,
           args: Array.isArray(args) ? args.map((entry) => entry.trim()) : undefined,
           commandline: readStringMap(step.commandline, `setup.steps.${normalizedStepId}.commandline`, manifestPath),
-          env: readStringMap(step.env, `setup.steps.${normalizedStepId}.env`, manifestPath),
+          env: readEnvMap(step.env, `setup.steps.${normalizedStepId}.env`, manifestPath),
           timeoutSeconds: expectOptionalWholeNumber(
             step.timeoutSeconds,
             `setup.steps.${normalizedStepId}.timeoutSeconds`,
@@ -981,7 +1005,7 @@ function readActionPolicy(value: unknown, manifestPath: string): ServiceManifest
           commandline,
           args: readStringArray(action.args, `${actionField}.args`, manifestPath),
           cwd: typeof action.cwd === "string" ? action.cwd.trim() : undefined,
-          env: readStringMap(action.env, `${actionField}.env`, manifestPath),
+          env: readEnvMap(action.env, `${actionField}.env`, manifestPath),
           timeoutSeconds: expectOptionalWholeNumber(action.timeoutSeconds, `${actionField}.timeoutSeconds`, manifestPath, 1),
           requiredState: expectOptionalEnum<ServiceActionRequiredState>(
             action.requiredState,
@@ -1268,8 +1292,8 @@ function readBrokerPolicy(value: unknown, manifestPath: string, serviceId: strin
 
 function validateBrokerCollisions(
   broker: ServiceManifest["broker"],
-  env: Record<string, string> | undefined,
-  globalenv: Record<string, string> | undefined,
+  env: ServiceEnvMap | undefined,
+  globalenv: ServiceEnvMap | undefined,
   manifestPath: string,
 ): void {
   if (!broker) {
@@ -1736,24 +1760,8 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     }
   }
 
-  const rawEnv = record.env;
-  if (
-    rawEnv !== undefined &&
-    (!rawEnv || typeof rawEnv !== "object" || Array.isArray(rawEnv) || Object.values(rawEnv).some((value) => typeof value !== "string"))
-  ) {
-    throw new Error(`Invalid service manifest at ${manifestPath}: expected \"env\" to be a string map.`);
-  }
-
-  const rawGlobalEnv = record.globalenv;
-  if (
-    rawGlobalEnv !== undefined &&
-    (!rawGlobalEnv ||
-      typeof rawGlobalEnv !== "object" ||
-      Array.isArray(rawGlobalEnv) ||
-      Object.values(rawGlobalEnv).some((value) => typeof value !== "string"))
-  ) {
-    throw new Error(`Invalid service manifest at ${manifestPath}: expected \"globalenv\" to be a string map.`);
-  }
+  const env = readEnvMap(record.env, "env", manifestPath);
+  const globalenv = readEnvMap(record.globalenv, "globalenv", manifestPath);
 
   const rawPorts = record.ports;
   if (
@@ -1832,10 +1840,6 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const broker = readBrokerPolicy(record.broker, manifestPath, serviceId);
   const endpoints = readManifestEndpoints(record.endpoints, manifestPath);
   const outputvarregex = readOutputVarRegex(record.outputvarregex, manifestPath);
-  const env = rawEnv ? Object.fromEntries(Object.entries(rawEnv as Record<string, string>).map(([key, value]) => [key.trim(), value])) : undefined;
-  const globalenv = rawGlobalEnv
-    ? Object.fromEntries(Object.entries(rawGlobalEnv as Record<string, string>).map(([key, value]) => [key.trim(), value]))
-    : undefined;
   validateBrokerCollisions(broker, env, globalenv, manifestPath);
   const artifact = readArtifact(record.artifact, manifestPath);
   const install = readActionMaterialization(record.install, "install", manifestPath);

--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -31,6 +31,7 @@ import {
   buildServiceVariables,
   compileServiceSelectorPlan,
   collectRuntimeGlobalEnv,
+  resolveServiceEnvValue,
   resolveServiceText,
   type ServiceVariableResolutionOptions,
 } from "../operator/variables.js";
@@ -561,7 +562,10 @@ function buildStopOverrideEnvironment(
     buildServiceVariables(service, {}, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
   );
   const actionEnv = Object.fromEntries(
-    Object.entries(action.env ?? {}).map(([key, value]) => [key, resolveServiceText(value, service, {}, resolvedPorts)]),
+    Object.entries(action.env ?? {}).map(([key, value]) => [
+      key,
+      resolveServiceEnvValue(value, service, {}, resolvedPorts),
+    ]),
   );
 
   return {

--- a/src/runtime/operator/secret-audit.ts
+++ b/src/runtime/operator/secret-audit.ts
@@ -1,4 +1,4 @@
-import type { DiscoveredService, ServiceBrokerImport } from "../../contracts/service.js";
+import type { DiscoveredService, ServiceBrokerImport, ServiceEnvMap, ServiceEnvValue } from "../../contracts/service.js";
 
 export type SecretReferenceAuditStatus = "present" | "missing" | "malformed";
 export type SecretAccessPolicyAssignmentStatus = "allowed" | "missing" | "not_applicable";
@@ -181,11 +181,16 @@ function isSecretLikeLocalSelector(selector: string): boolean {
 function addSelectorCandidates(
   candidates: CandidateRef[],
   declaredRefs: Set<string>,
-  value: string | undefined,
+  value: ServiceEnvValue | undefined,
   source: SecretReferenceAuditSource,
   location: string,
 ): void {
   if (!value) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => addSelectorCandidates(candidates, declaredRefs, entry, source, `${location}[${index}]`));
     return;
   }
 
@@ -216,7 +221,7 @@ function addSelectorCandidates(
 function addRecordSelectorCandidates(
   candidates: CandidateRef[],
   declaredRefs: Set<string>,
-  values: Record<string, string> | undefined,
+  values: ServiceEnvMap | undefined,
   source: SecretReferenceAuditSource,
   parentPath: string,
 ): void {

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -1,5 +1,5 @@
 import { getServiceStatePaths } from "../state/paths.js";
-import type { DiscoveredService } from "../../contracts/service.js";
+import type { DiscoveredService, ServiceEnvMap, ServiceEnvValue } from "../../contracts/service.js";
 import { getLifecycleState } from "../lifecycle/store.js";
 import path from "node:path";
 import { buildEndpointVariables } from "./endpoints.js";
@@ -214,7 +214,7 @@ function compileServiceSelectorTemplate(
 }
 
 function fingerprintSelectorValues(
-  values: string[] | Record<string, string>,
+  values: string[] | ServiceEnvMap,
 ): string {
   if (Array.isArray(values)) {
     return JSON.stringify({ kind: "array", values });
@@ -230,7 +230,7 @@ function fingerprintSelectorValues(
 
 export function compileCachedServiceSelectorPlan(
   cacheKey: string,
-  values: string[] | Record<string, string>,
+  values: string[] | ServiceEnvMap,
 ): ServiceSelectorPlan {
   const fingerprint = fingerprintSelectorValues(values);
   const cached = selectorPlanCache.get(cacheKey);
@@ -251,9 +251,11 @@ export function compileCachedServiceSelectorPlan(
 }
 
 export function compileServiceSelectorPlan(
-  values: string[] | Record<string, string>,
+  values: string[] | ServiceEnvMap,
 ): ServiceSelectorPlan {
-  const texts = Array.isArray(values) ? values : Object.values(values);
+  const texts = Array.isArray(values)
+    ? values
+    : Object.values(values).flatMap((value) => (Array.isArray(value) ? value : [value]));
   const selectors = new Map<string, ServiceSelectorRef>();
 
   for (const text of texts) {
@@ -272,6 +274,18 @@ export function compileServiceSelectorPlan(
       .filter((selector) => selector.kind === "broker")
       .map((selector) => selector.selector),
   };
+}
+
+function replaceEnvValueSelectors(
+  value: ServiceEnvValue,
+  variables: ServiceVariableEntry[],
+  options: ServiceTextResolutionOptions = {},
+): string {
+  if (Array.isArray(value)) {
+    return value.map((entry) => replaceVariableSelectors(entry, variables, options)).join(path.delimiter);
+  }
+
+  return replaceVariableSelectors(value, variables, options);
 }
 
 function mergeSelectorPlans(plans: ServiceSelectorPlan[]): ServiceSelectorPlan {
@@ -404,13 +418,12 @@ export function buildServiceVariables(
   const installArtifact = getLifecycleState(service.manifest.id)
     .installArtifacts.artifact;
   const executableHome = installArtifact?.extractedPath ?? service.serviceRoot;
-  const rawManifestVariables = Object.entries(service.manifest.env ?? {}).map(
-    ([key, value]) => ({
-      key,
-      value,
-      scope: "manifest" as const,
-    }),
-  );
+  const rawManifestEnv = service.manifest.env ?? {};
+  const rawManifestVariables = Object.entries(rawManifestEnv).map(([key, value]) => ({
+    key,
+    value: Array.isArray(value) ? value.join(path.delimiter) : value,
+    scope: "manifest" as const,
+  }));
 
   const globalVariables = Object.entries(sharedGlobalEnv).map(
     ([key, value]) => ({
@@ -484,10 +497,11 @@ export function buildServiceVariables(
     allowedBrokerRefs,
     diagnostics: manifestDiagnostics,
   };
-  const manifestVariables = rawManifestVariables.map((entry) => ({
-    ...entry,
-    value: replaceVariableSelectors(
-      entry.value,
+  const manifestVariables = Object.entries(rawManifestEnv).map(([key, value]) => ({
+    key,
+    scope: "manifest" as const,
+    value: replaceEnvValueSelectors(
+      value,
       [...rawManifestVariables, ...globalVariables, ...derivedVariables],
       brokerResolutionOptions,
     ),
@@ -591,7 +605,7 @@ export function collectServiceGlobalEnv(
   return Object.fromEntries(
     Object.entries(configuredGlobalEnv).map(([key, value]) => [
       key,
-      replaceVariableSelectors(value, variables),
+      replaceEnvValueSelectors(value, variables),
     ]),
   );
 }
@@ -676,6 +690,29 @@ export function resolveServiceText(
     (entry) => entry.ref,
   );
   return replaceVariableSelectors(value, variablesPayload.variables, {
+    ...options,
+    allowedBrokerRefs:
+      declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined,
+  });
+}
+
+export function resolveServiceEnvValue(
+  value: ServiceEnvValue,
+  service: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+  resolvedPorts: Record<string, number> = {},
+  options: ServiceTextResolutionOptions = {},
+): string {
+  const variablesPayload = buildServiceVariables(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+    options,
+  );
+  const declaredBrokerRefs = (service.manifest.broker?.imports ?? []).map(
+    (entry) => entry.ref,
+  );
+  return replaceEnvValueSelectors(value, variablesPayload.variables, {
     ...options,
     allowedBrokerRefs:
       declaredBrokerRefs.length > 0 ? declaredBrokerRefs : undefined,

--- a/src/runtime/providers/java.ts
+++ b/src/runtime/providers/java.ts
@@ -1,5 +1,15 @@
+import path from "node:path";
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "./types.js";
+
+function normalizeProviderEnv(manifest: ServiceManifest): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(manifest.env ?? {}).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.join(path.delimiter) : value,
+    ]),
+  );
+}
 
 export function createJavaExecutionPlan(
   serviceManifest: ServiceManifest,
@@ -18,7 +28,7 @@ export function createJavaExecutionPlan(
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
-    providerEnv: providerManifest.env ?? {},
+    providerEnv: normalizeProviderEnv(providerManifest),
     commandRoot: installedArtifact?.command ? installedArtifact.extractedPath : null,
   };
 }

--- a/src/runtime/providers/node.ts
+++ b/src/runtime/providers/node.ts
@@ -1,5 +1,15 @@
+import path from "node:path";
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "./types.js";
+
+function normalizeProviderEnv(manifest: ServiceManifest): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(manifest.env ?? {}).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.join(path.delimiter) : value,
+    ]),
+  );
+}
 
 export function createNodeExecutionPlan(
   serviceManifest: ServiceManifest,
@@ -18,7 +28,7 @@ export function createNodeExecutionPlan(
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
-    providerEnv: providerManifest.env ?? {},
+    providerEnv: normalizeProviderEnv(providerManifest),
     commandRoot: installedArtifact?.command ? installedArtifact.extractedPath : null,
   };
 }

--- a/src/runtime/providers/python.ts
+++ b/src/runtime/providers/python.ts
@@ -1,5 +1,15 @@
+import path from "node:path";
 import type { ServiceManifest } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "./types.js";
+
+function normalizeProviderEnv(manifest: ServiceManifest): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(manifest.env ?? {}).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.join(path.delimiter) : value,
+    ]),
+  );
+}
 
 export function createPythonExecutionPlan(
   serviceManifest: ServiceManifest,
@@ -18,7 +28,7 @@ export function createPythonExecutionPlan(
     executable,
     args,
     commandPreview: [executable, ...args].join(" ").trim(),
-    providerEnv: providerManifest.env ?? {},
+    providerEnv: normalizeProviderEnv(providerManifest),
     commandRoot: installedArtifact?.command ? installedArtifact.extractedPath : null,
   };
 }

--- a/src/runtime/recovery/doctor.ts
+++ b/src/runtime/recovery/doctor.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import type { DiscoveredService, ServiceDoctorPolicy, ServiceHookFailurePolicy, ServiceHookStep } from "../../contracts/service.js";
 import { LifecycleStateError } from "../../server/errors.js";
+import { resolveServiceEnvValue } from "../operator/variables.js";
 import { appendServiceRecoveryHistoryEvents } from "./history.js";
 
 export interface DoctorStepResult {
@@ -53,7 +54,12 @@ async function runDoctorStep(
     cwd: resolveStepCwd(service, step),
     env: {
       ...process.env,
-      ...(step.env ?? {}),
+      ...Object.fromEntries(
+        Object.entries(step.env ?? {}).map(([key, value]) => [
+          key,
+          resolveServiceEnvValue(value, service),
+        ]),
+      ),
       SERVICE_ID: service.manifest.id,
       SERVICE_ROOT: service.serviceRoot,
     },

--- a/src/runtime/recovery/hooks.ts
+++ b/src/runtime/recovery/hooks.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { spawn } from "node:child_process";
 import type { DiscoveredService, ServiceHookFailurePolicy, ServiceHookStep, ServiceLifecycleHooks } from "../../contracts/service.js";
+import { resolveServiceEnvValue } from "../operator/variables.js";
 
 export type ServiceHookPhase = keyof ServiceLifecycleHooks;
 
@@ -52,7 +53,12 @@ async function runHookStep(
     cwd: resolveStepCwd(service, step),
     env: {
       ...process.env,
-      ...(step.env ?? {}),
+      ...Object.fromEntries(
+        Object.entries(step.env ?? {}).map(([key, value]) => [
+          key,
+          resolveServiceEnvValue(value, service),
+        ]),
+      ),
       SERVICE_ID: service.manifest.id,
       SERVICE_ROOT: service.serviceRoot,
       SERVICE_HOOK_PHASE: phase,

--- a/src/runtime/setup/steps.ts
+++ b/src/runtime/setup/steps.ts
@@ -13,7 +13,7 @@ import { getLifecycleState, setLifecycleState } from "../lifecycle/store.js";
 import type { ServiceLifecycleState, ServiceSetupStepRunState, SetupStepStatus } from "../lifecycle/types.js";
 import { startService } from "../lifecycle/actions.js";
 import { waitForServiceReadiness } from "../health/waitForReadiness.js";
-import { buildServiceVariables, collectRuntimeGlobalEnv, resolveServiceText } from "../operator/variables.js";
+import { buildServiceVariables, collectRuntimeGlobalEnv, resolveServiceEnvValue, resolveServiceText } from "../operator/variables.js";
 import { parseCommandlineArgs, selectPlatformCommandline } from "../execution/commandline.js";
 import { writeServiceState } from "../state/writeState.js";
 
@@ -223,7 +223,10 @@ function buildProcessEnvironment(
     buildServiceVariables(service, sharedGlobalEnv, resolvedPorts).variables.map((entry) => [entry.key, entry.value]),
   );
   const stepEnv = Object.fromEntries(
-    Object.entries(step.env ?? {}).map(([key, value]) => [key, resolveServiceText(value, service, sharedGlobalEnv, resolvedPorts)]),
+    Object.entries(step.env ?? {}).map(([key, value]) => [
+      key,
+      resolveServiceEnvValue(value, service, sharedGlobalEnv, resolvedPorts),
+    ]),
   );
 
   return {

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -273,6 +273,77 @@ test("loadServiceManifest fails explicitly for malformed manifests", async () =>
   }
 });
 
+test("loadServiceManifest accepts env and globalenv string arrays", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "path-env-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "path-env-service",
+        name: "Path Env Service",
+        description: "Service with path-list environment entries.",
+        env: {
+          PATH: ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${SERVICE_ROOT}/bin"],
+          MODE: "demo",
+        },
+        globalenv: {
+          TOOL_PATHS: ["${SERVICE_ROOT}/tools", "${SERVICE_ROOT}/plugins"],
+        },
+        setup: {
+          steps: {
+            prepare: {
+              executable: "node",
+              args: ["prepare.mjs"],
+              env: {
+                SETUP_PATH: ["${SERVICE_ROOT}/setup", "${PATH}"],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const manifest = await loadServiceManifest(manifestPath);
+
+    assert.deepEqual(manifest.env?.PATH, ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${SERVICE_ROOT}/bin"]);
+    assert.equal(manifest.env?.MODE, "demo");
+    assert.deepEqual(manifest.globalenv?.TOOL_PATHS, ["${SERVICE_ROOT}/tools", "${SERVICE_ROOT}/plugins"]);
+    assert.deepEqual(manifest.setup?.steps?.prepare.env?.SETUP_PATH, ["${SERVICE_ROOT}/setup", "${PATH}"]);
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects invalid env array entries", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+  const manifestPath = path.join(servicesRoot, "bad-path-env-service", "service.json");
+
+  try {
+    await mkdir(path.dirname(manifestPath), { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        id: "bad-path-env-service",
+        name: "Bad Path Env Service",
+        description: "Service with invalid path-list environment entries.",
+        env: {
+          PATH: ["${SERVICE_ROOT}/bin", ""],
+        },
+      }),
+    );
+
+    await assert.rejects(
+      () => loadServiceManifest(manifestPath),
+      /expected "env" to be a map of strings or non-empty string arrays/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest accepts bounded tcp healthchecks", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const manifestPath = path.join(servicesRoot, "tcp-service", "service.json");

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -8,6 +8,7 @@ import {
   compileCachedServiceSelectorPlan,
   compileServiceMaterializationSelectorPlan,
   compileServiceSelectorPlan,
+  collectServiceGlobalEnv,
   getServiceSelectorPlanCacheStats,
   resetServiceSelectorPlanCache,
   resolveServiceText,
@@ -98,6 +99,50 @@ test("service variable resolution preserves local precedence and legacy globalen
   );
   assert.equal(byKey.FROM_DERIVED, "consumer:4310");
   assert.equal(byKey.FROM_GLOBAL, "C:/tools/legacy");
+});
+
+test("service variable resolution joins env arrays with path delimiter", () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      PATH: ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${SERVICE_ROOT}/bin"],
+    },
+    globalenv: {
+      TOOL_PATHS: ["${SERVICE_ROOT}/tools", "${PATH}"],
+    },
+  });
+  const sharedGlobalEnv = {
+    PYTHON_HOME: "C:/Python311",
+    PYTHON_SCRIPTS_PATH: "C:/Python311/Scripts",
+  };
+
+  const payload = buildServiceVariables(service, sharedGlobalEnv);
+  const byKey = Object.fromEntries(
+    payload.variables.map((entry) => [entry.key, entry.value]),
+  );
+  const serviceRoot = path.join(process.cwd(), "services", "consumer");
+
+  assert.equal(
+    byKey.PATH,
+    ["C:/Python311", "C:/Python311/Scripts", `${serviceRoot}/bin`].join(path.delimiter),
+  );
+
+  const globalEnv = collectServiceGlobalEnv(service, sharedGlobalEnv);
+  assert.equal(
+    globalEnv.TOOL_PATHS,
+    [`${serviceRoot}/tools`, byKey.PATH].join(path.delimiter),
+  );
+  assert.equal(payload.selectorPlan.localRefs.includes("PYTHON_HOME"), true);
+});
+
+test("selector planning inspects string array env entries", () => {
+  const plan = compileServiceSelectorPlan({
+    PATH: ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${vault.tool.path}"],
+    MODE: "demo",
+  });
+
+  assert.deepEqual(plan.localRefs, ["PYTHON_HOME", "PYTHON_SCRIPTS_PATH"]);
+  assert.deepEqual(plan.brokerRefs, ["vault.tool.path"]);
 });
 
 test("service variables include runtime-captured values for bare and selector resolution", () => {


### PR DESCRIPTION
## Issue
Closes #790

## Summary
- Widen manifest env/globalenv and hook/setup/action env typing to support string | string[] values.
- Resolve selectors inside env array entries and join them with path.delimiter before child-process spawn boundaries.
- Keep string env behavior unchanged and update docs/tests for PATH-style env arrays.

## Scope
- In scope: env/globalenv schema, manifest validation, selector planning/resolution, provider/action/setup/hook/doctor env normalization, redaction/audit compatibility.
- Out of scope: recursive manifest-local env expansion beyond the existing one-pass selector behavior.

## Spec / contract / fixture impact
- Updated: docs/reference/service-json-reference.md, src/contracts/service.ts.
- Tests: manifest validation accepts/rejects env arrays; selector planning inspects array entries; runtime env variables are final strings.

## Service Lasso invariant impact
- Invariant: launched process env values must be plain strings.
- Preservation proof: array env values normalize through esolveServiceEnvValue(...) before spawn env maps are built.

## Validation
- PASS 
pm run build after 
pm ci in the issue worktree: $logRoot\issue-790-npm-build-2.summary.json.
- PASS 
ode --test tests/manifest-discovery.test.js tests/variable-selector-planning.test.js: $logRoot\issue-790-focused-tests-2.summary.json.
- Startup gate before work: PASS 
pm run build; PASS demo-gate classification healthy: $logRoot\startup-npm-build.summary.json, $logRoot\startup-demo-gate.summary.json.

## Approval trail
- Required: no.
- Evidence: bounded issue implementation for #790.

## Cleanup
- Branch ix/issue-790-array-env-path tracks origin and targets develop.
- Canonical demo recycle/verify will be run after code changes before final handoff/merge.
