### PR TITLE
Restore optional HTTP healthcheck cookie handling

### DIFF
--- a/docs/reference/healthcheck-reference.md
+++ b/docs/reference/healthcheck-reference.md
@@ -109,7 +109,7 @@ Rules:
 - `url` is required.
 - `expected_status` defaults to `200` when omitted.
 - Selectors such as `${HTTP_PORT}` are resolved before the request.
-- Optional cookie handling may be supported for services whose readiness endpoint requires request state.
+- Optional `cookies` may be supplied as a string map for services whose readiness endpoint requires request state. Cookie values support the same selector resolution as `url`.
 
 Optional cookie form:
 

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -863,6 +863,20 @@ Sample:
 }
 ```
 
+HTTP healthchecks may include an optional `cookies` string map when a readiness endpoint requires cookie state. Cookie values support the same selector resolution as `url`; omit `cookies` for ordinary stateless health endpoints.
+
+```json
+"healthcheck": {
+  "type": "http",
+  "url": "http://localhost:${SERVICE_PORT}/healthcheck",
+  "expected_status": 200,
+  "cookies": {
+    "healthcheck": "ready",
+    "workspace": "${SERVICE_ID}"
+  }
+}
+```
+
 ### `tcp` healthcheck
 
 Use when:

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1681,11 +1681,13 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     if (healthRecord.type === "process") {
       healthcheck = { type: "process", ...readinessOptions };
     } else if (healthRecord.type === "http") {
+      const cookies = readStringMap(healthRecord.cookies, "healthcheck.cookies", manifestPath);
       healthcheck = {
         type: "http",
         url: expectNonEmptyString(healthRecord.url, "healthcheck.url", manifestPath),
         expected_status:
           typeof healthRecord.expected_status === "number" ? healthRecord.expected_status : undefined,
+        ...(cookies !== undefined ? { cookies } : {}),
         ...readinessOptions,
       };
     } else if (healthRecord.type === "tcp") {

--- a/src/runtime/health/checkHttp.ts
+++ b/src/runtime/health/checkHttp.ts
@@ -2,14 +2,28 @@ import type { HttpHealthcheck, ServiceHealthResult } from "./types.js";
 
 const DEFAULT_HTTP_HEALTHCHECK_TIMEOUT_MS = 2_000;
 
+function formatCookieHeader(cookies?: Record<string, string>): string | undefined {
+  if (!cookies || Object.keys(cookies).length === 0) {
+    return undefined;
+  }
+
+  return Object.entries(cookies)
+    .map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`)
+    .join("; ");
+}
+
 export async function checkHttpHealth(healthcheck: HttpHealthcheck): Promise<ServiceHealthResult> {
   const expectedStatus = healthcheck.expected_status ?? 200;
   const timeoutMs = healthcheck.timeout ?? DEFAULT_HTTP_HEALTHCHECK_TIMEOUT_MS;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const cookieHeader = formatCookieHeader(healthcheck.cookies);
 
   try {
-    const response = await fetch(healthcheck.url, { signal: controller.signal });
+    const response = await fetch(healthcheck.url, {
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+      signal: controller.signal,
+    });
 
     return {
       type: "http",

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -54,6 +54,14 @@ export async function evaluateServiceHealth(
     return checkHttpHealth({
       ...healthcheck,
       url: service ? resolveServiceText(healthcheck.url, service, sharedGlobalEnv, resolvedPorts) : healthcheck.url,
+      cookies: service
+        ? Object.fromEntries(
+            Object.entries(healthcheck.cookies ?? {}).map(([name, value]) => [
+              name,
+              resolveServiceText(value, service, sharedGlobalEnv, resolvedPorts),
+            ]),
+          )
+        : healthcheck.cookies,
     });
   }
 

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -13,6 +13,7 @@ export interface HttpHealthcheck extends HealthcheckReadinessOptions {
   type: "http";
   url: string;
   expected_status?: number;
+  cookies?: Record<string, string>;
 }
 
 export interface TcpHealthcheck extends HealthcheckReadinessOptions {

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -283,6 +283,57 @@ test("HTTP healthchecks resolve manifest port selectors", async () => {
   }
 });
 
+test("HTTP healthchecks resolve and send cookie selectors", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  const probeServer = createServer((request, res) => {
+    res.statusCode = request.headers.cookie === "healthcheck=http-cookie-service-ready" ? 200 : 401;
+    res.end("ok");
+  });
+  probeServer.listen(0, "127.0.0.1");
+  await once(probeServer, "listening");
+  const probeAddress = probeServer.address();
+  if (!probeAddress || typeof probeAddress === "string") {
+    throw new Error("Probe server failed to bind.");
+  }
+
+  await writeManifest(servicesRoot, "http-cookie-service", {
+    id: "http-cookie-service",
+    name: "HTTP Cookie Service",
+    description: "Temporary service for HTTP health cookie selector proof.",
+    ports: {
+      admin: probeAddress.port,
+    },
+    healthcheck: {
+      type: "http",
+      url: "http://127.0.0.1:${ADMIN_PORT}/health",
+      expected_status: 200,
+      cookies: {
+        healthcheck: "${SERVICE_ID}-ready",
+      },
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/http-cookie-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "http-cookie-service");
+    assert.equal(body.health.type, "http");
+    assert.equal(body.health.healthy, true);
+  } finally {
+    await apiServer.stop();
+    probeServer.close();
+    await once(probeServer, "close");
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("GET /api/services/:id/health supports bounded TCP healthchecks", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();

--- a/tests/health-timeouts.test.js
+++ b/tests/health-timeouts.test.js
@@ -36,6 +36,39 @@ test("HTTP healthchecks use configured per-attempt timeout", async () => {
   }
 });
 
+test("HTTP healthchecks send configured cookies", async () => {
+  let observedCookie = "";
+  const probeServer = createServer((request, response) => {
+    observedCookie = request.headers.cookie ?? "";
+    response.statusCode = observedCookie === "healthcheck=ready; workspace=demo%20space" ? 204 : 401;
+    response.end("ok");
+  });
+  probeServer.listen(0, "127.0.0.1");
+  await once(probeServer, "listening");
+  const address = probeServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("HTTP probe server failed to bind.");
+  }
+
+  try {
+    const health = await checkHttpHealth({
+      type: "http",
+      url: `http://127.0.0.1:${address.port}/health`,
+      expected_status: 204,
+      cookies: {
+        healthcheck: "ready",
+        workspace: "demo space",
+      },
+    });
+
+    assert.equal(health.healthy, true);
+    assert.equal(observedCookie, "healthcheck=ready; workspace=demo%20space");
+  } finally {
+    probeServer.close();
+    await once(probeServer, "close");
+  }
+});
+
 test("TCP healthchecks use configured per-attempt timeout", async () => {
   const originalCreateConnection = net.createConnection;
   const createdSockets = [];

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -652,6 +652,67 @@ test("loadServiceManifest accepts manifest readiness retry fields", async () => 
   }
 });
 
+test("loadServiceManifest accepts string HTTP healthcheck cookies", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "http-cookie-service", {
+      id: "http-cookie-service",
+      name: "HTTP Cookie Service",
+      description: "Manifest proving HTTP readiness cookie parsing.",
+      healthcheck: {
+        type: "http",
+        url: "http://127.0.0.1:18080/healthcheck",
+        expected_status: 200,
+        cookies: {
+          healthcheck: "ready",
+          workspace: "${SERVICE_ID}",
+        },
+      },
+    });
+
+    const manifest = await loadServiceManifest(path.join(servicesRoot, "http-cookie-service", "service.json"));
+
+    assert.deepEqual(manifest.healthcheck, {
+      type: "http",
+      url: "http://127.0.0.1:18080/healthcheck",
+      expected_status: 200,
+      cookies: {
+        healthcheck: "ready",
+        workspace: "${SERVICE_ID}",
+      },
+    });
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects non-string HTTP healthcheck cookies", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "bad-cookie-service", {
+      id: "bad-cookie-service",
+      name: "Bad Cookie Service",
+      description: "Manifest with an invalid HTTP readiness cookie.",
+      healthcheck: {
+        type: "http",
+        url: "http://127.0.0.1:18080/healthcheck",
+        cookies: {
+          healthcheck: true,
+        },
+      },
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "bad-cookie-service", "service.json")),
+      /healthcheck\.cookies.*string map/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest rejects invalid healthcheck timeout values", async () => {
   const servicesRoot = await makeTempServicesRoot();
 


### PR DESCRIPTION
## Issue
Closes #796

## Summary
- Restores optional `healthcheck.cookies` support for singular HTTP healthchecks.
- Validates cookie maps as string maps and preserves existing HTTP healthcheck shapes when cookies are omitted.
- Resolves cookie values through the same service selector path used for healthcheck URLs and sends them as the HTTP `Cookie` header.
- Documents optional cookie usage for readiness endpoints that require request state.

## Scope
- In scope: `HttpHealthcheck` type, manifest validation, HTTP checker, selector resolution, docs, and focused regressions.
- Out of scope: the future plural `healthchecks[]` migration and unrelated healthcheck aggregation work.

## Spec / contract / fixture impact
- Updated: `docs/reference/service-json-reference.md` and `docs/reference/healthcheck-reference.md`.

## Service Lasso invariant impact
- Invariant: existing HTTP healthchecks without cookies must behave unchanged.
- Preservation proof: manifest discovery regression confirms omitted cookies are not normalized into `cookies: undefined`; direct HTTP checker and API health regressions pass.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\dev-20260727T162936Z-9e9b19ce\issue-796-npm-build-rerun.out.log`
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `C:\projects\service-lasso\.work-agent\logs\dev-20260727T162936Z-9e9b19ce\issue-796-manifest-discovery-test-rerun.out.log`
- PASS `node --test --test-concurrency=1 --test-name-pattern 'HTTP healthchecks resolve and send cookie selectors' tests/health-state.test.js` — `C:\projects\service-lasso\.work-agent\logs\dev-20260727T162936Z-9e9b19ce\issue-796-health-state-cookie-test.out.log`
- PASS `node --test --test-concurrency=1 tests/health-timeouts.test.js` — `C:\projects\service-lasso\.work-agent\logs\dev-20260727T162936Z-9e9b19ce\issue-796-health-timeouts-test-rerun.out.log`
- PASS canonical demo gate + verifier on branch `issue-796-http-healthcheck-cookies`, commit `a5e3a28cd81f80578f2f0a714e026ee46cd5b2f0` — `C:\projects\service-lasso\.work-agent\logs\dev-20260727T162936Z-9e9b19ce\issue-796-demo-proof-summary.json`

## Approval trail
- Required: no special product approval identified for this bounded runtime contract restoration.

## Cleanup
- Branch cleanup after merge; return local checkout to clean `develop` where possible.