### PR TITLE
Issue #804 add config template materialization

### DIFF
--- a/.governance/specs/SPEC-002-core-standalone-runtime.md
+++ b/.governance/specs/SPEC-002-core-standalone-runtime.md
@@ -106,7 +106,7 @@ Required evidence for this spec:
 - direct proof that configured readiness wait loops can succeed and time out deterministically during bounded start behavior
 - direct proof that bounded manifest-driven `globalenv` values can be merged and injected into dependent service execution/runtime API output
 - direct proof that bounded runtime port negotiation can assign ports, resolve collisions deterministically, and surface resolved network data through the API
-- direct proof that bounded install/config actions can materialize service-scoped files on disk and persist artifact metadata for rerunnable effective config generation
+- direct proof that bounded install/config actions can materialize service-scoped inline files and service-root-relative templates on disk, render Service Lasso variables into generated outputs, reject unsafe source/target paths, and persist artifact metadata for rerunnable effective config generation
 - direct proof that at least one provider-backed service can execute through its provider path and report provider/runtime evidence through the API
 - direct proof that runtime-level `startAll` / `stopAll` orchestration can start and stop eligible services in deterministic order while reporting explicit skip reasons for ineligible services
 - direct proof that supervised processes write real stdout/stderr output into runtime-owned log files, that the logs API exposes recent captured output, and that persisted runtime state records the runtime log paths

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -42,6 +42,7 @@ This reference tracks each runtime-facing field as:
 | Field | Status | TypeScript contract | Runtime/lifecycle behavior |
 | --- | --- | --- | --- |
 | `actions` | implemented | `ServiceManifest.actions?: ServiceActionPolicy` with action definitions, payload policy, workflow steps, and schedule maps | Validated during manifest discovery, used by service action run APIs, used by lifecycle stop overrides, and published through `GET /api/workflows/registry` for enabled scheduled actions. Closed alignment issue: [#777](https://github.com/service-lasso/service-lasso/issues/777). |
+| `install` / `config` | implemented | `ServiceActionMaterialization` with `files[]` and `templates[]` | Lifecycle install/config can materialize inline file content and render service-root-relative template files into bounded generated targets, then persist generated paths in lifecycle artifact state. |
 | `files` | implemented | `ServiceManifest.files?: ServiceFilesPolicy` with service-root-relative workspace roots | Validated during manifest discovery and published through `GET /api/files/workspaces` as the `service-lasso-workspaces` registry for file-manager consumers. |
 | `outputvarregex` | compatibility | `ServiceManifest.outputvarregex?: Record<string, string>` | Validated during manifest discovery as a legacy-compatible stdout/stderr variable extraction contract for services that use `variable` healthchecks. |
 | `serviceorder` | implemented | `ServiceManifest.serviceorder?: number` | Validated as a top-level whole number and used by dependency graph ordering for otherwise-independent services. Closed alignment issue: [#778](https://github.com/service-lasso/service-lasso/issues/778). |
@@ -362,6 +363,46 @@ Schedule fields currently validated by discovery:
   - stop the service gracefully
 
 Finite lifecycle actions continue to use their existing bounded runtime behavior. Scheduled actions add contract metadata for later workflow/scheduler consumers; they do not turn cron into a separate service-level action list.
+
+### Install/config materialization
+
+`install.files[]` and `config.files[]` materialize inline content:
+
+```json
+{
+  "config": {
+    "files": [
+      {
+        "path": "./runtime/config.env",
+        "content": "SERVICE_PORT=${SERVICE_PORT}\n"
+      }
+    ]
+  }
+}
+```
+
+`install.templates[]` and `config.templates[]` render checked-in template files from the service package into generated output paths:
+
+```json
+{
+  "config": {
+    "templates": [
+      {
+        "source": "./templates/config.env.template",
+        "target": "./runtime/config.env"
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `source` resolves relative to the service root/package and must stay inside that root.
+- `target` supports the same Service Lasso variable resolution used by inline materialized file paths, then must stay inside the service root.
+- Template file content is rendered with Service Lasso variables before it is written.
+- Generated target paths are recorded in lifecycle `installArtifacts.files` or `configArtifacts.files` alongside inline file outputs.
+- Existing `files[]` behavior remains unchanged.
 
 The runtime publishes scheduled action workflows through `GET /api/workflows/registry`. The registry is generated from validated service manifests, hides disabled services and disabled schedules, and includes stable workflow ids, service/action/schedule metadata, tags, workflow steps, and per-entry checksums for Dagu drift detection.
 

--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -52,8 +52,14 @@ export interface ServiceMaterializedFile {
   content: string;
 }
 
+export interface ServiceMaterializedTemplate {
+  source: string;
+  target: string;
+}
+
 export interface ServiceActionMaterialization {
   files?: ServiceMaterializedFile[];
+  templates?: ServiceMaterializedTemplate[];
 }
 
 export type ServiceFilesRootMode = "read-only" | "read-write";

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -170,15 +170,52 @@ function readActionMaterialization(
     );
   }
 
-  if (!record.files) {
+  if (
+    record.templates !== undefined &&
+    (!Array.isArray(record.templates) ||
+      record.templates.some(
+        (entry) =>
+          !entry ||
+          typeof entry !== "object" ||
+          Array.isArray(entry) ||
+          typeof (entry as Record<string, unknown>).source !== "string" ||
+          typeof (entry as Record<string, unknown>).target !== "string",
+      ))
+  ) {
+    throw new Error(
+      `Invalid service manifest at ${manifestPath}: expected "${field}.templates" to be an array of { source, target } objects.`,
+    );
+  }
+
+  if (!record.files && !record.templates) {
     return {};
   }
 
   return {
-    files: record.files.map((entry) => ({
-      path: expectNonEmptyString((entry as Record<string, string>).path, `${field}.files.path`, manifestPath),
-      content: (entry as Record<string, string>).content,
-    })),
+    ...(record.files
+      ? {
+          files: record.files.map((entry) => ({
+            path: expectNonEmptyString((entry as Record<string, string>).path, `${field}.files.path`, manifestPath),
+            content: (entry as Record<string, string>).content,
+          })),
+        }
+      : {}),
+    ...(record.templates
+      ? {
+          templates: record.templates.map((entry) => ({
+            source: expectNonEmptyString(
+              (entry as Record<string, string>).source,
+              `${field}.templates.source`,
+              manifestPath,
+            ),
+            target: expectNonEmptyString(
+              (entry as Record<string, string>).target,
+              `${field}.templates.target`,
+              manifestPath,
+            ),
+          })),
+        }
+      : {}),
   };
 }
 

--- a/src/runtime/setup/materialize.ts
+++ b/src/runtime/setup/materialize.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import type { DiscoveredService, ServiceActionMaterialization } from "../../contracts/service.js";
 import { resolveServiceText, type ServiceTextResolutionOptions } from "../operator/variables.js";
 
@@ -34,6 +34,46 @@ function resolveArtifactPath(serviceRoot: string, relativePath: string): { absol
   };
 }
 
+function resolveTemplateSourcePath(serviceRoot: string, relativePath: string): { absolutePath: string; relativePath: string } {
+  if (relativePath.trim().length === 0) {
+    throw new Error("Materialized template source must be a non-empty relative path.");
+  }
+
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Materialized template source must stay relative to the service root: ${relativePath}`);
+  }
+
+  const absolutePath = path.resolve(serviceRoot, relativePath);
+  const normalizedRelative = path.relative(serviceRoot, absolutePath);
+  if (
+    normalizedRelative.length === 0 ||
+    normalizedRelative === "." ||
+    normalizedRelative.startsWith("..") ||
+    path.isAbsolute(normalizedRelative)
+  ) {
+    throw new Error(`Materialized template source escapes the service root: ${relativePath}`);
+  }
+
+  return {
+    absolutePath,
+    relativePath: normalizedRelative.replaceAll("\\", "/"),
+  };
+}
+
+async function readTemplateSource(serviceRoot: string, sourcePath: string): Promise<string> {
+  const resolved = resolveTemplateSourcePath(serviceRoot, sourcePath);
+
+  try {
+    return await readFile(resolved.absolutePath, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      throw new Error(`Materialized template source does not exist: ${resolved.relativePath}`);
+    }
+
+    throw error;
+  }
+}
+
 async function materializeFiles(
   service: DiscoveredService,
   definition: ServiceActionMaterialization | undefined,
@@ -47,6 +87,16 @@ async function materializeFiles(
   for (const file of files) {
     const renderedRelativePath = resolveServiceText(file.path, service, sharedGlobalEnv, resolvedPorts, options);
     const renderedContent = resolveServiceText(file.content, service, sharedGlobalEnv, resolvedPorts, options);
+    const { absolutePath, relativePath } = resolveArtifactPath(service.serviceRoot, renderedRelativePath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, renderedContent, "utf8");
+    materializedPaths.push(relativePath);
+  }
+
+  for (const template of definition?.templates ?? []) {
+    const sourceContent = await readTemplateSource(service.serviceRoot, template.source);
+    const renderedRelativePath = resolveServiceText(template.target, service, sharedGlobalEnv, resolvedPorts, options);
+    const renderedContent = resolveServiceText(sourceContent, service, sharedGlobalEnv, resolvedPorts, options);
     const { absolutePath, relativePath } = resolveArtifactPath(service.serviceRoot, renderedRelativePath);
     await mkdir(path.dirname(absolutePath), { recursive: true });
     await writeFile(absolutePath, renderedContent, "utf8");

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -159,8 +159,19 @@ test("install and config materialize bounded on-disk artifacts and persist them 
               "SERVICE_PORT=${SERVICE_PORT}\nSERVICE_ROOT=${SERVICE_ROOT}\n",
           },
         ],
+        templates: [
+          {
+            source: "./templates/templated.env",
+            target: "./runtime/${SERVICE_ID}.templated.env",
+          },
+        ],
       },
     },
+  );
+  await mkdir(path.join(serviceRoot, "templates"), { recursive: true });
+  await writeFile(
+    path.join(serviceRoot, "templates", "templated.env"),
+    "TEMPLATE_SERVICE=${SERVICE_ID}\nTEMPLATE_PORT=${SERVICE_PORT}\n",
   );
   const apiServer = await startApiServer({ port: 0, servicesRoot });
 
@@ -174,6 +185,7 @@ test("install and config materialize bounded on-disk artifacts and persist them 
 
     const installPath = path.join(serviceRoot, "runtime", "install.txt");
     const configPath = path.join(serviceRoot, "runtime", "config.env");
+    const templatedConfigPath = path.join(serviceRoot, "runtime", "materialized-service.templated.env");
     const stored = await readStoredState(serviceRoot);
 
     assert.equal(install.status, 200);
@@ -192,16 +204,120 @@ test("install and config materialize bounded on-disk artifacts and persist them 
     assert.equal(config.status, 200);
     assert.deepEqual(config.body.state.configArtifacts.files, [
       "runtime/config.env",
+      "runtime/materialized-service.templated.env",
     ]);
     assert.equal(typeof config.body.state.configArtifacts.updatedAt, "string");
     assert.equal(
       await readFile(configPath, "utf8"),
       `SERVICE_PORT=41234\nSERVICE_ROOT=${serviceRoot}\n`,
     );
+    assert.equal(
+      await readFile(templatedConfigPath, "utf8"),
+      "TEMPLATE_SERVICE=materialized-service\nTEMPLATE_PORT=41234\n",
+    );
     assert.deepEqual(stored.install.files, ["runtime/install.txt"]);
-    assert.deepEqual(stored.config.files, ["runtime/config.env"]);
+    assert.deepEqual(stored.config.files, [
+      "runtime/config.env",
+      "runtime/materialized-service.templated.env",
+    ]);
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config template materialization rejects sources outside the service root", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "unsafe-template-source-service", {
+    config: {
+      templates: [
+        {
+          source: "../outside.env",
+          target: "./runtime/generated.env",
+        },
+      ],
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+
+    await assert.rejects(
+      () => configService(service),
+      /Materialized template source escapes the service root: \.\.\/outside\.env/,
+    );
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config template materialization rejects missing source files", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "missing-template-service", {
+    config: {
+      templates: [
+        {
+          source: "./templates/missing.env",
+          target: "./runtime/generated.env",
+        },
+      ],
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+
+    await assert.rejects(
+      () => configService(service),
+      /Materialized template source does not exist: templates\/missing\.env/,
+    );
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("config template materialization rejects targets outside the service root", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(
+    servicesRoot,
+    "unsafe-template-target-service",
+    {
+      config: {
+        templates: [
+          {
+            source: "./templates/config.env",
+            target: "../outside.env",
+          },
+        ],
+      },
+    },
+  );
+  await mkdir(path.join(serviceRoot, "templates"), { recursive: true });
+  await writeFile(path.join(serviceRoot, "templates", "config.env"), "SAFE=${SERVICE_ID}\n");
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+
+    await assert.rejects(
+      () => configService(service),
+      /Materialized file path escapes the service root: \.\.\/outside\.env/,
+    );
+  } finally {
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -1794,6 +1794,12 @@ test("loadServiceManifest accepts bounded install/config file materialization", 
               content: "{\"port\":\"${SERVICE_PORT}\"}",
             },
           ],
+          templates: [
+            {
+              source: "./templates/config.env.template",
+              target: "./runtime/config.env",
+            },
+          ],
         },
       }),
     );
@@ -1813,6 +1819,12 @@ test("loadServiceManifest accepts bounded install/config file materialization", 
         {
           path: "./runtime/config.json",
           content: "{\"port\":\"${SERVICE_PORT}\"}",
+        },
+      ],
+      templates: [
+        {
+          source: "./templates/config.env.template",
+          target: "./runtime/config.env",
         },
       ],
     });


### PR DESCRIPTION
## Issue
Closes #804

## Summary
- Added install.templates[] / config.templates[] manifest support beside existing inline iles[] materialisation.
- Render template file content with Service Lasso variables, resolve generated targets with existing bounded output checks, and persist generated target paths in lifecycle artifact state.
- Documented the contract in the service.json reference and updated SPEC-002 evidence language.

## Scope
- In scope: manifest contract validation, service-root-relative template source reads, rendered target/content materialisation, focused tests, docs/spec traceability.
- Out of scope: changing existing config.files behavior or adding a new service manifest that consumes templates.

## Spec / contract / fixture impact
- Updated: .governance/specs/SPEC-002-core-standalone-runtime.md and docs/reference/service-json-reference.md.
- Tests cover inline compatibility, template render, missing source, unsafe source traversal, unsafe target traversal, and target variable substitution.

## Service Lasso invariant impact
- Invariant: generated install/config artifacts stay bounded to the service root and do not expose secrets in validation output.
- Preservation proof: template sources and targets are rejected if they escape the service root; lifecycle state records generated relative paths only.

## Validation
- PASS 
pm run build - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-072643\issue-804-final-npm-build.log
- PASS 
ode --test --test-name-pattern "materializ|template" tests\manifest-discovery.test.js tests\lifecycle-actions.test.js - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-072643\issue-804-final-targeted-materialization-tests.log
- PASS git diff --check - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-072643\issue-804-git-diff-check.log
- PASS post-change 
pm run build, scripts/demo-gate.mjs, and scripts/demo-verify-canonical.mjs - C:\projects\service-lasso\.work-agent\logs\9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-072643\issue-804-demo-npm-build.log, issue-804-demo-gate.log, issue-804-demo-verify-canonical.log

## Approval trail
- Required: no explicit human approval identified for this contract slice.
- Evidence: Ready queue selected #804 and Project #1 Status moved Ready -> In progress -> In review before branch work/PR handoff.

## Cleanup
- Supersedes non-compliant branch PR #929; this branch uses the required ix/ prefix.
- Post-merge cleanup will return the local repo to clean develop where possible.
