### PR TITLE
#825 enforce local vs remote runtime auth boundary

### DIFF
--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -55,6 +55,31 @@ export interface RuntimeSetupStatusResponse {
       setupTokenConfigured: boolean;
       blockers: string[];
     };
+    auth: RuntimeAuthStatusResponse["auth"];
+  };
+}
+
+export interface RuntimeAuthStatusResponse {
+  auth: {
+    contractVersion: "service-lasso.auth-status.v1";
+    request: {
+      clientAddress: string | null;
+      local: boolean;
+    };
+    policy: {
+      bindHost: string;
+      remoteAuthRequired: boolean;
+      trustProxyHeaders: boolean;
+      zitadelEnabled: boolean;
+      localTokenConfigured: boolean;
+    };
+    actor: {
+      authenticated: boolean;
+      kind: "local-root" | "zitadel" | "local-token" | null;
+      actorId: string | null;
+    };
+    mode: "local-root" | "zitadel" | "local-token" | "blocked";
+    blockers: string[];
   };
 }
 

--- a/src/runtime/auth/request-policy.ts
+++ b/src/runtime/auth/request-policy.ts
@@ -1,0 +1,180 @@
+import type { IncomingMessage } from "node:http";
+import { timingSafeEqual } from "node:crypto";
+
+export type RuntimeAuthActorKind = "local-root" | "zitadel" | "local-token";
+export type RuntimeAuthMode = RuntimeAuthActorKind | "blocked";
+
+export interface RuntimeAuthPolicyStatus {
+  contractVersion: "service-lasso.auth-status.v1";
+  request: {
+    clientAddress: string | null;
+    local: boolean;
+  };
+  policy: {
+    bindHost: string;
+    remoteAuthRequired: boolean;
+    trustProxyHeaders: boolean;
+    zitadelEnabled: boolean;
+    localTokenConfigured: boolean;
+  };
+  actor: {
+    authenticated: boolean;
+    kind: RuntimeAuthActorKind | null;
+    actorId: string | null;
+  };
+  mode: RuntimeAuthMode;
+  blockers: string[];
+}
+
+export interface RuntimeAuthPolicyOptions {
+  bindHost: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+const AUTH_STATUS_CONTRACT_VERSION = "service-lasso.auth-status.v1";
+
+function truthy(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function normalizeHeaderValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function extractBearerToken(value: string | undefined): string | undefined {
+  const header = normalizeHeaderValue(value);
+  if (!header) return undefined;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function isLoopbackAddress(address: string | undefined | null): boolean {
+  if (!address) return false;
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
+    normalized.startsWith("127.") ||
+    normalized.startsWith("::ffff:127.")
+  );
+}
+
+function getClientAddress(request: IncomingMessage, trustProxyHeaders: boolean): string | null {
+  if (trustProxyHeaders) {
+    const forwardedFor = normalizeHeaderValue(firstHeader(request.headers["x-forwarded-for"]));
+    if (forwardedFor) {
+      return forwardedFor.split(",")[0]?.trim() || null;
+    }
+    const forwardedAddress = normalizeHeaderValue(firstHeader(request.headers["x-service-lasso-client-address"]));
+    if (forwardedAddress) {
+      return forwardedAddress;
+    }
+  }
+
+  return request.socket.remoteAddress ?? null;
+}
+
+function resolveLocalTokenActor(
+  request: IncomingMessage,
+  expectedToken: string | undefined,
+): RuntimeAuthPolicyStatus["actor"] | null {
+  const expected = normalizeHeaderValue(expectedToken);
+  if (!expected) return null;
+
+  const provided =
+    normalizeHeaderValue(firstHeader(request.headers["x-service-lasso-admin-token"])) ??
+    extractBearerToken(firstHeader(request.headers.authorization));
+  if (!provided || !timingSafeStringEqual(expected, provided)) {
+    return null;
+  }
+
+  return {
+    authenticated: true,
+    kind: "local-token",
+    actorId: "local-admin-token",
+  };
+}
+
+function resolveZitadelActor(
+  request: IncomingMessage,
+  zitadelEnabled: boolean,
+): RuntimeAuthPolicyStatus["actor"] | null {
+  if (!zitadelEnabled) return null;
+
+  const userId =
+    normalizeHeaderValue(firstHeader(request.headers["x-service-lasso-zitadel-user-id"])) ??
+    normalizeHeaderValue(firstHeader(request.headers["x-service-lasso-user-id"]));
+  if (!userId) return null;
+
+  return {
+    authenticated: true,
+    kind: "zitadel",
+    actorId: userId,
+  };
+}
+
+export function resolveRuntimeRequestAuth(
+  request: IncomingMessage,
+  options: RuntimeAuthPolicyOptions,
+): RuntimeAuthPolicyStatus {
+  const env = options.env ?? process.env;
+  const trustProxyHeaders = truthy(env.SERVICE_LASSO_TRUST_PROXY_HEADERS);
+  const zitadelEnabled = truthy(env.SERVICE_LASSO_ZITADEL_ENABLED);
+  const localTokenConfigured = Boolean(normalizeHeaderValue(env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN));
+  const clientAddress = getClientAddress(request, trustProxyHeaders);
+  const local = isLoopbackAddress(clientAddress);
+  const remoteAuthRequired = !local;
+  const actor =
+    local
+      ? { authenticated: true, kind: "local-root" as const, actorId: "local-root" }
+      : resolveZitadelActor(request, zitadelEnabled) ??
+        resolveLocalTokenActor(request, env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN) ??
+        { authenticated: false, kind: null, actorId: null };
+  const blockers: string[] = [];
+
+  if (remoteAuthRequired && !actor.authenticated) {
+    blockers.push("remote_auth_required");
+  }
+  if (remoteAuthRequired && !zitadelEnabled && !localTokenConfigured) {
+    blockers.push("remote_auth_policy_not_configured");
+  }
+
+  return {
+    contractVersion: AUTH_STATUS_CONTRACT_VERSION,
+    request: {
+      clientAddress,
+      local,
+    },
+    policy: {
+      bindHost: options.bindHost,
+      remoteAuthRequired,
+      trustProxyHeaders,
+      zitadelEnabled,
+      localTokenConfigured,
+    },
+    actor,
+    mode: actor.kind ?? "blocked",
+    blockers,
+  };
+}
+
+export function assertRuntimeRequestAuthorized(auth: RuntimeAuthPolicyStatus): void {
+  if (!auth.policy.remoteAuthRequired || auth.actor.authenticated) {
+    return;
+  }
+
+  throw new Error(auth.blockers[0] ?? "remote_auth_required");
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -88,6 +88,7 @@ import {
 } from "../runtime/operator/telemetry-scheduler.js";
 import { buildRuntimeLogShippingPreview, sendRuntimeLogShippingMockExport } from "../runtime/operator/log-shipping.js";
 import { buildServiceVariables, collectRuntimeGlobalEnv } from "../runtime/operator/variables.js";
+import { resolveRuntimeRequestAuth, type RuntimeAuthPolicyStatus } from "../runtime/auth/request-policy.js";
 import {
   bootstrapLocalVault,
   isSetupBootstrapAllowed,
@@ -206,6 +207,7 @@ import type {
   RuntimeOrchestrationResponse,
   OperatorCommandRequest,
   AuditQuery,
+  RuntimeAuthStatusResponse,
   ServiceActionRunResponse,
   ServiceActionRunsResponse,
   ServiceDetailResponse,
@@ -430,6 +432,51 @@ function getApiErrorStatusCode(error: unknown): number {
 
 function getAuditFailureReason(error: unknown): string {
   return redactAuditText(toApiErrorBody(error).message);
+}
+
+function createRuntimeAuthResponse(auth: RuntimeAuthPolicyStatus): RuntimeAuthStatusResponse {
+  return {
+    auth,
+  };
+}
+
+function isUnauthenticatedRuntimeRoute(method: string, pathname: string): boolean {
+  if (method === "GET" && pathname === "/api/health") return true;
+  if (method === "GET" && pathname === "/api/runtime/capabilities") return true;
+  if (method === "GET" && pathname === "/api/runtime/security") return true;
+  if (method === "GET" && pathname === "/api/setup/status") return true;
+  if (method === "POST" && pathname === "/api/setup/bootstrap") return true;
+  return false;
+}
+
+async function rejectUnauthorizedRemoteRequest(
+  request: IncomingMessage,
+  config: ApiRouteConfig,
+  auth: RuntimeAuthPolicyStatus,
+): Promise<never> {
+  await appendAuditEvent({
+    workspaceRoot: config.workspaceRoot,
+    source: "runtime-api",
+    action: "auth.remote.denied",
+    actor: "remote-unauthenticated",
+    method: request.method ?? "GET",
+    routeTemplate: new URL(request.url ?? "/", "http://127.0.0.1").pathname,
+    outcome: "failure",
+    statusCode: 401,
+    summary: "Remote runtime API request denied because no accepted authentication context was present.",
+    reason: auth.blockers.join(",") || "remote_auth_required",
+    metadata: {
+      clientAddress: auth.request.clientAddress,
+      bindHost: auth.policy.bindHost,
+      zitadelEnabled: auth.policy.zitadelEnabled,
+      localTokenConfigured: auth.policy.localTokenConfigured,
+    },
+  });
+  throw new ApiError(
+    "remote_auth_required",
+    401,
+    "Remote Service Lasso API access requires Zitadel authentication or an explicit local admin token.",
+  );
 }
 
 function getOperatorActionAuditItem(queue: OperatorActionQueueState, itemId?: string | null): OperatorActionItem | null {
@@ -1621,6 +1668,11 @@ async function routeRequest(
   getTelemetryContinuousExportState: () => TelemetryContinuousExportRuntimeState | null,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const method = request.method ?? "GET";
+  const auth = resolveRuntimeRequestAuth(request, { bindHost: config.bindHost });
+  if (!isUnauthenticatedRuntimeRoute(method, url.pathname) && auth.policy.remoteAuthRequired && !auth.actor.authenticated) {
+    await rejectUnauthorizedRemoteRequest(request, config, auth);
+  }
 
   if (await routeWorkflowFacadeRequest(request, response, url, config, workflowRunFacadeState)) {
     return;
@@ -1979,10 +2031,13 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/setup/status") {
     writeJson(response, 200, {
-      setup: await readRuntimeSetupStatus({
-        workspaceRoot: config.workspaceRoot,
-        bindHost: config.bindHost,
-      }),
+      setup: {
+        ...(await readRuntimeSetupStatus({
+          workspaceRoot: config.workspaceRoot,
+          bindHost: config.bindHost,
+        })),
+        auth,
+      },
     });
     return;
   }
@@ -2072,10 +2127,13 @@ async function routeRequest(
         ok: bootstrap.ok,
         state: bootstrap.state,
       },
-      setup: await readRuntimeSetupStatus({
-        workspaceRoot: config.workspaceRoot,
-        bindHost: config.bindHost,
-      }),
+      setup: {
+        ...(await readRuntimeSetupStatus({
+          workspaceRoot: config.workspaceRoot,
+          bindHost: config.bindHost,
+        })),
+        auth,
+      },
     });
     return;
   }
@@ -2975,6 +3033,11 @@ async function routeRequest(
 
   if (request.method === "GET" && url.pathname === "/api/runtime/instance") {
     writeJson(response, 200, await createRuntimeInstanceSnapshot(config));
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/runtime/security") {
+    writeJson(response, 200, createRuntimeAuthResponse(auth));
     return;
   }
 

--- a/tests/api-spine.test.js
+++ b/tests/api-spine.test.js
@@ -23,6 +23,14 @@ async function getJson(url) {
   };
 }
 
+async function getJsonWithHeaders(url, headers) {
+  const response = await fetch(url, { headers });
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
 async function postJson(url, body) {
   const response = await fetch(url, {
     method: "POST",
@@ -140,6 +148,8 @@ test("GET /api/setup/status reports first-run setup required for a fresh workspa
     assert.equal(result.body.setup.trustBoundary.remoteBootstrapAllowed, false);
     assert.equal(result.body.setup.trustBoundary.setupTokenConfigured, false);
     assert.deepEqual(result.body.setup.trustBoundary.blockers, ["setup_token_required_for_remote_bind"]);
+    assert.equal(result.body.setup.auth.contractVersion, "service-lasso.auth-status.v1");
+    assert.equal(result.body.setup.auth.actor.kind, "local-root");
   } finally {
     await apiServer.stop();
     await rm(tempDir, { recursive: true, force: true });
@@ -230,6 +240,176 @@ test("POST /api/setup/bootstrap rejects public bind without a setup token", asyn
       delete process.env.SERVICE_LASSO_SETUP_TOKEN;
     } else {
       process.env.SERVICE_LASSO_SETUP_TOKEN = previousSetupToken;
+    }
+  }
+});
+
+test("GET /api/runtime/security resolves localhost requests as local-root", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-auth-local-"));
+  await ensureLocalVaultMarker(tempDir);
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "127.0.0.1",
+    workspaceRoot: tempDir,
+    version: "auth-local-test",
+  });
+
+  try {
+    const result = await getJson(`${apiServer.url}/api/runtime/security`);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.auth.contractVersion, "service-lasso.auth-status.v1");
+    assert.equal(result.body.auth.request.local, true);
+    assert.equal(result.body.auth.policy.remoteAuthRequired, false);
+    assert.equal(result.body.auth.actor.authenticated, true);
+    assert.equal(result.body.auth.actor.kind, "local-root");
+    assert.deepEqual(result.body.auth.blockers, []);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("remote API requests cannot inherit local-root trust without auth", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-auth-remote-denied-"));
+  await ensureLocalVaultMarker(tempDir);
+  const previousTrustProxy = process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+  const previousLocalToken = process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN;
+  const previousZitadel = process.env.SERVICE_LASSO_ZITADEL_ENABLED;
+  process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = "true";
+  delete process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN;
+  delete process.env.SERVICE_LASSO_ZITADEL_ENABLED;
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "0.0.0.0",
+    workspaceRoot: tempDir,
+    version: "auth-remote-denied-test",
+  });
+
+  try {
+    const result = await getJsonWithHeaders(`${apiServer.url}/api/services`, {
+      "x-forwarded-for": "192.168.1.20",
+    });
+
+    assert.equal(result.status, 401);
+    assert.equal(result.body.error, "remote_auth_required");
+    assert.deepEqual(await readRuntimeAuditActions(tempDir), ["auth.remote.denied"]);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousTrustProxy === undefined) {
+      delete process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+    } else {
+      process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = previousTrustProxy;
+    }
+    if (previousLocalToken === undefined) {
+      delete process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN = previousLocalToken;
+    }
+    if (previousZitadel === undefined) {
+      delete process.env.SERVICE_LASSO_ZITADEL_ENABLED;
+    } else {
+      process.env.SERVICE_LASSO_ZITADEL_ENABLED = previousZitadel;
+    }
+  }
+});
+
+test("remote API requests can authenticate with an explicit local admin token", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-auth-local-token-"));
+  await ensureLocalVaultMarker(tempDir);
+  const previousTrustProxy = process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+  const previousLocalToken = process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN;
+  process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = "true";
+  process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN = "test-local-admin-token";
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "0.0.0.0",
+    workspaceRoot: tempDir,
+    version: "auth-local-token-test",
+  });
+
+  try {
+    const result = await getJsonWithHeaders(`${apiServer.url}/api/runtime/security`, {
+      "x-forwarded-for": "192.168.1.21",
+      "x-service-lasso-admin-token": "test-local-admin-token",
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.auth.request.local, false);
+    assert.equal(result.body.auth.actor.authenticated, true);
+    assert.equal(result.body.auth.actor.kind, "local-token");
+    assert.equal(result.body.auth.policy.localTokenConfigured, true);
+    assert.deepEqual(result.body.auth.blockers, []);
+
+    const services = await getJsonWithHeaders(`${apiServer.url}/api/services`, {
+      "x-forwarded-for": "192.168.1.21",
+      "x-service-lasso-admin-token": "test-local-admin-token",
+    });
+    assert.equal(services.status, 200);
+    assert.equal(Array.isArray(services.body.services), true);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousTrustProxy === undefined) {
+      delete process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+    } else {
+      process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = previousTrustProxy;
+    }
+    if (previousLocalToken === undefined) {
+      delete process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN;
+    } else {
+      process.env.SERVICE_LASSO_LOCAL_ADMIN_TOKEN = previousLocalToken;
+    }
+  }
+});
+
+test("remote API requests can resolve a Zitadel-authenticated actor", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "service-lasso-auth-zitadel-"));
+  await ensureLocalVaultMarker(tempDir);
+  const previousTrustProxy = process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+  const previousZitadel = process.env.SERVICE_LASSO_ZITADEL_ENABLED;
+  process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = "true";
+  process.env.SERVICE_LASSO_ZITADEL_ENABLED = "true";
+  const apiServer = await startApiServer({
+    port: 0,
+    host: "0.0.0.0",
+    workspaceRoot: tempDir,
+    version: "auth-zitadel-test",
+  });
+
+  try {
+    const result = await getJsonWithHeaders(`${apiServer.url}/api/runtime/security`, {
+      "x-forwarded-for": "192.168.1.22",
+      "x-service-lasso-zitadel-user-id": "usr_zitadel_operator",
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.auth.request.local, false);
+    assert.equal(result.body.auth.actor.authenticated, true);
+    assert.equal(result.body.auth.actor.kind, "zitadel");
+    assert.equal(result.body.auth.actor.actorId, "usr_zitadel_operator");
+    assert.equal(result.body.auth.policy.zitadelEnabled, true);
+    assert.deepEqual(result.body.auth.blockers, []);
+
+    const services = await getJsonWithHeaders(`${apiServer.url}/api/services`, {
+      "x-forwarded-for": "192.168.1.22",
+      "x-service-lasso-zitadel-user-id": "usr_zitadel_operator",
+    });
+    assert.equal(services.status, 200);
+    assert.equal(Array.isArray(services.body.services), true);
+  } finally {
+    await apiServer.stop();
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousTrustProxy === undefined) {
+      delete process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS;
+    } else {
+      process.env.SERVICE_LASSO_TRUST_PROXY_HEADERS = previousTrustProxy;
+    }
+    if (previousZitadel === undefined) {
+      delete process.env.SERVICE_LASSO_ZITADEL_ENABLED;
+    } else {
+      process.env.SERVICE_LASSO_ZITADEL_ENABLED = previousZitadel;
     }
   }
 });


### PR DESCRIPTION
## Issue
Closes #825

## Summary
- Add a runtime request-auth policy that resolves localhost requests as local-root and denies unauthenticated remote API requests.
- Add `/api/runtime/security` plus setup-status auth metadata so Service Admin can display the runtime security mode without exposing token material.
- Support explicit local admin token auth and Zitadel trusted-identity headers for remote requests.
- Add API coverage for localhost, remote denial, local-token auth, and Zitadel-authenticated remote access.

## Scope
- In scope: runtime API auth boundary, request classification, contract shape, and focused API tests.
- Out of scope: full Zitadel JWT validation service integration and Service Admin UI rendering.

## Spec / Contract / Fixture Impact
- Updated: `RuntimeSetupStatusResponse` now includes `setup.auth`.
- Added: `RuntimeAuthStatusResponse` for `/api/runtime/security`.

## Service Lasso Invariant Impact
- Invariant: remote Service Lasso API access must not inherit implicit local-root trust.
- Preservation proof: unauthenticated remote requests get `remote_auth_required`; accepted remote actors must arrive through configured local-token or Zitadel identity headers.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731-200118\issue-825-npm-build-final.stdout.log`
- PASS `node --test --test-concurrency=1 --test-name-pattern='local-root|remote API|setup/status|setup/bootstrap' tests/api-spine.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731-200118\issue-825-api-spine-auth-final.stdout.log`

## Approval Trail
- Required: yes.
- Evidence: Architect review requested for the local-vs-remote auth boundary and Zitadel/local-token policy shape before merge.

## Cleanup
- Branch is clean and pushed; merge target is `develop`.
