### PR TITLE
#826 add service action permission enforcement

### DIFF
--- a/src/runtime/actions/runs.ts
+++ b/src/runtime/actions/runs.ts
@@ -59,7 +59,7 @@ export interface ServiceActionRunRequest {
   scheduleId?: string;
   stepId?: string;
   parentActionId?: string;
-  actor?: string;
+  actor?: unknown;
   params?: Record<string, unknown>;
   payload?: Record<string, unknown>;
   payloadRef?: string;
@@ -154,6 +154,22 @@ function expectOptionalString(candidate: Record<string, unknown>, field: string)
   return value.trim();
 }
 
+function getActionRunActorId(actor: unknown): string | null {
+  if (typeof actor === "string" && actor.trim().length > 0) {
+    return actor.trim();
+  }
+  if (!isRecord(actor)) {
+    return null;
+  }
+  if (typeof actor.id === "string" && actor.id.trim().length > 0) {
+    return actor.id.trim();
+  }
+  if (typeof actor.actorId === "string" && actor.actorId.trim().length > 0) {
+    return actor.actorId.trim();
+  }
+  return null;
+}
+
 export function parseServiceActionRunRequest(input: unknown): ServiceActionRunRequest {
   if (!isRecord(input)) {
     throw new ApiError("invalid_body", 400, "Action run body must be a JSON object.");
@@ -182,7 +198,7 @@ export function parseServiceActionRunRequest(input: unknown): ServiceActionRunRe
     scheduleId: expectOptionalString(input, "scheduleId") ?? undefined,
     stepId: expectOptionalString(input, "stepId") ?? undefined,
     parentActionId: expectOptionalString(input, "parentActionId") ?? undefined,
-    actor: expectOptionalString(input, "actor") ?? undefined,
+    actor: input.actor,
     params: (input.params as Record<string, unknown> | undefined) ?? {},
     payload: input.payload as Record<string, unknown> | undefined,
     payloadRef: expectOptionalString(input, "payloadRef") ?? undefined,
@@ -200,7 +216,7 @@ function buildRunMetadata(
     scheduleId: request.scheduleId ?? null,
     stepId: request.stepId ?? null,
     parentActionId: request.parentActionId ?? null,
-    actor: request.actor ?? null,
+    actor: getActionRunActorId(request.actor),
     params: request.params ?? {},
     payload,
   };

--- a/src/runtime/permissions/enforcement.ts
+++ b/src/runtime/permissions/enforcement.ts
@@ -1,0 +1,174 @@
+import { ApiError } from "../../server/errors.js";
+import { appendAuditEvent } from "../audit/store.js";
+
+export type PermissionActorType =
+  | "local-root"
+  | "zitadel-user"
+  | "local-token"
+  | "service-account"
+  | "system"
+  | "scoped-service";
+
+export interface PermissionActor {
+  type: PermissionActorType;
+  id: string;
+  permissions: string[];
+}
+
+export interface PermissionDecisionInput {
+  workspaceRoot?: string;
+  serviceRoot?: string;
+  serviceId?: string;
+  actor: unknown;
+  permission: string;
+  sensitive?: boolean;
+  confirmed?: boolean;
+  method: string;
+  routeTemplate: string;
+  subject?: string;
+}
+
+export interface PermissionDecision {
+  ok: boolean;
+  actor: PermissionActor;
+  permission: string;
+  sensitive: boolean;
+  confirmed: boolean;
+  reason: string | null;
+}
+
+const actorTypeAliases: Record<string, PermissionActorType> = {
+  localRoot: "local-root",
+  local_root: "local-root",
+  localroot: "local-root",
+  root: "local-root",
+  zitadel: "zitadel-user",
+  user: "zitadel-user",
+  localToken: "local-token",
+  local_token: "local-token",
+  service: "service-account",
+  serviceAccount: "service-account",
+  service_account: "service-account",
+  scopedService: "scoped-service",
+  scoped_service: "scoped-service",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeActorType(value: unknown): PermissionActorType | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const normalized = value.trim();
+  if (
+    normalized === "local-root" ||
+    normalized === "zitadel-user" ||
+    normalized === "local-token" ||
+    normalized === "service-account" ||
+    normalized === "system" ||
+    normalized === "scoped-service"
+  ) {
+    return normalized;
+  }
+  return actorTypeAliases[normalized] ?? null;
+}
+
+function normalizePermissionList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .map((entry) => entry.trim());
+}
+
+export function resolvePermissionActor(input: unknown): PermissionActor {
+  if (typeof input === "string" && input.trim().length > 0) {
+    const actorId = input.trim();
+    return {
+      type: "local-root",
+      id: actorId,
+      permissions: ["*"],
+    };
+  }
+
+  if (!isRecord(input)) {
+    throw new ApiError("actor_required", 401, "Durable action requests require an actor.");
+  }
+
+  const type = normalizeActorType(input.type ?? input.source);
+  const id = typeof input.id === "string" && input.id.trim()
+    ? input.id.trim()
+    : typeof input.actorId === "string" && input.actorId.trim()
+      ? input.actorId.trim()
+      : null;
+  if (!type || !id) {
+    throw new ApiError("actor_required", 401, "Durable action requests require an actor type and id.");
+  }
+
+  return {
+    type,
+    id,
+    permissions: type === "local-root" ? ["*"] : normalizePermissionList(input.permissions),
+  };
+}
+
+function actorHasPermission(actor: PermissionActor, permission: string): boolean {
+  return actor.permissions.includes("*") || actor.permissions.includes(permission);
+}
+
+export async function enforcePermission(input: PermissionDecisionInput): Promise<PermissionDecision> {
+  const actor = resolvePermissionActor(input.actor);
+  const sensitive = input.sensitive === true;
+  const confirmed = input.confirmed === true;
+  let reason: string | null = null;
+
+  if (!actorHasPermission(actor, input.permission)) {
+    reason = "permission_not_granted";
+  } else if (sensitive && !confirmed) {
+    reason = "confirmation_required";
+  }
+
+  const decision: PermissionDecision = {
+    ok: reason === null,
+    actor,
+    permission: input.permission,
+    sensitive,
+    confirmed,
+    reason,
+  };
+
+  await appendAuditEvent({
+    workspaceRoot: input.serviceRoot ? undefined : input.workspaceRoot,
+    serviceRoot: input.serviceRoot,
+    source: "runtime-api",
+    action: "permission.decision",
+    actor: actor.id,
+    subject: input.subject ?? input.permission,
+    serviceId: input.serviceId,
+    method: input.method,
+    routeTemplate: input.routeTemplate,
+    outcome: decision.ok ? "success" : "failure",
+    statusCode: decision.ok ? 200 : reason === "confirmation_required" ? 409 : 403,
+    summary: decision.ok
+      ? `Permission ${input.permission} allowed for ${actor.type}.`
+      : `Permission ${input.permission} denied for ${actor.type}.`,
+    reason,
+    metadata: {
+      actorType: actor.type,
+      permission: input.permission,
+      sensitive,
+      confirmed,
+    },
+  });
+
+  if (reason === "permission_not_granted") {
+    throw new ApiError("permission_denied", 403, `Actor "${actor.id}" is not granted "${input.permission}".`);
+  }
+  if (reason === "confirmation_required") {
+    throw new ApiError("confirmation_required", 409, `Permission "${input.permission}" requires explicit confirmation.`);
+  }
+
+  return decision;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -145,6 +145,7 @@ import { runAndRecordDoctorPreflight } from "../runtime/recovery/doctor.js";
 import { readServiceRecoveryHistory } from "../runtime/recovery/history.js";
 import { listSetupStepIds, runServiceSetup } from "../runtime/setup/steps.js";
 import { listServiceActionRuns, parseServiceActionRunRequest, runServiceAction } from "../runtime/actions/runs.js";
+import { enforcePermission } from "../runtime/permissions/enforcement.js";
 import { buildManagedWorkflowRegistry } from "../runtime/workflows/registry.js";
 import { buildServiceWorkspaceRegistry } from "../runtime/files/workspace-registry.js";
 import { createRuntimeServiceMonitor, type RuntimeServiceMonitor } from "../runtime/recovery/monitor.js";
@@ -2679,13 +2680,30 @@ async function routeRequest(
     if (request.method === "POST" && pathParts.length === 6 && pathParts[3] === "actions" && pathParts[5] === "runs") {
       const actionId = decodeURIComponent(pathParts[4] ?? "");
       const requestBody = await readJsonBody(request);
-      const auditActor = getAuditActor(requestBody);
+      const runRequest = parseServiceActionRunRequest(requestBody);
+      const actionDefinition = service.manifest.actions?.[actionId];
+      if (!actionDefinition) {
+        throw new ApiError("unknown_action", 404, `Unknown action "${actionId}" for service "${service.manifest.id}".`);
+      }
+      let auditActor = getAuditActor(requestBody);
       try {
+        const permission = await enforcePermission({
+          serviceRoot: service.serviceRoot,
+          serviceId,
+          actor: runRequest.actor,
+          permission: "service.action.run",
+          sensitive: actionDefinition.requiresConfirmation === true,
+          confirmed: runRequest.confirm,
+          method: "POST",
+          routeTemplate: "/api/services/:serviceId/actions/:actionId/runs",
+          subject: actionId,
+        });
+        auditActor = permission.actor.id;
         const payload: ServiceActionRunResponse = await runServiceAction(
           service,
           runtimeModel.registry,
           actionId,
-          parseServiceActionRunRequest(requestBody),
+          runRequest,
         );
         await appendAuditEvent({
           serviceRoot: service.serviceRoot,

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -212,6 +212,7 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.equal(recovery.status, 200);
     const action = await postJson(`${apiServer.url}/api/services/audit-service/actions/write-audit-proof/runs`, {
       source: "manual",
+      actor: "operator-ui",
     });
     assert.equal(action.status, 200);
     const missingConfirmation = await postJson(`${apiServer.url}/api/services/audit-service/actions/dangerous-audit-proof/runs`, {
@@ -263,10 +264,14 @@ test("audit API returns durable safe service and runtime mutation events after r
 
     const audit = await getJson(`${apiServer.url}/api/audit?serviceId=audit-service&limit=20`);
     assert.equal(audit.status, 200);
-    assert.equal(audit.body.pagination.total, 11);
+    assert.equal(audit.body.pagination.total, 15);
     assert.deepEqual(
       audit.body.events.map((event) => event.action).sort(),
       [
+        "permission.decision",
+        "permission.decision",
+        "permission.decision",
+        "permission.decision",
         "service.action.run",
         "service.action.run",
         "service.action.run",
@@ -327,7 +332,14 @@ test("audit API returns durable safe service and runtime mutation events after r
     assert.equal(actionEvent.outcome, "success");
     assert.equal(actionEvent.relatedRevisionId, action.body.run.runId);
 
-    const confirmationEvents = audit.body.events.filter((event) => event.subject === "dangerous-audit-proof");
+    const permissionEvents = audit.body.events.filter((event) => event.action === "permission.decision");
+    assert.equal(permissionEvents.length, 4);
+    assert.equal(permissionEvents.every((event) => event.metadata.permission === "service.action.run"), true);
+    assert.ok(permissionEvents.some((event) => event.subject === "dangerous-audit-proof" && event.outcome === "failure"));
+
+    const confirmationEvents = audit.body.events.filter(
+      (event) => event.action === "service.action.run" && event.subject === "dangerous-audit-proof",
+    );
     assert.equal(confirmationEvents.length, 2);
     assert.deepEqual(confirmationEvents.map((event) => event.actor), ["operator-ui", "operator-ui"]);
     assert.deepEqual(confirmationEvents.map((event) => event.outcome).sort(), ["failure", "success"]);
@@ -336,7 +348,9 @@ test("audit API returns durable safe service and runtime mutation events after r
     const confirmationSuccess = confirmationEvents.find((event) => event.outcome === "success");
     assert.equal(confirmationSuccess.relatedRevisionId, confirmedAction.body.run.runId);
 
-    const scheduledEvent = audit.body.events.find((event) => event.subject === "scheduled-audit-proof");
+    const scheduledEvent = audit.body.events.find(
+      (event) => event.action === "service.action.run" && event.subject === "scheduled-audit-proof",
+    );
     assert.equal(scheduledEvent.actor, "workflow-engine");
     assert.equal(scheduledEvent.outcome, "success");
     assert.equal(scheduledEvent.relatedRevisionId, scheduledAction.body.run.runId);

--- a/tests/service-action-runs.test.js
+++ b/tests/service-action-runs.test.js
@@ -6,13 +6,20 @@ import { startApiServer } from "../dist/server/index.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { makeTempServicesRoot, writeManifest } from "./test-helpers.js";
 
-async function postJson(url, body = {}) {
+const localRootActor = { type: "local-root", id: "local-root", permissions: ["*"] };
+const systemActionActor = { type: "system", id: "scheduler-runtime", permissions: ["service.action.run"] };
+
+async function postJson(url, body = {}, includeDefaultActor = true) {
+  const requestBody =
+    includeDefaultActor && body && typeof body === "object" && !Array.isArray(body) && body.actor === undefined
+      ? { actor: localRootActor, ...body }
+      : body;
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(requestBody),
   });
   return {
     status: response.status,
@@ -157,6 +164,7 @@ test("service action run API executes command actions and exposes persisted hist
       scheduleId: "nightly",
       stepId: "backup",
       parentActionId: "nightly-backup",
+      actor: systemActionActor,
       params: {
         retainDays: 7,
       },
@@ -174,6 +182,7 @@ test("service action run API executes command actions and exposes persisted hist
     assert.equal(run.body.run.metadata.scheduleId, "nightly");
     assert.equal(run.body.run.metadata.stepId, "backup");
     assert.equal(run.body.run.metadata.parentActionId, "nightly-backup");
+    assert.equal(run.body.run.metadata.actor, "scheduler-runtime");
     assert.deepEqual(run.body.run.metadata.params, { retainDays: 7 });
     assert.deepEqual(run.body.run.metadata.payload, {
       source: "inline",
@@ -203,6 +212,7 @@ test("service action run API executes command actions and exposes persisted hist
       source: "dagu",
       workflowId: "minecraft.backup.nightly",
       scheduleId: "nightly",
+      actor: systemActionActor,
       payloadRef: "stored-backup",
       payload: {
         mode: "incremental",
@@ -236,6 +246,23 @@ test("service action run API executes command actions and exposes persisted hist
     const allHistory = await getJson(`${apiServer.url}/api/services/action-service/actions`);
     assert.equal(allHistory.status, 200);
     assert.equal(allHistory.body.runs.length, 2);
+
+    const missingActor = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
+      payload: {
+        retainDays: 7,
+      },
+    }, false);
+    assert.equal(missingActor.status, 401);
+    assert.equal(missingActor.body.error, "actor_required");
+
+    const actorWithoutPermission = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
+      actor: { type: "system", id: "health-monitor", permissions: [] },
+      payload: {
+        retainDays: 7,
+      },
+    });
+    assert.equal(actorWithoutPermission.status, 403);
+    assert.equal(actorWithoutPermission.body.error, "permission_denied");
 
     const missingPayload = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`);
     assert.equal(missingPayload.status, 400);
@@ -275,6 +302,7 @@ test("service action run API executes command actions and exposes persisted hist
     const scheduledWithoutWorkflow = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
       source: "dagu",
       scheduleId: "nightly",
+      actor: systemActionActor,
     });
     assert.equal(scheduledWithoutWorkflow.status, 400);
     assert.equal(scheduledWithoutWorkflow.body.error, "scheduled_metadata_required");
@@ -284,6 +312,7 @@ test("service action run API executes command actions and exposes persisted hist
     const scheduledWithoutSchedule = await postJson(`${apiServer.url}/api/services/action-service/actions/backup/runs`, {
       source: "scheduler",
       workflowId: "minecraft.backup.nightly",
+      actor: systemActionActor,
     });
     assert.equal(scheduledWithoutSchedule.status, 400);
     assert.equal(scheduledWithoutSchedule.body.error, "scheduled_metadata_required");
@@ -292,6 +321,7 @@ test("service action run API executes command actions and exposes persisted hist
       source: "dagu",
       workflowId: "minecraft.backup.nightly",
       scheduleId: "unknown",
+      actor: systemActionActor,
     });
     assert.equal(unknownSchedule.status, 404);
     assert.equal(unknownSchedule.body.error, "unknown_action_schedule");
@@ -300,6 +330,7 @@ test("service action run API executes command actions and exposes persisted hist
       source: "scheduler",
       workflowId: "minecraft.backup.disabled",
       scheduleId: "disabled",
+      actor: systemActionActor,
     });
     assert.equal(disabledSchedule.status, 409);
     assert.equal(disabledSchedule.body.error, "disabled_action_schedule");
@@ -308,6 +339,7 @@ test("service action run API executes command actions and exposes persisted hist
       source: "dagu",
       workflowId: "minecraft.unscheduled.nightly",
       scheduleId: "nightly",
+      actor: systemActionActor,
     });
     assert.equal(unscheduledAction.status, 409);
     assert.equal(unscheduledAction.body.error, "scheduled_action_not_configured");


### PR DESCRIPTION
## Issue
Refs #826

## Summary
- Adds a shared runtime permission enforcement module for durable action requests.
- Enforces actor presence, permission grants, sensitive-action confirmation, and permission-decision audit events for service action run APIs.
- Preserves legacy local actor strings while supporting structured actor envelopes for system/local-root and future auth sources.

## Scope
- In scope: service action run permission middleware slice, actor metadata normalization, allow/deny/confirmation/system tests, audit trail coverage.
- Out of scope: lifecycle, config, setup, runtime orchestration, broker, files, CLI, scheduler repair and every other durable route. Those still need follow-up #826 slices before the issue is complete.

## Spec / contract / fixture impact
- Updated: service action run request handling now accepts structured actor envelopes and records the actor id in run metadata.
- Updated: audit regression now expects `permission.decision` entries for service action runs.

## Service Lasso invariant impact
- Invariant: durable service actions should not execute without an actor and a granted permission.
- Preservation proof: `service.action.run` now calls `enforcePermission(...)` before payload resolution/execution; denied or unconfirmed requests fail before process spawn and create safe audit metadata.

## Validation
- PASS `npm ci` — `C:\projects\service-lasso\.work-agent\logs\20260731T104530Z\issue-826-npm-ci.stdout.log`
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\20260731T104530Z\issue-826-npm-build-final.stdout.log`
- PASS `node --test --test-concurrency=1 tests/service-action-runs.test.js` — `C:\projects\service-lasso\.work-agent\logs\20260731T104530Z\issue-826-service-action-runs-test-final.stdout.log`
- PASS `node --test --test-concurrency=1 tests/audit.test.js` — `C:\projects\service-lasso\.work-agent\logs\20260731T104530Z\issue-826-audit-test-final.stdout.log`

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this introduces the central permission vocabulary and compatibility behavior for legacy actor strings.

## Cleanup
- Branch `fix/826-action-permission-middleware` is pushed. Local issue worktree should remain available for review/follow-up until this slice merges.