### PR TITLE
docs: standardise service setup helper conventions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Use this short list as the public documentation map:
 - [Service Catalog](service-catalog.md): available core services, app-owned add-on services, and reference apps.
 - [Quick Start](quick-start.md): clone the repo, install dependencies, start the baseline services, open the useful URLs, and stop cleanly.
 - [Service Authoring Overview](service-authoring/overview.md): ordered process for planning, manifesting, releasing, wiring, and validating a service.
+- [Setup Helper Conventions](service-authoring/setup-helper-conventions.md): standard layout and manifest pattern for helper-backed setup steps.
 - [service.json Reference](reference/service-json-reference.md): canonical manifest fields, artifact metadata, health checks, actions, env, dependencies, and update policy.
 - [Healthcheck Reference](reference/healthcheck-reference.md): canonical `healthchecks[]` contract, readiness defaults, TCP/UDP semantics, output-derived variables, and result shape.
 - [Healthchecks Examples](reference/healthchecks-examples.md): concrete manifest examples for HTTP, TCP, UDP, variable, and optional diagnostic checks.
@@ -52,6 +53,7 @@ Current canonical files:
 - [Healthchecks Examples](reference/healthchecks-examples.md)
 - [Healthchecks Implementation Plan](reference/healthchecks-implementation-plan.md)
 - [One-shot Jobs](reference/one-shot-jobs.md)
+- [Setup Helper Conventions](service-authoring/setup-helper-conventions.md)
 
 ## Repo boundary rule
 
@@ -82,6 +84,7 @@ That guide is the canonical handoff for:
 - `@` prefix rules for core-owned services
 - required release artifacts and artifact naming
 - `service.json` artifact metadata
+- setup helper conventions for maintainable service-owned bootstrap code
 - service repo verification
 - PR, merge, and branch archive hygiene
 

--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -54,6 +54,7 @@ lasso-foo/
     workflows/
       release.yml
   scripts/
+    lasso-foo.mjs
     package.mjs
     verify-release.mjs
   service.json
@@ -62,7 +63,7 @@ lasso-foo/
   package.json
 ```
 
-Add service-owned runtime source or assets only when the service repo builds its own wrapper. Provider repos often package upstream archives instead.
+Add service-owned runtime source or assets only when the service repo builds its own wrapper. Provider repos often package upstream archives instead. If setup needs cross-platform orchestration, prefer a service helper at `scripts/lasso-<service>.mjs`; keep each setup step declared in `service.json` and let the helper implement focused subcommands. Use [Setup Helper Conventions](../service-authoring/setup-helper-conventions.md) for the full pattern and the platform-script fallback.
 
 ## `service.json` Minimum Contract
 
@@ -89,6 +90,7 @@ Managed services should also declare:
 - `env` and `globalenv` where operator or dependent services need resolved values
 - `install.files` or `config.files` when Service Lasso must materialize runtime config
 - `depend_on` when startup requires another service first
+- `setup.steps` when install/config must run idempotent one-shot helper commands before start
 
 Provider services should declare:
 
@@ -97,6 +99,50 @@ Provider services should declare:
 - a cheap version/probe command in platform `args`
 
 Use `SERVICE_ROOT` as the canonical service package root in service-local env, setup, config, commandline, and healthcheck selectors. `SERVICE_PATH` is available as a compatibility alias for authoring examples that use package-path wording. Provider-level names such as `NODE_HOME`, `PYTHON_HOME`, and `PYTHON_SCRIPTS_PATH` must be exported by the provider service through `globalenv`; ordinary services should not assume those names exist unless they depend on the provider that publishes them.
+
+## Setup Helper Convention
+
+When setup work is longer than a small command, keep `service.json` declarative and put service-specific orchestration in helper code.
+
+Preferred Node-backed layout:
+
+```text
+lasso-foo/
+  scripts/
+    lasso-foo.mjs
+  service.json
+```
+
+Typical subcommands:
+
+```powershell
+node scripts/lasso-keycloak.mjs generate-keystore
+node scripts/lasso-keycloak.mjs ensure-database
+node scripts/lasso-keycloak.mjs build
+```
+
+Bind those subcommands from manifest-visible setup steps:
+
+```json
+{
+  "depend_on": ["@node", "postgres"],
+  "setup": {
+    "steps": {
+      "ensure-database": {
+        "description": "Create the service database and role when missing.",
+        "execservice": "@node",
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": "scripts/lasso-foo.mjs ensure-database",
+        "depend_on": ["postgres"],
+        "timeoutSeconds": 120,
+        "rerun": "ifMissing"
+      }
+    }
+  }
+}
+```
+
+Use the Node helper pattern only when the service already requires Node or can declare the `@node` provider. When Node should not be required, use platform scripts under `scripts/setup/*.ps1` and `scripts/setup/*.sh` instead. In both cases, the helper or scripts must be idempotent, poll bounded readiness signals, return accurate exit codes, avoid leaking secrets, and log enough context for operators to diagnose failures. See [Setup Helper Conventions](../service-authoring/setup-helper-conventions.md) for the detailed contract.
 
 ## Managed Binary Example
 
@@ -297,6 +343,7 @@ Use this checklist before handing off:
 - Repo name follows the [`service-lasso/lasso-<name>`](https://github.com/service-lasso?q=lasso-&type=repositories) pattern.
 - Service ID follows the prefix rule.
 - `service.json` has artifact download metadata in the manifest itself.
+- Setup helper layout, provider/runtime dependencies, idempotence, logging, and secret-handling rules are documented when setup delegates to helper code.
 - Release workflow creates `yyyy.m.d-<shortsha>` releases from protected-branch pushes.
 - Artifact names include exact upstream versions when applicable.
 - Released archive paths match platform `command` values.
@@ -310,4 +357,5 @@ Use this checklist before handing off:
 ## Related Docs
 
 - [Service Authoring Overview](../service-authoring/overview.md)
+- [Setup Helper Conventions](../service-authoring/setup-helper-conventions.md)
 - [service.json Reference](../reference/service-json-reference.md)

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -1099,6 +1099,7 @@ Runtime rules:
 ### Setup lifecycle steps
 
 `setup.steps` defines Service Lasso's first-class one-shot job contract. Use setup for named local preparation work that runs after `install` and `config` but is not a daemon process.
+When setup work needs service-owned orchestration, keep the step visible here and move the implementation into a helper such as `scripts/lasso-<service>.mjs` or platform scripts under `scripts/setup/`. See [Setup Helper Conventions](../service-authoring/setup-helper-conventions.md) for the recommended layout, provider/runtime requirements, idempotence rules, readiness polling, exit-code behavior, logging, and sensitive-value handling.
 
 For operator behavior, CLI/API surfaces, dependency ordering, provider-backed execution, rerun policy, and TypeDB init/sample guidance, see [One-shot Jobs](one-shot-jobs.md).
 

--- a/docs/service-authoring/02-write-service-json.md
+++ b/docs/service-authoring/02-write-service-json.md
@@ -52,6 +52,7 @@ Provider services usually need:
 Use `setup.steps` for work that must execute locally after install/config but should not be supervised as a long-running daemon. Common examples include generating local certificates, installing service-local Python dependencies, creating a database schema, or loading sample data.
 
 This is Service Lasso's first-class one-shot job contract. Use [One-shot Jobs](../reference/one-shot-jobs.md) for CLI/API behavior, dependency ordering, provider-backed execution, rerun policy, and persisted setup history.
+Use [Setup Helper Conventions](setup-helper-conventions.md) when a setup step is better maintained as service-owned helper code instead of a long inline command.
 Use [Legacy Setup Migration](../reference/legacy-setup-migration.md) when
 converting donor-era `execconfig.setup` arrays or punctuation-prefixed setup
 lines into `setup.steps`.
@@ -83,6 +84,8 @@ Rules:
 - `commandline.win32`, `commandline.linux`, and `commandline.darwin` override `commandline.default`.
 - `rerun: "ifMissing"` is the default bootstrap-friendly behavior.
 - `rerun: "manual"` is for destructive or sample/demo steps that should only run when explicitly requested.
+
+Keep setup steps visible in the manifest even when the implementation delegates to `scripts/lasso-<service>.mjs` or platform scripts under `scripts/setup/`. The manifest remains the operator-readable contract; helper code owns the detailed orchestration, idempotence checks, readiness polling, exit codes, logging, and sensitive-value handling.
 
 ## Pin the Release
 

--- a/docs/service-authoring/overview.md
+++ b/docs/service-authoring/overview.md
@@ -31,6 +31,7 @@ A finished service has:
 The numbered pages are the process. Use these references only when you need detail while doing a step:
 
 - [service.json Reference](../reference/service-json-reference.md) for exact manifest fields.
+- [Setup Helper Conventions](setup-helper-conventions.md) for helper-backed setup steps that need maintainable cross-platform orchestration.
 - [Create a New Lasso Service](../development/new-lasso-service-guide.md) for the full repo creation handoff.
 
 ## Rule of Thumb

--- a/docs/service-authoring/setup-helper-conventions.md
+++ b/docs/service-authoring/setup-helper-conventions.md
@@ -1,0 +1,163 @@
+---
+id: setup-helper-conventions
+title: Setup Helper Conventions
+---
+
+# Setup Helper Conventions
+
+Service manifests should stay reviewable. When setup work grows beyond a short command, keep the operator-visible step in `service.json` and move the service-specific orchestration into service-owned helper code.
+
+Use this convention for setup work such as certificate generation, database preparation, optimized framework builds, schema loading, bootstrap users, local trust material, and other one-shot jobs that must be repeatable on Windows, Linux, and macOS.
+
+## Preferred Layout
+
+Prefer a Node ESM helper when the service can depend on a Node provider or already packages Node-based tooling:
+
+```text
+lasso-<service>/
+  scripts/
+    lasso-<service>.mjs
+  service.json
+```
+
+The helper should expose small subcommands instead of one large bootstrap mode:
+
+```powershell
+node scripts/lasso-keycloak.mjs generate-keystore
+node scripts/lasso-keycloak.mjs ensure-database
+node scripts/lasso-keycloak.mjs build
+```
+
+Each subcommand should own one durable result. That keeps setup logs, rerun policy, and failure recovery aligned with the `setup.steps` entry that invoked it.
+
+## Manifest Pattern
+
+Keep each setup step visible in `service.json`, even when the implementation lives in the helper. Operators and consuming apps should be able to inspect the manifest and understand what local preparation will run.
+
+```json
+{
+  "depend_on": ["@node", "postgres"],
+  "setup": {
+    "steps": {
+      "generate-keystore": {
+        "description": "Generate the local Keycloak HTTPS keystore.",
+        "execservice": "@node",
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": "scripts/lasso-keycloak.mjs generate-keystore",
+        "timeoutSeconds": 60,
+        "rerun": "ifMissing"
+      },
+      "ensure-database": {
+        "description": "Create the Keycloak database and role when missing.",
+        "execservice": "@node",
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": "scripts/lasso-keycloak.mjs ensure-database",
+        "depend_on": ["postgres"],
+        "timeoutSeconds": 120,
+        "rerun": "ifMissing"
+      },
+      "build-optimized": {
+        "description": "Run the service optimized build after config is materialized.",
+        "execservice": "@node",
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": "scripts/lasso-keycloak.mjs build",
+        "depend_on": ["generate-keystore", "ensure-database"],
+        "timeoutSeconds": 300,
+        "rerun": "ifMissing"
+      }
+    }
+  }
+}
+```
+
+Use `execservice: "@node"` when Service Lasso should run the helper through the Node provider. The manifest must declare the provider dependency in the same way it would for any other provider-backed command. Do not assume `node`, `NODE_HOME`, or other provider paths are present unless the manifest depends on the provider that exports them.
+
+Use direct commands only when the service repo owns the executable path and does not need a provider:
+
+```json
+{
+  "setup": {
+    "steps": {
+      "prepare-data": {
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": {
+          "win32": ".\\bin\\service-tool.exe prepare-data",
+          "default": "./bin/service-tool prepare-data"
+        },
+        "rerun": "ifMissing"
+      }
+    }
+  }
+}
+```
+
+## Platform Script Fallback
+
+Platform-specific scripts remain appropriate when a service should not require Node, when the upstream toolchain is already shell or PowerShell native, or when a provider would make the install path heavier than the setup work.
+
+Use this layout:
+
+```text
+lasso-<service>/
+  scripts/
+    setup/
+      generate-keystore.ps1
+      generate-keystore.sh
+      ensure-database.ps1
+      ensure-database.sh
+  service.json
+```
+
+Then bind the same manifest-visible step to the platform script:
+
+```json
+{
+  "setup": {
+    "steps": {
+      "generate-keystore": {
+        "description": "Generate local development certificates.",
+        "cwd": "${SERVICE_ROOT}",
+        "commandline": {
+          "win32": "pwsh -NoLogo -NoProfile -File scripts\\setup\\generate-keystore.ps1",
+          "default": "sh scripts/setup/generate-keystore.sh"
+        },
+        "timeoutSeconds": 60,
+        "rerun": "ifMissing"
+      }
+    }
+  }
+}
+```
+
+If the Windows and POSIX scripts cannot share behavior naturally, keep them small and document the shared contract in the service repo README.
+
+## Helper Requirements
+
+Helper code is part of the service contract. Treat it like release code, not an ad hoc bootstrap script.
+
+- Idempotence: each subcommand must be safe to rerun. Check for existing files, databases, users, schemas, and build outputs before mutating them. Prefer no-op success when the desired state already exists.
+- Readiness polling: when a helper depends on another service, poll a bounded readiness signal instead of sleeping a fixed amount. Respect the setup step timeout and fail with a clear message when the dependency never becomes ready.
+- Exit codes: return `0` only when the desired state exists. Return non-zero for invalid input, missing provider tools, failed readiness, failed writes, or failed verification.
+- Logging: write concise progress to stdout and actionable diagnostics to stderr. Avoid dumping full environment blocks, generated config, or command lines that include sensitive values.
+- Sensitive values: read secrets through Service Lasso-provided environment variables or broker-backed files. Do not write raw secrets into `service.json`, logs, issue comments, release notes, or persisted setup state.
+- Paths: resolve service-local files from `SERVICE_ROOT`, runtime state from Service Lasso-provided state/data variables, and provider tools from provider-exported env. Do not depend on the caller's current working directory except through the manifest `cwd`.
+- Arguments: keep subcommand names stable and explicit. Avoid positional argument contracts that are hard to review in `service.json`.
+- Verification: after mutating local state, confirm the expected artifact, database, schema, file, or command output exists before exiting successfully.
+
+## Author Checklist
+
+Before releasing a service with helper-backed setup:
+
+- `service.json` lists every setup step operators need to know about.
+- The helper or platform scripts live under `scripts/`.
+- Provider-backed helpers declare `execservice` and the matching provider dependency.
+- Each setup step has a clear `description`, `cwd`, timeout, rerun policy, and dependency list when needed.
+- Helper subcommands are idempotent and produce bounded logs.
+- Secrets are resolved at runtime and never stored in the manifest or helper output.
+- Local validation runs the setup path at least twice: once from a clean state and once as an idempotent rerun.
+
+## Related References
+
+- [Write `service.json`](02-write-service-json.md)
+- [One-shot Jobs](../reference/one-shot-jobs.md)
+- [Create a New Lasso Service](../development/new-lasso-service-guide.md)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -43,6 +43,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "service-authoring/setup-helper-conventions",
+          label: "Setup Helper Conventions",
+        },
+        {
+          type: "doc",
           id: "service-authoring/03-create-release-repo",
           label: "3. Create the Release Repo",
         },


### PR DESCRIPTION
## Issue
Closes #809

## Summary
- Adds a dedicated service-authoring page for setup helper conventions.
- Documents the preferred `scripts/lasso-<service>.mjs` Node ESM helper layout and platform-script fallback.
- Links the convention from service authoring, service repo handoff, docs home, sidebar, and `service.json` setup lifecycle reference.

## Scope
- In scope: documentation for helper-backed setup steps, provider/runtime requirements, manifest visibility, idempotence, readiness polling, exit codes, logging, and sensitive-value handling.
- Out of scope: runtime behavior changes, service manifest changes, service-template repository changes.

## Spec / contract / fixture impact
- Updated: docs-only service authoring contract guidance.
- Not required because: no runtime schema, fixtures, service manifests, or generated code changed.

## Service Lasso invariant impact
- Invariant: `service.json` remains the operator-readable source of truth for setup behavior.
- Preservation proof: helper implementation is documented as delegated code while each setup step remains visible in `service.json` examples.

## Validation
- PASS `npm run build` - evidence: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-123315\validation-npm-build.log`
- PASS `npm run docs:build` - evidence: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-123315\validation-docs-build.log`
- PASS startup `demo-gate` before selection (`classification=healthy`) - evidence: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260728-123315\demo-gate.json`

## Approval trail
- Required: no local approval requested by this worker.
- Evidence: docs-only change, validation passed locally.

## Cleanup
- Branch targets `develop`.
- Post-merge cleanup should return the local checkout to clean `develop` where possible.
