### PR TITLE
Resolve file healthcheck selectors

### DIFF
--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -926,9 +926,13 @@ Sample:
 ```json
 "healthcheck": {
   "type": "file",
-  "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
+  "file": "${SERVICE_ROOT}/runtime/ready.txt"
 }
 ```
+
+Selector resolution applies before the filesystem check. Relative paths remain
+resolved against the service root, absolute paths remain supported, and health
+details report the resolved path that was checked.
 
 ### `variable` healthcheck
 

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -104,7 +104,15 @@ export async function evaluateServiceHealth(
   }
 
   if (healthcheck.type === "file") {
-    return checkFileHealth(healthcheck, serviceRoot);
+    return checkFileHealth(
+      {
+        ...healthcheck,
+        file: service
+          ? resolveServiceText(healthcheck.file, service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.file,
+      },
+      serviceRoot,
+    );
   }
 
   if (healthcheck.type === "variable") {

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -604,6 +604,78 @@ test("GET /api/services/:id/health supports bounded file healthchecks", async ()
   }
 });
 
+test("file healthchecks resolve service selectors before checking paths", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const serviceRoot = await writeManifest(servicesRoot, "file-selector-service", {
+    id: "file-selector-service",
+    name: "File Selector Service",
+    description: "Temporary service for file health selector proof.",
+    healthcheck: {
+      type: "file",
+      file: "${SERVICE_ROOT}/runtime/ready.txt",
+    },
+  });
+  const readyPath = path.join(serviceRoot, "runtime", "ready.txt");
+  await mkdir(path.dirname(readyPath), { recursive: true });
+  await writeFile(readyPath, "ok");
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/file-selector-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "file-selector-service");
+    assert.equal(body.health.type, "file");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /found expected file/i);
+    assert.equal(body.health.detail.includes("${SERVICE_ROOT}"), false);
+    const checkedPath = body.health.detail.replace(/^File healthcheck found expected file: /, "");
+    assert.equal(path.normalize(checkedPath), readyPath);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("file healthchecks support absolute paths", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const absoluteReadyPath = path.join(tempRoot, "external-ready.txt");
+  await writeFile(absoluteReadyPath, "ok");
+
+  await writeManifest(servicesRoot, "file-absolute-service", {
+    id: "file-absolute-service",
+    name: "File Absolute Service",
+    description: "Temporary service for absolute file health proof.",
+    healthcheck: {
+      type: "file",
+      file: absoluteReadyPath,
+    },
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/file-absolute-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "file-absolute-service");
+    assert.equal(body.health.type, "file");
+    assert.equal(body.health.healthy, true);
+    assert.match(body.health.detail, /found expected file/i);
+    assert.ok(body.health.detail.includes(absoluteReadyPath));
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
 test("file healthcheck lifecycle actions stay 200 when the file is unavailable", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot();


### PR DESCRIPTION
## Issue
Closes #797

## Summary
- Resolve file healthcheck ile paths through the normal service selector pipeline before filesystem checks.
- Preserve service-root-relative path handling and absolute path support.
- Update the service manifest reference to prefer ${SERVICE_ROOT} and document file healthcheck resolution rules.

## Scope
- In scope: singular healthcheck.type=file runtime behavior, API health tests, reference doc wording.
- Out of scope: broader healthchecks[] migration and unrelated healthcheck schema changes.

## Spec / contract / fixture impact
- Updated: docs/reference/service-json-reference.md file healthcheck example and behavior note.
- Tests added for selector-resolved and absolute file paths; existing relative and missing-file tests remain in place.

## Service Lasso invariant impact
- Invariant: file healthchecks report the resolved target path and do not change relative/absolute path semantics.
- Preservation proof: targeted file healthcheck tests pass and 
pm run build passes.

## Validation
- PASS 
pm run build — C:\projects\service-lasso\.work-agent\logs\dev-cron-20260728-042835\issue-797-npm-build-3.log
- PASS 
ode --test --test-concurrency=1 --test-name-pattern "file healthchecks" tests/health-state.test.js — C:\projects\service-lasso\.work-agent\logs\dev-cron-20260728-042835\issue-797-file-health-tests-2.log
- NOTE broader 
ode --test --test-concurrency=1 tests/health-state.test.js hit an existing HTTP unavailable lifecycle timeout before reaching the new file cases — C:\projects\service-lasso\.work-agent\logs\dev-cron-20260728-042835\issue-797-health-state-test-1.log

## Approval trail
- Required: no special approval identified beyond repository merge rules.
- Evidence: focused runtime/docs/test change for #797.

## Cleanup
- Branch: ix/issue-797-file-healthcheck-selectors
- Post-merge plan: return local checkout to clean develop where possible.
