### PR TITLE
Issue #801 add setup step cwd support

### DIFF
--- a/docs/reference/one-shot-jobs.md
+++ b/docs/reference/one-shot-jobs.md
@@ -23,6 +23,7 @@ Declare jobs under `setup.steps`:
         "description": "Initialize the TypeDB schema.",
         "depend_on": ["typedb"],
         "execservice": "@java",
+        "cwd": "${SERVICE_ROOT}/jobs",
         "commandline": {
           "win32": "-jar \"${SERVICE_ROOT}\\jobs\\typedb-init.jar\" --address ${TYPEDB_ADDRESS}",
           "default": "-jar \"${SERVICE_ROOT}/jobs/typedb-init.jar\" --address ${TYPEDB_ADDRESS}"
@@ -50,6 +51,7 @@ Common fields:
 - `execservice`: optional provider service such as `@node`, `@python`, or `@java`.
 - `commandline`: platform map where `win32`, `linux`, or `darwin` override `default`.
 - `executable` and `args`: structured command form when a platform commandline is not needed.
+- `cwd`: optional working directory for the setup command. It supports normal Service Lasso variable selectors, resolves relative paths from the service root, must stay inside the service root, and must exist before the command runs.
 - `env`: setup-step environment additions.
 - `timeoutSeconds`: maximum runtime before the step is failed.
 - `rerun`: `ifMissing`, `manual`, or `always`.
@@ -63,6 +65,7 @@ Runtime behavior is intentionally different from daemon startup:
 - Direct setup omits `execservice`; the selected commandline is parsed as executable plus args, or `executable` plus `args` can be used.
 - Provider-backed setup uses the acquired provider command from `@node`, `@python`, `@java`, or another provider service.
 - Variables from service env, `globalenv`, provider globals, and runtime paths are resolved before execution.
+- When `cwd` is declared, Service Lasso resolves it before spawning the command, fails the setup step if it is missing or outside the service root, and records the resolved working directory in setup run history. When omitted, setup still runs from the service root.
 - Service dependencies are installed/configured first; non-provider service dependencies are started and health-checked before the step runs.
 - Setup step dependencies wait for the referenced setup step result before execution.
 - Stdout, stderr, exit code, timeout, start/end time, and status are persisted under `.state/setup.json`.

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -1031,6 +1031,7 @@ Examples:
   "steps": {
     "install-python-deps": {
       "description": "Install service-local Python dependencies.",
+      "cwd": "${SERVICE_ROOT}",
       "commandline": {
         "win32": "pip.exe install --user -r \"${SERVICE_ROOT}\\requirements.txt\"",
         "default": "pip install --user -r \"${SERVICE_ROOT}/requirements.txt\""
@@ -1058,6 +1059,7 @@ Runtime behavior:
 - Direct setup: omit `execservice`; the selected `commandline` is parsed as the executable plus arguments, or `executable` plus `args` can be used.
 - Provider-backed setup: set `execservice` to `@node`, `@python`, or `@java`; `commandline` or `args` becomes the provider executable's argument payload.
 - Platform selection uses `commandline[process.platform]` with `commandline.default` fallback.
+- Optional `cwd` selects the setup command's working directory. It supports Service Lasso variables, relative paths resolve from `SERVICE_ROOT`, absolute paths must still be inside `SERVICE_ROOT`, missing/non-directory values fail before spawn, and setup run history records the resolved cwd.
 - Dependencies in `depend_on` can name services or setup steps using `<serviceId>:<stepId>`.
 - Service dependencies must be installed/configured; non-provider service dependencies are started and health-checked before the setup step runs.
 - Setup runs capture stdout/stderr logs and persist results in `.state/setup.json`.

--- a/docs/service-authoring/02-write-service-json.md
+++ b/docs/service-authoring/02-write-service-json.md
@@ -59,6 +59,7 @@ This is Service Lasso's first-class one-shot job contract. Use [One-shot Jobs](.
     "steps": {
       "generate-cert": {
         "description": "Generate local development certificates.",
+        "cwd": "${SERVICE_ROOT}",
         "commandline": {
           "win32": "mkcert.exe -key-file \"${SERVICE_DATA_PATH}\\mkcert.key\" -cert-file \"${SERVICE_DATA_PATH}\\mkcert.pem\" *.localhost",
           "default": "mkcert -key-file \"${SERVICE_DATA_PATH}/mkcert.key\" -cert-file \"${SERVICE_DATA_PATH}/mkcert.pem\" *.localhost"
@@ -75,6 +76,7 @@ Rules:
 
 - No `execservice` means the setup command runs directly.
 - `execservice` runs the setup step through a provider such as `@node`, `@python`, or `@java`.
+- `cwd` optionally picks the working directory for the setup command. It uses the same variable selectors as `commandline` and `env`, defaults to the service root, and must resolve to an existing directory inside the service root.
 - `commandline.win32`, `commandline.linux`, and `commandline.darwin` override `commandline.default`.
 - `rerun: "ifMissing"` is the default bootstrap-friendly behavior.
 - `rerun: "manual"` is for destructive or sample/demo steps that should only run when explicitly requested.

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -188,6 +188,7 @@ export interface ServiceSetupStep {
   executable?: string;
   args?: string[];
   commandline?: Record<string, string>;
+  cwd?: string;
   env?: ServiceEnvMap;
   timeoutSeconds?: number;
   rerun?: ServiceSetupRerunPolicy;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -434,6 +434,13 @@ function readSetupPolicy(value: unknown, manifestPath: string): ServiceManifest[
         );
       }
 
+      const cwd = step.cwd;
+      if (cwd !== undefined && (typeof cwd !== "string" || cwd.trim().length === 0)) {
+        throw new Error(
+          `Invalid service manifest at ${manifestPath}: expected "setup.steps.${normalizedStepId}.cwd" to be a non-empty string when present.`,
+        );
+      }
+
       const rawRerun = step.rerun;
       if (rawRerun !== undefined && (typeof rawRerun !== "string" || !setupRerunPolicies.has(rawRerun))) {
         throw new Error(
@@ -450,6 +457,7 @@ function readSetupPolicy(value: unknown, manifestPath: string): ServiceManifest[
           executable: typeof step.executable === "string" ? step.executable.trim() : undefined,
           args: Array.isArray(args) ? args.map((entry) => entry.trim()) : undefined,
           commandline: readStringMap(step.commandline, `setup.steps.${normalizedStepId}.commandline`, manifestPath),
+          cwd: typeof cwd === "string" ? cwd.trim() : undefined,
           env: readEnvMap(step.env, `setup.steps.${normalizedStepId}.env`, manifestPath),
           timeoutSeconds: expectOptionalWholeNumber(
             step.timeoutSeconds,

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -52,6 +52,7 @@ export interface ServiceSetupStepRunState {
   finishedAt: string;
   durationMs: number;
   command: string;
+  cwd?: string;
   exitCode: number | null;
   signal: string | null;
   message: string;

--- a/src/runtime/setup/steps.ts
+++ b/src/runtime/setup/steps.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { createWriteStream, type WriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import type { DiscoveredService, ServiceSetupStep } from "../../contracts/service.js";
 import type { ProviderExecutionPlan } from "../providers/types.js";
@@ -118,8 +118,44 @@ function resolveExecutable(service: DiscoveredService, executionPlan: ProviderEx
   return executable;
 }
 
-function resolveWorkingDirectory(service: DiscoveredService, _executionPlan: ProviderExecutionPlan, _executable: string): string {
-  return service.serviceRoot;
+function isPathInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+class SetupWorkingDirectoryError extends Error {
+  constructor(message: string, readonly cwd?: string) {
+    super(message);
+  }
+}
+
+async function resolveWorkingDirectory(
+  service: DiscoveredService,
+  step: ServiceSetupStep,
+  sharedGlobalEnv: Record<string, string>,
+  resolvedPorts: Record<string, number>,
+): Promise<string> {
+  if (!step.cwd) {
+    return service.serviceRoot;
+  }
+
+  const resolved = resolveServiceText(step.cwd, service, sharedGlobalEnv, resolvedPorts);
+  const cwd = path.resolve(service.serviceRoot, resolved);
+  if (!isPathInside(service.serviceRoot, cwd)) {
+    throw new SetupWorkingDirectoryError(`Setup step cwd for "${service.manifest.id}" must stay inside the service root.`, cwd);
+  }
+
+  const cwdStat = await stat(cwd).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      throw new SetupWorkingDirectoryError(`Setup step cwd for "${service.manifest.id}" does not exist: ${cwd}`, cwd);
+    }
+    throw error;
+  });
+  if (!cwdStat.isDirectory()) {
+    throw new SetupWorkingDirectoryError(`Setup step cwd for "${service.manifest.id}" is not a directory: ${cwd}`, cwd);
+  }
+
+  return cwd;
 }
 
 function buildStepService(service: DiscoveredService, step: ServiceSetupStep): DiscoveredService {
@@ -256,6 +292,41 @@ function recordSetupRun(serviceId: string, run: ServiceSetupStepRunState): Servi
       },
     },
   });
+}
+
+async function createFailedSetupRun(
+  service: DiscoveredService,
+  stepId: string,
+  command: string,
+  message: string,
+  cwd?: string,
+): Promise<ServiceSetupStepRunState> {
+  const now = new Date().toISOString();
+  const runId = buildRunId(stepId);
+  const logs = getSetupRunLogPaths(service.serviceRoot, stepId, runId);
+  await mkdir(path.dirname(logs.logPath), { recursive: true });
+  const combined = createWriteStream(logs.logPath, { flags: "w" });
+  const stdout = createWriteStream(logs.stdoutPath, { flags: "w" });
+  const stderr = createWriteStream(logs.stderrPath, { flags: "w" });
+  stderr.write(`${message}\n`);
+  writeCombinedLogEntry(combined, "stderr", message);
+  await Promise.all([closeWriteStream(combined), closeWriteStream(stdout), closeWriteStream(stderr)]);
+
+  return {
+    runId,
+    serviceId: service.manifest.id,
+    stepId,
+    status: "failed",
+    startedAt: now,
+    finishedAt: now,
+    durationMs: 0,
+    command,
+    ...(cwd ? { cwd } : {}),
+    exitCode: null,
+    signal: null,
+    message,
+    logs,
+  };
 }
 
 function shouldSkipStep(
@@ -400,6 +471,30 @@ export async function runSetupStep(
   const executable = resolveExecutable(service, executionPlan);
   const args = executionPlan.args;
   const command = [executable, ...args].join(" ");
+  let cwd: string;
+  try {
+    cwd = await resolveWorkingDirectory(service, step, sharedGlobalEnv, resolvedPorts);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : `Setup step "${stepId}" failed before command execution.`;
+    const run = await createFailedSetupRun(
+      service,
+      stepId,
+      command,
+      message,
+      error instanceof SetupWorkingDirectoryError ? error.cwd : undefined,
+    );
+    const nextState = recordSetupRun(serviceId, run);
+    visiting.delete(visitKey);
+    return {
+      ok: false,
+      action: "setup",
+      serviceId,
+      stepId,
+      state: nextState,
+      run,
+      message,
+    };
+  }
   const startedAt = new Date().toISOString();
   const runId = buildRunId(stepId);
   const logs = getSetupRunLogPaths(service.serviceRoot, stepId, runId);
@@ -409,7 +504,7 @@ export async function runSetupStep(
   const stdout = createWriteStream(logs.stdoutPath, { flags: "w" });
   const stderr = createWriteStream(logs.stderrPath, { flags: "w" });
   const child = spawn(executable, args, {
-    cwd: resolveWorkingDirectory(service, executionPlan, executable),
+    cwd,
     env: buildProcessEnvironment(service, executionPlan, step, sharedGlobalEnv, resolvedPorts),
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
@@ -451,6 +546,7 @@ export async function runSetupStep(
     finishedAt,
     durationMs,
     command,
+    cwd,
     exitCode: exit.exitCode,
     signal: exit.signal,
     message,

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -350,6 +350,7 @@ function parseSetupRun(value: unknown): ServiceSetupStepRunState | null {
     finishedAt: record.finishedAt,
     durationMs: record.durationMs,
     command: record.command,
+    cwd: typeof record.cwd === "string" ? record.cwd : undefined,
     exitCode: typeof record.exitCode === "number" ? record.exitCode : null,
     signal: typeof record.signal === "string" ? record.signal : null,
     message: record.message,

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -1711,6 +1711,7 @@ test("loadServiceManifest accepts bounded setup lifecycle steps", async () => {
                 win32: "-jar \"${SERVICE_ROOT}\\jobs\\init-schema.jar\"",
                 default: "-jar \"${SERVICE_ROOT}/jobs/init-schema.jar\"",
               },
+              cwd: "${SERVICE_ROOT}/jobs",
               env: {
                 SCHEMA_PATH: "${SERVICE_ROOT}/schema",
               },
@@ -1742,6 +1743,7 @@ test("loadServiceManifest accepts bounded setup lifecycle steps", async () => {
         win32: "-jar \"${SERVICE_ROOT}\\jobs\\init-schema.jar\"",
         default: "-jar \"${SERVICE_ROOT}/jobs/init-schema.jar\"",
       },
+      cwd: "${SERVICE_ROOT}/jobs",
       env: {
         SCHEMA_PATH: "${SERVICE_ROOT}/schema",
       },
@@ -1755,6 +1757,7 @@ test("loadServiceManifest accepts bounded setup lifecycle steps", async () => {
       executable: undefined,
       args: ["jobs/load-sample/basic_upload.py"],
       commandline: undefined,
+      cwd: undefined,
       env: undefined,
       timeoutSeconds: 300,
       rerun: "manual",

--- a/tests/setup-lifecycle.test.js
+++ b/tests/setup-lifecycle.test.js
@@ -52,6 +52,7 @@ async function writeSetupScript(serviceRoot, name = "setup-writer.mjs") {
       "  serviceId: process.env.SERVICE_ID,",
       "  serviceRoot: process.env.SERVICE_ROOT,",
       "  dataPath: process.env.SERVICE_DATA_PATH,",
+      "  cwd: process.cwd(),",
       "  inherited: process.env.INHERITED_GLOBAL ?? null,",
       "  stepValue: process.env.STEP_VALUE ?? null",
       "}, null, 2));",
@@ -104,14 +105,126 @@ test("setup run executes direct steps, captures logs, and persists setup history
     assert.equal(output.serviceId, "setup-service");
     assert.equal(output.serviceRoot, serviceRoot);
     assert.equal(output.dataPath, path.join(serviceRoot, "data"));
+    assert.equal(path.resolve(output.cwd), path.resolve(serviceRoot));
     assert.equal(output.stepValue, "configured-setup-service");
 
     const stored = await readStoredState(serviceRoot);
     assert.equal(stored.setup.steps["write-file"].status, "succeeded");
+    assert.equal(path.resolve(stored.setup.steps["write-file"].lastRun.cwd), path.resolve(serviceRoot));
     assert.equal(stored.runtime.lastAction, "setup");
     assert.deepEqual(stored.runtime.actionHistory, ["install", "config", "setup"]);
     assert.match(await readFile(stored.setup.steps["write-file"].lastRun.logs.stdoutPath, "utf8"), /setup writer complete/);
     assert.match(await readFile(stored.setup.steps["write-file"].lastRun.logs.stderrPath, "utf8"), /setup writer stderr/);
+  } finally {
+    await apiServer.stop();
+    await resetSetupTestState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("setup run resolves explicit cwd selectors and records cwd in history", async () => {
+  await resetSetupTestState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-setup-cwd-");
+  const serviceRoot = await writeManifest(servicesRoot, "setup-cwd", {
+    id: "setup-cwd",
+    name: "Setup Cwd",
+    description: "Explicit setup cwd proof.",
+    setup: {
+      steps: {
+        "service-root": {
+          executable: process.execPath,
+          cwd: "${SERVICE_ROOT}",
+          args: ["runtime/setup-writer.mjs"],
+          timeoutSeconds: 5,
+        },
+        "artifact-bin": {
+          executable: process.execPath,
+          cwd: "${SERVICE_ROOT}/runtime/bin",
+          args: ["runtime/setup-writer.mjs"],
+          env: {
+            SETUP_OUTPUT_PATH: "./cwd-output.json",
+          },
+          timeoutSeconds: 5,
+        },
+      },
+    },
+  });
+  await writeSetupScript(serviceRoot);
+  await mkdir(path.join(serviceRoot, "runtime", "bin"), { recursive: true });
+  await writeSetupScript(path.join(serviceRoot, "runtime", "bin"));
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/setup-cwd/install`);
+    await postJson(`${apiServer.url}/api/services/setup-cwd/config`);
+
+    const serviceRootRun = await postJson(`${apiServer.url}/api/services/setup-cwd/setup/run/service-root`);
+    assert.equal(serviceRootRun.status, 200);
+    assert.equal(serviceRootRun.body.ok, true);
+    assert.equal(path.resolve(serviceRootRun.body.runs[0].cwd), path.resolve(serviceRoot));
+
+    const artifactBinRun = await postJson(`${apiServer.url}/api/services/setup-cwd/setup/run/artifact-bin`);
+    assert.equal(artifactBinRun.status, 200);
+    assert.equal(artifactBinRun.body.ok, true);
+    assert.equal(path.resolve(artifactBinRun.body.runs[0].cwd), path.resolve(serviceRoot, "runtime", "bin"));
+
+    const output = JSON.parse(await readFile(path.join(serviceRoot, "runtime", "bin", "cwd-output.json"), "utf8"));
+    assert.equal(path.resolve(output.cwd), path.resolve(serviceRoot, "runtime", "bin"));
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(path.resolve(stored.setup.steps["service-root"].lastRun.cwd), path.resolve(serviceRoot));
+    assert.equal(path.resolve(stored.setup.steps["artifact-bin"].lastRun.cwd), path.resolve(serviceRoot, "runtime", "bin"));
+  } finally {
+    await apiServer.stop();
+    await resetSetupTestState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("setup run fails before spawning when cwd is missing or outside the service root", async () => {
+  await resetSetupTestState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-setup-cwd-invalid-");
+  const serviceRoot = await writeManifest(servicesRoot, "bad-setup-cwd", {
+    id: "bad-setup-cwd",
+    name: "Bad Setup Cwd",
+    description: "Invalid setup cwd proof.",
+    setup: {
+      steps: {
+        missing: {
+          executable: process.execPath,
+          cwd: "${SERVICE_ROOT}/missing",
+          args: ["-e", "process.exit(99)"],
+          timeoutSeconds: 5,
+          rerun: "always",
+        },
+        escape: {
+          executable: process.execPath,
+          cwd: "../outside",
+          args: ["-e", "process.exit(99)"],
+          timeoutSeconds: 5,
+          rerun: "always",
+        },
+      },
+    },
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/bad-setup-cwd/install`);
+    await postJson(`${apiServer.url}/api/services/bad-setup-cwd/config`);
+
+    const missing = await postJson(`${apiServer.url}/api/services/bad-setup-cwd/setup/run/missing`);
+    assert.equal(missing.status, 200);
+    assert.equal(missing.body.ok, false);
+    assert.equal(missing.body.runs[0].exitCode, null);
+    assert.match(missing.body.runs[0].message, /does not exist/);
+    assert.equal(path.resolve(missing.body.runs[0].cwd), path.resolve(serviceRoot, "missing"));
+
+    const escape = await postJson(`${apiServer.url}/api/services/bad-setup-cwd/setup/run/escape`);
+    assert.equal(escape.status, 200);
+    assert.equal(escape.body.ok, false);
+    assert.equal(escape.body.runs[0].exitCode, null);
+    assert.match(escape.body.runs[0].message, /must stay inside the service root/);
   } finally {
     await apiServer.stop();
     await resetSetupTestState();


### PR DESCRIPTION
## Issue
Closes #801

## Summary
- Add optional `setup.steps.<stepId>.cwd` to the manifest contract and runtime setup execution.
- Resolve setup cwd with Service Lasso variables, default omitted cwd to the service root, and fail missing/out-of-root cwd values before spawning.
- Persist resolved cwd in setup run history and document the authoring contract.

## Scope
- In scope: setup-step schema/type support, runtime cwd validation/execution, persisted state rehydrate compatibility, focused tests, docs.
- Out of scope: changing daemon/action cwd semantics or adding new provider-specific path variables.

## Spec / contract / fixture impact
- Updated: setup step TypeScript contract, manifest discovery validation, one-shot job docs, service.json reference, authoring guide.

## Service Lasso invariant impact
- Invariant: setup commands remain service-owned one-shot jobs.
- Preservation proof: declared cwd resolves from variables, relative values anchor at the service root, absolute values must remain inside the service root, and invalid cwd values fail before command spawn.

## Validation
- PASS `npm run build` - C:\projects\service-lasso\.work-agent\logs\20260728-062913\issue-801-final-npm-build.stdout.log
- PASS `node --test --test-concurrency=1 --test-name-pattern="cwd|bounded setup lifecycle" tests/setup-lifecycle.test.js tests/manifest-discovery.test.js` - C:\projects\service-lasso\.work-agent\logs\20260728-062913\issue-801-cwd-tests.stdout.log
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` - C:\projects\service-lasso\.work-agent\logs\20260728-062913\issue-801-manifest-discovery.stdout.log
- PASS `node --test --test-concurrency=1 --test-name-pattern="setup run executes direct steps|provider-backed setup runs through execservice|cwd" tests/setup-lifecycle.test.js` - C:\projects\service-lasso\.work-agent\logs\20260728-062913\issue-801-setup-selected-tests.stdout.log
- TIMEOUT `node --test --test-concurrency=1 tests/setup-lifecycle.test.js tests/manifest-discovery.test.js` at 5 minutes with empty output; stale test node processes from this command were stopped, then narrower targeted commands above passed.

## Approval trail
- Required: no explicit approval gate identified.
- Evidence: local focused validation passed.

## Cleanup
- Branch cleanup after merge; return local checkout to clean `develop` after demo proof and merge when allowed.
