### PR TITLE
Migrate checked-in manifests to healthchecks arrays

### DIFF
--- a/docs/development/new-lasso-service-guide.md
+++ b/docs/development/new-lasso-service-guide.md
@@ -40,7 +40,7 @@ Choose the closest pattern before writing files.
 | Type | When to use | Manifest shape |
 | --- | --- | --- |
 | Provider | The service supplies a runtime/tool to other services and should not run as a daemon. | `role: "provider"` plus `artifact` and `globalenv` |
-| Managed binary | The service owns and runs its executable. | `artifact`, platform `command`, `ports`, `healthcheck` |
+| Managed binary | The service owns and runs its executable. | `artifact`, platform `command`, `ports`, `healthchecks[]` |
 | Provider-backed app | The service runs through another provider such as `@node`, `@python`, or `@java`. | `execservice`, `executable`, `args`, `depend_on` |
 | App-owned add-on service | Consumers opt in by copying its released manifest. | `enabled: false` when unsafe to start without app config |
 
@@ -86,7 +86,7 @@ Managed services should also declare:
 
 - `ports`
 - `urls`
-- `healthcheck`
+- `healthchecks[]`
 - `env` and `globalenv` where operator or dependent services need resolved values
 - `install.files` or `config.files` when Service Lasso must materialize runtime config
 - `depend_on` when startup requires another service first
@@ -176,11 +176,14 @@ Use the Node helper pattern only when the service already requires Node or can d
       }
     }
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${HTTP_PORT}/health",
-    "expected_status": 200
-  }
+  "healthchecks": [
+    {
+      "id": "http-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${HTTP_PORT}/health",
+      "expected_status": 200
+    }
+  ]
 }
 ```
 
@@ -268,7 +271,7 @@ For a managed service, also prove:
 
 1. Service Lasso can install/acquire the archive.
 2. Service Lasso can config/start/stop the service.
-3. The declared healthcheck becomes healthy.
+3. The declared required healthcheck becomes healthy.
 4. Logs/state/network surfaces are visible when the service claims them.
 
 ## Core Integration

--- a/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
+++ b/docs/reference/SERVICE-JSON-COMPLETE-UNION-SCHEMA.md
@@ -318,16 +318,19 @@ This keeps `install` and `config` explicit (as discussed), but removes unnecessa
     "outputvarregex": {
       "<OUTPUT_KEY>": "<regex>"
     },
-    "healthcheck": {
-      "type": "<process|http|tcp|file|variable>",
-      "url": "<health-url>",
-      "expected_status": "<http-status>",
-      "retries": "<retry-count>",
-      "variable": "<variable-name>",
-      "cookies": {
-        "<COOKIE_KEY>": "<cookie-value>"
+    "healthchecks": [
+      {
+        "id": "<healthcheck-id>",
+        "type": "<process|http|tcp|file|variable>",
+        "url": "<health-url>",
+        "expected_status": "<http-status>",
+        "retries": "<retry-count>",
+        "variable": "<variable-name>",
+        "cookies": {
+          "<COOKIE_KEY>": "<cookie-value>"
+        }
       }
-    },
+    ],
     "execshell": "<shell>",
     "ignoreexiterror": "<boolean>"
   }
@@ -534,16 +537,19 @@ The raw credential is launch-only authority: it is not stored in lifecycle state
     "outputvarregex": {
       "<OUTPUT_KEY>": "<value>"
     },
-    "healthcheck": {
-      "type": "<value>",
-      "url": "<value>",
-      "expected_status": "<value>",
-      "retries": "<value>",
-      "variable": "<value>",
-      "cookies": {
-        "<COOKIE_KEY>": "<value>"
+    "healthchecks": [
+      {
+        "id": "<value>",
+        "type": "<value>",
+        "url": "<value>",
+        "expected_status": "<value>",
+        "retries": "<value>",
+        "variable": "<value>",
+        "cookies": {
+          "<COOKIE_KEY>": "<value>"
+        }
       }
-    },
+    ],
     "execshell": "<value>",
     "ignoreexiterror": "<value>"
   }

--- a/docs/reference/service-json-reference.md
+++ b/docs/reference/service-json-reference.md
@@ -113,9 +113,12 @@ The current sample in this repo is:
       "ECHO_MESSAGE": "hello from service-template"
     },
     "depend_on": [],
-    "healthcheck": {
-      "type": "process"
-    }
+    "healthchecks": [
+      {
+        "id": "process-health",
+        "type": "process"
+      }
+    ]
   }
 }
 ```
@@ -881,9 +884,12 @@ Current rule:
 Example:
 
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-health",
+    "type": "process"
+  }
+]
 ```
 
 This is the right default for a simple sample service.
@@ -899,7 +905,7 @@ Service Lasso supports these explicit healthcheck types:
 
 `process` is the current template default direction; use one of the explicit types above when a service needs a stronger readiness signal.
 
-When a service declares an explicit `healthcheck`, startup readiness waits by default even if the manifest omits readiness timing fields. Default readiness settings are:
+When a service declares an explicit `healthchecks[]` item, startup readiness waits by default even if the manifest omits readiness timing fields. Default readiness settings are:
 
 - `retries`: `10`
 - `interval`: `1000` milliseconds
@@ -919,9 +925,12 @@ Use when:
 Sample:
 
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-health",
+    "type": "process"
+  }
+]
 ```
 
 ### `http` healthcheck
@@ -933,26 +942,32 @@ Use when:
 Sample:
 
 ```json
-"healthcheck": {
-  "type": "http",
-  "url": "http://localhost:${SERVICE_PORT}/health",
-  "expected_status": 200,
-  "timeout": 2000
-}
+"healthchecks": [
+  {
+    "id": "http-health",
+    "type": "http",
+    "url": "http://localhost:${SERVICE_PORT}/health",
+    "expected_status": 200,
+    "timeout": 2000
+  }
+]
 ```
 
 HTTP healthchecks may include an optional `cookies` string map when a readiness endpoint requires cookie state. Cookie values support the same selector resolution as `url`; omit `cookies` for ordinary stateless health endpoints.
 
 ```json
-"healthcheck": {
-  "type": "http",
-  "url": "http://localhost:${SERVICE_PORT}/healthcheck",
-  "expected_status": 200,
-  "cookies": {
-    "healthcheck": "ready",
-    "workspace": "${SERVICE_ID}"
+"healthchecks": [
+  {
+    "id": "http-cookie-health",
+    "type": "http",
+    "url": "http://localhost:${SERVICE_PORT}/healthcheck",
+    "expected_status": 200,
+    "cookies": {
+      "healthcheck": "ready",
+      "workspace": "${SERVICE_ID}"
+    }
   }
-}
+]
 ```
 
 ### `tcp` healthcheck
@@ -964,10 +979,13 @@ Use when:
 Sample:
 
 ```json
-"healthcheck": {
-  "type": "tcp",
-  "timeout": 2000
-}
+"healthchecks": [
+  {
+    "id": "tcp-health",
+    "type": "tcp",
+    "timeout": 2000
+  }
+]
 ```
 
 Bare `type: "tcp"` uses `127.0.0.1` and infers the port only when the service has exactly one unambiguous declared or resolved port.
@@ -975,20 +993,26 @@ Bare `type: "tcp"` uses `127.0.0.1` and infers the port only when the service ha
 Use `address` when a single TCP target string is clearer:
 
 ```json
-"healthcheck": {
-  "type": "tcp",
-  "address": "127.0.0.1:${HTTP_PORT}"
-}
+"healthchecks": [
+  {
+    "id": "tcp-address-health",
+    "type": "tcp",
+    "address": "127.0.0.1:${HTTP_PORT}"
+  }
+]
 ```
 
 Use `host` + `port` when the values should be edited independently:
 
 ```json
-"healthcheck": {
-  "type": "tcp",
-  "host": "127.0.0.1",
-  "port": "${HTTP_PORT}"
-}
+"healthchecks": [
+  {
+    "id": "tcp-port-health",
+    "type": "tcp",
+    "host": "127.0.0.1",
+    "port": "${HTTP_PORT}"
+  }
+]
 ```
 
 Multiple-port services must declare `address` or `host` + `port`. Legacy alias names such as `tcphost` and `tcpport` are not supported.
@@ -1002,10 +1026,13 @@ Use when:
 Sample:
 
 ```json
-"healthcheck": {
-  "type": "file",
-  "file": "${SERVICE_ROOT}/runtime/ready.txt"
-}
+"healthchecks": [
+  {
+    "id": "ready-file",
+    "type": "file",
+    "file": "${SERVICE_ROOT}/runtime/ready.txt"
+  }
+]
 ```
 
 Selector resolution applies before the filesystem check. Relative paths remain
@@ -1022,10 +1049,13 @@ Use when:
 Sample:
 
 ```json
-"healthcheck": {
-  "type": "variable",
-  "variable": "${SERVICE_URL}"
-}
+"healthchecks": [
+  {
+    "id": "service-url-ready",
+    "type": "variable",
+    "variable": "${SERVICE_URL}"
+  }
+]
 ```
 
 ### `outputvarregex`
@@ -1038,11 +1068,14 @@ Example:
 "outputvarregex": {
   "FILEBEAT_ENABLED_INPUTS": ".*Enabled inputs: (\\d+).*"
 },
-"healthcheck": {
-  "type": "variable",
-  "variable": "FILEBEAT_ENABLED_INPUTS",
-  "retries": 180
-}
+"healthchecks": [
+  {
+    "id": "filebeat-inputs-ready",
+    "type": "variable",
+    "variable": "FILEBEAT_ENABLED_INPUTS",
+    "retries": 180
+  }
+]
 ```
 
 Runtime contract:

--- a/docs/service-authoring/01-plan-service.md
+++ b/docs/service-authoring/01-plan-service.md
@@ -27,7 +27,7 @@ Pick one shape before writing `service.json`:
 | Shape | Use when | Common fields |
 | --- | --- | --- |
 | Provider | The service supplies a runtime or tool to other services and should not run as a daemon. | `role: "provider"`, `artifact`, `globalenv` |
-| Managed daemon | The service owns and runs its executable. | `artifact`, platform command, `ports`, `healthcheck` |
+| Managed daemon | The service owns and runs its executable. | `artifact`, platform command, `ports`, `healthchecks[]` |
 | Provider-backed app | The service runs through another provider such as `@node`, `@python`, or `@java`. | `execservice`, `executable`, `args`, `depend_on` |
 | App-owned add-on service | Consumers opt in and must configure it first. | `enabled: false`, explicit env/config notes |
 

--- a/docs/service-authoring/02-write-service-json.md
+++ b/docs/service-authoring/02-write-service-json.md
@@ -32,7 +32,7 @@ Managed services usually also need:
 
 - `ports` for named service ports
 - `urls` for operator-facing links
-- `healthcheck` for process, HTTP, TCP, file, or variable readiness
+- `healthchecks[]` for process, HTTP, TCP, file, or variable readiness
 - `env` for service-local runtime values
 - `globalenv` for values other services can consume
 - `depend_on` for startup ordering
@@ -45,7 +45,7 @@ Provider services usually need:
 - `globalenv` entries that expose installed tool paths
 - a cheap probe/version command where useful
 - setup steps when the provider must generate local files, install trust material, or prepare a tool cache
-- no long-running daemon healthcheck unless the provider truly starts a process
+- no long-running daemon healthcheck item unless the provider truly starts a process
 
 ## Add Setup Steps When Needed
 

--- a/fixtures/zitadel-consumer-app/services/postgres/service.json
+++ b/fixtures/zitadel-consumer-app/services/postgres/service.json
@@ -70,10 +70,13 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "tcp",
-    "address": "${POSTGRES_HOST}:${POSTGRES_PORT}",
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "postgres-tcp-ready",
+      "type": "tcp",
+      "address": "${POSTGRES_HOST}:${POSTGRES_PORT}",
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/fixtures/zitadel-consumer-app/services/zitadel/service.json
+++ b/fixtures/zitadel-consumer-app/services/zitadel/service.json
@@ -101,11 +101,14 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${HTTP_PORT}/debug/ready",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 500
-  }
+  "healthchecks": [
+    {
+      "id": "zitadel-http-ready",
+      "type": "http",
+      "url": "http://127.0.0.1:${HTTP_PORT}/debug/ready",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 500
+    }
+  ]
 }

--- a/scripts/baseline-start-smoke.mjs
+++ b/scripts/baseline-start-smoke.mjs
@@ -182,7 +182,7 @@ async function writeLongRunningService(servicesRoot, serviceId, options = {}) {
     executable: process.execPath,
     args: [path.relative(serviceRoot, scriptPath)],
     depend_on: options.depend_on,
-    healthcheck: { type: "process" },
+    healthchecks: [{ id: "process-health", type: "process" }],
     install: {
       files: [{ path: "./runtime/install.txt", content: "installed ${SERVICE_ID}\n" }],
     },
@@ -282,10 +282,12 @@ async function writeNginxService(servicesRoot, httpPort) {
         [process.platform]: nginxPlatformArtifact(),
       },
     },
-    healthcheck: {
-      ...coreNginxManifest.healthcheck,
-      url: `http://127.0.0.1:${httpPort}/health`,
-    },
+    healthchecks: [
+      {
+        ...coreNginxManifest.healthchecks[0],
+        url: `http://127.0.0.1:${httpPort}/health`,
+      },
+    ],
   });
 }
 
@@ -379,7 +381,16 @@ async function writeHttpService(servicesRoot, serviceId, portName, options = {})
     depend_on: options.depend_on,
     ports: options.ports,
     urls: options.urls,
-    healthcheck: { type: "http", url: options.healthUrl, expected_status: 200, retries: 20, interval: 250 },
+    healthchecks: [
+      {
+        id: "http-health",
+        type: "http",
+        url: options.healthUrl,
+        expected_status: 200,
+        retries: 20,
+        interval: 250,
+      },
+    ],
     install: {
       files: [{ path: "./runtime/install.txt", content: "installed ${SERVICE_ID}\n" }],
     },
@@ -472,13 +483,16 @@ async function writeTraefikService(servicesRoot, ports, options = {}) {
         },
       ],
     },
-    healthcheck: {
-      type: "http",
-      url: `http://127.0.0.1:${ports.admin}/ping`,
-      expected_status: 200,
-      retries: 80,
-      interval: 250,
-    },
+    healthchecks: [
+      {
+        id: "traefik-ping-health",
+        type: "http",
+        url: `http://127.0.0.1:${ports.admin}/ping`,
+        expected_status: 200,
+        retries: 80,
+        interval: 250,
+      },
+    ],
   });
 }
 

--- a/scripts/demo-verify-canonical.mjs
+++ b/scripts/demo-verify-canonical.mjs
@@ -168,6 +168,13 @@ function manifestUrlEndpoints(manifest) {
     }));
 }
 
+function manifestHealthchecks(manifest) {
+  if (Array.isArray(manifest.healthchecks)) {
+    return manifest.healthchecks;
+  }
+  return manifest.healthcheck ? [manifest.healthcheck] : [];
+}
+
 export function buildReachabilityTargets(serviceId, manifest, ports = {}) {
   const targets = [];
   const seen = new Set();
@@ -189,15 +196,19 @@ export function buildReachabilityTargets(serviceId, manifest, ports = {}) {
     });
   }
 
-  if (manifest.healthcheck?.type === "http" && manifest.healthcheck.url) {
-    const resolvedUrl = resolveServiceText(manifest.healthcheck.url, ports);
+  for (const healthcheck of manifestHealthchecks(manifest)) {
+    if (healthcheck?.type !== "http" || !healthcheck.url) {
+      continue;
+    }
+    const resolvedUrl = resolveServiceText(healthcheck.url, ports);
     if (!resolvedUrl.includes("${") && !seen.has(resolvedUrl)) {
       targets.push({
-        label: "healthcheck",
+        label: healthcheck.id ?? "healthcheck",
         url: resolvedUrl,
-        source: "healthcheck",
-        expectedStatus: manifest.healthcheck.expected_status ?? 200,
+        source: "healthchecks",
+        expectedStatus: healthcheck.expected_status ?? 200,
       });
+      seen.add(resolvedUrl);
     }
   }
 

--- a/services/@nginx/service.json
+++ b/services/@nginx/service.json
@@ -91,11 +91,14 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${HTTP_PORT}/health",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "nginx-http-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${HTTP_PORT}/health",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/services/@secretsbroker/service.json
+++ b/services/@secretsbroker/service.json
@@ -50,11 +50,14 @@
       }
     }
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${SERVICE_PORT}/health",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "secretsbroker-http-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/health",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -371,11 +371,14 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "${endpoint.ping.url}",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "traefik-ping-health",
+      "type": "http",
+      "url": "${endpoint.ping.url}",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -73,7 +73,10 @@
       "kind": "local"
     }
   ],
-  "healthcheck": {
-    "type": "process"
-  }
+  "healthchecks": [
+    {
+      "id": "process-health",
+      "type": "process"
+    }
+  ]
 }

--- a/services/node-sample-service/service.json
+++ b/services/node-sample-service/service.json
@@ -31,13 +31,16 @@
       "kind": "local"
     }
   ],
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${SERVICE_PORT}/health",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  },
+  "healthchecks": [
+    {
+      "id": "http-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/health",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ],
   "broker": {
     "enabled": true,
     "namespace": "services/node-sample-service",

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1934,6 +1934,7 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
       healthcheckIds.add(id);
       return healthcheckEntry;
     });
+    healthcheck = healthchecks.find((entry) => entry.required !== false) ?? healthchecks[0];
   }
 
   const env = readEnvMap(record.env, "env", manifestPath);

--- a/src/runtime/discovery/validateManifest.ts
+++ b/src/runtime/discovery/validateManifest.ts
@@ -1934,7 +1934,11 @@ export function validateServiceManifest(input: unknown, manifestPath: string): S
       healthcheckIds.add(id);
       return healthcheckEntry;
     });
-    healthcheck = healthchecks.find((entry) => entry.required !== false) ?? healthchecks[0];
+    if (record.role === "provider") {
+      healthcheck = healthchecks.find((entry) => entry.required !== false && entry.type !== "process");
+    } else {
+      healthcheck = healthchecks.find((entry) => entry.required !== false) ?? healthchecks[0];
+    }
   }
 
   const env = readEnvMap(record.env, "env", manifestPath);

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readdir, readFile, writeFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 import { loadServiceManifest } from "../dist/runtime/discovery/loadManifest.js";
@@ -20,6 +20,53 @@ async function writeManifest(servicesRoot, serviceId, body) {
   await mkdir(serviceRoot, { recursive: true });
   await writeFile(path.join(serviceRoot, "service.json"), JSON.stringify(body, null, 2));
 }
+
+async function findServiceManifests(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const manifests = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      manifests.push(...await findServiceManifests(entryPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name === "service.json") {
+      manifests.push(entryPath);
+    }
+  }
+
+  return manifests;
+}
+
+test("checked-in service manifests use canonical healthchecks arrays", async () => {
+  const manifestPaths = [
+    ...await findServiceManifests(path.join(repoRoot, "services")),
+    ...await findServiceManifests(path.join(repoRoot, "fixtures")),
+  ];
+
+  assert.ok(manifestPaths.length > 0);
+  for (const manifestPath of manifestPaths) {
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    assert.equal(
+      Object.hasOwn(manifest, "healthcheck"),
+      false,
+      `${path.relative(repoRoot, manifestPath)} must not use singular healthcheck`,
+    );
+    if (manifest.healthchecks !== undefined) {
+      assert.ok(Array.isArray(manifest.healthchecks), `${path.relative(repoRoot, manifestPath)} healthchecks must be an array`);
+      assert.ok(manifest.healthchecks.length > 0, `${path.relative(repoRoot, manifestPath)} healthchecks must not be empty`);
+      for (const [index, healthcheck] of manifest.healthchecks.entries()) {
+        assert.equal(
+          typeof healthcheck.id,
+          "string",
+          `${path.relative(repoRoot, manifestPath)} healthchecks[${index}].id must be stable`,
+        );
+        assert.ok(healthcheck.id.trim().length > 0, `${path.relative(repoRoot, manifestPath)} healthchecks[${index}].id must not be empty`);
+      }
+    }
+  }
+});
 
 test("discoverServices loads valid service manifests from a services root", async () => {
   const servicesRoot = await makeTempServicesRoot();
@@ -137,9 +184,11 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@nginx")?.artifact?.platforms.win32?.assetName, "lasso-nginx-1.30.0-win32.zip");
   assert.deepEqual(byId.get("@nginx")?.ports, { http: 18080 });
   assert.deepEqual(byId.get("@nginx")?.healthcheck, {
+    id: "nginx-http-health",
     type: "http",
     url: "http://127.0.0.1:${HTTP_PORT}/health",
     expected_status: 200,
+    required: true,
     retries: 80,
     interval: 250,
   });
@@ -230,9 +279,11 @@ test("core services root declares the clean-clone baseline inventory", async () 
   assert.equal(byId.get("@traefik")?.globalenv?.TRAEFIK_TRAEFIK_URL, "${endpoint.dashboard.url}");
   assert.equal(byId.get("@traefik")?.globalenv?.TRAEFIK_HOST_DOMAIN, "localhost");
   assert.deepEqual(byId.get("@traefik")?.healthcheck, {
+    id: "traefik-ping-health",
     type: "http",
     url: "${endpoint.ping.url}",
     expected_status: 200,
+    required: true,
     retries: 80,
     interval: 250,
   });
@@ -545,7 +596,15 @@ test("loadServiceManifest accepts canonical healthchecks arrays", async () => {
         required: true,
       },
     ]);
-    assert.equal(manifest.healthcheck, undefined);
+    assert.deepEqual(manifest.healthcheck, {
+      id: "tcp-port-open",
+      type: "tcp",
+      host: "127.0.0.1",
+      port: "${HTTP_PORT}",
+      retries: 30,
+      interval: 250,
+      required: true,
+    });
   } finally {
     await rm(servicesRoot, { recursive: true, force: true });
   }

--- a/tests/manifest-discovery.test.js
+++ b/tests/manifest-discovery.test.js
@@ -610,6 +610,42 @@ test("loadServiceManifest accepts canonical healthchecks arrays", async () => {
   }
 });
 
+test("loadServiceManifest does not project provider process healthchecks into daemon health", async () => {
+  const servicesRoot = await makeTempServicesRoot();
+
+  try {
+    await writeManifest(servicesRoot, "@node", {
+      id: "@node",
+      name: "Node Runtime",
+      description: "Provider with a version probe healthcheck.",
+      role: "provider",
+      healthchecks: [
+        {
+          id: "node-version",
+          type: "process",
+          retries: 3,
+          interval: 1000,
+        },
+      ],
+    });
+
+    const manifest = await loadServiceManifest(path.join(servicesRoot, "@node", "service.json"));
+
+    assert.equal(manifest.healthcheck, undefined);
+    assert.deepEqual(manifest.healthchecks, [
+      {
+        id: "node-version",
+        type: "process",
+        retries: 3,
+        interval: 1000,
+        required: true,
+      },
+    ]);
+  } finally {
+    await rm(servicesRoot, { recursive: true, force: true });
+  }
+});
+
 test("loadServiceManifest rejects invalid healthchecks arrays", async () => {
   const servicesRoot = await makeTempServicesRoot();
 


### PR DESCRIPTION
## Issue
Closes #817

## Summary
- Migrates checked-in core service manifests and ZITADEL fixture manifests from singular healthcheck to canonical healthchecks[].
- Adds stable healthcheck ids and preserves runtime behavior by projecting the first required canonical healthcheck into the compatibility manifest.healthcheck field.
- Updates canonical demo verification and docs/examples to read and show healthchecks[].
- Adds a manifest discovery guard that fails if checked-in service or fixture manifests reintroduce singular healthcheck.

## Scope
- In scope: checked-in manifests under services/ and ixtures/, docs/examples, runtime discovery compatibility, canonical verifier reachability targets, targeted tests.
- Out of scope: removing legacy singular healthcheck parsing for external/backward-compatible manifests.

## Spec / contract / fixture impact
- Updated: canonical checked-in manifest examples and schema skeletons use healthchecks[].
- Compatibility preserved: legacy singular parsing still rejects mixed fields and remains covered by existing tests.

## Service Lasso invariant impact
- Invariant: canonical demo startup and Service Admin same-origin APIs remain healthy after manifest migration.
- Preservation proof: updated-code demo gate and canonical verifier passed against http://192.168.1.53:17883 and http://192.168.1.53:17700/.

## Validation
- PASS 
pm run build — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-npm-build-rerun.stdout.log
- PASS 
ode --test --test-concurrency=1 tests/manifest-discovery.test.js — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-manifest-discovery-rerun.stdout.log
- PASS 
pm run build before demo proof — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-demo-npm-build.stdout.log
- PASS 
ode scripts/demo-gate.mjs --host=0.0.0.0 --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-demo-gate.stdout.log
- PASS 
ode scripts/demo-verify-canonical.mjs --runtime-url=http://192.168.1.53:17883 --port=17883 --admin-url=http://192.168.1.53:17700/ --workspace-root=workspace/demo-instance --services-root=workspace/canonical-services-root --json — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-demo-verify-canonical.stdout.log
- PASS git diff --check — C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260728T190928+1000\issue-817-git-diff-check.stdout.log

## Approval trail
- Required: no, unless repository branch protection requires review before merge.
- Evidence: PR targets develop; checks/review status will be inspected before merge.

## Cleanup
- Branch: issue-817-healthchecks-manifests
- Post-merge plan: return local repo to clean develop where possible.
