### PR TITLE
Block unresolved env selectors before launch

### DIFF
--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -33,6 +33,7 @@ import {
   collectRuntimeGlobalEnv,
   resolveServiceEnvValue,
   resolveServiceText,
+  type ServiceSelectorDiagnostic,
   type ServiceVariableResolutionOptions,
 } from "../operator/variables.js";
 import { resolveServiceEndpoints } from "../operator/endpoints.js";
@@ -401,12 +402,31 @@ function failStartTraceAndThrow(
   attempt: ServiceStartTraceAttempt,
   phase: ServiceStartTracePhase,
   message: string,
+  metadata: Record<string, string | number | boolean | null | string[]> = {},
 ): never {
   if (phase !== "terminal_outcome") {
-    recordStartTraceEvent(serviceId, attempt, phase, "blocked", message);
+    recordStartTraceEvent(serviceId, attempt, phase, "blocked", message, metadata);
   }
   finishStartTrace(serviceId, attempt, "blocked", message);
   throw new LifecycleStateError(message);
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))].sort();
+}
+
+function formatUnresolvedLocalSelectorMessage(
+  serviceId: string,
+  diagnostics: ServiceSelectorDiagnostic[],
+): string {
+  const refs = diagnostics
+    .map((diagnostic) =>
+      diagnostic.key
+        ? `${diagnostic.key}:${diagnostic.selector}`
+        : diagnostic.selector,
+    )
+    .join(", ");
+  return `Cannot start service "${serviceId}" because required local env selectors are unresolved (${refs}).`;
 }
 
 function formatStartupBrokerFailureMessage(
@@ -904,10 +924,41 @@ export async function startService(
     service,
     options,
   );
+  const variablePayload = buildServiceVariables(
+    service,
+    sharedGlobalEnv,
+    resolvedPorts,
+    variableResolution,
+  );
+  const unresolvedLocalDiagnostics = variablePayload.diagnostics.filter(
+    (diagnostic) =>
+      diagnostic.kind === "local" &&
+      diagnostic.reason === "unresolved-local",
+  );
   const selectorPlan = compileServiceSelectorPlan({
     ...(service.manifest.globalenv ?? {}),
     ...(service.manifest.env ?? {}),
   });
+  if (unresolvedLocalDiagnostics.length > 0) {
+    failStartTraceAndThrow(
+      serviceId,
+      trace,
+      "env_merge",
+      formatUnresolvedLocalSelectorMessage(serviceId, unresolvedLocalDiagnostics),
+      {
+        unresolvedSelectors: uniqueStrings(
+          unresolvedLocalDiagnostics.map((diagnostic) => diagnostic.selector),
+        ),
+        unresolvedEnvKeys: uniqueStrings(
+          unresolvedLocalDiagnostics.map((diagnostic) => diagnostic.key),
+        ),
+        unresolvedRawSelectors: uniqueStrings(
+          unresolvedLocalDiagnostics.map((diagnostic) => diagnostic.raw),
+        ),
+        brokerRefCount: selectorPlan.brokerRefs.length,
+      },
+    );
+  }
   recordStartTraceEvent(
     serviceId,
     trace,

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -58,11 +58,14 @@ export interface ServiceSelectorDiagnostic {
   selector: string;
   kind: ServiceSelectorKind;
   reason: ServiceSelectorDiagnosticReason;
+  key?: string;
+  raw?: string;
 }
 
 export interface ServiceTextResolutionOptions {
   brokerValues?: Record<string, string>;
   diagnostics?: ServiceSelectorDiagnostic[];
+  diagnosticKey?: string;
   allowedBrokerRefs?: Set<string> | string[];
   deniedBrokerRefs?: Set<string> | string[];
   lockedBrokerRefs?: Set<string> | string[];
@@ -318,6 +321,23 @@ function hasRef(
   return Array.isArray(refs) ? refs.includes(ref) : refs.has(ref);
 }
 
+function pushSelectorDiagnostic(
+  diagnostics: ServiceSelectorDiagnostic[] | undefined,
+  diagnostic: ServiceSelectorDiagnostic,
+  options: ServiceTextResolutionOptions,
+  raw: string,
+): void {
+  if (!diagnostics) {
+    return;
+  }
+
+  diagnostics.push(
+    options.diagnosticKey
+      ? { ...diagnostic, key: options.diagnosticKey, raw }
+      : diagnostic,
+  );
+}
+
 function replaceVariableSelectors(
   value: string,
   variables: ServiceVariableEntry[],
@@ -336,72 +356,112 @@ function replaceVariableSelectors(
           options.allowedBrokerRefs &&
           !hasRef(options.allowedBrokerRefs, ref.selector)
         ) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "denied-broker",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "denied-broker",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         if (hasRef(options.deniedBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "denied-broker",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "denied-broker",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         if (hasRef(options.lockedBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "locked-broker",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "locked-broker",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         if (hasRef(options.sourceAuthRequiredBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "source-auth-required",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "source-auth-required",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         if (hasRef(options.sourceUnavailableBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "source-unavailable",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "source-unavailable",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         if (hasRef(options.degradedBrokerRefs, ref.selector)) {
-          options.diagnostics?.push({
-            selector: ref.selector,
-            kind: "broker",
-            reason: "degraded-broker",
-          });
+          pushSelectorDiagnostic(
+            options.diagnostics,
+            {
+              selector: ref.selector,
+              kind: "broker",
+              reason: "degraded-broker",
+            },
+            options,
+            raw,
+          );
           return raw;
         }
         const brokerValue = options.brokerValues?.[ref.selector];
         if (brokerValue !== undefined) {
           return brokerValue;
         }
-        options.diagnostics?.push({
-          selector: ref.selector,
-          kind: "broker",
-          reason: "missing-broker",
-        });
+        pushSelectorDiagnostic(
+          options.diagnostics,
+          {
+            selector: ref.selector,
+            kind: "broker",
+            reason: "missing-broker",
+          },
+          options,
+          raw,
+        );
         return raw;
       }
 
       const entry = variables.find((candidate) => candidate.key === ref.key);
       if (!entry) {
-        options.diagnostics?.push({
-          selector: ref.selector,
-          kind: "local",
-          reason: "unresolved-local",
-        });
+        pushSelectorDiagnostic(
+          options.diagnostics,
+          {
+            selector: ref.selector,
+            kind: "local",
+            reason: "unresolved-local",
+          },
+          options,
+          raw,
+        );
       }
       return entry ? entry.value : raw;
     })
@@ -503,7 +563,7 @@ export function buildServiceVariables(
     value: replaceEnvValueSelectors(
       value,
       [...rawManifestVariables, ...globalVariables, ...derivedVariables],
-      brokerResolutionOptions,
+      { ...brokerResolutionOptions, diagnosticKey: key },
     ),
   }));
 

--- a/tests/service-start-trace.test.js
+++ b/tests/service-start-trace.test.js
@@ -118,3 +118,54 @@ test("service start trace API records failed start without leaking request mater
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("service start trace blocks unresolved local env selectors before spawn", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-start-trace-env-block-");
+  await writeExecutableFixtureService(servicesRoot, "trace-env-blocked", {
+    env: {
+      PATH: ["${PYTHON_HOME}", "${NODE_HOME}"],
+    },
+    healthcheck: { type: "process" },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot: path.join(tempRoot, "workspace") });
+
+  try {
+    assert.equal((await postJson(apiServer.url + "/api/services/trace-env-blocked/install")).status, 200);
+    assert.equal((await postJson(apiServer.url + "/api/services/trace-env-blocked/config")).status, 200);
+    const blocked = await postJson(apiServer.url + "/api/services/trace-env-blocked/start");
+    assert.equal(blocked.status, 409);
+    assert.equal(blocked.body.error, "invalid_lifecycle_state");
+    assert.match(blocked.body.message, /PYTHON_HOME/);
+    assert.match(blocked.body.message, /NODE_HOME/);
+
+    const result = await getJson(apiServer.url + "/api/services/trace-env-blocked/start-trace");
+    assert.equal(result.status, 200);
+    assert.equal(result.body.trace.status, "blocked");
+    assert.deepEqual(
+      result.body.trace.events.map((event) => event.phase),
+      [
+        "dependency_resolution",
+        "port_selection",
+        "artifact_acquisition",
+        "env_merge",
+        "terminal_outcome",
+      ],
+    );
+    const envMerge = result.body.trace.events.find((event) => event.phase === "env_merge");
+    assert.equal(envMerge.status, "blocked");
+    assert.deepEqual(envMerge.metadata.unresolvedEnvKeys, ["PATH"]);
+    assert.deepEqual(envMerge.metadata.unresolvedSelectors, [
+      "NODE_HOME",
+      "PYTHON_HOME",
+    ]);
+    assert.deepEqual(envMerge.metadata.unresolvedRawSelectors, [
+      "${NODE_HOME}",
+      "${PYTHON_HOME}",
+    ]);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -135,6 +135,35 @@ test("service variable resolution joins env arrays with path delimiter", () => {
   assert.equal(payload.selectorPlan.localRefs.includes("PYTHON_HOME"), true);
 });
 
+test("service variable diagnostics identify unresolved manifest env selectors", () => {
+  resetLifecycleState();
+  const service = fixtureService({
+    env: {
+      PATH: ["${PYTHON_HOME}", "${NODE_HOME}", "${SERVICE_ROOT}/bin"],
+      LOG_ROOT: "${SERVICE_ROOT}/logs",
+    },
+  });
+
+  const payload = buildServiceVariables(service);
+
+  assert.deepEqual(payload.diagnostics, [
+    {
+      selector: "PYTHON_HOME",
+      kind: "local",
+      reason: "unresolved-local",
+      key: "PATH",
+      raw: "${PYTHON_HOME}",
+    },
+    {
+      selector: "NODE_HOME",
+      kind: "local",
+      reason: "unresolved-local",
+      key: "PATH",
+      raw: "${NODE_HOME}",
+    },
+  ]);
+});
+
 test("selector planning inspects string array env entries", () => {
   const plan = compileServiceSelectorPlan({
     PATH: ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${vault.tool.path}"],
@@ -380,12 +409,26 @@ test("broker selectors require explicit imports and report denied/source auth di
   assert.equal(serializedPayload.includes("denied-secret"), false);
   assert.equal(serializedPayload.includes("auth-secret"), false);
   assert.deepEqual(payload.diagnostics, [
-    { selector: "vault.API_TOKEN", kind: "broker", reason: "denied-broker" },
-    { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
+    {
+      selector: "vault.API_TOKEN",
+      kind: "broker",
+      reason: "denied-broker",
+      key: "UNDECLARED",
+      raw: "${vault.API_TOKEN}",
+    },
+    {
+      selector: "database.DENIED",
+      kind: "broker",
+      reason: "denied-broker",
+      key: "DENIED",
+      raw: "${database.DENIED}",
+    },
     {
       selector: "database.SOURCE_AUTH",
       kind: "broker",
       reason: "source-auth-required",
+      key: "NEEDS_AUTH",
+      raw: "${database.SOURCE_AUTH}",
     },
     { selector: "database.DENIED", kind: "broker", reason: "denied-broker" },
     {
@@ -685,11 +728,41 @@ test("startup broker resolution classifies required failures without leaking loo
     ],
   );
   assert.deepEqual(payload.diagnostics, [
-    { selector: "vault.LOCKED", kind: "broker", reason: "locked-broker" },
-    { selector: "vault.DENIED", kind: "broker", reason: "denied-broker" },
-    { selector: "vault.AUTH", kind: "broker", reason: "source-auth-required" },
-    { selector: "vault.OFFLINE", kind: "broker", reason: "source-unavailable" },
-    { selector: "vault.DEGRADED", kind: "broker", reason: "degraded-broker" },
+    {
+      selector: "vault.LOCKED",
+      kind: "broker",
+      reason: "locked-broker",
+      key: "LOCKED",
+      raw: "${vault.LOCKED}",
+    },
+    {
+      selector: "vault.DENIED",
+      kind: "broker",
+      reason: "denied-broker",
+      key: "DENIED",
+      raw: "${vault.DENIED}",
+    },
+    {
+      selector: "vault.AUTH",
+      kind: "broker",
+      reason: "source-auth-required",
+      key: "AUTH",
+      raw: "${vault.AUTH}",
+    },
+    {
+      selector: "vault.OFFLINE",
+      kind: "broker",
+      reason: "source-unavailable",
+      key: "OFFLINE",
+      raw: "${vault.OFFLINE}",
+    },
+    {
+      selector: "vault.DEGRADED",
+      kind: "broker",
+      reason: "degraded-broker",
+      key: "DEGRADED",
+      raw: "${vault.DEGRADED}",
+    },
     { selector: "vault.MISSING", kind: "broker", reason: "missing-broker" },
   ]);
   const serialized = JSON.stringify({ resolution, payload });


### PR DESCRIPTION
## Issue
Closes #792

## Summary
- Adds manifest env selector diagnostics with env key and original selector context when available.
- Blocks start during nv_merge when required local env selectors remain unresolved, before process spawn.
- Records blocked start trace metadata with unresolved env keys, selectors, and raw selector tokens.

## Scope
- In scope: launch-time local env selector diagnostics and blocking behavior.
- Out of scope: optional selector policy and unrelated dependency diagnostics behavior.

## Spec / contract / fixture impact
- Updated: runtime variable diagnostics now include optional key and aw fields for manifest env/globalenv resolution diagnostics.
- Updated: start trace API now surfaces unresolved env selector blockers in nv_merge.

## Service Lasso invariant impact
- Invariant: managed process spawn must not receive unresolved required local env selector tokens.
- Preservation proof: startService checks uildServiceVariables() diagnostics before calling startManagedProcess().

## Validation
- PASS 
pm run build - $logDir\issue-792-npm-build.stdout.log
- PASS 
ode --test --test-concurrency=1 tests/variable-selector-planning.test.js tests/service-start-trace.test.js - $logDir\issue-792-targeted-tests-rerun.stdout.log
- PASS git diff --check - $logDir\issue-792-git-diff-check.log
- ATTEMPTED 
pm test - timed out after 5 minutes; captured one unrelated diagnostics expectation failure where oxtrot-unhealthy readiness was eady instead of expected degraded; evidence $logDir\issue-792-npm-test.stdout.log

## Approval trail
- Required: yes, normal PR review/checks if branch protection requires it.
- Evidence: focused validation passed locally; full suite did not complete inside cron timeout.

## Cleanup
- Branch: issue-792-env-selector-launch-block
- Post-merge target: return local checkout to clean develop when merge is allowed.
