### PR TITLE
#818 add healthchecks array regression coverage

### DIFF
--- a/src/runtime/health/checkUdp.ts
+++ b/src/runtime/health/checkUdp.ts
@@ -1,0 +1,121 @@
+import dgram from "node:dgram";
+import type { ServiceHealthResult, UdpHealthcheck } from "./types.js";
+
+const DEFAULT_UDP_HEALTHCHECK_TIMEOUT_MS = 2_000;
+
+export async function checkUdpHealth(healthcheck: UdpHealthcheck): Promise<ServiceHealthResult> {
+  const target =
+    healthcheck.address !== undefined
+      ? parseUdpAddress(healthcheck.address)
+      : parseUdpHostPort(healthcheck.host, healthcheck.port);
+
+  if (!target) {
+    return {
+      type: "udp",
+      healthy: false,
+      detail: "UDP healthcheck target is invalid; expected address or host + port.",
+    };
+  }
+
+  if (!Number.isInteger(target.port) || target.port < 1 || target.port > 65535) {
+    return {
+      type: "udp",
+      healthy: false,
+      detail: `UDP healthcheck port is invalid: ${target.address}`,
+    };
+  }
+
+  const timeoutMs = healthcheck.timeout ?? DEFAULT_UDP_HEALTHCHECK_TIMEOUT_MS;
+  const socket = dgram.createSocket("udp4");
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish({
+        type: "udp",
+        healthy: false,
+        detail: `UDP healthcheck timed out after ${timeoutMs}ms: ${target.address}`,
+      });
+    }, timeoutMs);
+
+    function finish(payload: ServiceHealthResult) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      socket.close();
+      resolve(payload);
+    }
+
+    socket.once("error", (error) => {
+      finish({
+        type: "udp",
+        healthy: false,
+        detail: `UDP healthcheck failed: ${error.message}`,
+      });
+    });
+
+    socket.on("message", (message) => {
+      const response = message.toString("utf8");
+      finish({
+        type: "udp",
+        healthy: response === healthcheck.expect,
+        detail:
+          response === healthcheck.expect
+            ? `UDP healthcheck received expected response from ${target.address}.`
+            : `UDP healthcheck received "${response}", expected "${healthcheck.expect}".`,
+      });
+    });
+
+    socket.send(Buffer.from(healthcheck.send), target.port, target.host, (error) => {
+      if (error) {
+        finish({
+          type: "udp",
+          healthy: false,
+          detail: `UDP healthcheck failed: ${error.message}`,
+        });
+      }
+    });
+  });
+}
+
+function parseUdpAddress(address: string): { host: string; port: number; address: string } | undefined {
+  const resolvedAddress = address.trim();
+  const separator = resolvedAddress.lastIndexOf(":");
+
+  if (separator <= 0 || separator === resolvedAddress.length - 1) {
+    return undefined;
+  }
+
+  const host = resolvedAddress.slice(0, separator).trim();
+  const port = Number(resolvedAddress.slice(separator + 1).trim());
+  if (!host) {
+    return undefined;
+  }
+
+  return {
+    host,
+    port,
+    address: `${host}:${Number.isFinite(port) ? port : resolvedAddress.slice(separator + 1).trim()}`,
+  };
+}
+
+function parseUdpHostPort(
+  host: string | undefined,
+  port: string | number | undefined,
+): { host: string; port: number; address: string } | undefined {
+  const resolvedHost = host?.trim();
+  const resolvedPort = typeof port === "number" ? port : Number(port?.trim());
+
+  if (!resolvedHost) {
+    return undefined;
+  }
+
+  return {
+    host: resolvedHost,
+    port: resolvedPort,
+    address: `${resolvedHost}:${Number.isFinite(resolvedPort) ? resolvedPort : String(port ?? "").trim()}`,
+  };
+}

--- a/src/runtime/health/evaluateHealth.ts
+++ b/src/runtime/health/evaluateHealth.ts
@@ -5,8 +5,9 @@ import { checkFileHealth } from "./checkFile.js";
 import { checkHttpHealth } from "./checkHttp.js";
 import { checkProcessHealth } from "./checkProcess.js";
 import { checkTcpHealth } from "./checkTcp.js";
+import { checkUdpHealth } from "./checkUdp.js";
 import { checkVariableHealth } from "./checkVariable.js";
-import type { ServiceHealthResult } from "./types.js";
+import type { ServiceHealthcheck, ServiceHealthcheckResult, ServiceHealthResult } from "./types.js";
 import { isProviderRole } from "../roles.js";
 import { resolveServiceText } from "../operator/variables.js";
 
@@ -24,27 +25,15 @@ function inferSingleTcpPort(resolvedPorts: Record<string, number>): number | str
   return "TCP healthcheck requires an explicit address or host + port because multiple service ports are available.";
 }
 
-export async function evaluateServiceHealth(
+async function evaluateHealthcheck(
+  healthcheck: ServiceHealthcheck,
   manifest: ServiceManifest,
   lifecycle: ServiceLifecycleState,
   serviceRoot?: string,
   service?: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
 ): Promise<ServiceHealthResult> {
-  const healthcheck = manifest.healthcheck;
-
-  if (!healthcheck && isProviderRole(manifest)) {
-    const ready = lifecycle.installed && lifecycle.configured;
-    return {
-      type: "provider",
-      healthy: ready,
-      detail: ready
-        ? "Provider is installed/configured and does not require a managed daemon process."
-        : "Provider is not installed/configured yet.",
-    };
-  }
-
-  if (!healthcheck || healthcheck.type === "process") {
+  if (healthcheck.type === "process") {
     return checkProcessHealth(lifecycle);
   }
 
@@ -103,6 +92,28 @@ export async function evaluateServiceHealth(
     });
   }
 
+  if (healthcheck.type === "udp") {
+    return checkUdpHealth({
+      ...healthcheck,
+      address:
+        service && healthcheck.address !== undefined
+          ? resolveServiceText(healthcheck.address, service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.address,
+      host:
+        service && healthcheck.host !== undefined
+          ? resolveServiceText(healthcheck.host, service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.host,
+      port:
+        service && healthcheck.port !== undefined
+          ? resolveServiceText(String(healthcheck.port), service, sharedGlobalEnv, resolvedPorts)
+          : healthcheck.port,
+      send: service ? resolveServiceText(healthcheck.send, service, sharedGlobalEnv, resolvedPorts) : healthcheck.send,
+      expect: service
+        ? resolveServiceText(healthcheck.expect, service, sharedGlobalEnv, resolvedPorts)
+        : healthcheck.expect,
+    });
+  }
+
   if (healthcheck.type === "file") {
     return checkFileHealth(
       {
@@ -129,4 +140,85 @@ export async function evaluateServiceHealth(
     healthy: false,
     detail: "Unsupported healthcheck type.",
   };
+}
+
+function toCheckResult(
+  healthcheck: ServiceHealthcheck,
+  health: ServiceHealthResult,
+  attempts = 1,
+): ServiceHealthcheckResult {
+  return {
+    id: healthcheck.id ?? healthcheck.type,
+    type: healthcheck.type,
+    required: healthcheck.required !== false,
+    healthy: health.healthy,
+    attempts,
+    detail: health.detail,
+  };
+}
+
+function aggregateHealth(checks: ServiceHealthcheckResult[]): ServiceHealthResult {
+  const failedRequired = checks.filter((check) => check.required && !check.healthy);
+
+  return {
+    type: "aggregate",
+    healthy: failedRequired.length === 0,
+    detail:
+      failedRequired.length === 0
+        ? "All required healthchecks passed."
+        : `Required healthcheck(s) failed: ${failedRequired.map((check) => check.id).join(", ")}.`,
+    checks,
+  };
+}
+
+export async function evaluateServiceHealthcheck(
+  healthcheck: ServiceHealthcheck,
+  manifest: ServiceManifest,
+  lifecycle: ServiceLifecycleState,
+  serviceRoot?: string,
+  service?: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): Promise<ServiceHealthcheckResult> {
+  const health = await evaluateHealthcheck(healthcheck, manifest, lifecycle, serviceRoot, service, sharedGlobalEnv);
+  return toCheckResult(healthcheck, health);
+}
+
+export function buildAggregateHealth(checks: ServiceHealthcheckResult[]): ServiceHealthResult {
+  return aggregateHealth(checks);
+}
+
+export async function evaluateServiceHealth(
+  manifest: ServiceManifest,
+  lifecycle: ServiceLifecycleState,
+  serviceRoot?: string,
+  service?: DiscoveredService,
+  sharedGlobalEnv: Record<string, string> = {},
+): Promise<ServiceHealthResult> {
+  const healthcheck = manifest.healthcheck;
+  const healthchecks = manifest.healthchecks && (!isProviderRole(manifest) || healthcheck) ? manifest.healthchecks : undefined;
+
+  if (healthchecks && healthchecks.length > 0) {
+    const checks: ServiceHealthcheckResult[] = [];
+    for (const entry of healthchecks) {
+      checks.push(await evaluateServiceHealthcheck(entry, manifest, lifecycle, serviceRoot, service, sharedGlobalEnv));
+    }
+    return aggregateHealth(checks);
+  }
+
+  if (!healthcheck && isProviderRole(manifest)) {
+    const ready = lifecycle.installed && lifecycle.configured;
+    return {
+      type: "provider",
+      healthy: ready,
+      detail: ready
+        ? "Provider is installed/configured and does not require a managed daemon process."
+        : "Provider is not installed/configured yet.",
+    };
+  }
+
+  if (!healthcheck || healthcheck.type === "process") {
+    return checkProcessHealth(lifecycle);
+  }
+
+  return evaluateHealthcheck(healthcheck, manifest, lifecycle, serviceRoot, service, sharedGlobalEnv);
 }

--- a/src/runtime/health/types.ts
+++ b/src/runtime/health/types.ts
@@ -55,8 +55,18 @@ export type ServiceHealthcheck =
   | FileHealthcheck
   | VariableHealthcheck;
 
+export interface ServiceHealthcheckResult {
+  id: string;
+  type: ServiceHealthcheck["type"];
+  required: boolean;
+  healthy: boolean;
+  attempts: number;
+  detail: string;
+}
+
 export interface ServiceHealthResult {
-  type: ServiceHealthcheck["type"] | "provider" | "unknown";
+  type: ServiceHealthcheck["type"] | "aggregate" | "provider" | "unknown";
   healthy: boolean;
   detail: string;
+  checks?: ServiceHealthcheckResult[];
 }

--- a/src/runtime/health/waitForReadiness.ts
+++ b/src/runtime/health/waitForReadiness.ts
@@ -1,8 +1,8 @@
 import { setTimeout as delay } from "node:timers/promises";
 import type { DiscoveredService } from "../../contracts/service.js";
 import { getLifecycleState } from "../lifecycle/store.js";
-import { evaluateServiceHealth } from "./evaluateHealth.js";
-import type { ServiceHealthcheck, ServiceHealthResult } from "./types.js";
+import { buildAggregateHealth, evaluateServiceHealth, evaluateServiceHealthcheck } from "./evaluateHealth.js";
+import type { ServiceHealthcheck, ServiceHealthcheckResult, ServiceHealthResult } from "./types.js";
 
 const DEFAULT_READINESS_INTERVAL_MS = 1_000;
 const DEFAULT_READINESS_ATTEMPTS = 10;
@@ -42,6 +42,71 @@ export async function waitForServiceReadiness(
   service: DiscoveredService,
   sharedGlobalEnv: Record<string, string> = {},
 ): Promise<ReadinessWaitResult> {
+  if (service.manifest.healthchecks && service.manifest.healthchecks.length > 0) {
+    const checks: ServiceHealthcheckResult[] = [];
+
+    for (const healthcheck of service.manifest.healthchecks) {
+      const { attempts, intervalMs, startPeriodMs } = resolveReadinessOptions(healthcheck);
+      const required = healthcheck.required !== false;
+      let lastCheck: ServiceHealthcheckResult | undefined;
+
+      if (startPeriodMs > 0) {
+        await delay(startPeriodMs);
+      }
+
+      const maxAttempts = required ? attempts : 1;
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        lastCheck = {
+          ...(await evaluateServiceHealthcheck(
+            healthcheck,
+            service.manifest,
+            getLifecycleState(service.manifest.id),
+            service.serviceRoot,
+            service,
+            sharedGlobalEnv,
+          )),
+          attempts: attempt,
+        };
+
+        if (lastCheck.healthy || !required) {
+          break;
+        }
+
+        if (attempt < maxAttempts) {
+          await delay(intervalMs);
+        }
+      }
+
+      if (lastCheck) {
+        checks.push(lastCheck);
+      }
+
+      if (required && lastCheck && !lastCheck.healthy) {
+        const health = buildAggregateHealth(checks);
+        return {
+          enabled: true,
+          ready: false,
+          health,
+          attempts: checks.reduce((total, check) => total + check.attempts, 0),
+          message:
+            `Service did not become ready because healthcheck "${lastCheck.id}" failed after ${lastCheck.attempts} readiness attempt(s)` +
+            ` with interval ${intervalMs}ms and start period ${startPeriodMs}ms.`,
+        };
+      }
+    }
+
+    const health = buildAggregateHealth(checks);
+    return {
+      enabled: true,
+      ready: health.healthy,
+      health,
+      attempts: checks.reduce((total, check) => total + check.attempts, 0),
+      message: health.healthy
+        ? `Start completed after ${checks.length} healthcheck(s) reached required readiness.`
+        : `Service did not become ready: ${health.detail}`,
+    };
+  }
+
   const { enabled, attempts, intervalMs, startPeriodMs } = resolveReadinessOptions(service.manifest.healthcheck);
   let lastHealth = await evaluateServiceHealth(
     service.manifest,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3182,6 +3182,13 @@ export function createApiServer(options: ApiServerOptions = {}): Server {
   });
 }
 
+async function closeApiServer(server: Server): Promise<void> {
+  server.close();
+  server.closeIdleConnections?.();
+  server.closeAllConnections?.();
+  await once(server, "close");
+}
+
 export async function startApiServer(options: ApiServerOptions = {}): Promise<RunningApiServer> {
   const bindHost = options.host ?? process.env.SERVICE_LASSO_HOST ?? "0.0.0.0";
   const publicHost = bindHost === "0.0.0.0" ? "127.0.0.1" : bindHost;
@@ -3311,8 +3318,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
     await updateScheduler?.stop();
     await telemetryExportScheduler.stop();
     await markRuntimeInstanceStopped(config);
-    server.close();
-    await once(server, "close");
+    await closeApiServer(server);
     await transitionProcessOwnership(
       config.workspaceRoot,
       "runtime",
@@ -3346,8 +3352,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
       await telemetryExportScheduler?.stop();
       await stopAllManagedProcesses();
       await markRuntimeInstanceStopped(config);
-      server.close();
-      await once(server, "close");
+      await closeApiServer(server);
       await transitionProcessOwnership(
         config.workspaceRoot,
         "runtime",

--- a/tests/health-state.test.js
+++ b/tests/health-state.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
+import dgram from "node:dgram";
 import path from "node:path";
 import { promisify } from "node:util";
 import { execFile as execFileCallback } from "node:child_process";
@@ -501,6 +502,264 @@ test("bare TCP healthchecks report ambiguous multi-port services", async () => {
     assert.equal(body.health.healthy, false);
     assert.match(body.health.detail, /multiple service ports/i);
     assert.match(body.health.detail, /address or host \+ port/i);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("GET /api/services/:id/health aggregates canonical HTTP and TCP healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  const httpServer = createServer((_, res) => {
+    res.statusCode = 200;
+    res.end("ok");
+  });
+  httpServer.listen(0, "127.0.0.1");
+  await once(httpServer, "listening");
+  const httpAddress = httpServer.address();
+  if (!httpAddress || typeof httpAddress === "string") {
+    throw new Error("HTTP probe server failed to bind.");
+  }
+
+  const tcpServer = net.createServer((socket) => {
+    socket.end("OK");
+  });
+  tcpServer.listen(0, "127.0.0.1");
+  await once(tcpServer, "listening");
+  const tcpAddress = tcpServer.address();
+  if (!tcpAddress || typeof tcpAddress === "string") {
+    throw new Error("TCP probe server failed to bind.");
+  }
+
+  await writeManifest(servicesRoot, "aggregate-health-service", {
+    id: "aggregate-health-service",
+    name: "Aggregate Health Service",
+    description: "Temporary service for healthchecks array aggregation.",
+    ports: {
+      http: httpAddress.port,
+      tcp: tcpAddress.port,
+    },
+    healthchecks: [
+      {
+        id: "tcp-port-open",
+        type: "tcp",
+        host: "127.0.0.1",
+        port: "${TCP_PORT}",
+      },
+      {
+        id: "http-ready",
+        type: "http",
+        url: "http://127.0.0.1:${HTTP_PORT}/health",
+        expected_status: 200,
+      },
+    ],
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/aggregate-health-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.serviceId, "aggregate-health-service");
+    assert.equal(body.health.type, "aggregate");
+    assert.equal(body.health.healthy, true);
+    assert.deepEqual(
+      body.health.checks.map((check) => [check.id, check.type, check.required, check.healthy, check.attempts]),
+      [
+        ["tcp-port-open", "tcp", true, true, 1],
+        ["http-ready", "http", true, true, 1],
+      ],
+    );
+  } finally {
+    await apiServer.stop();
+    httpServer.close();
+    tcpServer.close();
+    await Promise.all([once(httpServer, "close"), once(tcpServer, "close")]);
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("GET /api/services/:id/health reports optional failures without failing the aggregate", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const serviceRoot = await writeManifest(servicesRoot, "optional-health-service", {
+    id: "optional-health-service",
+    name: "Optional Health Service",
+    description: "Temporary service for optional healthchecks.",
+    healthchecks: [
+      {
+        id: "required-file",
+        type: "file",
+        file: "${SERVICE_ROOT}/runtime/ready.txt",
+      },
+      {
+        id: "optional-diagnostic",
+        type: "file",
+        file: "runtime/diagnostic.txt",
+        required: false,
+      },
+    ],
+  });
+  const readyPath = path.join(serviceRoot, "runtime", "ready.txt");
+  await mkdir(path.dirname(readyPath), { recursive: true });
+  await writeFile(readyPath, "ok");
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/optional-health-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.health.type, "aggregate");
+    assert.equal(body.health.healthy, true);
+    assert.equal(body.health.checks.find((check) => check.id === "required-file").healthy, true);
+    assert.equal(body.health.checks.find((check) => check.id === "optional-diagnostic").healthy, false);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("GET /api/services/:id/health supports UDP send expect healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+  const udpServer = dgram.createSocket("udp4");
+  udpServer.on("message", (message, remote) => {
+    if (message.toString("utf8") === "ping") {
+      udpServer.send(Buffer.from("pong"), remote.port, remote.address);
+    }
+  });
+  udpServer.bind(0, "127.0.0.1");
+  await once(udpServer, "listening");
+  const udpAddress = udpServer.address();
+
+  await writeManifest(servicesRoot, "udp-health-service", {
+    id: "udp-health-service",
+    name: "UDP Health Service",
+    description: "Temporary service for UDP healthchecks.",
+    ports: {
+      udp: udpAddress.port,
+    },
+    healthchecks: [
+      {
+        id: "udp-ready",
+        type: "udp",
+        host: "127.0.0.1",
+        port: "${UDP_PORT}",
+        send: "ping",
+        expect: "pong",
+        timeout: 250,
+      },
+    ],
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/udp-health-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.health.type, "aggregate");
+    assert.equal(body.health.healthy, true);
+    assert.deepEqual(body.health.checks.map((check) => [check.id, check.type, check.healthy]), [
+      ["udp-ready", "udp", true],
+    ]);
+  } finally {
+    await apiServer.stop();
+    udpServer.close();
+    await once(udpServer, "close");
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("GET /api/services/:id/health reports UDP timeout by check id", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  await writeManifest(servicesRoot, "udp-timeout-service", {
+    id: "udp-timeout-service",
+    name: "UDP Timeout Service",
+    description: "Temporary service for UDP timeout healthchecks.",
+    healthchecks: [
+      {
+        id: "udp-timeout",
+        type: "udp",
+        address: "127.0.0.1:9",
+        send: "ping",
+        expect: "pong",
+        timeout: 25,
+      },
+    ],
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/udp-timeout-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.health.type, "aggregate");
+    assert.equal(body.health.healthy, false);
+    assert.match(body.health.detail, /udp-timeout/);
+    assert.equal(body.health.checks[0].id, "udp-timeout");
+    assert.match(body.health.checks[0].detail, /timed out after 25ms/i);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+    resetLifecycleState();
+  }
+});
+
+test("GET /api/services/:id/health supports bare and selector variable healthchecks", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot();
+
+  await writeManifest(servicesRoot, "variable-array-service", {
+    id: "variable-array-service",
+    name: "Variable Array Service",
+    description: "Temporary service for variable healthchecks array.",
+    env: {
+      BARE_READY: "ready",
+      SELECTOR_READY: "ready",
+    },
+    healthchecks: [
+      {
+        id: "bare-variable",
+        type: "variable",
+        variable: "BARE_READY",
+      },
+      {
+        id: "selector-variable",
+        type: "variable",
+        variable: "${SELECTOR_READY}",
+      },
+    ],
+  });
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    const response = await fetch(`${apiServer.url}/api/services/variable-array-service/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.health.type, "aggregate");
+    assert.equal(body.health.healthy, true);
+    assert.deepEqual(body.health.checks.map((check) => [check.id, check.type, check.healthy]), [
+      ["bare-variable", "variable", true],
+      ["selector-variable", "variable", true],
+    ]);
   } finally {
     await apiServer.stop();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -663,6 +663,138 @@ test("start waits for configured readiness and returns healthy once ready", asyn
   }
 });
 
+test("start waits for each required healthchecks array item and reports attempts", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-healthchecks-array-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "array-ready-service", {
+    readyFileAfterMs: 500,
+    readyFileRelativePath: "./runtime/ready.txt",
+    healthchecks: [
+      {
+        id: "process-started",
+        type: "process",
+        retries: 2,
+        interval: 10,
+      },
+      {
+        id: "ready-file",
+        type: "file",
+        file: "./runtime/ready.txt",
+        retries: 20,
+        interval: 50,
+        start_period: 0,
+      },
+    ],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/array-ready-service/install`);
+    await postJson(`${apiServer.url}/api/services/array-ready-service/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/array-ready-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.health.type, "aggregate");
+    assert.equal(start.body.health.healthy, true);
+    assert.deepEqual(start.body.health.checks.map((check) => check.id), ["process-started", "ready-file"]);
+    assert.equal(start.body.health.checks.find((check) => check.id === "ready-file").attempts >= 1, true);
+    assert.match(start.body.message, /2 healthcheck/i);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("start blocks on a failed required healthchecks item and names the check id", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-healthchecks-fail-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "array-not-ready-service", {
+    healthchecks: [
+      {
+        id: "process-started",
+        type: "process",
+      },
+      {
+        id: "missing-ready-file",
+        type: "file",
+        file: "./runtime/ready.txt",
+        retries: 3,
+        interval: 25,
+      },
+    ],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/array-not-ready-service/install`);
+    await postJson(`${apiServer.url}/api/services/array-not-ready-service/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/array-not-ready-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, false);
+    assert.equal(start.body.health.type, "aggregate");
+    assert.equal(start.body.health.healthy, false);
+    assert.match(start.body.message, /missing-ready-file/);
+    assert.match(start.body.message, /failed after 3 readiness attempt/i);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("start does not block on failed optional healthchecks array items", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-lifecycle-healthchecks-optional-",
+  );
+  await writeExecutableFixtureService(servicesRoot, "optional-array-service", {
+    healthchecks: [
+      {
+        id: "process-started",
+        type: "process",
+      },
+      {
+        id: "optional-ready-file",
+        type: "file",
+        file: "./runtime/optional.txt",
+        required: false,
+        retries: 5,
+        interval: 25,
+      },
+    ],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/optional-array-service/install`);
+    await postJson(`${apiServer.url}/api/services/optional-array-service/config`);
+
+    const start = await postJson(`${apiServer.url}/api/services/optional-array-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.ok, true);
+    assert.equal(start.body.health.type, "aggregate");
+    assert.equal(start.body.health.healthy, true);
+    const optional = start.body.health.checks.find((check) => check.id === "optional-ready-file");
+    assert.equal(optional.required, false);
+    assert.equal(optional.healthy, false);
+    assert.equal(optional.attempts, 1);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("explicit HTTP healthcheck without readiness options waits with default attempts", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot(

--- a/tests/operator-data.test.js
+++ b/tests/operator-data.test.js
@@ -711,6 +711,48 @@ test("runtime-captured output variables satisfy healthchecks and API variable sc
   }
 });
 
+test("runtime-captured output variables satisfy canonical healthchecks arrays", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-outputvarregex-array-");
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "captured-variable-array-service", {
+    stdoutLines: ["Loading and starting Inputs completed. Enabled inputs: 4"],
+    outputvarregex: {
+      FILEBEAT_ENABLED_INPUTS: ".*Enabled inputs: (\\d+).*",
+    },
+    healthchecks: [
+      {
+        id: "filebeat-inputs-ready",
+        type: "variable",
+        variable: "${FILEBEAT_ENABLED_INPUTS}",
+        retries: 10,
+        interval: 25,
+      },
+    ],
+  });
+  const apiServer = await startApiServer({ port: 0, servicesRoot });
+
+  try {
+    await postJson(`${apiServer.url}/api/services/captured-variable-array-service/install`);
+    await postJson(`${apiServer.url}/api/services/captured-variable-array-service/config`);
+    const start = await postJson(`${apiServer.url}/api/services/captured-variable-array-service/start`);
+
+    assert.equal(start.status, 200);
+    assert.equal(start.body.health.type, "aggregate");
+    assert.equal(start.body.health.healthy, true);
+    assert.equal(start.body.health.checks[0].id, "filebeat-inputs-ready");
+    assert.match(start.body.health.checks[0].detail, /resolved FILEBEAT_ENABLED_INPUTS from runtime scope/i);
+
+    const persistedRuntime = JSON.parse(await readFile(path.join(serviceRoot, ".state", "runtime.json"), "utf8"));
+    assert.equal(persistedRuntime.variables.FILEBEAT_ENABLED_INPUTS.value, "4");
+
+    await postJson(`${apiServer.url}/api/services/captured-variable-array-service/stop`);
+  } finally {
+    await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("GET /api/globalenv returns the merged bounded shared env map", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-globalenv-");

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -59,6 +59,7 @@ export async function writeExecutableFixtureService(
     autoExitMs = null,
     exitCode = 0,
     healthcheck = { type: "process" },
+    healthchecks = undefined,
     readyFileAfterMs = null,
     readyFileRelativePath = "./runtime/ready.txt",
     captureEnvKeys = [],
@@ -218,7 +219,9 @@ if (Number.isFinite(autoExitMs) && autoExitMs > 0) {
     config,
     setup,
     actions,
-    healthcheck: healthcheck === null ? undefined : healthcheck,
+    ...(healthchecks === undefined
+      ? { healthcheck: healthcheck === null ? undefined : healthcheck }
+      : { healthchecks }),
   });
 
   return { serviceRoot, scriptPath };


### PR DESCRIPTION
## Issue
Closes #818

## Summary
- Adds aggregate `healthchecks[]` runtime evaluation with per-check result details.
- Adds per-check startup readiness handling for required and optional healthchecks.
- Adds UDP send/expect healthcheck support and regression coverage.
- Adds regression coverage for output-captured variables feeding canonical healthchecks arrays.
- Tightens API server shutdown cleanup for test/runtime stop paths.

## Scope
- In scope: healthchecks array evaluation/readiness and #818 regression tests.
- Out of scope: `restartPolicy`, healthcheck monitoring/recovery policy, and supervised restart behavior tracked separately.

## Spec / contract / fixture impact
- Updated runtime health result typing to expose aggregate checks.
- Updated test fixture helper to emit canonical `healthchecks[]` manifests when requested.
- No manifest contract rename or new manifest block.

## Service Lasso invariant impact
- Invariant: startup readiness continues through normal lifecycle start behavior.
- Preservation proof: lifecycle tests exercise install/config/start and assert aggregate readiness payloads; automatic startup still uses the normal API lifecycle path.

## Validation
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\cron-20260728-232944\build-after-close-helper.stdout.log`
- PASS `node --test --test-concurrency=1 --test-timeout=30000 --test-name-pattern <new health-state patterns> tests/health-state.test.js` - `C:\projects\service-lasso\.work-agent\logs\cron-20260728-232944\health-state-pattern30-summary.json`
- PASS lifecycle/operator/schema targeted patterns - `C:\projects\service-lasso\.work-agent\logs\cron-20260728-232944\targeted-pattern-validation-summary.json`
- PASS startup `npm run build` and `demo-gate` before this replacement PR - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260729T015326+1000\startup-npm-build.result.json`, `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260729T015326+1000\startup-demo-gate.result.json`
- NOTE whole-file validation with 10s per-test timeout exposed environment stop latency, not assertion failures; isolated patterns pass with 30s timeout.

## Approval trail
- Required: yes
- Evidence: Architect review requested for merge because this changes runtime health aggregation behavior and API server shutdown cleanup.

## Cleanup
- Branch pushed as `fix/818-healthchecks-regression-tests`.
- Replaces policy-failing PR #943, whose branch name lacked the required work-prefix.
- Post-merge cleanup: return local checkout to clean `develop` after PR merge and demo proof.
