### PR TITLE
Make explicit healthchecks gate readiness by default

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -809,6 +809,14 @@ Service Lasso supports these explicit healthcheck types:
 
 `process` is the current template default direction; use one of the explicit types above when a service needs a stronger readiness signal.
 
+When a service declares an explicit `healthcheck`, startup readiness waits by default even if the manifest omits readiness timing fields. Default readiness settings are:
+
+- `retries`: `10`
+- `interval`: `1000` milliseconds
+- `start_period`: `0` milliseconds
+
+Existing manifests that set `retries`, `interval`, or `start_period` keep those explicit values.
+
 ### `process` healthcheck
 
 Use when:

--- a/src/runtime/health/waitForReadiness.ts
+++ b/src/runtime/health/waitForReadiness.ts
@@ -5,6 +5,7 @@ import { evaluateServiceHealth } from "./evaluateHealth.js";
 import type { ServiceHealthcheck, ServiceHealthResult } from "./types.js";
 
 const DEFAULT_READINESS_INTERVAL_MS = 1_000;
+const DEFAULT_READINESS_ATTEMPTS = 10;
 
 export interface ReadinessWaitResult {
   enabled: boolean;
@@ -29,14 +30,9 @@ function resolveReadinessOptions(healthcheck?: ServiceHealthcheck): {
     };
   }
 
-  const enabled =
-    healthcheck.retries !== undefined ||
-    healthcheck.interval !== undefined ||
-    healthcheck.start_period !== undefined;
-
   return {
-    enabled,
-    attempts: Math.max(healthcheck.retries ?? 1, 1),
+    enabled: true,
+    attempts: Math.max(healthcheck.retries ?? DEFAULT_READINESS_ATTEMPTS, 1),
     intervalMs: healthcheck.interval ?? DEFAULT_READINESS_INTERVAL_MS,
     startPeriodMs: healthcheck.start_period ?? 0,
   };

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import net from "node:net";
+import { createServer } from "node:http";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { startApiServer as startRuntimeApiServer } from "../dist/server/index.js";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
@@ -540,6 +542,104 @@ test("start waits for configured readiness and returns healthy once ready", asyn
     assert.ok(elapsedMs >= 75);
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("explicit HTTP healthcheck without readiness options waits with default attempts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-http-default-readiness-",
+  );
+  const readyAt = Date.now() + 120;
+  const probeServer = createServer((_, response) => {
+    response.statusCode = Date.now() >= readyAt ? 200 : 503;
+    response.end("ok");
+  });
+  probeServer.listen(0, "127.0.0.1");
+  await new Promise((resolve) => probeServer.once("listening", resolve));
+  const probeAddress = probeServer.address();
+  if (!probeAddress || typeof probeAddress === "string") {
+    throw new Error("HTTP probe server failed to bind.");
+  }
+
+  await writeExecutableFixtureService(servicesRoot, "http-default-readiness", {
+    healthcheck: {
+      type: "http",
+      url: `http://127.0.0.1:${probeAddress.port}/health`,
+      expected_status: 200,
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/http-default-readiness/install`);
+    await postJson(`${apiServer.url}/api/services/http-default-readiness/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/http-default-readiness/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.health.type, "http");
+    assert.equal(start.body.health.healthy, true);
+    assert.match(start.body.message, /of 10/i);
+  } finally {
+    await apiServer.stop();
+    await new Promise((resolve) => probeServer.close(resolve));
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("explicit TCP healthcheck without retries uses default attempts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-tcp-default-readiness-",
+  );
+  const reservationServer = net.createServer();
+  reservationServer.listen(0, "127.0.0.1");
+  await new Promise((resolve) => reservationServer.once("listening", resolve));
+  const reservedAddress = reservationServer.address();
+  if (!reservedAddress || typeof reservedAddress === "string") {
+    throw new Error("TCP probe reservation failed to bind.");
+  }
+  const probePort = reservedAddress.port;
+  await new Promise((resolve) => reservationServer.close(resolve));
+
+  const delayedProbeServer = net.createServer((socket) => {
+    socket.end("OK");
+  });
+  const openProbe = setTimeout(() => {
+    delayedProbeServer.listen(probePort, "127.0.0.1");
+  }, 80);
+
+  await writeExecutableFixtureService(servicesRoot, "tcp-default-attempts", {
+    healthcheck: {
+      type: "tcp",
+      address: `127.0.0.1:${probePort}`,
+      interval: 20,
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/tcp-default-attempts/install`);
+    await postJson(`${apiServer.url}/api/services/tcp-default-attempts/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/tcp-default-attempts/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.health.type, "tcp");
+    assert.equal(start.body.health.healthy, true);
+    assert.match(start.body.message, /of 10/i);
+  } finally {
+    clearTimeout(openProbe);
+    await apiServer.stop();
+    if (delayedProbeServer.listening) {
+      await new Promise((resolve) => delayedProbeServer.close(resolve));
+    }
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Issue
Closes #791

## Summary
- Treat any explicit healthcheck as a startup readiness gate.
- Default omitted readiness attempts to 10, interval to 1000ms, and start period to 0ms.
- Cover explicit HTTP and TCP healthchecks that omit retries.
- Document the default readiness semantics in the service JSON reference.

## Scope
- In scope: singular healthcheck readiness semantics used by the current runtime path.
- Out of scope: future healthchecks[] migration and any future healthcheck.enabled: false flag.

## Spec / contract / fixture impact
- Updated: docs/reference/service-json-reference.md readiness defaults.

## Service Lasso invariant impact
- Invariant: explicit healthchecks must gate startup readiness while manifests with explicit timing retain their values.
- Preservation proof: existing no-healthcheck services keep the process default; explicit healthchecks now wait with bounded defaults.

## Validation
- PASS 
pm run build - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727T193106\issue-791-npm-build.log
- PASS 
ode --test --test-concurrency=1 --test-name-pattern "explicit (HTTP|TCP) healthcheck" tests/lifecycle-actions.test.js - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727T193106\issue-791-targeted-readiness-tests.log
- PASS post-change 
pm run build - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727T193106\issue-791-postchange-npm-build.log
- PASS post-change demo-gate - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727T193106\issue-791-postchange-demo-gate.json
- PASS post-change demo-verify-canonical - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260727T193106\issue-791-postchange-demo-verify-canonical.json

## Approval trail
- Required: no, unless repository rules require review before merge.
- Evidence: PR checks/review state will be used before merge.

## Cleanup
- Branch will be cleaned up after merge when allowed.
