### PR TITLE
Adopt canonical healthchecks array in service manifest

### DIFF
--- a/src/contracts/service.ts
+++ b/src/contracts/service.ts
@@ -355,6 +355,7 @@ export interface ServiceManifest {
   requires?: ServiceCapabilityMap;
   provides?: ServiceCapabilityMap;
   healthcheck?: ServiceHealthcheck;
+  healthchecks?: ServiceHealthcheck[];
   outputvarregex?: Record<string, string>;
   env?: ServiceEnvMap;
   globalenv?: ServiceEnvMap;

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -120,16 +120,17 @@ function expectOptionalFailurePolicy(
 function readHealthcheckReadinessOptions(
   healthRecord: Record<string, unknown>,
   manifestPath: string,
+  fieldPrefix = "healthcheck",
 ): Record<string, number> {
-  const interval = expectOptionalWholeNumber(healthRecord.interval, "healthcheck.interval", manifestPath, 1);
-  const retries = expectOptionalWholeNumber(healthRecord.retries, "healthcheck.retries", manifestPath, 1);
+  const interval = expectOptionalWholeNumber(healthRecord.interval, `${fieldPrefix}.interval`, manifestPath, 1);
+  const retries = expectOptionalWholeNumber(healthRecord.retries, `${fieldPrefix}.retries`, manifestPath, 1);
   const startPeriod = expectOptionalWholeNumber(
     healthRecord.start_period,
-    "healthcheck.start_period",
+    `${fieldPrefix}.start_period`,
     manifestPath,
     0,
   );
-  const timeout = expectOptionalWholeNumber(healthRecord.timeout, "healthcheck.timeout", manifestPath, 1);
+  const timeout = expectOptionalWholeNumber(healthRecord.timeout, `${fieldPrefix}.timeout`, manifestPath, 1);
 
   return {
     ...(interval !== undefined ? { interval } : {}),
@@ -137,6 +138,187 @@ function readHealthcheckReadinessOptions(
     ...(startPeriod !== undefined ? { start_period: startPeriod } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
   };
+}
+
+function readHealthcheckRecord(
+  rawHealthcheck: unknown,
+  manifestPath: string,
+  fieldPrefix = "healthcheck",
+  options: { requireId?: boolean; defaultRequired?: boolean } = {},
+): ServiceHealthcheck {
+  if (!rawHealthcheck || typeof rawHealthcheck !== "object" || Array.isArray(rawHealthcheck)) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: expected "${fieldPrefix}" to be an object.`);
+  }
+
+  const healthRecord = rawHealthcheck as Record<string, unknown>;
+  const readinessOptions = readHealthcheckReadinessOptions(healthRecord, manifestPath, fieldPrefix);
+  const id =
+    options.requireId || healthRecord.id !== undefined
+      ? expectNonEmptyString(healthRecord.id, `${fieldPrefix}.id`, manifestPath)
+      : undefined;
+  const required =
+    options.defaultRequired || healthRecord.required !== undefined
+      ? (expectOptionalBoolean(healthRecord.required, `${fieldPrefix}.required`, manifestPath) ?? true)
+      : undefined;
+  const sharedFields = {
+    ...(id !== undefined ? { id } : {}),
+    ...(required !== undefined ? { required } : {}),
+    ...readinessOptions,
+  };
+
+  if (healthRecord.type === "process") {
+    return { type: "process", ...sharedFields };
+  }
+
+  if (healthRecord.type === "http") {
+    const cookies = readStringMap(healthRecord.cookies, `${fieldPrefix}.cookies`, manifestPath);
+    return {
+      type: "http",
+      url: expectNonEmptyString(healthRecord.url, `${fieldPrefix}.url`, manifestPath),
+      expected_status:
+        typeof healthRecord.expected_status === "number" ? healthRecord.expected_status : undefined,
+      ...(cookies !== undefined ? { cookies } : {}),
+      ...sharedFields,
+    };
+  }
+
+  if (healthRecord.type === "tcp") {
+    if (healthRecord.tcphost !== undefined || healthRecord.tcpport !== undefined) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: "tcphost" and "tcpport" are not supported; use "${fieldPrefix}.host" + "${fieldPrefix}.port" or "${fieldPrefix}.address".`,
+      );
+    }
+
+    const hasAddress = healthRecord.address !== undefined;
+    const hasHost = healthRecord.host !== undefined;
+    const hasPort = healthRecord.port !== undefined;
+    const rawPort = healthRecord.port;
+
+    if (hasAddress && (hasHost || hasPort)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: TCP healthcheck must use either "${fieldPrefix}.address" or "${fieldPrefix}.host" + "${fieldPrefix}.port", not both.`,
+      );
+    }
+
+    if (hasHost !== hasPort) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: TCP healthcheck "host" and "port" must be supplied together.`,
+      );
+    }
+
+    if (
+      hasPort &&
+      typeof rawPort !== "string" &&
+      (typeof rawPort !== "number" ||
+        !Number.isInteger(rawPort) ||
+        rawPort < 1 ||
+        rawPort > 65535)
+    ) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: expected "${fieldPrefix}.port" to be a non-empty string selector or an integer port between 1 and 65535.`,
+      );
+    }
+
+    if (typeof rawPort === "string" && rawPort.trim().length === 0) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected non-empty string for "${fieldPrefix}.port".`);
+    }
+
+    const normalizedPort =
+      rawPort === undefined
+        ? undefined
+        : typeof rawPort === "number"
+          ? rawPort
+          : typeof rawPort === "string"
+            ? rawPort.trim()
+            : undefined;
+
+    return {
+      type: "tcp",
+      ...(hasAddress ? { address: expectNonEmptyString(healthRecord.address, `${fieldPrefix}.address`, manifestPath) } : {}),
+      ...(hasHost ? { host: expectNonEmptyString(healthRecord.host, `${fieldPrefix}.host`, manifestPath) } : {}),
+      ...(normalizedPort !== undefined ? { port: normalizedPort } : {}),
+      ...sharedFields,
+    };
+  }
+
+  if (healthRecord.type === "udp") {
+    const hasAddress = healthRecord.address !== undefined;
+    const hasHost = healthRecord.host !== undefined;
+    const hasPort = healthRecord.port !== undefined;
+    const rawPort = healthRecord.port;
+
+    if (hasAddress && (hasHost || hasPort)) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: UDP healthcheck must use either "${fieldPrefix}.address" or "${fieldPrefix}.host" + "${fieldPrefix}.port", not both.`,
+      );
+    }
+
+    if (hasHost !== hasPort) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: UDP healthcheck "host" and "port" must be supplied together.`,
+      );
+    }
+
+    if (!hasAddress && !hasHost) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: UDP healthcheck must define either "${fieldPrefix}.address" or "${fieldPrefix}.host" + "${fieldPrefix}.port".`,
+      );
+    }
+
+    if (
+      hasPort &&
+      typeof rawPort !== "string" &&
+      (typeof rawPort !== "number" ||
+        !Number.isInteger(rawPort) ||
+        rawPort < 1 ||
+        rawPort > 65535)
+    ) {
+      throw new Error(
+        `Invalid service manifest at ${manifestPath}: expected "${fieldPrefix}.port" to be a non-empty string selector or an integer port between 1 and 65535.`,
+      );
+    }
+
+    if (typeof rawPort === "string" && rawPort.trim().length === 0) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected non-empty string for "${fieldPrefix}.port".`);
+    }
+
+    const normalizedPort =
+      rawPort === undefined
+        ? undefined
+        : typeof rawPort === "number"
+          ? rawPort
+          : typeof rawPort === "string"
+            ? rawPort.trim()
+            : undefined;
+
+    return {
+      type: "udp",
+      ...(hasAddress ? { address: expectNonEmptyString(healthRecord.address, `${fieldPrefix}.address`, manifestPath) } : {}),
+      ...(hasHost ? { host: expectNonEmptyString(healthRecord.host, `${fieldPrefix}.host`, manifestPath) } : {}),
+      ...(normalizedPort !== undefined ? { port: normalizedPort } : {}),
+      send: expectNonEmptyString(healthRecord.send, `${fieldPrefix}.send`, manifestPath),
+      expect: expectNonEmptyString(healthRecord.expect, `${fieldPrefix}.expect`, manifestPath),
+      ...sharedFields,
+    };
+  }
+
+  if (healthRecord.type === "file") {
+    return {
+      type: "file",
+      file: expectNonEmptyString(healthRecord.file, `${fieldPrefix}.file`, manifestPath),
+      ...sharedFields,
+    };
+  }
+
+  if (healthRecord.type === "variable") {
+    return {
+      type: "variable",
+      variable: expectNonEmptyString(healthRecord.variable, `${fieldPrefix}.variable`, manifestPath),
+      ...sharedFields,
+    };
+  }
+
+  throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);
 }
 
 function readActionMaterialization(
@@ -1717,99 +1899,41 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
   const serviceorder = rawServiceOrder ?? execconfig?.serviceorder;
 
   const rawHealthcheck = record.healthcheck;
+  const rawHealthchecks = record.healthchecks;
   let healthcheck: ServiceHealthcheck | undefined;
+  let healthchecks: ServiceHealthcheck[] | undefined;
+
+  if (rawHealthcheck !== undefined && rawHealthchecks !== undefined) {
+    throw new Error(`Invalid service manifest at ${manifestPath}: use either "healthcheck" or "healthchecks", not both.`);
+  }
 
   if (rawHealthcheck !== undefined) {
-    if (!rawHealthcheck || typeof rawHealthcheck !== "object" || Array.isArray(rawHealthcheck)) {
-      throw new Error(`Invalid service manifest at ${manifestPath}: expected \"healthcheck\" to be an object.`);
+    healthcheck = readHealthcheckRecord(rawHealthcheck, manifestPath);
+  }
+
+  if (rawHealthchecks !== undefined) {
+    if (!Array.isArray(rawHealthchecks)) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "healthchecks" to be an array.`);
     }
 
-    const healthRecord = rawHealthcheck as Record<string, unknown>;
-    const readinessOptions = readHealthcheckReadinessOptions(healthRecord, manifestPath);
-    if (healthRecord.type === "process") {
-      healthcheck = { type: "process", ...readinessOptions };
-    } else if (healthRecord.type === "http") {
-      const cookies = readStringMap(healthRecord.cookies, "healthcheck.cookies", manifestPath);
-      healthcheck = {
-        type: "http",
-        url: expectNonEmptyString(healthRecord.url, "healthcheck.url", manifestPath),
-        expected_status:
-          typeof healthRecord.expected_status === "number" ? healthRecord.expected_status : undefined,
-        ...(cookies !== undefined ? { cookies } : {}),
-        ...readinessOptions,
-      };
-    } else if (healthRecord.type === "tcp") {
-      if (healthRecord.tcphost !== undefined || healthRecord.tcpport !== undefined) {
-        throw new Error(
-          `Invalid service manifest at ${manifestPath}: "tcphost" and "tcpport" are not supported; use "healthcheck.host" + "healthcheck.port" or "healthcheck.address".`,
-        );
-      }
-
-      const hasAddress = healthRecord.address !== undefined;
-      const hasHost = healthRecord.host !== undefined;
-      const hasPort = healthRecord.port !== undefined;
-      const rawPort = healthRecord.port;
-
-      if (hasAddress && (hasHost || hasPort)) {
-        throw new Error(
-          `Invalid service manifest at ${manifestPath}: TCP healthcheck must use either "healthcheck.address" or "healthcheck.host" + "healthcheck.port", not both.`,
-        );
-      }
-
-      if (hasHost !== hasPort) {
-        throw new Error(
-          `Invalid service manifest at ${manifestPath}: TCP healthcheck "host" and "port" must be supplied together.`,
-        );
-      }
-
-      if (
-        hasPort &&
-        typeof rawPort !== "string" &&
-        (typeof rawPort !== "number" ||
-          !Number.isInteger(rawPort) ||
-          rawPort < 1 ||
-          rawPort > 65535)
-      ) {
-        throw new Error(
-          `Invalid service manifest at ${manifestPath}: expected "healthcheck.port" to be a non-empty string selector or an integer port between 1 and 65535.`,
-        );
-      }
-
-      if (typeof rawPort === "string" && rawPort.trim().length === 0) {
-        throw new Error(`Invalid service manifest at ${manifestPath}: expected non-empty string for "healthcheck.port".`);
-      }
-
-      const normalizedPort =
-        rawPort === undefined
-          ? undefined
-          : typeof rawPort === "number"
-            ? rawPort
-            : typeof rawPort === "string"
-              ? rawPort.trim()
-              : undefined;
-
-      healthcheck = {
-        type: "tcp",
-        ...(hasAddress ? { address: expectNonEmptyString(healthRecord.address, "healthcheck.address", manifestPath) } : {}),
-        ...(hasHost ? { host: expectNonEmptyString(healthRecord.host, "healthcheck.host", manifestPath) } : {}),
-        ...(normalizedPort !== undefined ? { port: normalizedPort } : {}),
-        ...readinessOptions,
-      };
-    } else if (healthRecord.type === "file") {
-      healthcheck = {
-        type: "file",
-        file: expectNonEmptyString(healthRecord.file, "healthcheck.file", manifestPath),
-        ...readinessOptions,
-      };
-    } else if (healthRecord.type === "variable") {
-      healthcheck = {
-        type: "variable",
-        variable: expectNonEmptyString(healthRecord.variable, "healthcheck.variable", manifestPath),
-        ...readinessOptions,
-      };
-    } else {
-      throw new Error(`Invalid service manifest at ${manifestPath}: unsupported healthcheck type.`);
+    if (rawHealthchecks.length === 0) {
+      throw new Error(`Invalid service manifest at ${manifestPath}: expected "healthchecks" to contain at least one item.`);
     }
+
+    const healthcheckIds = new Set<string>();
+    healthchecks = rawHealthchecks.map((entry, index) => {
+      const fieldPrefix = `healthchecks[${index}]`;
+      const healthcheckEntry = readHealthcheckRecord(entry, manifestPath, fieldPrefix, {
+        requireId: true,
+        defaultRequired: true,
+      });
+      const id = healthcheckEntry.id as string;
+      if (healthcheckIds.has(id)) {
+        throw new Error(`Invalid service manifest at ${manifestPath}: duplicate healthchecks id "${id}".`);
+      }
+      healthcheckIds.add(id);
+      return healthcheckEntry;
+    });
   }
 
   const env = readEnvMap(record.env, "env", manifestPath);
@@ -1918,6 +2042,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
     requires,
     provides,
     healthcheck,
+    healthchecks,
     outputvarregex,
     env,
     globalenv,

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -5,30 +5,44 @@ export interface HealthcheckReadinessOptions {
   timeout?: number;
 }
 
-export interface ProcessHealthcheck extends HealthcheckReadinessOptions {
+export interface ServiceHealthcheckBase extends HealthcheckReadinessOptions {
+  id?: string;
+  required?: boolean;
+}
+
+export interface ProcessHealthcheck extends ServiceHealthcheckBase {
   type: "process";
 }
 
-export interface HttpHealthcheck extends HealthcheckReadinessOptions {
+export interface HttpHealthcheck extends ServiceHealthcheckBase {
   type: "http";
   url: string;
   expected_status?: number;
   cookies?: Record<string, string>;
 }
 
-export interface TcpHealthcheck extends HealthcheckReadinessOptions {
+export interface TcpHealthcheck extends ServiceHealthcheckBase {
   type: "tcp";
   address?: string;
   host?: string;
   port?: string | number;
 }
 
-export interface FileHealthcheck extends HealthcheckReadinessOptions {
+export interface UdpHealthcheck extends ServiceHealthcheckBase {
+  type: "udp";
+  address?: string;
+  host?: string;
+  port?: string | number;
+  send: string;
+  expect: string;
+}
+
+export interface FileHealthcheck extends ServiceHealthcheckBase {
   type: "file";
   file: string;
 }
 
-export interface VariableHealthcheck extends HealthcheckReadinessOptions {
+export interface VariableHealthcheck extends ServiceHealthcheckBase {
   type: "variable";
   variable: string;
 }
@@ -37,6 +51,7 @@ export type ServiceHealthcheck =
   | ProcessHealthcheck
   | HttpHealthcheck
   | TcpHealthcheck
+  | UdpHealthcheck
   | FileHealthcheck
   | VariableHealthcheck;
 

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -465,6 +465,173 @@ test("loadServiceManifest rejects legacy tcp healthcheck aliases", async () => {
   }
 });
 
+test("loadServiceManifest accepts canonical healthchecks arrays", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "canonical-healthchecks-service", {
+      id: "canonical-healthchecks-service",
+      name: "Canonical Healthchecks Service",
+      description: "Service with canonical healthchecks.",
+      outputvarregex: {
+        FILEBEAT_ENABLED_INPUTS: ".*Enabled inputs: (\\d+).*",
+      },
+      healthchecks: [
+        {
+          id: "tcp-port-open",
+          type: "tcp",
+          host: "127.0.0.1",
+          port: "${HTTP_PORT}",
+          retries: 30,
+          interval: 250,
+        },
+        {
+          id: "http-ready",
+          type: "http",
+          url: "http://127.0.0.1:${HTTP_PORT}/health",
+          expected_status: 200,
+          required: false,
+        },
+        {
+          id: "udp-ready",
+          type: "udp",
+          address: "127.0.0.1:${UDP_PORT}",
+          send: "ping",
+          expect: "pong",
+          timeout: 1000,
+        },
+        {
+          id: "filebeat-inputs-ready",
+          type: "variable",
+          variable: "FILEBEAT_ENABLED_INPUTS",
+        },
+      ],
+    });
+
+    const manifest = await loadServiceManifest(
+      path.join(servicesRoot, "canonical-healthchecks-service", "service.json"),
+    );
+
+    assert.deepEqual(manifest.healthchecks, [
+      {
+        id: "tcp-port-open",
+        type: "tcp",
+        host: "127.0.0.1",
+        port: "${HTTP_PORT}",
+        retries: 30,
+        interval: 250,
+        required: true,
+      },
+      {
+        id: "http-ready",
+        type: "http",
+        url: "http://127.0.0.1:${HTTP_PORT}/health",
+        expected_status: 200,
+        required: false,
+      },
+      {
+        id: "udp-ready",
+        type: "udp",
+        address: "127.0.0.1:${UDP_PORT}",
+        send: "ping",
+        expect: "pong",
+        timeout: 1000,
+        required: true,
+      },
+      {
+        id: "filebeat-inputs-ready",
+        type: "variable",
+        variable: "FILEBEAT_ENABLED_INPUTS",
+        required: true,
+      },
+    ]);
+    assert.equal(manifest.healthcheck, undefined);
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
+test("loadServiceManifest rejects invalid healthchecks arrays", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "empty-healthchecks-service", {
+      id: "empty-healthchecks-service",
+      name: "Empty Healthchecks Service",
+      description: "Service with empty canonical healthchecks.",
+      healthchecks: [],
+    });
+    await writeManifest(servicesRoot, "missing-healthcheck-id-service", {
+      id: "missing-healthcheck-id-service",
+      name: "Missing Healthcheck ID Service",
+      description: "Service with a missing healthcheck id.",
+      healthchecks: [{ type: "process" }],
+    });
+    await writeManifest(servicesRoot, "duplicate-healthcheck-id-service", {
+      id: "duplicate-healthcheck-id-service",
+      name: "Duplicate Healthcheck ID Service",
+      description: "Service with duplicate healthcheck ids.",
+      healthchecks: [
+        { id: "ready", type: "process" },
+        { id: "ready", type: "file", file: "ready.txt" },
+      ],
+    });
+    await writeManifest(servicesRoot, "unknown-healthcheck-type-service", {
+      id: "unknown-healthcheck-type-service",
+      name: "Unknown Healthcheck Type Service",
+      description: "Service with an unknown healthcheck type.",
+      healthchecks: [{ id: "ready", type: "smtp" }],
+    });
+    await writeManifest(servicesRoot, "tcp-alias-healthchecks-service", {
+      id: "tcp-alias-healthchecks-service",
+      name: "TCP Alias Healthchecks Service",
+      description: "Service with unsupported TCP aliases in healthchecks.",
+      healthchecks: [
+        {
+          id: "tcp-ready",
+          type: "tcp",
+          tcphost: "127.0.0.1",
+          tcpport: "4012",
+        },
+      ],
+    });
+    await writeManifest(servicesRoot, "mixed-healthcheck-fields-service", {
+      id: "mixed-healthcheck-fields-service",
+      name: "Mixed Healthcheck Fields Service",
+      description: "Service with both migration and canonical healthcheck fields.",
+      healthcheck: { type: "process" },
+      healthchecks: [{ id: "ready", type: "process" }],
+    });
+
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "empty-healthchecks-service", "service.json")),
+      /healthchecks.*at least one item/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "missing-healthcheck-id-service", "service.json")),
+      /healthchecks\[0\]\.id/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "duplicate-healthcheck-id-service", "service.json")),
+      /duplicate healthchecks id "ready"/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "unknown-healthcheck-type-service", "service.json")),
+      /unsupported healthcheck type/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "tcp-alias-healthchecks-service", "service.json")),
+      /tcphost.*tcpport.*healthchecks\[0\]\.host.*healthchecks\[0\]\.port.*healthchecks\[0\]\.address/i,
+    );
+    await assert.rejects(
+      () => loadServiceManifest(path.join(servicesRoot, "mixed-healthcheck-fields-service", "service.json")),
+      /either "healthcheck" or "healthchecks", not both/i,
+    );
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest accepts bounded file healthchecks", async () => {
   const servicesRoot = await makeTempServicesRoot();
   const manifestPath = path.join(servicesRoot, "file-service", "service.json");


### PR DESCRIPTION
## Issue
Closes #814

## Summary
- Adds canonical top-level `healthchecks?: ServiceHealthcheck[]` to the manifest contract.
- Refactors manifest healthcheck validation through one reader that supports singular migration `healthcheck` and canonical `healthchecks[]`.
- Requires stable IDs and default `required: true` for canonical array items, rejects empty arrays, duplicate IDs, unknown types, and old TCP alias fields.
- Adds validator coverage for valid canonical HTTP/TCP/UDP/variable checks and invalid array shapes.

## Scope
- In scope: manifest contract/types, manifest validator, manifest discovery tests.
- Out of scope: converting checked-in service manifests from singular `healthcheck`, runtime evaluation of multiple healthchecks, and unrelated diagnostics readiness behavior.

## Spec / contract / fixture impact
- Updated: `ServiceManifest` now exposes `healthchecks?: ServiceHealthcheck[]`; `ServiceHealthcheck` items include shared `id`, `required`, `retries`, `interval`, `start_period`, and `timeout` fields.
- Docs checked: `docs/reference/healthcheck-reference.md`, `docs/reference/healthchecks-implementation-plan.md`, and `docs/reference/healthchecks-examples.md` already describe the canonical array contract.

## Service Lasso invariant impact
- Invariant: singular `healthcheck` remains accepted only as a migration bridge; canonical `healthchecks[]` rejects ambiguous mixed declarations.
- Preservation proof: targeted manifest tests cover both the bridge and the new canonical contract.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-20260728-142543\issue-814-npm-build.out.log`.
- PASS `node --test --test-concurrency=1 tests/manifest-discovery.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-20260728-142543\issue-814-manifest-test.out.log`.
- BLOCKED `npm test` — timed out after 5 minutes; before timeout, `tests/api-spine.test.js` reported `GET /api/diagnostics/dependencies reports start blockers and safe next actions` failing with actual readiness `ready` vs expected `degraded` for `foxtrot-unhealthy`. Isolated command confirms the same diagnostics assertion at `tests/api-spine.test.js:297`; log: `C:\projects\service-lasso\.work-agent\logs\cron-20260728-142543\issue-814-api-diagnostics-single.out.log`.

## Approval trail
- Required: yes.
- Evidence: Developer validation passed for the manifest contract path; Architect review requested for the diagnostics-suite gap before merge.

## Cleanup
- Branch: `issue-814-healthchecks-array`.
- Post-merge cleanup: return local checkout to clean `develop` after PR merge.