### PR TITLE
#824 add vault key bootstrap contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Use this short list as the public documentation map:
 - [Healthchecks Implementation Plan](reference/healthchecks-implementation-plan.md): worker-facing implementation handoff for schema, runtime, APIs, migration, and tests.
 - [Release Manifest Verification](reference/release-manifest-verification.md): read-only checks for service release manifests, platform assets, release labels, and checksums.
 - [One-shot Jobs](reference/one-shot-jobs.md): setup-step contract for schema init, sample data loading, certificate generation, and other non-daemon workloads.
+- [Vault Key Bootstrap](reference/vault-key-bootstrap.md): vault key source order, one-time reveal rules, and safe bootstrap response metadata.
 - [Audit](reference/audit.md): durable metadata-only event history, storage layout, sensitive-data rules, and tamper-evidence meaning.
 - [Process Ownership Registry](reference/process-ownership-registry.md): durable OS process identity, PID-reuse protection, atomic persistence, and safe legacy migration.
 - [Template Upgrade Compatibility](reference/template-upgrade-compatibility.md): read-only checker for app/template inventories against current core provider expectations.
@@ -53,6 +54,7 @@ Current canonical files:
 - [Healthchecks Examples](reference/healthchecks-examples.md)
 - [Healthchecks Implementation Plan](reference/healthchecks-implementation-plan.md)
 - [One-shot Jobs](reference/one-shot-jobs.md)
+- [Vault Key Bootstrap](reference/vault-key-bootstrap.md)
 - [Setup Helper Conventions](service-authoring/setup-helper-conventions.md)
 
 ## Repo boundary rule

--- a/docs/reference/vault-key-bootstrap.md
+++ b/docs/reference/vault-key-bootstrap.md
@@ -1,0 +1,60 @@
+# Vault key bootstrap
+
+This document is the implementation reference for
+[service-lasso/service-lasso#824](https://github.com/service-lasso/service-lasso/issues/824).
+
+## Purpose
+
+Fresh setup needs one durable vault key contract for local onboarding and
+headless/container deployments. The runtime may use raw key material internally
+while creating the vault, but API responses, audit events, logs, and setup state
+must expose only safe source metadata and a fingerprint.
+
+## Source order
+
+Service Lasso resolves vault key material in this order:
+
+1. OS-managed keychain provider.
+2. Mounted secret file, such as `SERVICE_LASSO_VAULT_KEY_FILE`.
+3. Environment variable, such as `SERVICE_LASSO_VAULT_KEY`.
+4. CLI parameter.
+5. Generated local setup key.
+
+CLI parameters are supported for compatibility and local scripts, but they are
+the least-preferred supplied source because process listings and shell history
+can expose command-line values.
+
+## Supplied keys
+
+When a supplied key is used before the vault exists:
+
+- create the vault with that key
+- do not reveal or echo the key through setup UI, API responses, logs, or audit
+- expose the source type and source label, such as file path or env var name
+- expose a safe SHA-256 fingerprint so the operator can compare sources
+- audit the source type and fingerprint without storing the raw key
+
+## Generated keys
+
+When no supplied key is available:
+
+- generate at least 32 random bytes
+- reveal the generated key once during local setup
+- require the operator to confirm it was saved before setup completes
+- store only safe verification metadata and the vault material needed to unlock
+  the vault
+- never re-reveal the generated key after setup completion
+
+The public bootstrap response uses `contractVersion:
+"vault-key-bootstrap.v1"`. `oneTimeReveal` is only populated for generated-key
+setup responses that explicitly request first reveal.
+
+## Runtime input names
+
+The first implementation slice reserves these runtime input names:
+
+- `SERVICE_LASSO_VAULT_KEY_FILE`: mounted file containing the vault key.
+- `SERVICE_LASSO_VAULT_KEY`: raw key material supplied by environment.
+
+Future CLI wiring should map a CLI vault-key argument into the lower-priority
+CLI source without changing the public response shape.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -103,6 +103,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/vault-key-bootstrap",
+          label: "Vault Key Bootstrap",
+        },
+        {
+          type: "doc",
           id: "reference/legacy-setup-migration",
           label: "Legacy Setup Migration",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -390,6 +390,37 @@ export interface RuntimeCapabilitiesResponse {
   };
 }
 
+export type VaultKeySourceType = "os-managed" | "file" | "env" | "cli" | "generated";
+
+export interface VaultKeyFingerprintResponse {
+  algorithm: "sha256";
+  value: string;
+  display: string;
+}
+
+export interface VaultKeySourceResponse {
+  type: VaultKeySourceType;
+  supplied: boolean;
+  reveal: "never" | "once";
+  envName?: string;
+  filePath?: string;
+  fingerprint: VaultKeyFingerprintResponse;
+}
+
+export interface VaultKeyOneTimeRevealResponse {
+  key: string;
+  confirmationRequired: true;
+  warning: string;
+}
+
+export interface VaultKeyBootstrapResponse {
+  contractVersion: "vault-key-bootstrap.v1";
+  status: "ready";
+  source: VaultKeySourceResponse;
+  oneTimeReveal: VaultKeyOneTimeRevealResponse | null;
+  warnings: string[];
+}
+
 export type OperatorCommandKind =
   | "status"
   | "services"

--- a/src/runtime/setup/vault-key.ts
+++ b/src/runtime/setup/vault-key.ts
@@ -1,0 +1,137 @@
+import { createHash, randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type {
+  VaultKeyBootstrapResponse,
+  VaultKeyFingerprintResponse,
+  VaultKeySourceResponse,
+  VaultKeySourceType,
+} from "../../contracts/api.js";
+
+export const DEFAULT_VAULT_KEY_ENV_NAME = "SERVICE_LASSO_VAULT_KEY";
+export const DEFAULT_VAULT_KEY_FILE_ENV_NAME = "SERVICE_LASSO_VAULT_KEY_FILE";
+export const DEFAULT_GENERATED_VAULT_KEY_BYTES = 32;
+
+export interface ResolveVaultKeyOptions {
+  osManagedKey?: string | null;
+  filePath?: string | null;
+  env?: NodeJS.ProcessEnv;
+  envName?: string;
+  fileEnvName?: string;
+  cliValue?: string | null;
+  allowGeneration?: boolean;
+  generatedByteLength?: number;
+}
+
+export interface ResolvedVaultKeyMaterial {
+  source: VaultKeySourceResponse;
+  keyMaterial: string;
+  generated: boolean;
+}
+
+export function fingerprintVaultKey(keyMaterial: string): VaultKeyFingerprintResponse {
+  const value = createHash("sha256").update(keyMaterial, "utf8").digest("hex");
+  return {
+    algorithm: "sha256",
+    value,
+    display: `sha256:${value.slice(0, 16)}`,
+  };
+}
+
+export async function resolveVaultKey(options: ResolveVaultKeyOptions = {}): Promise<ResolvedVaultKeyMaterial> {
+  const env = options.env ?? process.env;
+  const envName = options.envName ?? DEFAULT_VAULT_KEY_ENV_NAME;
+  const fileEnvName = options.fileEnvName ?? DEFAULT_VAULT_KEY_FILE_ENV_NAME;
+
+  const osManagedKey = readNonEmptyValue(options.osManagedKey);
+  if (osManagedKey) {
+    return resolved("os-managed", osManagedKey);
+  }
+
+  const filePath = readNonEmptyValue(options.filePath) ?? readNonEmptyValue(env[fileEnvName]);
+  if (filePath) {
+    const keyMaterial = readNonEmptyValue(stripTrailingLineBreaks(await readFile(filePath, "utf8")));
+    if (keyMaterial) {
+      return resolved("file", keyMaterial, { filePath });
+    }
+  }
+
+  const envValue = readNonEmptyValue(env[envName]);
+  if (envValue) {
+    return resolved("env", envValue, { envName });
+  }
+
+  const cliValue = readNonEmptyValue(options.cliValue);
+  if (cliValue) {
+    return resolved("cli", cliValue);
+  }
+
+  if (options.allowGeneration === false) {
+    throw new Error("Vault key is required but no configured source supplied one.");
+  }
+
+  const byteLength = options.generatedByteLength ?? DEFAULT_GENERATED_VAULT_KEY_BYTES;
+  if (!Number.isInteger(byteLength) || byteLength < 32) {
+    throw new Error("Generated vault keys must use at least 32 random bytes.");
+  }
+
+  return resolved("generated", randomBytes(byteLength).toString("base64url"));
+}
+
+export function buildVaultKeyBootstrapResponse(
+  resolution: ResolvedVaultKeyMaterial,
+  options: { revealGeneratedKey?: boolean } = {},
+): VaultKeyBootstrapResponse {
+  const revealGeneratedKey = options.revealGeneratedKey === true && resolution.generated;
+
+  return {
+    contractVersion: "vault-key-bootstrap.v1",
+    status: "ready",
+    source: {
+      ...resolution.source,
+      reveal: revealGeneratedKey ? "once" : "never",
+    },
+    oneTimeReveal: revealGeneratedKey
+      ? {
+          key: resolution.keyMaterial,
+          confirmationRequired: true,
+          warning: "Save this vault key now. Service Lasso will not reveal it again after setup completes.",
+        }
+      : null,
+    warnings: resolution.generated
+      ? ["Generated vault keys are revealed once and must be saved before setup is completed."]
+      : ["Supplied vault keys are never echoed back by setup status or bootstrap responses."],
+  };
+}
+
+function resolved(
+  sourceType: VaultKeySourceType,
+  keyMaterial: string,
+  metadata: { envName?: string; filePath?: string } = {},
+): ResolvedVaultKeyMaterial {
+  const generated = sourceType === "generated";
+
+  return {
+    keyMaterial,
+    generated,
+    source: {
+      type: sourceType,
+      supplied: !generated,
+      reveal: generated ? "once" : "never",
+      fingerprint: fingerprintVaultKey(keyMaterial),
+      ...metadata,
+    },
+  };
+}
+
+function readNonEmptyValue(value: string | null | undefined): string | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function stripTrailingLineBreaks(value: string): string {
+  return value.replace(/[\r\n]+$/u, "");
+}

--- a/tests/vault-key-bootstrap.test.js
+++ b/tests/vault-key-bootstrap.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+
+import {
+  buildVaultKeyBootstrapResponse,
+  resolveVaultKey,
+} from "../dist/runtime/setup/vault-key.js";
+
+test("vault key resolution prefers OS-managed, file, env, then CLI sources", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-vault-key-"));
+  const keyFile = path.join(tempRoot, "vault-key.txt");
+  await writeFile(keyFile, "file-key-material\n");
+
+  try {
+    const osManaged = await resolveVaultKey({
+      osManagedKey: "os-managed-key-material",
+      filePath: keyFile,
+      env: {
+        SERVICE_LASSO_VAULT_KEY: "env-key-material",
+      },
+      cliValue: "cli-key-material",
+    });
+    assert.equal(osManaged.source.type, "os-managed");
+    assert.equal(osManaged.keyMaterial, "os-managed-key-material");
+
+    const file = await resolveVaultKey({
+      filePath: keyFile,
+      env: {
+        SERVICE_LASSO_VAULT_KEY: "env-key-material",
+      },
+      cliValue: "cli-key-material",
+    });
+    assert.equal(file.source.type, "file");
+    assert.equal(file.source.filePath, keyFile);
+    assert.equal(file.keyMaterial, "file-key-material");
+
+    const env = await resolveVaultKey({
+      env: {
+        SERVICE_LASSO_VAULT_KEY: "env-key-material",
+      },
+      cliValue: "cli-key-material",
+    });
+    assert.equal(env.source.type, "env");
+    assert.equal(env.source.envName, "SERVICE_LASSO_VAULT_KEY");
+    assert.equal(env.keyMaterial, "env-key-material");
+
+    const cli = await resolveVaultKey({
+      env: {},
+      cliValue: "cli-key-material",
+    });
+    assert.equal(cli.source.type, "cli");
+    assert.equal(cli.keyMaterial, "cli-key-material");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("vault key bootstrap responses never echo supplied key material", async () => {
+  const supplied = await resolveVaultKey({
+    env: {
+      SERVICE_LASSO_VAULT_KEY: "externally-supplied-key-material",
+    },
+  });
+
+  const response = buildVaultKeyBootstrapResponse(supplied, { revealGeneratedKey: true });
+  const serialized = JSON.stringify(response);
+
+  assert.equal(response.source.type, "env");
+  assert.equal(response.source.supplied, true);
+  assert.equal(response.source.reveal, "never");
+  assert.equal(response.oneTimeReveal, null);
+  assert.match(response.source.fingerprint.display, /^sha256:[a-f0-9]{16}$/u);
+  assert.equal(serialized.includes("externally-supplied-key-material"), false);
+});
+
+test("generated vault keys require one-time reveal confirmation", async () => {
+  const generated = await resolveVaultKey({
+    env: {},
+    generatedByteLength: 32,
+  });
+
+  const response = buildVaultKeyBootstrapResponse(generated, { revealGeneratedKey: true });
+
+  assert.equal(generated.source.type, "generated");
+  assert.equal(generated.source.supplied, false);
+  assert.equal(response.source.reveal, "once");
+  assert.equal(response.oneTimeReveal?.key, generated.keyMaterial);
+  assert.equal(response.oneTimeReveal?.confirmationRequired, true);
+  assert.ok(response.warnings.some((warning) => warning.includes("revealed once")));
+});


### PR DESCRIPTION
## Issue
Closes #824

## Summary
- Adds a ault-key-bootstrap.v1 API response contract for safe vault-key setup metadata.
- Adds esolveVaultKey / uildVaultKeyBootstrapResponse helpers for OS-managed, file, env, CLI, and generated key source precedence.
- Documents one-time reveal behavior, reserved env/file input names, and supplied-key redaction rules.

## Scope
- In scope: source precedence contract, safe fingerprint metadata, one-time generated-key response shape, targeted tests, reference docs/sidebar links.
- Out of scope: wiring the helper into the pending first-run runtime/API flow from #823, OS keychain provider implementation, Service Admin UI.

## Spec / contract / fixture impact
- Updated: src/contracts/api.ts with vault key bootstrap response types.
- Added: docs/reference/vault-key-bootstrap.md as the implementation reference.
- Added: 	ests/vault-key-bootstrap.test.js covering source precedence and no echo for supplied keys.

## Service Lasso invariant impact
- Invariant: supplied or generated vault keys must not be persisted or exposed beyond the intended bootstrap boundary.
- Preservation proof: supplied-key bootstrap responses omit raw key material; generated keys require explicit one-time reveal and confirmation.

## Validation
- PASS 
pm run build - C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260731T192542\issue-824-npm-build-after-ci.log
- PASS 
ode --test --test-concurrency=1 tests/vault-key-bootstrap.test.js - C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260731T192542\issue-824-vault-key-test-after-ci.log
- Pending: canonical updated-code demo proof after branch push.

## Approval trail
- Required: yes
- Evidence: Architect review requested for vault-key source precedence, one-time reveal semantics, and fingerprint exposure.

## Cleanup
- Branch pushed as ix/824-vault-key-sources.
- Post-review cleanup: merge to develop, run final demo proof, close #824, and return local checkout to clean develop where possible.
