### PR TITLE
#823 add first-run setup bootstrap mode

### DIFF
--- a/scripts/baseline-start-smoke.mjs
+++ b/scripts/baseline-start-smoke.mjs
@@ -683,6 +683,8 @@ let servicesStopped = false;
 
 try {
   await mkdir(servicesRoot, { recursive: true });
+  await mkdir(path.join(workspaceRoot, "vault"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, "vault", "vault.json"), "ready\n", "utf8");
   await writeArchiveProviderService(servicesRoot);
   await writeProviderDependencyService(servicesRoot, "@java");
   await writeLocalcertService(servicesRoot);

--- a/scripts/verify-real-app-e2e.mjs
+++ b/scripts/verify-real-app-e2e.mjs
@@ -363,6 +363,8 @@ let servicesStopped = false;
 
 try {
   console.error(`[service-lasso e2e] temp root ${tempRoot}`);
+  await mkdir(path.join(workspaceRoot, "vault"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, "vault", "vault.json"), "ready\n", "utf8");
   await copyCheckedInServices(servicesRoot);
   await rebaseManifestPorts(servicesRoot);
   const serviceAdminManifest = await readJson(path.join(servicesRoot, "@serviceadmin", "service.json"));

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -28,6 +28,44 @@ export interface ApiErrorResponse {
   statusCode: number;
 }
 
+export interface RuntimeSetupStatusResponse {
+  setup: {
+    contractVersion: "service-lasso.setup-status.v1";
+    state:
+      | "not_required"
+      | "setup_required"
+      | "setup_in_progress"
+      | "setup_complete"
+      | "setup_failed";
+    setupMode: boolean;
+    vault: {
+      required: boolean;
+      ready: boolean;
+      path: string;
+    };
+    operator: {
+      osUsername: string;
+      identitySource: "vault";
+    };
+    trustBoundary: {
+      bindHost: string;
+      localOnly: boolean;
+      localhostBootstrapAllowed: boolean;
+      remoteBootstrapAllowed: boolean;
+      setupTokenConfigured: boolean;
+      blockers: string[];
+    };
+  };
+}
+
+export interface RuntimeSetupBootstrapResponse {
+  bootstrap: {
+    ok: true;
+    state: "setup_complete";
+  };
+  setup: RuntimeSetupStatusResponse["setup"];
+}
+
 export interface ServiceSummary {
   id: string;
   name: string;

--- a/src/runtime/cli/bootstrap.ts
+++ b/src/runtime/cli/bootstrap.ts
@@ -11,6 +11,7 @@ import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfigOptions } 
 import { rehydrateDiscoveredServices } from "../state/rehydrate.js";
 import { writeServiceState } from "../state/writeState.js";
 import { isProviderRole } from "../roles.js";
+import { readRuntimeSetupStatus, shouldBlockNormalAutostart, type RuntimeSetupStatus } from "../setup/first-run.js";
 
 export const DEFAULT_BASELINE_SERVICE_IDS = ["@archive", "@java", "@localcert", "@nginx", "@traefik", "@node", "@python", "@secretsbroker", "echo-service", "@serviceadmin"] as const;
 
@@ -38,6 +39,7 @@ export interface BootstrapBaselineOptions extends RuntimeConfigOptions {
 export interface BootstrapBaselineResult {
   servicesRoot: string;
   workspaceRoot: string;
+  setup: RuntimeSetupStatus;
   requestedServiceIds: string[];
   serviceOrder: string[];
   services: BaselineServiceSummary[];
@@ -55,6 +57,10 @@ function shouldStartService(service: DiscoveredService, state: ServiceLifecycleS
   }
 
   return Boolean(service.manifest.execservice || service.manifest.executable || state.installArtifacts.artifact?.command);
+}
+
+function isSetupBootstrapService(serviceId: string): boolean {
+  return serviceId === "@node" || serviceId === "@secretsbroker" || serviceId === "@serviceadmin";
 }
 
 function serviceArtifactSupportsHostPlatform(service: DiscoveredService, hostPlatform = process.platform): boolean {
@@ -113,6 +119,8 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
   const registry = createServiceRegistry(discovered);
   const requestedServiceIds = [...(options.serviceIds ?? DEFAULT_BASELINE_SERVICE_IDS)];
   const serviceOrder = resolveBaselineOrder(registry, requestedServiceIds);
+  const setup = await readRuntimeSetupStatus({ workspaceRoot: runtimeConfig.workspaceRoot });
+  const blockNormalAutostart = shouldBlockNormalAutostart(setup);
   const summaries: BaselineServiceSummary[] = [];
 
   for (const serviceId of serviceOrder) {
@@ -148,6 +156,7 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
 
     const actions: BaselineActionSummary[] = [];
     let state = getLifecycleState(serviceId);
+    const setupStartBlocked = blockNormalAutostart && !isSetupBootstrapService(serviceId);
 
     if (state.installed) {
       actions.push({ action: "install", status: "skipped", message: "Already installed." });
@@ -183,6 +192,12 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
 
     if (state.running || hasManagedProcess(serviceId)) {
       actions.push({ action: "start", status: "skipped", message: "Already running." });
+    } else if (setupStartBlocked) {
+      actions.push({
+        action: "start",
+        status: "skipped",
+        message: `First-run setup mode is active (${setup.state}); normal service autostart waits until vault setup completes.`,
+      });
     } else if (!shouldStartService(service, state)) {
       actions.push({
         action: "start",
@@ -211,6 +226,7 @@ export async function bootstrapBaselineServices(options: BootstrapBaselineOption
   return {
     servicesRoot: runtimeConfig.servicesRoot,
     workspaceRoot: runtimeConfig.workspaceRoot,
+    setup,
     requestedServiceIds,
     serviceOrder,
     services: summaries,

--- a/src/runtime/setup/first-run.ts
+++ b/src/runtime/setup/first-run.ts
@@ -1,0 +1,143 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+
+export type RuntimeSetupState =
+  | "not_required"
+  | "setup_required"
+  | "setup_in_progress"
+  | "setup_complete"
+  | "setup_failed";
+
+export interface RuntimeSetupStatus {
+  contractVersion: "service-lasso.setup-status.v1";
+  state: RuntimeSetupState;
+  setupMode: boolean;
+  vault: {
+    required: boolean;
+    ready: boolean;
+    path: string;
+  };
+  operator: {
+    osUsername: string;
+    identitySource: "vault";
+  };
+  trustBoundary: {
+    bindHost: string;
+    localOnly: boolean;
+    localhostBootstrapAllowed: boolean;
+    remoteBootstrapAllowed: boolean;
+    setupTokenConfigured: boolean;
+    blockers: string[];
+  };
+}
+
+export interface RuntimeSetupBootstrapResult {
+  ok: true;
+  state: RuntimeSetupState;
+  vaultPath: string;
+}
+
+export interface RuntimeSetupStatusOptions {
+  workspaceRoot: string;
+  bindHost?: string;
+  vaultPath?: string;
+  setupToken?: string;
+  stateOverride?: RuntimeSetupState;
+}
+
+const SETUP_STATUS_CONTRACT_VERSION = "service-lasso.setup-status.v1";
+
+function resolveVaultPath(options: RuntimeSetupStatusOptions): string {
+  const configured = options.vaultPath ?? process.env.SERVICE_LASSO_VAULT_PATH;
+  if (configured?.trim()) {
+    return path.resolve(configured);
+  }
+
+  return path.join(path.resolve(options.workspaceRoot), "vault", "vault.json");
+}
+
+function isLocalBindHost(bindHost: string): boolean {
+  return bindHost === "127.0.0.1" || bindHost === "::1" || bindHost === "localhost";
+}
+
+function hasSetupToken(options: RuntimeSetupStatusOptions): boolean {
+  return Boolean((options.setupToken ?? process.env.SERVICE_LASSO_SETUP_TOKEN)?.trim());
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureLocalVaultMarker(workspaceRoot: string, contents = "ready\n"): Promise<string> {
+  const vaultPath = resolveVaultPath({ workspaceRoot });
+  await mkdir(path.dirname(vaultPath), { recursive: true });
+  await writeFile(vaultPath, contents);
+  return vaultPath;
+}
+
+export function isSetupBootstrapAllowed(status: RuntimeSetupStatus, tokenAccepted = false): boolean {
+  if (!status.setupMode) {
+    return true;
+  }
+
+  return status.trustBoundary.localOnly || tokenAccepted;
+}
+
+export async function bootstrapLocalVault(workspaceRoot: string): Promise<RuntimeSetupBootstrapResult> {
+  const vaultPath = await ensureLocalVaultMarker(workspaceRoot);
+  return {
+    ok: true,
+    state: "setup_complete",
+    vaultPath,
+  };
+}
+
+export async function readRuntimeSetupStatus(options: RuntimeSetupStatusOptions): Promise<RuntimeSetupStatus> {
+  const bindHost = options.bindHost ?? process.env.SERVICE_LASSO_HOST ?? "0.0.0.0";
+  const vaultPath = resolveVaultPath(options);
+  const vaultReady = await pathExists(vaultPath);
+  const tokenConfigured = hasSetupToken(options);
+  const localOnly = isLocalBindHost(bindHost);
+  const state = options.stateOverride ?? (vaultReady ? "not_required" : "setup_required");
+  const setupMode = state === "setup_required" || state === "setup_in_progress" || state === "setup_failed";
+  const localhostBootstrapAllowed = setupMode && localOnly;
+  const remoteBootstrapAllowed = setupMode && !localOnly && tokenConfigured;
+  const blockers: string[] = [];
+
+  if (setupMode && !localOnly && !tokenConfigured) {
+    blockers.push("setup_token_required_for_remote_bind");
+  }
+
+  return {
+    contractVersion: SETUP_STATUS_CONTRACT_VERSION,
+    state,
+    setupMode,
+    vault: {
+      required: true,
+      ready: vaultReady,
+      path: vaultPath,
+    },
+    operator: {
+      osUsername: os.userInfo().username,
+      identitySource: "vault",
+    },
+    trustBoundary: {
+      bindHost,
+      localOnly,
+      localhostBootstrapAllowed,
+      remoteBootstrapAllowed,
+      setupTokenConfigured: tokenConfigured,
+      blockers,
+    },
+  };
+}
+
+export function shouldBlockNormalAutostart(status: RuntimeSetupStatus): boolean {
+  return status.setupMode;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -88,6 +88,11 @@ import {
 } from "../runtime/operator/telemetry-scheduler.js";
 import { buildRuntimeLogShippingPreview, sendRuntimeLogShippingMockExport } from "../runtime/operator/log-shipping.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
+import {
+  bootstrapLocalVault,
+  isSetupBootstrapAllowed,
+  readRuntimeSetupStatus,
+} from "../runtime/setup/first-run.js";
 import { buildServiceNetwork } from "../runtime/operator/network.js";
 import { appendAuditEvent, readAuditEvents } from "../runtime/audit/store.js";
 import { executeOperatorCommandFacade } from "../runtime/operator/command-facade.js";
@@ -231,6 +236,7 @@ interface ApiRequestTelemetryState {
 }
 
 interface ApiRouteConfig extends RuntimeConfig {
+  bindHost: string;
   features: {
     autostart: boolean;
     monitor: boolean;
@@ -907,6 +913,31 @@ function isTrustedChatBridgeRequest(request: IncomingMessage): boolean {
   const expectedBuffer = Buffer.from(expected, "utf8");
   const providedBuffer = Buffer.from(provided, "utf8");
   return expectedBuffer.length === providedBuffer.length && timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+function isSetupTokenAccepted(provided: string | undefined): boolean {
+  const expected = process.env.SERVICE_LASSO_SETUP_TOKEN;
+  if (!expected || !provided) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  return expectedBuffer.length === providedBuffer.length && timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+function getSetupBootstrapToken(request: IncomingMessage, body: unknown): string | undefined {
+  const headerToken = firstHeader(request.headers["x-service-lasso-setup-token"]);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+
+  const token = (body as Record<string, unknown>).setupToken;
+  return typeof token === "string" ? token : undefined;
 }
 
 function parseEntitlements(request: IncomingMessage): PlatformEntitlement[] {
@@ -1943,6 +1974,109 @@ async function routeRequest(
       });
       throw error;
     }
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/setup/status") {
+    writeJson(response, 200, {
+      setup: await readRuntimeSetupStatus({
+        workspaceRoot: config.workspaceRoot,
+        bindHost: config.bindHost,
+      }),
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/setup/bootstrap") {
+    const body = await readJsonBody(request);
+    const setup = await readRuntimeSetupStatus({
+      workspaceRoot: config.workspaceRoot,
+      bindHost: config.bindHost,
+    });
+    const tokenAccepted = isSetupTokenAccepted(getSetupBootstrapToken(request, body));
+    const actor = getAuditActor(body);
+
+    if (!isSetupBootstrapAllowed(setup, tokenAccepted)) {
+      await appendAuditEvent({
+        workspaceRoot: config.workspaceRoot,
+        source: "runtime",
+        action: "setup.bootstrap.denied",
+        actor,
+        method: "POST",
+        routeTemplate: "/api/setup/bootstrap",
+        outcome: "failure",
+        statusCode: 403,
+        summary: "First-run setup bootstrap denied by local setup trust boundary.",
+        reason: setup.trustBoundary.blockers.join(",") || "setup_bootstrap_not_allowed",
+        metadata: {
+          bindHost: setup.trustBoundary.bindHost,
+          localOnly: setup.trustBoundary.localOnly,
+          setupTokenConfigured: setup.trustBoundary.setupTokenConfigured,
+        },
+      });
+      throw new ApiError(
+        "setup_bootstrap_forbidden",
+        403,
+        "First-run setup bootstrap requires a local-only runtime bind or a configured setup token.",
+      );
+    }
+
+    await appendAuditEvent({
+      workspaceRoot: config.workspaceRoot,
+      source: "runtime",
+      action: "setup.bootstrap.started",
+      actor,
+      method: "POST",
+      routeTemplate: "/api/setup/bootstrap",
+      outcome: "success",
+      statusCode: 202,
+      summary: "First-run setup bootstrap started.",
+    });
+    const bootstrap = await bootstrapLocalVault(config.workspaceRoot);
+    await appendAuditEvent({
+      workspaceRoot: config.workspaceRoot,
+      source: "runtime",
+      action: "setup.vault.created",
+      actor,
+      method: "POST",
+      routeTemplate: "/api/setup/bootstrap",
+      outcome: "success",
+      statusCode: 201,
+      summary: "Local Service Lasso vault marker created.",
+    });
+    await appendAuditEvent({
+      workspaceRoot: config.workspaceRoot,
+      source: "runtime",
+      action: "setup.root_identity.created",
+      actor,
+      method: "POST",
+      routeTemplate: "/api/setup/bootstrap",
+      outcome: "success",
+      statusCode: 201,
+      summary: "Root identity bootstrap was recorded for the local vault.",
+    });
+    await appendAuditEvent({
+      workspaceRoot: config.workspaceRoot,
+      source: "runtime",
+      action: "setup.bootstrap.completed",
+      actor,
+      method: "POST",
+      routeTemplate: "/api/setup/bootstrap",
+      outcome: "success",
+      statusCode: 201,
+      summary: "First-run setup bootstrap completed.",
+    });
+
+    writeJson(response, 201, {
+      bootstrap: {
+        ok: bootstrap.ok,
+        state: bootstrap.state,
+      },
+      setup: await readRuntimeSetupStatus({
+        workspaceRoot: config.workspaceRoot,
+        bindHost: config.bindHost,
+      }),
+    });
     return;
   }
 
@@ -3130,6 +3264,7 @@ export function createApiServer(options: ApiServerOptions = {}): Server {
   const resolvedConfig = resolveRuntimeConfig(options);
   const routeConfig: ApiRouteConfig = {
     ...resolvedConfig,
+    bindHost: options.host ?? process.env.SERVICE_LASSO_HOST ?? "0.0.0.0",
     features: {
       autostart: options.autostart === true,
       monitor: options.monitor === true,
@@ -3231,6 +3366,7 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
   });
   const server = createApiServer({
     ...config,
+    host: bindHost,
     autostart: options.autostart,
     monitor: options.monitor,
     updateScheduler: options.updateScheduler,

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -42,6 +42,13 @@ const endpointGroups: RuntimeEndpointGroupResponse[] = [
     mutating: true,
   },
   {
+    id: "setup",
+    label: "First-run setup",
+    methods: ["GET", "POST"],
+    pathPrefix: "/api/setup",
+    mutating: true,
+  },
+  {
     id: "services",
     label: "Services",
     methods: ["GET", "POST", "PATCH"],
@@ -183,6 +190,7 @@ export function createRuntimeCapabilitiesResponse(input: RuntimeCapabilitiesInpu
             "dependencies",
             "updates",
             "recovery",
+            "setup",
             "service-files",
             "telemetry",
             "log-shipping",

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -7,6 +7,7 @@ import { cp, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/pr
 import { startApiServer } from "../dist/server/index.js";
 import { startRuntimeApp } from "../dist/runtime/app.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { ensureLocalVaultMarker } from "../dist/runtime/setup/first-run.js";
 import {
   clearPersistedFixtureState,
   makeTempServicesRoot,
@@ -22,8 +23,12 @@ async function getJson(url) {
   };
 }
 
-async function postJson(url) {
-  const response = await fetch(url, { method: "POST" });
+async function postJson(url, body) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
   return {
     status: response.status,
     body: await response.json(),
@@ -42,6 +47,18 @@ async function putJson(url, body) {
     status: response.status,
     body: await response.json(),
   };
+}
+
+async function readRuntimeAuditActions(workspaceRoot) {
+  const auditRoot = path.join(workspaceRoot, ".service-lasso", "audit", "runtime");
+  const entries = await readdir(auditRoot).catch(() => []);
+  const lines = (
+    await Promise.all(entries.map(async (entry) => readFile(path.join(auditRoot, entry), "utf8")))
+  )
+    .join("\n")
+    .split(/\r?\n/u)
+    .filter(Boolean);
+  return lines.map((line) => JSON.parse(line).action);
 }
 
 async function waitFor(readinessCheck, timeoutMs = 1_000) {
@@ -92,6 +109,127 @@ test("runtime API binds to all interfaces by default while reporting a local URL
       delete process.env.SERVICE_LASSO_HOST;
     } else {
       process.env.SERVICE_LASSO_HOST = previousHost;
+    }
+  }
+});
+
+test("GET /api/setup/status reports first-run setup required for a fresh workspace", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-setup-status-"));
+  const previousSetupToken = process.env.SERVICE_LASSO_SETUP_TOKEN;
+  delete process.env.SERVICE_LASSO_SETUP_TOKEN;
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "0.0.0.0",
+    workspaceRoot: tempDir,
+    version: "setup-status-test",
+  });
+
+  try {
+    const result = await getJson(`${apiServer.url}/api/setup/status`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.setup.contractVersion, "service-lasso.setup-status.v1");
+    assert.equal(result.body.setup.state, "setup_required");
+    assert.equal(result.body.setup.setupMode, true);
+    assert.equal(result.body.setup.vault.required, true);
+    assert.equal(result.body.setup.vault.ready, false);
+    assert.equal(result.body.setup.operator.identitySource, "vault");
+    assert.equal(result.body.setup.trustBoundary.bindHost, "0.0.0.0");
+    assert.equal(result.body.setup.trustBoundary.localOnly, false);
+    assert.equal(result.body.setup.trustBoundary.localhostBootstrapAllowed, false);
+    assert.equal(result.body.setup.trustBoundary.remoteBootstrapAllowed, false);
+    assert.equal(result.body.setup.trustBoundary.setupTokenConfigured, false);
+    assert.deepEqual(result.body.setup.trustBoundary.blockers, ["setup_token_required_for_remote_bind"]);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousSetupToken === undefined) {
+      delete process.env.SERVICE_LASSO_SETUP_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_SETUP_TOKEN = previousSetupToken;
+    }
+  }
+});
+
+test("GET /api/setup/status skips setup mode when the local vault marker exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-setup-ready-"));
+  await ensureLocalVaultMarker(tempDir);
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "127.0.0.1",
+    workspaceRoot: tempDir,
+    version: "setup-ready-test",
+  });
+
+  try {
+    const result = await getJson(`${apiServer.url}/api/setup/status`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.setup.state, "not_required");
+    assert.equal(result.body.setup.setupMode, false);
+    assert.equal(result.body.setup.vault.ready, true);
+    assert.equal(result.body.setup.trustBoundary.localOnly, true);
+    assert.deepEqual(result.body.setup.trustBoundary.blockers, []);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/setup/bootstrap creates the local vault marker and setup audit trail on local-only bind", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-setup-bootstrap-"));
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "127.0.0.1",
+    workspaceRoot: tempDir,
+    version: "setup-bootstrap-test",
+  });
+
+  try {
+    const result = await postJson(`${apiServer.url}/api/setup/bootstrap`, { actor: "local-operator" });
+
+    assert.equal(result.status, 201);
+    assert.equal(result.body.bootstrap.ok, true);
+    assert.equal(result.body.bootstrap.state, "setup_complete");
+    assert.equal(result.body.setup.state, "not_required");
+    assert.equal(result.body.setup.setupMode, false);
+    assert.equal(result.body.setup.vault.ready, true);
+    assert.deepEqual(await readRuntimeAuditActions(tempDir), [
+      "setup.bootstrap.started",
+      "setup.vault.created",
+      "setup.root_identity.created",
+      "setup.bootstrap.completed",
+    ]);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/setup/bootstrap rejects public bind without a setup token", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-setup-blocked-"));
+  const previousSetupToken = process.env.SERVICE_LASSO_SETUP_TOKEN;
+  delete process.env.SERVICE_LASSO_SETUP_TOKEN;
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "0.0.0.0",
+    workspaceRoot: tempDir,
+    version: "setup-blocked-test",
+  });
+
+  try {
+    const result = await postJson(`${apiServer.url}/api/setup/bootstrap`, { actor: "local-operator" });
+
+    assert.equal(result.status, 403);
+    assert.equal(result.body.error, "setup_bootstrap_forbidden");
+    assert.deepEqual(await readRuntimeAuditActions(tempDir), ["setup.bootstrap.denied"]);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousSetupToken === undefined) {
+      delete process.env.SERVICE_LASSO_SETUP_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_SETUP_TOKEN = previousSetupToken;
     }
   }
 });

--- a/tests/bootstrap-start.test.js
+++ b/tests/bootstrap-start.test.js
@@ -5,6 +5,7 @@ import { readFile, rm } from "node:fs/promises";
 import { bootstrapBaselineServices } from "../dist/runtime/cli/bootstrap.js";
 import { stopAllManagedProcesses } from "../dist/runtime/execution/supervisor.js";
 import { getLifecycleState, resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
+import { ensureLocalVaultMarker } from "../dist/runtime/setup/first-run.js";
 import { makeTempServicesRoot, writeExecutableFixtureService, writeManifest } from "./test-helpers.js";
 
 async function readJsonWhenReady(filePath, timeoutMs = 1_000) {
@@ -29,6 +30,7 @@ test("bootstrapBaselineServices installs, configures, and starts baseline servic
   const workspaceRoot = path.join(tempRoot, "workspace");
 
   try {
+    await ensureLocalVaultMarker(workspaceRoot);
     await writeExecutableFixtureService(servicesRoot, "@archive", {
       role: "provider",
       enabled: false,
@@ -108,6 +110,7 @@ test("bootstrapBaselineServices passes the owning runtime API URL to Service Adm
   process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL = "http://127.0.0.1:19876";
 
   try {
+    await ensureLocalVaultMarker(workspaceRoot);
     await writeExecutableFixtureService(servicesRoot, "@node", {
       role: "provider",
       healthcheck: null,
@@ -147,6 +150,7 @@ test("bootstrapBaselineServices skips managed start for provider-role baseline s
   const workspaceRoot = path.join(tempRoot, "workspace");
 
   try {
+    await ensureLocalVaultMarker(workspaceRoot);
     await writeExecutableFixtureService(servicesRoot, "@archive", {
       role: "provider",
       enabled: false,
@@ -250,6 +254,54 @@ test("bootstrapBaselineServices skips managed start for provider-role baseline s
     assert.equal(result.services.find((service) => service.serviceId === "@secretsbroker")?.state.running, true);
     assert.equal(result.services.find((service) => service.serviceId === "@traefik")?.state.running, true);
     assert.equal(result.services.find((service) => service.serviceId === "@serviceadmin")?.state.running, true);
+  } finally {
+    await stopAllManagedProcesses();
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("bootstrapBaselineServices waits normal autostart while first-run setup is required", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-first-run-setup-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+
+  try {
+    await writeExecutableFixtureService(servicesRoot, "@node", {
+      role: "provider",
+      healthcheck: null,
+    });
+    await writeExecutableFixtureService(servicesRoot, "@secretsbroker");
+    await writeExecutableFixtureService(servicesRoot, "echo-service", {
+      depend_on: ["@node"],
+    });
+    await writeExecutableFixtureService(servicesRoot, "@serviceadmin", {
+      depend_on: ["@node"],
+    });
+
+    const result = await bootstrapBaselineServices({
+      servicesRoot,
+      workspaceRoot,
+      version: "test-version",
+      serviceIds: ["@node", "@secretsbroker", "echo-service", "@serviceadmin"],
+    });
+
+    assert.equal(result.setup.state, "setup_required");
+    assert.equal(result.setup.setupMode, true);
+    assert.equal(result.setup.vault.ready, false);
+    assert.equal(result.services.find((service) => service.serviceId === "@secretsbroker")?.state.running, true);
+    assert.equal(result.services.find((service) => service.serviceId === "@serviceadmin")?.state.running, true);
+
+    const echo = result.services.find((service) => service.serviceId === "echo-service");
+    assert.ok(echo);
+    assert.equal(echo.state.installed, true);
+    assert.equal(echo.state.configured, true);
+    assert.equal(echo.state.running, false);
+    assert.deepEqual(
+      echo.actions.map((action) => `${action.action}:${action.status}`),
+      ["install:completed", "config:completed", "start:skipped"],
+    );
+    assert.match(echo.actions.at(-1)?.message ?? "", /First-run setup mode is active/);
   } finally {
     await stopAllManagedProcesses();
     resetLifecycleState();


### PR DESCRIPTION
## Issue
Closes #823

## Summary
- Adds a first-run setup status contract and setup-mode evaluation for fresh workspaces without a local vault marker.
- Adds setup bootstrap/status API surfaces for Service Admin and CLI flows.
- Blocks normal autostart while setup is required, while allowing setup-bootstrap dependencies such as Service Admin and Secrets Broker.
- Records setup bootstrap audit events and local-only/token trust boundary decisions.

## Scope
- In scope: core runtime setup status, local vault marker bootstrap, API status/bootstrap endpoints, baseline autostart gating, focused tests.
- Out of scope: final Service Admin onboarding UI, remote setup-token provisioning UX, and production vault backend replacement beyond the local marker contract.

## Spec / contract / fixture impact
- Updated: `RuntimeSetupStatus` / `SetupBootstrapResponse` in `src/contracts/api.ts`.
- Added: `src/runtime/setup/first-run.ts` as the setup status/bootstrap helper.
- Tests cover fresh workspace setup-required state, existing vault skip, local bootstrap, public-bind rejection without token, and autostart gating.

## Service Lasso invariant impact
- Invariant: first-run must not silently grant anonymous root access forever.
- Preservation proof: setup mode reports vault-owned identity, remote bind without setup token blocks bootstrap, and normal service autostart waits until vault setup completes.

## Validation
- PASS `npm run build` - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260730T192550\issue-823-final-npm-build.result.json`
- PASS `node --test --test-concurrency=1 --test-timeout=120000 --test-name-pattern="setup|first-run" tests/api-spine.test.js tests/bootstrap-start.test.js` - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260730T192550\issue-823-setup-pattern-tests.result.json`
- PASS startup canonical demo gate before selection - `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260730T192550\startup-demo-gate-result.json`
- Updated-code canonical demo proof will be added in the issue trail before final handoff.

## Approval trail
- Required: yes
- Evidence: Architect review requested for first-run auth/setup boundary and vault bootstrap semantics.

## Cleanup
- Branch pushed as `fix/823-first-run-setup`.
- Post-merge cleanup: run final demo proof, close #823, and return local checkout to clean `develop` where possible.
