### PR TITLE
Add SERVICE_PATH compatibility alias

### DIFF
--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -96,6 +96,8 @@ Provider services should declare:
 - `globalenv` entries that expose installed tool paths through `${SERVICE_ARTIFACT_COMMAND}` and `${SERVICE_ARTIFACT_ROOT}`
 - a cheap version/probe command in platform `args`
 
+Use `SERVICE_ROOT` as the canonical service package root in service-local env, setup, config, commandline, and healthcheck selectors. `SERVICE_PATH` is available as a compatibility alias for authoring examples that use package-path wording. Provider-level names such as `NODE_HOME`, `PYTHON_HOME`, and `PYTHON_SCRIPTS_PATH` must be exported by the provider service through `globalenv`; ordinary services should not assume those names exist unless they depend on the provider that publishes them.
+
 ## Managed Binary Example
 
 ```json

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -511,6 +511,18 @@ Current direction:
 - env and `globalenv` values can be strings or arrays of non-empty strings
 - string arrays resolve selectors per entry and join with the host path delimiter before a process is spawned
 
+Canonical derived path variables:
+
+- `SERVICE_ROOT` is the canonical service package root.
+- `SERVICE_PATH` is a compatibility alias for `SERVICE_ROOT`, intended for portable donor-style examples that refer to the service package path.
+- `SERVICE_STATE_ROOT` points at the runtime state root for the service.
+- `SERVICE_DATA_PATH` points at the service-local `data` directory.
+- `SERVICE_EXECUTABLE_HOME` points at the installed artifact extraction root when a release artifact is installed, otherwise the service package root.
+- `SERVICE_ARTIFACT_ROOT` is present only when an installed release artifact has an extracted path.
+- `SERVICE_ARTIFACT_COMMAND` is present only when the installed release artifact declares both an extracted path and command.
+
+Provider-level path variables such as `NODE_HOME`, `PYTHON_HOME`, and `PYTHON_SCRIPTS_PATH` are not derived automatically for every service. Provider services should export the concrete names they support through their own `globalenv` entries, usually from `SERVICE_ARTIFACT_ROOT` or `SERVICE_ARTIFACT_COMMAND`, and consuming services should depend on the provider that supplies them.
+
 ### `broker`
 
 `broker` is the first-class Secrets Broker manifest contract. It lets a service declare the namespaces and refs it consumes, the values it exports, and which generated secrets it may write back.

--- a/src/runtime/operator/variables.ts
+++ b/src/runtime/operator/variables.ts
@@ -505,6 +505,11 @@ export function buildServiceVariables(
       scope: "derived",
     },
     {
+      key: "SERVICE_PATH",
+      value: service.serviceRoot,
+      scope: "derived",
+    },
+    {
       key: "SERVICE_STATE_ROOT",
       value: statePaths.stateRoot,
       scope: "derived",

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -651,6 +651,8 @@ test("GET /api/services/:id/variables returns manifest and derived variables", a
     assert.equal(response.status, 200);
     assert.equal(body.variables.serviceId, "echo-service");
     assert.ok(body.variables.variables.some((entry) => entry.key === "ECHO_MESSAGE" && entry.scope === "manifest"));
+    assert.ok(body.variables.variables.some((entry) => entry.key === "SERVICE_ROOT" && entry.scope === "derived"));
+    assert.ok(body.variables.variables.some((entry) => entry.key === "SERVICE_PATH" && entry.scope === "derived"));
     assert.ok(body.variables.variables.some((entry) => entry.key === "SERVICE_STATE_ROOT" && entry.scope === "derived"));
   } finally {
     await apiServer.stop();

--- a/tests/variable-selector-planning.test.js
+++ b/tests/variable-selector-planning.test.js
@@ -105,6 +105,7 @@ test("service variable resolution joins env arrays with path delimiter", () => {
   resetLifecycleState();
   const service = fixtureService({
     env: {
+      PACKAGE_PATH: "${SERVICE_PATH}/__packages__",
       PATH: ["${PYTHON_HOME}", "${PYTHON_SCRIPTS_PATH}", "${SERVICE_ROOT}/bin"],
     },
     globalenv: {
@@ -122,6 +123,9 @@ test("service variable resolution joins env arrays with path delimiter", () => {
   );
   const serviceRoot = path.join(process.cwd(), "services", "consumer");
 
+  assert.equal(byKey.SERVICE_ROOT, serviceRoot);
+  assert.equal(byKey.SERVICE_PATH, serviceRoot);
+  assert.equal(byKey.PACKAGE_PATH, `${serviceRoot}/__packages__`);
   assert.equal(
     byKey.PATH,
     ["C:/Python311", "C:/Python311/Scripts", `${serviceRoot}/bin`].join(path.delimiter),


### PR DESCRIPTION
## Issue
Closes #793

## Summary
- Add `SERVICE_PATH` as a derived compatibility alias for `SERVICE_ROOT`.
- Document the canonical path variable set and clarify provider-exported path globals.
- Add selector/API regression coverage for the new alias.

## Scope
- In scope: core runtime variable resolution, focused docs, and alias coverage.
- Out of scope: adding provider-specific globals automatically or changing provider manifests.

## Spec / contract / fixture impact
- Updated: `docs/reference/service-json-reference.md` and `docs/development/new-lasso-service-guide.md`.

## Service Lasso invariant impact
- Invariant: `SERVICE_ROOT` remains canonical; `SERVICE_PATH` is only an alias with the same value.
- Preservation proof: focused selector/API tests pass.

## Validation
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-npm-build.log`
- PASS `node --test tests/variable-selector-planning.test.js` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-variable-selector-tests.log`
- PASS `node --test --test-name-pattern 'GET /api/services/:id/variables returns manifest and derived variables' tests/operator-data.test.js` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-operator-variables-test.log`
- PASS `git diff --check` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-diff-check.log`
- PASS post-change `npm run build` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-postchange-npm-build.log`
- PASS post-change `node scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-postchange-demo-gate-rerun.json`
- PASS post-change `node scripts/demo-verify-canonical.mjs --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json` - `C:\projects\service-lasso\.work-agent\logs\20260727-224043\issue-793-postchange-demo-verify-canonical.json`

## Approval trail
- Required: no special approval expected for this compatibility alias.
- Evidence: issue acceptance criteria request alias-or-reject decision and docs alignment.

## Cleanup
- Branch cleanup after merge; return target checkout to clean `develop` when worktree constraints allow.
