### PR TITLE
#820 implement crash restart supervision

### DIFF
--- a/src/runtime/lifecycle/actions.ts
+++ b/src/runtime/lifecycle/actions.ts
@@ -1,4 +1,8 @@
-import type { DiscoveredService, ServiceActionDefinition } from "../../contracts/service.js";
+import type {
+  DiscoveredService,
+  ServiceActionDefinition,
+  ServiceRestartPolicy,
+} from "../../contracts/service.js";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { LifecycleStateError } from "../../server/errors.js";
@@ -56,12 +60,15 @@ import type {
   LifecycleAction,
   LifecycleActionResult,
   ServiceLifecycleState,
+  ServiceRuntimeSupervisionRestartReason,
   ServiceStartTraceAttempt,
   ServiceStartTraceEventStatus,
   ServiceStartTracePhase,
 } from "./types.js";
 
 const START_TRACE_HISTORY_LIMIT = 5;
+const DEFAULT_RESTART_MAX_ATTEMPTS = 3;
+const DEFAULT_RESTART_BACKOFF_SECONDS = 5;
 const SECRETSBROKER_SERVICE_ID = "@secretsbroker";
 const LAUNCH_LEASE_COMMAND_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_COMMAND";
 const LAUNCH_LEASE_ARGS_ENV = "SERVICE_LASSO_SECRETSBROKER_LAUNCH_LEASE_ARGS_JSON";
@@ -70,6 +77,26 @@ const DEFAULT_STOP_ACTION_TIMEOUT_SECONDS = 30;
 const SECRET_LIKE_VALUE_PATTERN =
   /(BEGIN PRIVATE KEY|access_token\s*[:=]\s*[^\s,;}]+|refresh_token\s*[:=]\s*[^\s,;}]+|id_token\s*[:=]\s*[^\s,;}]+|session_cookie\s*[:=]\s*[^\s,;}]+|client_secret\s*[:=]\s*[^\s,;}]+|provider_credential\s*[:=]\s*[^\s,;}]+|raw_secret\s*[:=]\s*[^\s,;}]+|password\s*[:=]\s*[^\s,;}]+|token\s*[:=]\s*[^\s,;}]+|Bearer\s+[A-Za-z0-9._~+/-]{12,})/gi;
 const SECRET_LIKE_KEY_PATTERN = /(secret|token|password|credential|private|cookie|key)/i;
+const scheduledSupervisionRestarts = new Map<string, ReturnType<typeof setTimeout>>();
+
+function createEmptySupervisionState(): ServiceLifecycleState["runtime"]["supervision"] {
+  return {
+    restartAttempts: 0,
+    lastRestartAttemptAt: null,
+    lastRestartReason: null,
+    lastRestartResult: null,
+    nextRestartAt: null,
+  };
+}
+
+export function cancelScheduledSupervisionRestart(serviceId: string): void {
+  const timer = scheduledSupervisionRestarts.get(serviceId);
+  if (!timer) {
+    return;
+  }
+  clearTimeout(timer);
+  scheduledSupervisionRestarts.delete(serviceId);
+}
 
 function calculateRunDurationMs(
   startedAt: string | null,
@@ -198,6 +225,10 @@ export interface ServiceLifecycleActionOptions {
   brokerLookup?: BrokerLaunchLookup;
   workspaceRoot?: string;
   runtimeInstanceId?: string | null;
+  supervisionRestart?: {
+    reason: ServiceRuntimeSupervisionRestartReason;
+    attemptNumber: number;
+  };
 }
 
 function isUsablePort(value: unknown): value is number {
@@ -465,9 +496,21 @@ async function resolveLaunchVariableResolution(
   );
 }
 
+function classifyUnexpectedTermination(
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+): "exited" | "crashed" {
+  if (signal) {
+    return "crashed";
+  }
+
+  return (exitCode ?? 0) === 0 ? "exited" : "crashed";
+}
+
 async function persistProcessExit(
   service: DiscoveredService,
   exitCode: number | null,
+  signal: NodeJS.Signals | null = null,
 ): Promise<void> {
   const finishedAt = new Date().toISOString();
   const revokedIdentities = revokeServiceScopedBrokerIdentities(
@@ -477,12 +520,10 @@ async function persistProcessExit(
   const revokedIdentity =
     revokedIdentities.at(-1) ??
     getLifecycleState(service.manifest.id).runtime.brokerIdentity;
-  const termination =
-    (exitCode ??
-      getLifecycleState(service.manifest.id).runtime.exitCode ??
-      0) === 0
-      ? "exited"
-      : "crashed";
+  const termination = classifyUnexpectedTermination(
+    exitCode ?? getLifecycleState(service.manifest.id).runtime.exitCode,
+    signal,
+  );
   const state = updateRuntimeState(service.manifest.id, (current) => ({
     ...current,
     running: false,
@@ -498,6 +539,200 @@ async function persistProcessExit(
   }));
 
   await writeServiceState(service, state);
+}
+
+function resolveRestartMaxAttempts(policy: ServiceRestartPolicy): number {
+  return policy.maxAttempts ?? DEFAULT_RESTART_MAX_ATTEMPTS;
+}
+
+function resolveRestartBackoffSeconds(policy: ServiceRestartPolicy): number {
+  return policy.backoffSeconds ?? DEFAULT_RESTART_BACKOFF_SECONDS;
+}
+
+function restartPolicyAllowsCrash(policy: ServiceRestartPolicy): boolean {
+  return policy.enabled === true && policy.onCrash !== false;
+}
+
+async function recordSupervisionDecision(
+  service: DiscoveredService,
+  nextSupervision: ServiceLifecycleState["runtime"]["supervision"],
+  message: string,
+  ok: boolean,
+): Promise<void> {
+  const state = updateRuntimeState(service.manifest.id, (current) => ({
+    ...current,
+    runtime: {
+      ...current.runtime,
+      supervision: nextSupervision,
+    },
+  }));
+  await writeServiceState(service, state);
+  await appendServiceRecoveryHistoryEvents(service, [
+    {
+      kind: "restart",
+      serviceId: service.manifest.id,
+      ok,
+      message,
+      at: new Date().toISOString(),
+    },
+  ]);
+}
+
+async function blockSupervisionRestart(
+  service: DiscoveredService,
+  reason: ServiceRuntimeSupervisionRestartReason,
+  message: string,
+): Promise<void> {
+  const current = getLifecycleState(service.manifest.id);
+  await recordSupervisionDecision(
+    service,
+    {
+      ...current.runtime.supervision,
+      lastRestartReason: reason,
+      lastRestartResult: "blocked",
+      nextRestartAt: null,
+    },
+    message,
+    false,
+  );
+}
+
+async function runScheduledSupervisionRestart(
+  service: DiscoveredService,
+  registry: ServiceRegistry | undefined,
+  options: ServiceLifecycleActionOptions,
+  reason: ServiceRuntimeSupervisionRestartReason,
+  attemptNumber: number,
+): Promise<void> {
+  const serviceId = service.manifest.id;
+  scheduledSupervisionRestarts.delete(serviceId);
+  const targetService = registry?.getById(serviceId) ?? service;
+  const current = getLifecycleState(serviceId);
+
+  if (registry && !registry.getById(serviceId)) {
+    await blockSupervisionRestart(service, reason, `Automatic restart blocked for "${serviceId}" because it is no longer present in the registry.`);
+    return;
+  }
+  if (targetService.manifest.enabled === false) {
+    await blockSupervisionRestart(targetService, reason, `Automatic restart blocked for "${serviceId}" because the service is disabled.`);
+    return;
+  }
+  if (!current.installed || !current.configured) {
+    await blockSupervisionRestart(targetService, reason, `Automatic restart blocked for "${serviceId}" because it is not installed and configured.`);
+    return;
+  }
+  if (current.running) {
+    await blockSupervisionRestart(targetService, reason, `Automatic restart blocked for "${serviceId}" because it is already running.`);
+    return;
+  }
+
+  try {
+    const result = await startService(targetService, registry, {
+      ...options,
+      supervisionRestart: { reason, attemptNumber },
+    });
+    await writeServiceState(targetService, result.state);
+    await recordSupervisionDecision(
+      targetService,
+      {
+        ...result.state.runtime.supervision,
+        restartAttempts: result.ok ? 0 : attemptNumber,
+        lastRestartAttemptAt: new Date().toISOString(),
+        lastRestartReason: reason,
+        lastRestartResult: result.ok ? "started" : "failed",
+        nextRestartAt: null,
+      },
+      result.ok
+        ? `Automatic restart started "${serviceId}" after ${reason}.`
+        : `Automatic restart failed for "${serviceId}": ${result.message}`,
+      result.ok,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const failedState = getLifecycleState(serviceId);
+    await recordSupervisionDecision(
+      targetService,
+      {
+        ...failedState.runtime.supervision,
+        restartAttempts: attemptNumber,
+        lastRestartAttemptAt: new Date().toISOString(),
+        lastRestartReason: reason,
+        lastRestartResult: "failed",
+        nextRestartAt: null,
+      },
+      `Automatic restart failed for "${serviceId}": ${message}`,
+      false,
+    );
+  }
+}
+
+async function superviseUnexpectedProcessExit(
+  service: DiscoveredService,
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+  registry: ServiceRegistry | undefined,
+  options: ServiceLifecycleActionOptions,
+): Promise<void> {
+  await persistProcessExit(service, exitCode, signal);
+
+  const serviceId = service.manifest.id;
+  const termination = classifyUnexpectedTermination(exitCode, signal);
+  const reason: ServiceRuntimeSupervisionRestartReason = "crash";
+  const policy = service.manifest.restartPolicy;
+
+  if (!policy || policy.enabled !== true) {
+    await blockSupervisionRestart(service, reason, `Automatic restart skipped for "${serviceId}" because restartPolicy is not enabled.`);
+    return;
+  }
+  if (service.manifest.enabled === false) {
+    await blockSupervisionRestart(service, reason, `Automatic restart blocked for "${serviceId}" because the service is disabled.`);
+    return;
+  }
+  if (termination !== "crashed") {
+    await blockSupervisionRestart(service, reason, `Automatic restart skipped for "${serviceId}" because the unexpected exit was clean.`);
+    return;
+  }
+  if (!restartPolicyAllowsCrash(policy)) {
+    await blockSupervisionRestart(service, reason, `Automatic restart skipped for "${serviceId}" because restartPolicy.onCrash is disabled.`);
+    return;
+  }
+
+  const current = getLifecycleState(serviceId);
+  if (!current.installed || !current.configured) {
+    await blockSupervisionRestart(service, reason, `Automatic restart blocked for "${serviceId}" because it is not installed and configured.`);
+    return;
+  }
+
+  const maxAttempts = resolveRestartMaxAttempts(policy);
+  const attemptNumber = current.runtime.supervision.restartAttempts + 1;
+  if (attemptNumber > maxAttempts) {
+    await blockSupervisionRestart(service, reason, `Automatic restart blocked for "${serviceId}" because maxAttempts was reached.`);
+    return;
+  }
+
+  const now = new Date();
+  const backoffSeconds = resolveRestartBackoffSeconds(policy);
+  const nextRestartAt = new Date(now.getTime() + backoffSeconds * 1000).toISOString();
+  cancelScheduledSupervisionRestart(serviceId);
+  await recordSupervisionDecision(
+    service,
+    {
+      ...current.runtime.supervision,
+      restartAttempts: attemptNumber,
+      lastRestartAttemptAt: now.toISOString(),
+      lastRestartReason: reason,
+      lastRestartResult: "scheduled",
+      nextRestartAt,
+    },
+    `Automatic restart scheduled for "${serviceId}" after ${reason} (attempt ${attemptNumber} of ${maxAttempts}).`,
+    true,
+  );
+
+  const timer = setTimeout(() => {
+    void runScheduledSupervisionRestart(service, registry, options, reason, attemptNumber);
+  }, backoffSeconds * 1000);
+  timer.unref?.();
+  scheduledSupervisionRestarts.set(serviceId, timer);
 }
 
 function resolveExecutionPlanForLifecycle(
@@ -771,6 +1006,9 @@ export async function startService(
   options: ServiceLifecycleActionOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
+  if (!options.supervisionRestart) {
+    cancelScheduledSupervisionRestart(serviceId);
+  }
   const trace = beginStartTrace(serviceId, "start");
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
@@ -990,11 +1228,11 @@ export async function startService(
       workspaceRoot: options.workspaceRoot,
       runtimeInstanceId: options.runtimeInstanceId,
       allocationRevision,
-      onExit: async ({ exitCode, wasStopping }) => {
+      onExit: async ({ exitCode, signal, wasStopping }) => {
         if (wasStopping) {
           return;
         }
-        await persistProcessExit(service, exitCode);
+        await superviseUnexpectedProcessExit(service, exitCode, signal, registry, options);
       },
     });
   } catch (error) {
@@ -1114,6 +1352,9 @@ export async function startService(
         providerServiceId: executionPlan.providerServiceId,
         lastTermination: processStillManaged ? null : state.runtime.lastTermination,
         brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
+        supervision: options.supervisionRestart
+          ? state.runtime.supervision
+          : createEmptySupervisionState(),
       },
     },
     message: readiness.message,
@@ -1126,6 +1367,7 @@ export async function stopService(
   service: DiscoveredService,
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
+  cancelScheduledSupervisionRestart(serviceId);
   const current = getLifecycleState(serviceId);
   if (!current.running) {
     throw new LifecycleStateError(
@@ -1165,6 +1407,7 @@ export async function restartService(
   options: ServiceLifecycleActionOptions = {},
 ): Promise<LifecycleActionResult> {
   const serviceId = service.manifest.id;
+  cancelScheduledSupervisionRestart(serviceId);
   const current = getLifecycleState(serviceId);
   if (!current.installed) {
     throw new LifecycleStateError(
@@ -1231,11 +1474,11 @@ export async function restartService(
     workspaceRoot: options.workspaceRoot,
     runtimeInstanceId: options.runtimeInstanceId,
     allocationRevision,
-    onExit: async ({ exitCode, wasStopping }) => {
+    onExit: async ({ exitCode, signal, wasStopping }) => {
       if (wasStopping) {
         return;
       }
-      await persistProcessExit(service, exitCode);
+      await superviseUnexpectedProcessExit(service, exitCode, signal, registry, options);
     },
   });
 
@@ -1327,6 +1570,7 @@ export async function restartService(
         providerServiceId: executionPlan.providerServiceId,
         lastTermination: null,
         brokerIdentity: scopedBrokerIdentity?.metadata ?? null,
+        supervision: createEmptySupervisionState(),
       },
     },
     message: readiness.message.replace(/^Start/, "Restart"),

--- a/src/runtime/lifecycle/store.ts
+++ b/src/runtime/lifecycle/store.ts
@@ -2,6 +2,16 @@ import type { ServiceLifecycleState } from "./types.js";
 
 const lifecycleState = new Map<string, ServiceLifecycleState>();
 
+function createInitialSupervisionState(): ServiceLifecycleState["runtime"]["supervision"] {
+  return {
+    restartAttempts: 0,
+    lastRestartAttemptAt: null,
+    lastRestartReason: null,
+    lastRestartResult: null,
+    nextRestartAt: null,
+  };
+}
+
 function cloneBrokerIdentity(identity: ServiceLifecycleState["runtime"]["brokerIdentity"]): ServiceLifecycleState["runtime"]["brokerIdentity"] {
   if (!identity) {
     return null;
@@ -111,6 +121,7 @@ function createInitialState(): ServiceLifecycleState {
         current: null,
         history: [],
       },
+      supervision: createInitialSupervisionState(),
     },
   };
 }
@@ -203,6 +214,9 @@ export function getLifecycleState(serviceId: string): ServiceLifecycleState {
       ),
       brokerIdentity: cloneBrokerIdentity(current.runtime.brokerIdentity),
       startTrace: cloneStartTrace(current.runtime.startTrace),
+      supervision: current.runtime.supervision
+        ? { ...current.runtime.supervision }
+        : createInitialSupervisionState(),
     },
   };
 }
@@ -289,6 +303,9 @@ export function setLifecycleState(serviceId: string, nextState: ServiceLifecycle
       ),
       brokerIdentity: cloneBrokerIdentity(nextState.runtime.brokerIdentity),
       startTrace: cloneStartTrace(nextState.runtime.startTrace),
+      supervision: nextState.runtime.supervision
+        ? { ...nextState.runtime.supervision }
+        : createInitialSupervisionState(),
     },
   };
 

--- a/src/runtime/lifecycle/types.ts
+++ b/src/runtime/lifecycle/types.ts
@@ -115,6 +115,17 @@ export interface ServiceRuntimeVariableState {
   matchedAt: string;
 }
 
+export type ServiceRuntimeSupervisionRestartReason = "crash" | "unhealthy";
+export type ServiceRuntimeSupervisionRestartResult = "scheduled" | "started" | "failed" | "blocked";
+
+export interface ServiceRuntimeSupervisionState {
+  restartAttempts: number;
+  lastRestartAttemptAt: string | null;
+  lastRestartReason: ServiceRuntimeSupervisionRestartReason | null;
+  lastRestartResult: ServiceRuntimeSupervisionRestartResult | null;
+  nextRestartAt: string | null;
+}
+
 export interface ServiceRuntimeState {
   pid: number | null;
   startedAt: string | null;
@@ -136,6 +147,7 @@ export interface ServiceRuntimeState {
   variables: Record<string, ServiceRuntimeVariableState>;
   brokerIdentity: ScopedBrokerIdentityMetadata | null;
   startTrace: ServiceStartTraceState;
+  supervision: ServiceRuntimeSupervisionState;
 }
 
 export interface ServiceLifecycleState {

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -90,6 +90,7 @@ interface StoredRuntimeState {
   variables?: unknown;
   brokerIdentity?: ServiceLifecycleState["runtime"]["brokerIdentity"];
   startTrace?: unknown;
+  supervision?: unknown;
   lastAction?: LifecycleAction | null;
   actionHistory?: LifecycleAction[];
 }
@@ -317,6 +318,39 @@ function parseRuntimeVariables(value: unknown): ServiceLifecycleState["runtime"]
   );
 }
 
+function parseSupervisionState(value: unknown): ServiceLifecycleState["runtime"]["supervision"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {
+      restartAttempts: 0,
+      lastRestartAttemptAt: null,
+      lastRestartReason: null,
+      lastRestartResult: null,
+      nextRestartAt: null,
+    };
+  }
+
+  const record = value as Partial<ServiceLifecycleState["runtime"]["supervision"]>;
+  return {
+    restartAttempts:
+      typeof record.restartAttempts === "number" && Number.isInteger(record.restartAttempts) && record.restartAttempts > 0
+        ? record.restartAttempts
+        : 0,
+    lastRestartAttemptAt: typeof record.lastRestartAttemptAt === "string" ? record.lastRestartAttemptAt : null,
+    lastRestartReason:
+      record.lastRestartReason === "crash" || record.lastRestartReason === "unhealthy"
+        ? record.lastRestartReason
+        : null,
+    lastRestartResult:
+      record.lastRestartResult === "scheduled" ||
+      record.lastRestartResult === "started" ||
+      record.lastRestartResult === "failed" ||
+      record.lastRestartResult === "blocked"
+        ? record.lastRestartResult
+        : null,
+    nextRestartAt: typeof record.nextRestartAt === "string" ? record.nextRestartAt : null,
+  };
+}
+
 function parseSetupRun(value: unknown): ServiceSetupStepRunState | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -520,6 +554,7 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
       variables: parseRuntimeVariables(runtime?.variables),
       brokerIdentity: parseBrokerIdentity(runtime?.brokerIdentity),
       startTrace: parseStartTraceState(runtime?.startTrace),
+      supervision: parseSupervisionState(runtime?.supervision),
     },
   };
 }

--- a/src/runtime/state/writeState.ts
+++ b/src/runtime/state/writeState.ts
@@ -88,6 +88,7 @@ export async function writeServiceState(
           variables: lifecycle.runtime.variables,
           brokerIdentity: lifecycle.runtime.brokerIdentity,
           startTrace: lifecycle.runtime.startTrace,
+          supervision: lifecycle.runtime.supervision,
           lastAction: lifecycle.lastAction,
           actionHistory: lifecycle.actionHistory,
         },

--- a/tests/lifecycle-actions.test.js
+++ b/tests/lifecycle-actions.test.js
@@ -11,6 +11,7 @@ import {
   configService,
   startService,
   stopService,
+  cancelScheduledSupervisionRestart,
 } from "../dist/runtime/lifecycle/actions.js";
 import {
   hasManagedProcess,
@@ -52,6 +53,54 @@ async function waitFor(predicate, timeoutMs = 1_000) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function writeCrashOnceService(servicesRoot, serviceId, restartPolicy) {
+  const serviceRoot = path.join(servicesRoot, serviceId);
+  const runtimeRoot = path.join(serviceRoot, "runtime");
+  await mkdir(runtimeRoot, { recursive: true });
+  await writeFile(
+    path.join(runtimeRoot, "crash-once.mjs"),
+    `
+import { access, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const runtimeRoot = path.resolve(process.cwd(), "runtime");
+const markerPath = path.join(runtimeRoot, "crashed-once.txt");
+const readyPath = path.join(runtimeRoot, "ready.txt");
+await mkdir(runtimeRoot, { recursive: true });
+
+try {
+  await access(markerPath);
+  setTimeout(() => {
+    void writeFile(readyPath, "ready");
+  }, 60);
+  setInterval(() => {}, 1000);
+} catch {
+  await writeFile(readyPath, "ready");
+  await writeFile(markerPath, "yes");
+  setTimeout(() => {
+    void rm(readyPath, { force: true }).finally(() => process.exit(7));
+  }, 50);
+}
+`.trim(),
+  );
+  await writeManifest(servicesRoot, serviceId, {
+    id: serviceId,
+    name: serviceId,
+    description: "Fixture that crashes once before staying up.",
+    executable: process.execPath,
+    args: ["runtime/crash-once.mjs"],
+    restartPolicy,
+    healthcheck: {
+      type: "file",
+      file: "./runtime/ready.txt",
+      retries: 10,
+      interval: 20,
+      start_period: 0,
+    },
+  });
+  return { serviceRoot };
 }
 
 test("lifecycle actions execute in the expected bounded order", async () => {
@@ -658,6 +707,304 @@ test("start waits for configured readiness and returns healthy once ready", asyn
     assert.ok(elapsedMs >= 75);
   } finally {
     await apiServer.stop();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("unexpected crash without restartPolicy records no automatic restart", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-no-policy-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "no-policy-crash", {
+    autoExitMs: 30,
+    exitCode: 7,
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.running === false;
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.lastTermination, "crashed");
+    assert.equal(stored.runtime.supervision.lastRestartResult, "blocked");
+    assert.equal(stored.runtime.supervision.restartAttempts, 0);
+    assert.equal(hasManagedProcess("no-policy-crash"), false);
+  } finally {
+    await stopManagedProcess("no-policy-crash", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("disabled restartPolicy records no automatic restart after crash", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-disabled-policy-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "disabled-policy-crash", {
+    autoExitMs: 30,
+    exitCode: 7,
+    restartPolicy: {
+      enabled: false,
+      onCrash: true,
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.running === false;
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.lastTermination, "crashed");
+    assert.equal(stored.runtime.supervision.lastRestartResult, "blocked");
+    assert.equal(stored.runtime.supervision.restartAttempts, 0);
+  } finally {
+    await stopManagedProcess("disabled-policy-crash", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("enabled crash restart policy starts service again through readiness", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-crash-restart-",
+  );
+  const { serviceRoot } = await writeCrashOnceService(servicesRoot, "crash-once-service", {
+    enabled: true,
+    onCrash: true,
+    maxAttempts: 2,
+    backoffSeconds: 0,
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    const firstStart = await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return (
+        stored.runtime?.running === true &&
+        stored.runtime?.metrics?.launchCount >= 2 &&
+        stored.runtime?.supervision?.lastRestartResult === "started"
+      );
+    }, 2_000);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(firstStart.ok, true);
+    assert.equal(stored.runtime.running, true);
+    assert.notEqual(stored.runtime.pid, firstStart.state.runtime.pid);
+    assert.equal(stored.runtime.supervision.restartAttempts, 0);
+    assert.equal(stored.runtime.supervision.lastRestartReason, "crash");
+    assert.equal(stored.runtime.supervision.nextRestartAt, null);
+    assert.equal(
+      stored.runtime.startTrace.current.events.some(
+        (event) => event.phase === "health_check" && event.status === "completed",
+      ),
+      true,
+    );
+  } finally {
+    await stopManagedProcess("crash-once-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("manual stop does not trigger automatic restart", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-manual-stop-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "manual-stop-service", {
+    restartPolicy: {
+      enabled: true,
+      onCrash: true,
+      backoffSeconds: 0,
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+    const stop = await stopService(service);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    assert.equal(stop.state.running, false);
+    assert.equal(stop.state.runtime.lastTermination, "stopped");
+    assert.equal(stop.state.runtime.metrics.launchCount, 1);
+    assert.equal(stop.state.runtime.supervision.lastRestartResult, null);
+  } finally {
+    await stopManagedProcess("manual-stop-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("clean unexpected exit does not restart under crash policy", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-clean-exit-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "clean-exit-service", {
+    autoExitMs: 30,
+    exitCode: 0,
+    restartPolicy: {
+      enabled: true,
+      onCrash: true,
+      backoffSeconds: 0,
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.running === false;
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.lastTermination, "exited");
+    assert.equal(stored.runtime.supervision.lastRestartResult, "blocked");
+    assert.equal(stored.runtime.metrics.launchCount, 1);
+  } finally {
+    await stopManagedProcess("clean-exit-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("maxAttempts blocks crash restart attempts at the configured limit", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-max-attempts-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "max-attempts-service", {
+    autoExitMs: 30,
+    exitCode: 7,
+    restartPolicy: {
+      enabled: true,
+      onCrash: true,
+      maxAttempts: 0,
+      backoffSeconds: 0,
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.supervision?.lastRestartResult === "blocked";
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, false);
+    assert.equal(stored.runtime.supervision.restartAttempts, 0);
+    assert.equal(stored.runtime.metrics.launchCount, 1);
+  } finally {
+    await stopManagedProcess("max-attempts-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("backoff records the next restart time before launching again", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-backoff-",
+  );
+  const { serviceRoot } = await writeCrashOnceService(servicesRoot, "backoff-service", {
+    enabled: true,
+    onCrash: true,
+    maxAttempts: 1,
+    backoffSeconds: 1,
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.supervision?.lastRestartResult === "scheduled";
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, false);
+    assert.equal(stored.runtime.metrics.launchCount, 1);
+    assert.equal(stored.runtime.supervision.restartAttempts, 1);
+    assert.ok(Date.parse(stored.runtime.supervision.nextRestartAt) > Date.parse(stored.runtime.supervision.lastRestartAttemptAt));
+    cancelScheduledSupervisionRestart("backoff-service");
+  } finally {
+    cancelScheduledSupervisionRestart("backoff-service");
+    await stopManagedProcess("backoff-service", 100).catch(() => null);
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("disabled service is not automatically restarted after crash", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot(
+    "service-lasso-supervision-disabled-service-",
+  );
+  const { serviceRoot } = await writeExecutableFixtureService(servicesRoot, "disabled-service-crash", {
+    enabled: false,
+    autoExitMs: 30,
+    exitCode: 7,
+    restartPolicy: {
+      enabled: true,
+      onCrash: true,
+      backoffSeconds: 0,
+    },
+  });
+
+  try {
+    const [service] = await discoverServices(servicesRoot);
+    await installService(service);
+    await configService(service);
+    await startService(service);
+
+    await waitFor(async () => {
+      const stored = await readStoredState(serviceRoot);
+      return stored.runtime?.supervision?.lastRestartResult === "blocked";
+    }, 1_500);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, false);
+    assert.equal(stored.runtime.metrics.launchCount, 1);
+    assert.equal(stored.runtime.supervision.restartAttempts, 0);
+  } finally {
+    await stopManagedProcess("disabled-service-crash", 100).catch(() => null);
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Issue
Closes #820

## Summary
- Adds persisted `runtime.supervision` state for automatic restart attempts, result, reason, and next scheduled restart time.
- Wires unexpected managed-process exits into `restartPolicy` evaluation for crash restarts.
- Schedules allowed crash restarts after fixed backoff and starts the service through the normal lifecycle start path.
- Records blocked/scheduled/started/failed restart decisions in runtime state and recovery history.
- Adds focused lifecycle regression tests for missing/disabled policy, crash restart, manual stop, clean exit, maxAttempts, backoff, readiness, and disabled services.

## Scope
- In scope: process-crash restart path for manifest `restartPolicy`.
- Out of scope: polling-based `restartPolicy.onUnhealthy` integration and any `supervision` manifest rename/migration.

## Spec / contract / fixture impact
- Updated persisted runtime state to include `runtime.supervision`.
- Added backward-compatible rehydration defaults for older runtime snapshots without supervision state.
- No new manifest block or contract rename.

## Service Lasso invariant impact
- Invariant: automatic restarts must reuse normal lifecycle start behavior.
- Preservation proof: the restart-success regression uses a file-readiness fixture and asserts the restarted process passes the normal health_check trace event.
- Manual stop remains non-restarting because the supervisor callback still honors `wasStopping`.

## Validation
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260729-023421\issue-820-build-3.stdout.log`
- PASS new supervision focused tests: `node --test --test-concurrency=1 --test-timeout=30000 --test-name-pattern "unexpected crash without restartPolicy|disabled restartPolicy|enabled crash restart policy|manual stop does not trigger automatic restart|clean unexpected exit|maxAttempts blocks|backoff records|disabled service is not automatically restarted" tests/lifecycle-actions.test.js` - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260729-023421\issue-820-supervision-tests.stdout.log`
- PASS existing restart regression with longer timeout: `node --test --test-concurrency=1 --test-timeout=60000 --test-name-pattern "^restart replaces the running process" tests/lifecycle-actions.test.js` - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260729-023421\issue-820-existing-restart-test.stdout.log`
- PASS startup demo gate before selection - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260729-023421\startup-demo-summary.json`

## Approval trail
- Required: yes
- Evidence: Architect review requested because this adds automatic process supervision behavior and persisted runtime state.

## Cleanup
- Branch pushed as `fix/820-supervised-restart-policy`.
- Post-merge cleanup: run canonical demo proof for the merged commit, close #820, and return local checkout to clean `develop` where possible.
