### PR TITLE
Issue #795 add readiness healthcheck timeout

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -826,8 +826,10 @@ When a service declares an explicit `healthcheck`, startup readiness waits by de
 - `retries`: `10`
 - `interval`: `1000` milliseconds
 - `start_period`: `0` milliseconds
+- `timeout`: `2000` milliseconds per network attempt
 
-Existing manifests that set `retries`, `interval`, or `start_period` keep those explicit values.
+Existing manifests that set `retries`, `interval`, `start_period`, or `timeout` keep those explicit values.
+`timeout` is optional and must be an integer number of milliseconds when present. HTTP and TCP healthchecks use it as the per-attempt network wait limit. Process, file, and variable healthchecks accept the shared field for manifest compatibility, but their immediate readiness evaluation does not wait on external network I/O.
 
 ### `process` healthcheck
 
@@ -856,7 +858,8 @@ Sample:
 "healthcheck": {
   "type": "http",
   "url": "http://localhost:${SERVICE_PORT}/health",
-  "expected_status": 200
+  "expected_status": 200,
+  "timeout": 2000
 }
 ```
 
@@ -870,7 +873,8 @@ Sample:
 
 ```json
 "healthcheck": {
-  "type": "tcp"
+  "type": "tcp",
+  "timeout": 2000
 }
 ```
 

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -129,11 +129,13 @@ function readHealthcheckReadinessOptions(
     manifestPath,
     0,
   );
+  const timeout = expectOptionalWholeNumber(healthRecord.timeout, "healthcheck.timeout", manifestPath, 1);
 
   return {
     ...(interval !== undefined ? { interval } : {}),
     ...(retries !== undefined ? { retries } : {}),
     ...(startPeriod !== undefined ? { start_period: startPeriod } : {}),
+    ...(timeout !== undefined ? { timeout } : {}),
   };
 }
 

--- a/src/runtime/health/checkHttp.ts
+++ b/src/runtime/health/checkHttp.ts
@@ -1,9 +1,15 @@
 import type { HttpHealthcheck, ServiceHealthResult } from "./types.js";
 
+const DEFAULT_HTTP_HEALTHCHECK_TIMEOUT_MS = 2_000;
+
 export async function checkHttpHealth(healthcheck: HttpHealthcheck): Promise<ServiceHealthResult> {
   const expectedStatus = healthcheck.expected_status ?? 200;
+  const timeoutMs = healthcheck.timeout ?? DEFAULT_HTTP_HEALTHCHECK_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
   try {
-    const response = await fetch(healthcheck.url);
+    const response = await fetch(healthcheck.url, { signal: controller.signal });
 
     return {
       type: "http",
@@ -14,6 +20,14 @@ export async function checkHttpHealth(healthcheck: HttpHealthcheck): Promise<Ser
           : `HTTP healthcheck returned ${response.status}, expected ${expectedStatus}.`,
     };
   } catch (error: unknown) {
+    if (controller.signal.aborted) {
+      return {
+        type: "http",
+        healthy: false,
+        detail: `HTTP healthcheck timed out after ${timeoutMs}ms: ${healthcheck.url}`,
+      };
+    }
+
     const detail = error instanceof Error ? error.message : "HTTP healthcheck request failed.";
 
     return {
@@ -21,5 +35,7 @@ export async function checkHttpHealth(healthcheck: HttpHealthcheck): Promise<Ser
       healthy: false,
       detail: `HTTP healthcheck failed: ${detail}`,
     };
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/src/runtime/health/checkTcp.ts
+++ b/src/runtime/health/checkTcp.ts
@@ -1,6 +1,8 @@
 import net from "node:net";
 import type { ServiceHealthResult, TcpHealthcheck } from "./types.js";
 
+const DEFAULT_TCP_HEALTHCHECK_TIMEOUT_MS = 2_000;
+
 export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<ServiceHealthResult> {
   const target =
     healthcheck.address !== undefined
@@ -25,6 +27,7 @@ export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<Servi
 
   return new Promise((resolve) => {
     const socket = net.createConnection({ host: target.host, port: target.port });
+    const timeoutMs = healthcheck.timeout ?? DEFAULT_TCP_HEALTHCHECK_TIMEOUT_MS;
     let settled = false;
 
     const finish = (payload: ServiceHealthResult) => {
@@ -54,12 +57,12 @@ export async function checkTcpHealth(healthcheck: TcpHealthcheck): Promise<Servi
       });
     });
 
-    socket.setTimeout(2_000, () => {
+    socket.setTimeout(timeoutMs, () => {
       socket.destroy();
       finish({
         type: "tcp",
         healthy: false,
-        detail: `TCP healthcheck timed out: ${target.address}`,
+        detail: `TCP healthcheck timed out after ${timeoutMs}ms: ${target.address}`,
       });
     });
   });

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -2,6 +2,7 @@ export interface HealthcheckReadinessOptions {
   interval?: number;
   retries?: number;
   start_period?: number;
+  timeout?: number;
 }
 
 export interface ProcessHealthcheck extends HealthcheckReadinessOptions {

--- a/tests/health-timeouts.test.js
+++ b/tests/health-timeouts.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import net from "node:net";
+import { EventEmitter, once } from "node:events";
+import { checkHttpHealth } from "../dist/runtime/health/checkHttp.js";
+import { checkTcpHealth } from "../dist/runtime/health/checkTcp.js";
+
+test("HTTP healthchecks use configured per-attempt timeout", async () => {
+  const probeServer = createServer((_, response) => {
+    setTimeout(() => {
+      response.statusCode = 200;
+      response.end("ok");
+    }, 150);
+  });
+  probeServer.listen(0, "127.0.0.1");
+  await once(probeServer, "listening");
+  const address = probeServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("HTTP probe server failed to bind.");
+  }
+
+  try {
+    const health = await checkHttpHealth({
+      type: "http",
+      url: `http://127.0.0.1:${address.port}/health`,
+      timeout: 25,
+    });
+
+    assert.equal(health.healthy, false);
+    assert.equal(health.type, "http");
+    assert.match(health.detail, /timed out after 25ms/i);
+  } finally {
+    probeServer.close();
+    await once(probeServer, "close");
+  }
+});
+
+test("TCP healthchecks use configured per-attempt timeout", async () => {
+  const originalCreateConnection = net.createConnection;
+  const createdSockets = [];
+
+  net.createConnection = () => {
+    const socket = new EventEmitter();
+    socket.destroyed = false;
+    socket.destroy = () => {
+      socket.destroyed = true;
+      return socket;
+    };
+    socket.end = () => socket;
+    socket.setTimeout = (timeoutMs, callback) => {
+      socket.timeoutMs = timeoutMs;
+      setTimeout(callback, 0);
+      return socket;
+    };
+    createdSockets.push(socket);
+    return socket;
+  };
+
+  try {
+    const health = await checkTcpHealth({
+      type: "tcp",
+      address: "127.0.0.1:43123",
+      timeout: 35,
+    });
+
+    assert.equal(health.healthy, false);
+    assert.equal(health.type, "tcp");
+    assert.match(health.detail, /timed out after 35ms/i);
+    assert.equal(createdSockets[0].timeoutMs, 35);
+    assert.equal(createdSockets[0].destroyed, true);
+  } finally {
+    net.createConnection = originalCreateConnection;
+  }
+});

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -632,6 +632,7 @@ test("loadServiceManifest accepts manifest readiness retry fields", async () => 
         retries: 5,
         interval: 250,
         start_period: 100,
+        timeout: 750,
       },
     });
 
@@ -644,7 +645,32 @@ test("loadServiceManifest accepts manifest readiness retry fields", async () => 
       retries: 5,
       interval: 250,
       start_period: 100,
+      timeout: 750,
     });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects invalid healthcheck timeout values", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "bad-timeout-service", {
+      id: "bad-timeout-service",
+      name: "Bad Timeout Service",
+      description: "Manifest with invalid readiness timeout.",
+      healthcheck: {
+        type: "http",
+        url: "http://127.0.0.1:18080/health",
+        timeout: 0,
+      },
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-timeout-service", "service.json")),
+      /healthcheck\.timeout.*integer greater than or equal to 1/i,
+    );
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Issue
Closes #795

## Summary
- Adds `healthcheck.timeout` to shared readiness options and manifest validation.
- Applies the configured per-attempt timeout to HTTP fetch probes and TCP connect probes.
- Reports explicit timed-out health details for network readiness attempts.
- Documents timeout defaults and immediate-check behavior in the service JSON reference.

## Scope
- In scope: singular `healthcheck` readiness timeout parsing and HTTP/TCP per-attempt waits.
- Out of scope: canonical `healthchecks[]` array migration and future UDP implementation.

## Spec / contract / fixture impact
- Updated: `docs/reference/service-json-reference.md`.
- Tests added/updated for manifest parsing, invalid timeout validation, and HTTP/TCP timeout behavior.

## Service Lasso invariant impact
- Invariant: manifest readiness checks remain bounded and deterministic.
- Preservation proof: invalid values are rejected; omitted values keep existing defaults; file/process/variable checks remain immediate.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\run-20260727T142934Z\issue-795-build-final.log` and `issue-795-updated-npm-build.stdout.log`.
- PASS `node --test --test-concurrency=1 tests/health-timeouts.test.js` — `C:\projects\service-lasso\.work-agent\logs\run-20260727T142934Z\issue-795-health-timeouts-test-final.log`.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js --test-name-pattern "healthcheck timeout|readiness retry"` — `C:\projects\service-lasso\.work-agent\logs\run-20260727T142934Z\issue-795-manifest-timeout-test-final.log`.
- PASS updated-code canonical demo gate — `C:\projects\service-lasso\.work-agent\logs\run-20260727T142934Z\issue-795-updated-demo-gate.stdout.json`.
- PASS updated-code canonical demo verifier — `C:\projects\service-lasso\.work-agent\logs\run-20260727T142934Z\issue-795-updated-demo-verify-canonical.stdout.json`.
- NOTE broad `tests/health-state.test.js` attempt hit the outer command timeout; changed behavior is covered by the direct timeout and manifest tests above.

## Approval trail
- Required: no special approval identified; merge allowed after normal PR checks are green.
- Evidence: focused tests and canonical demo proof are attached above.

## Cleanup
- Branch cleanup after merge; local branch currently tracks `origin/issue-795-readiness-timeout`.