### PR TITLE
#821 add archive selection export API

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -207,6 +207,39 @@ export interface ServiceWorkspaceRegistryResponse {
   registry: ServiceWorkspaceRegistry;
 }
 
+export interface ServiceFileExportArchiveResponse {
+  ok: true;
+  action: "archive-selection";
+  export: {
+    contractVersion: "service-lasso.file-export-artifact.v1";
+    artifactId: string;
+    createdAt: string;
+    serviceId: string;
+    sourceId: string;
+    rootId: string;
+    selectedPaths: string[];
+    archiveFormat: "7z";
+    provider: {
+      serviceId: "@archive";
+      actionId: "archive-selection";
+      version: string | null;
+      runId: string;
+      status: "succeeded";
+    };
+    artifact: {
+      id: string;
+      fileName: string;
+      format: "7z";
+      sizeBytes: number;
+      checksum: {
+        algorithm: "sha256";
+        value: string;
+      };
+      downloadUrl: string;
+    };
+  };
+}
+
 export interface ServiceDetailResponse {
   service: ServiceSummary;
 }

--- a/src/runtime/files/archive-export.ts
+++ b/src/runtime/files/archive-export.ts
@@ -1,0 +1,287 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ServiceFileExportArchiveResponse } from "../../contracts/api.js";
+import type { DiscoveredService } from "../../contracts/service.js";
+import { ApiError } from "../../server/errors.js";
+import { runServiceAction } from "../actions/runs.js";
+import type { ServiceRegistry } from "../manager/ServiceRegistry.js";
+import { buildServiceWorkspaceRegistry, type ServiceWorkspaceRegistryEntry } from "./workspace-registry.js";
+
+const archiveProviderServiceId = "@archive";
+const archiveProviderActionId = "archive-selection";
+const artifactContractVersion = "service-lasso.file-export-artifact.v1";
+
+export interface ArchiveSelectionExportRequest {
+  actor?: string;
+  source: {
+    type: "file-selection";
+    sourceId: string;
+    serviceId: string;
+    paths: string[];
+    archiveFormat?: "7z";
+    include?: string[];
+    exclude?: string[];
+  };
+  archiveFormat?: "7z";
+}
+
+interface ResolvedSelection {
+  workspace: ServiceWorkspaceRegistryEntry;
+  selectedPaths: string[];
+  resolvedPaths: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, field: string): string {
+  const value = record[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ApiError("invalid_body", 400, `"${field}" must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function optionalStringArray(record: Record<string, unknown>, field: string): string[] | undefined {
+  const value = record[field];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)) {
+    throw new ApiError("invalid_body", 400, `"${field}" must be an array of non-empty strings when present.`);
+  }
+  return value.map((entry) => entry.trim());
+}
+
+export function parseArchiveSelectionExportRequest(input: unknown): ArchiveSelectionExportRequest {
+  if (!isRecord(input)) {
+    throw new ApiError("invalid_body", 400, "Archive export body must be a JSON object.");
+  }
+
+  if (!isRecord(input.source)) {
+    throw new ApiError("invalid_body", 400, "\"source\" must be a JSON object.");
+  }
+  if (input.source.type !== "file-selection") {
+    throw new ApiError("invalid_body", 400, "\"source.type\" must be \"file-selection\".");
+  }
+
+  const source = input.source;
+  const archiveFormat = input.archiveFormat ?? source.archiveFormat ?? "7z";
+  if (archiveFormat !== "7z") {
+    throw new ApiError("unsupported_archive_format", 400, "Only archiveFormat \"7z\" is supported.");
+  }
+
+  const paths = optionalStringArray(source, "paths");
+  if (!paths || paths.length === 0) {
+    throw new ApiError("invalid_body", 400, "\"source.paths\" must contain at least one selected path.");
+  }
+
+  return {
+    actor: typeof input.actor === "string" && input.actor.trim().length > 0 ? input.actor.trim() : undefined,
+    archiveFormat,
+    source: {
+      type: "file-selection",
+      serviceId: stringField(source, "serviceId"),
+      sourceId: stringField(source, "sourceId"),
+      paths,
+      archiveFormat,
+      include: optionalStringArray(source, "include"),
+      exclude: optionalStringArray(source, "exclude"),
+    },
+  };
+}
+
+function toPortablePath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function normalizeSelectedPath(value: string): string {
+  const portable = value.trim().replace(/\\/g, "/");
+  if (path.isAbsolute(value) || /^[A-Za-z]:\//.test(portable)) {
+    throw new ApiError("path_outside_workspace", 400, "Selected paths must be relative to the registered file source.");
+  }
+
+  const segments = portable.split("/").filter((segment) => segment.length > 0 && segment !== ".");
+  if (segments.some((segment) => segment === "..")) {
+    throw new ApiError("path_outside_workspace", 400, "Selected paths must not traverse outside the registered file source.");
+  }
+
+  return segments.length > 0 ? segments.join("/") : ".";
+}
+
+function assertInsideBoundary(rootPath: string, selectedPath: string): void {
+  const relative = path.relative(rootPath, selectedPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new ApiError("path_outside_workspace", 400, "Selected paths must stay inside the registered file source.");
+  }
+}
+
+async function resolveSelection(services: DiscoveredService[], request: ArchiveSelectionExportRequest): Promise<ResolvedSelection> {
+  const registry = buildServiceWorkspaceRegistry(services);
+  const workspace = registry.workspaces.find(
+    (entry) =>
+      entry.serviceId === request.source.serviceId &&
+      (entry.id === request.source.sourceId || entry.rootId === request.source.sourceId),
+  );
+  if (!workspace) {
+    throw new ApiError("unknown_file_source", 404, "The selected file source is not registered for that service.");
+  }
+
+  const rootPath = path.resolve(workspace.resolvedPath);
+  const selectedPaths = request.source.paths.map(normalizeSelectedPath);
+  const resolvedPaths = selectedPaths.map((selectedPath) => path.resolve(rootPath, selectedPath));
+  for (const resolvedPath of resolvedPaths) {
+    assertInsideBoundary(rootPath, resolvedPath);
+    try {
+      await stat(resolvedPath);
+    } catch (error: unknown) {
+      if (isRecord(error) && error.code === "ENOENT") {
+        throw new ApiError("selected_path_not_found", 404, "A selected path was not found inside the registered file source.");
+      }
+      throw error;
+    }
+  }
+
+  return { workspace, selectedPaths, resolvedPaths };
+}
+
+function getExportRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".service-lasso", "file-exports");
+}
+
+function getArtifactPath(workspaceRoot: string, artifactId: string, archiveFormat: "7z"): string {
+  return path.join(getExportRoot(workspaceRoot), "artifacts", `${artifactId}.${archiveFormat}`);
+}
+
+function getMetadataPath(workspaceRoot: string, artifactId: string): string {
+  return path.join(getExportRoot(workspaceRoot), `${artifactId}.json`);
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
+}
+
+export async function readArchiveExportArtifact(
+  workspaceRoot: string,
+  artifactId: string,
+): Promise<{ metadata: ServiceFileExportArchiveResponse["export"]; bytes: Buffer }> {
+  if (!/^[A-Za-z0-9_.-]+$/.test(artifactId)) {
+    throw new ApiError("invalid_artifact_id", 400, "Artifact id may only contain letters, numbers, dot, dash, and underscore.");
+  }
+
+  const parsed = JSON.parse(await readFile(getMetadataPath(workspaceRoot, artifactId), "utf8")) as ServiceFileExportArchiveResponse["export"];
+  const artifactPath = getArtifactPath(workspaceRoot, artifactId, parsed.artifact.format);
+  return {
+    metadata: parsed,
+    bytes: await readFile(artifactPath),
+  };
+}
+
+export async function createArchiveSelectionExport(input: {
+  services: DiscoveredService[];
+  registry: ServiceRegistry;
+  workspaceRoot: string;
+  request: ArchiveSelectionExportRequest;
+}): Promise<ServiceFileExportArchiveResponse> {
+  const selection = await resolveSelection(input.services, input.request);
+  const sourceService = input.registry.getById(input.request.source.serviceId);
+  if (!sourceService) {
+    throw new ApiError("unknown_service", 404, `Unknown service "${input.request.source.serviceId}".`);
+  }
+
+  const provider = input.registry.getById(archiveProviderServiceId);
+  if (!provider || provider.manifest.enabled === false) {
+    throw new ApiError("archive_provider_unavailable", 409, "Archive-backed file export requires the @archive provider to be available.");
+  }
+  if (!provider.manifest.actions?.[archiveProviderActionId]) {
+    throw new ApiError(
+      "archive_provider_action_unavailable",
+      409,
+      "Archive-backed file export requires @archive to expose the archive-selection action.",
+    );
+  }
+
+  const createdAt = new Date().toISOString();
+  const artifactId = `file-export-${createdAt.replace(/[:.]/g, "-")}-${randomUUID()}`;
+  const artifactPath = getArtifactPath(input.workspaceRoot, artifactId, input.request.archiveFormat ?? "7z");
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+
+  const actionRun = await runServiceAction(provider, input.registry, archiveProviderActionId, {
+    source: "manual",
+    actor: input.request.actor,
+    payload: {
+      contractVersion: "service-lasso.file-export-request.v1",
+      serviceId: sourceService.manifest.id,
+      sourceId: selection.workspace.id,
+      rootId: selection.workspace.rootId,
+      selectedPaths: selection.selectedPaths,
+      resolvedPaths: selection.resolvedPaths,
+      include: input.request.source.include ?? [],
+      exclude: input.request.source.exclude ?? [],
+      archiveFormat: input.request.archiveFormat ?? "7z",
+      artifact: {
+        id: artifactId,
+        path: artifactPath,
+        format: input.request.archiveFormat ?? "7z",
+      },
+    },
+  });
+
+  if (!actionRun.ok) {
+    throw new ApiError("archive_provider_failed", 502, actionRun.message);
+  }
+
+  const artifactStats = await stat(artifactPath).catch((error: unknown) => {
+    if (isRecord(error) && error.code === "ENOENT") {
+      throw new ApiError("archive_artifact_missing", 502, "The @archive provider completed without producing the expected artifact.");
+    }
+    throw error;
+  });
+  const checksum = await sha256File(artifactPath);
+  const fileName = path.basename(artifactPath);
+  const exportMetadata: ServiceFileExportArchiveResponse["export"] = {
+    contractVersion: artifactContractVersion,
+    artifactId,
+    createdAt,
+    serviceId: sourceService.manifest.id,
+    sourceId: selection.workspace.id,
+    rootId: selection.workspace.rootId,
+    selectedPaths: selection.selectedPaths,
+    archiveFormat: input.request.archiveFormat ?? "7z",
+    provider: {
+      serviceId: archiveProviderServiceId,
+      actionId: archiveProviderActionId,
+      version: provider.manifest.version ?? null,
+      runId: actionRun.run.runId,
+      status: "succeeded",
+    },
+    artifact: {
+      id: artifactId,
+      fileName,
+      format: input.request.archiveFormat ?? "7z",
+      sizeBytes: artifactStats.size,
+      checksum: {
+        algorithm: "sha256",
+        value: checksum,
+      },
+      downloadUrl: `/api/files/exports/${encodeURIComponent(artifactId)}/download`,
+    },
+  };
+
+  await mkdir(getExportRoot(input.workspaceRoot), { recursive: true });
+  await writeFile(getMetadataPath(input.workspaceRoot, artifactId), JSON.stringify({
+    ...exportMetadata,
+    internal: {
+      artifactPath,
+      sourceRoot: selection.workspace.resolvedPath,
+    },
+  }, null, 2));
+
+  return {
+    ok: true,
+    action: "archive-selection",
+    export: exportMetadata,
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -142,6 +142,11 @@ import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
 import { listServiceActionRuns, parseServiceActionRunRequest, runServiceAction } from "../runtime/actions/runs.js";
 import { buildManagedWorkflowRegistry } from "../runtime/workflows/registry.js";
 import { buildServiceWorkspaceRegistry } from "../runtime/files/workspace-registry.js";
+import {
+  createArchiveSelectionExport,
+  parseArchiveSelectionExportRequest,
+  readArchiveExportArtifact,
+} from "../runtime/files/archive-export.js";
 import { createRuntimeServiceMonitor, type RuntimeServiceMonitor } from "../runtime/recovery/monitor.js";
 import { readServiceUpdateState } from "../runtime/updates/state.js";
 import { createRuntimeUpdateScheduler, type RuntimeUpdateScheduler } from "../runtime/updates/scheduler.js";
@@ -1663,6 +1668,90 @@ async function routeRequest(
   if (request.method === "GET" && url.pathname === "/api/files/workspaces") {
     const runtimeModel = await loadRuntimeModel(config.servicesRoot);
     writeJson(response, 200, createServiceWorkspaceRegistryResponse(buildServiceWorkspaceRegistry(runtimeModel.discovered)));
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/files/archive-selection") {
+    const requestBody = await readJsonBody(request);
+    const auditActor = getAuditActor(requestBody);
+    const parsedRequest = parseArchiveSelectionExportRequest(requestBody);
+    const runtimeModel = await loadRuntimeModel(config.servicesRoot);
+    const service = runtimeModel.registry.getById(parsedRequest.source.serviceId);
+
+    try {
+      const payload = await createArchiveSelectionExport({
+        services: runtimeModel.discovered,
+        registry: runtimeModel.registry,
+        workspaceRoot: config.workspaceRoot,
+        request: parsedRequest,
+      });
+      await appendAuditEvent({
+        serviceRoot: service?.serviceRoot,
+        workspaceRoot: service ? undefined : config.workspaceRoot,
+        source: "runtime-api",
+        action: "service.file.export",
+        actor: auditActor,
+        subject: payload.export.artifactId,
+        serviceId: payload.export.serviceId,
+        method: "POST",
+        routeTemplate: "/api/files/archive-selection",
+        outcome: "success",
+        statusCode: 200,
+        summary: `Archived ${payload.export.selectedPaths.length} file selection item(s) through @archive.`,
+        relatedRevisionId: payload.export.provider.runId,
+        metadata: {
+          sourceId: payload.export.sourceId,
+          rootId: payload.export.rootId,
+          archiveFormat: payload.export.archiveFormat,
+          artifactId: payload.export.artifactId,
+          artifactFileName: payload.export.artifact.fileName,
+          artifactSizeBytes: payload.export.artifact.sizeBytes,
+          checksumAlgorithm: payload.export.artifact.checksum.algorithm,
+          providerServiceId: payload.export.provider.serviceId,
+          providerActionId: payload.export.provider.actionId,
+          providerVersion: payload.export.provider.version,
+          selectedPaths: payload.export.selectedPaths,
+        },
+      });
+      writeJson(response, 200, payload);
+    } catch (error) {
+      await appendAuditEvent({
+        serviceRoot: service?.serviceRoot,
+        workspaceRoot: service ? undefined : config.workspaceRoot,
+        source: "runtime-api",
+        action: "service.file.export",
+        actor: auditActor,
+        subject: parsedRequest.source.sourceId,
+        serviceId: parsedRequest.source.serviceId,
+        method: "POST",
+        routeTemplate: "/api/files/archive-selection",
+        outcome: "failure",
+        statusCode: getApiErrorStatusCode(error),
+        summary: "Failed to archive a selected file source through @archive.",
+        reason: getAuditFailureReason(error),
+        metadata: {
+          sourceId: parsedRequest.source.sourceId,
+          archiveFormat: parsedRequest.archiveFormat ?? "7z",
+          selectedPathCount: parsedRequest.source.paths.length,
+        },
+      });
+      throw error;
+    }
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/api/files/exports/") && url.pathname.endsWith("/download")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    if (pathParts.length !== 5) {
+      notFound(response);
+      return;
+    }
+
+    const artifact = await readArchiveExportArtifact(config.workspaceRoot, decodeURIComponent(pathParts[3] ?? ""));
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/x-7z-compressed");
+    response.setHeader("content-disposition", `attachment; filename="${artifact.metadata.artifact.fileName}"`);
+    response.end(artifact.bytes);
     return;
   }
 

--- a/tests/file-export-api.test.js
+++ b/tests/file-export-api.test.js
@@ -1,0 +1,230 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+import { makeTempServicesRoot, writeManifest } from "./test-helpers.js";
+
+async function postJson(url, body = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function getBytes(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    bytes: Buffer.from(await response.arrayBuffer()),
+  };
+}
+
+async function writeArchiveProvider(servicesRoot) {
+  const serviceRoot = await writeManifest(servicesRoot, "@archive", {
+    id: "@archive",
+    name: "Archive Provider",
+    description: "Archive provider fixture.",
+    version: "fixture-7z",
+    role: "provider",
+    enabled: true,
+    actions: {
+      "archive-selection": {
+        mode: "command",
+        command: process.execPath,
+        args: ["runtime/archive-provider.mjs"],
+        payload: {
+          inline: true,
+          required: true,
+          schema: {
+            type: "object",
+            required: ["serviceId", "sourceId", "selectedPaths", "resolvedPaths", "artifact"],
+          },
+          recordInlineFields: ["serviceId", "sourceId", "selectedPaths", "archiveFormat"],
+        },
+        timeoutSeconds: 5,
+      },
+    },
+  });
+  const runtimeRoot = path.join(serviceRoot, "runtime");
+  await mkdir(runtimeRoot, { recursive: true });
+  await writeFile(
+    path.join(runtimeRoot, "archive-provider.mjs"),
+    [
+      "import { mkdir, writeFile } from 'node:fs/promises';",
+      "import path from 'node:path';",
+      "const payload = JSON.parse(process.env.SERVICE_LASSO_ACTION_PAYLOAD ?? '{}');",
+      "await mkdir(path.dirname(payload.artifact.path), { recursive: true });",
+      "await writeFile(payload.artifact.path, JSON.stringify({",
+      "  serviceId: payload.serviceId,",
+      "  sourceId: payload.sourceId,",
+      "  selectedPaths: payload.selectedPaths,",
+      "  archiveFormat: payload.archiveFormat",
+      "}, null, 2));",
+      "console.log('archive artifact created');",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+test("POST /api/files/archive-selection delegates selected file exports to @archive and records metadata", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-file-export-");
+  const serviceRoot = await writeManifest(servicesRoot, "alpha-service", {
+    id: "alpha-service",
+    name: "Alpha Service",
+    description: "Service with exportable files.",
+    files: {
+      enabled: true,
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: ".",
+          mode: "read-write",
+        },
+      ],
+    },
+  });
+  await mkdir(path.join(serviceRoot, "runtime", "data"), { recursive: true });
+  await writeFile(path.join(serviceRoot, "runtime", "data", "example.txt"), "export me\n", "utf8");
+  await writeArchiveProvider(servicesRoot);
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+  try {
+    const result = await postJson(`${apiServer.url}/api/files/archive-selection`, {
+      actor: "service-admin-web",
+      source: {
+        type: "file-selection",
+        serviceId: "alpha-service",
+        sourceId: "workspace",
+        paths: ["runtime/data"],
+        archiveFormat: "7z",
+      },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.ok, true);
+    assert.equal(result.body.action, "archive-selection");
+    assert.equal(result.body.export.serviceId, "alpha-service");
+    assert.equal(result.body.export.sourceId, "alpha-service:workspace");
+    assert.deepEqual(result.body.export.selectedPaths, ["runtime/data"]);
+    assert.equal(result.body.export.archiveFormat, "7z");
+    assert.equal(result.body.export.provider.serviceId, "@archive");
+    assert.equal(result.body.export.provider.actionId, "archive-selection");
+    assert.equal(result.body.export.provider.version, "fixture-7z");
+    assert.equal(result.body.export.provider.status, "succeeded");
+    assert.equal(result.body.export.artifact.format, "7z");
+    assert.equal(result.body.export.artifact.fileName.endsWith(".7z"), true);
+    assert.equal(result.body.export.artifact.checksum.algorithm, "sha256");
+    assert.equal(JSON.stringify(result.body).includes(serviceRoot), false);
+
+    const download = await getBytes(`${apiServer.url}${result.body.export.artifact.downloadUrl}`);
+    assert.equal(download.status, 200);
+    assert.match(download.contentType, /application\/x-7z-compressed/);
+    assert.equal(
+      createHash("sha256").update(download.bytes).digest("hex"),
+      result.body.export.artifact.checksum.value,
+    );
+    assert.deepEqual(JSON.parse(download.bytes.toString("utf8")).selectedPaths, ["runtime/data"]);
+
+    const history = await getJson(`${apiServer.url}/api/services/%40archive/actions/archive-selection/runs`);
+    assert.equal(history.status, 200);
+    assert.equal(history.body.runs.length, 1);
+    assert.equal(history.body.runs[0].metadata.payload.inline.serviceId, "alpha-service");
+    assert.deepEqual(history.body.runs[0].metadata.payload.inline.selectedPaths, ["runtime/data"]);
+    assert.equal(JSON.stringify(history.body.runs[0].metadata.payload.inline).includes(serviceRoot), false);
+
+    const audit = await getJson(`${apiServer.url}/api/audit?serviceId=alpha-service&action=service.file.export`);
+    assert.equal(audit.status, 200);
+    assert.equal(audit.body.events.length, 1);
+    assert.equal(audit.body.events[0].outcome, "success");
+    assert.equal(audit.body.events[0].metadata.artifactId, result.body.export.artifactId);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/files/archive-selection rejects paths outside the registered file source", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-file-export-boundary-");
+  await writeManifest(servicesRoot, "alpha-service", {
+    id: "alpha-service",
+    name: "Alpha Service",
+    description: "Service with exportable files.",
+    files: {
+      enabled: true,
+      roots: [{ id: "workspace", label: "Workspace", path: ".", mode: "read-write" }],
+    },
+  });
+  await writeArchiveProvider(servicesRoot);
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+  try {
+    const result = await postJson(`${apiServer.url}/api/files/archive-selection`, {
+      source: {
+        type: "file-selection",
+        serviceId: "alpha-service",
+        sourceId: "workspace",
+        paths: ["../outside"],
+        archiveFormat: "7z",
+      },
+    });
+
+    assert.equal(result.status, 400);
+    assert.equal(result.body.error, "path_outside_workspace");
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/files/archive-selection fails clearly when @archive is unavailable", async () => {
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-file-export-provider-");
+  const serviceRoot = await writeManifest(servicesRoot, "alpha-service", {
+    id: "alpha-service",
+    name: "Alpha Service",
+    description: "Service with exportable files.",
+    files: {
+      enabled: true,
+      roots: [{ id: "workspace", label: "Workspace", path: ".", mode: "read-write" }],
+    },
+  });
+  await writeFile(path.join(serviceRoot, "example.txt"), "export me\n", "utf8");
+
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+  try {
+    const result = await postJson(`${apiServer.url}/api/files/archive-selection`, {
+      source: {
+        type: "file-selection",
+        serviceId: "alpha-service",
+        sourceId: "workspace",
+        paths: ["example.txt"],
+        archiveFormat: "7z",
+      },
+    });
+
+    assert.equal(result.status, 409);
+    assert.equal(result.body.error, "archive_provider_unavailable");
+    assert.match(result.body.message, /@archive provider/);
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Issue
Closes #821

## Summary
- Adds a narrow `POST /api/files/archive-selection` API for Files UI archive/export requests.
- Validates service file selections against the registered Files workspace registry before provider execution.
- Delegates archive creation to the `@archive` provider through the existing service action-run system; no host-tool fallback is used.
- Records artifact metadata with `.7z` format, provider/action run id, size, checksum, portable selected paths, and a download URL.
- Adds `GET /api/files/exports/:artifactId/download` for the produced artifact reference.
- Emits service-scoped audit events for success and failure.

## Scope
- In scope: core API and runtime helper for archive-backed selected file/folder export.
- Out of scope: Service Admin UI wiring, SFTP delivery adapter, and production `@archive` provider action packaging beyond the existing action-run delegation contract.

## Spec / contract / fixture impact
- Updated: `ServiceFileExportArchiveResponse` in `src/contracts/api.ts`.
- Existing reference: `docs/reference/backup-file-export-sftp.md`.
- Fixture coverage uses an enabled `@archive` provider action to prove delegation without shelling out from the API route.

## Service Lasso invariant impact
- Invariant: archive-backed exports must run through Service Lasso and the `@archive` provider rather than arbitrary host tools.
- Preservation proof: missing/unavailable provider returns `archive_provider_unavailable`, and successful export requires an `@archive` `archive-selection` action run.
- Source path safety: caller responses and action-run inline metadata carry portable selected paths, not arbitrary host source paths.

## Validation
- PASS `npm ci` in the issue worktree - `C:\projects\service-lasso\.work-agent\logs\dev-20260730T002645Z-9e9b19ce\issue-821-npm-ci.result.json`
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\dev-20260730T002645Z-9e9b19ce\issue-821-build-2.result.json`
- PASS `node --test --test-concurrency=1 tests/file-export-api.test.js` - `C:\projects\service-lasso\.work-agent\logs\dev-20260730T002645Z-9e9b19ce\issue-821-file-export-tests.result.json`
- Startup demo gate before selection passed - `C:\projects\service-lasso\.work-agent\logs\dev-20260730T002645Z-9e9b19ce\startup-demo-gate-summary.json`
- Updated-code canonical demo proof will be added after this PR is opened.

## Approval trail
- Required: yes
- Evidence: Architect review requested because this introduces a new export API contract and provider delegation path.

## Cleanup
- Branch pushed as `fix/821-archive-export-api`.
- Post-merge cleanup: run merged canonical demo proof, close #821, and return local checkout to clean `develop` where possible.
