### PR TITLE
#827 map Zitadel actors and roles to Service Lasso permissions

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -158,6 +158,25 @@ workspace as the requested broker namespace. Workflow/run resolution requires
 `workflow:run`; if a workflow uses provider connection metadata, it also
 requires `secrets-broker-source:use` for each referenced Secrets Broker source metadata record.
 
+### `zitadel_role_mappings`
+
+ZITADEL claims are inputs to an explicit Service Lasso mapping, not direct
+runtime permissions. A mapping record contains:
+
+| Field | Notes |
+| --- | --- |
+| `workspaceId` | Workspace where the mapping is valid. |
+| `claim` | `group` or `role`; other raw claims are not executable grants. |
+| `value` | Exact safe claim value supplied by the trusted app-owned identity layer. |
+| `serviceLassoRole` | Internal role name to load from `roles`, such as `owner`, `admin`, `operator`, `viewer`, `file-export-operator`, `backup-restore-operator`, or `service-account`. |
+
+The resolver merges safe ZITADEL groups/roles from the linked identity record
+and the current trusted session, resolves them through `zitadel_role_mappings`,
+then flattens entitlements only from matching Service Lasso roles in the active
+workspace. Unmapped groups or roles produce no entitlements and fail closed as
+`unauthorized`. This keeps the permission vocabulary in Service Lasso while
+allowing ZITADEL projects to choose their own provider-side group/role labels.
+
 ## Secrets Broker source metadata API
 
 The facade exposes CRUD for Secrets Broker source/ref metadata only. These routes intentionally do not create provider accounts, perform OAuth, refresh provider tokens, manage callbacks, or store provider credentials:
@@ -322,12 +341,18 @@ internal context as follows:
 2. Resolve the internal `userId` and allowed `workspaceIds` from that record.
 3. Select the active workspace from request routing or the user's default
    workspace.
-4. Load roles for that workspace and flatten them to entitlements.
+4. Map safe ZITADEL groups/roles through `zitadel_role_mappings` and load only
+   the matching Service Lasso roles for that workspace.
 5. Produce a request context containing `userId`, `workspaceId`, `instanceId`,
    `linkedIdentityId`, actor metadata, auth method, safe audit metadata, and
    entitlements.
-6. Fail closed if the linked identity, workspace, user, session freshness, or
-   required entitlement is missing.
+6. Fail closed if the linked identity, workspace, user, session freshness,
+   mapping, or required entitlement is missing.
+
+Audit metadata may include safe ZITADEL actor context: issuer, subject, groups,
+roles, linked identity id, resolved internal actor id, and resolved Service
+Lasso role names. It must not include raw credentials, tokens, cookies, session
+secrets, or provider response bodies.
 
 ZITADEL remains app/service-owned. This facade contract describes the safe identity metadata core may consume after authentication; it does not make ZITADEL, OIDC sessions, callbacks, or token handling part of the Service Lasso core baseline.
 
@@ -381,6 +406,7 @@ The TypeScript contract lives in `src/platform/facade.ts`. Tests in
 
 - required facade model and endpoint concepts exist,
 - ZITADEL session context maps to internal user/workspace context,
+- ZITADEL group/role claims map explicitly to Service Lasso roles,
 - provider connection metadata is split from secret payloads,
 - Secrets Broker and workflow authorization boundaries are testable, and
 - sensitive strings are rejected or absent from fixture/API shapes.

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -26,8 +26,17 @@ export type PlatformAuthFailureReason =
 export type PlatformRole = {
   id: string;
   workspaceId: string;
-  name: "owner" | "admin" | "developer" | "operator" | "viewer" | string;
+  name: PlatformRoleName;
   entitlements: PlatformEntitlement[];
+};
+
+export type PlatformRoleName = "owner" | "admin" | "developer" | "operator" | "viewer" | "file-export-operator" | "backup-restore-operator" | "service-account" | string;
+
+export type ZitadelRoleMapping = {
+  workspaceId: string;
+  claim: "group" | "role";
+  value: string;
+  serviceLassoRole: PlatformRoleName;
 };
 
 export type PlatformServiceIdentity = {
@@ -73,6 +82,7 @@ export type LinkedIdentity = {
     email?: string;
     preferredUsername?: string;
     groups?: string[];
+    roles?: string[];
   };
   createdAt: string;
   lastSeenAt?: string;
@@ -144,6 +154,7 @@ export type ZitadelSessionContext = {
   email?: string;
   preferredUsername?: string;
   groups?: string[];
+  roles?: string[];
   expiresAt?: string;
 };
 
@@ -155,6 +166,11 @@ export type PlatformAuditActorMetadata = {
   linkedIdentityId?: string;
   serviceIdentityId?: string;
   authMethod: PlatformAuthMethod;
+  zitadelIssuer?: string;
+  zitadelSubject?: string;
+  zitadelGroups?: string[];
+  zitadelRoles?: string[];
+  serviceLassoRoles?: PlatformRoleName[];
 };
 
 export type PlatformRequestContext = {
@@ -163,6 +179,7 @@ export type PlatformRequestContext = {
   instanceId: string;
   linkedIdentityId: string;
   entitlements: PlatformEntitlement[];
+  roleNames: PlatformRoleName[];
   actor: {
     kind: PlatformActorKind;
     id: string;
@@ -233,6 +250,7 @@ export type PlatformFacadeState = {
   workspaces: PlatformWorkspace[];
   linkedIdentities: LinkedIdentity[];
   roles: PlatformRole[];
+  zitadelRoleMappings: ZitadelRoleMapping[];
   serviceIdentities: PlatformServiceIdentity[];
   providerConnections: ProviderConnectionMetadata[];
 };
@@ -272,12 +290,85 @@ export const examplePlatformFacadeState = {
         email: "operator@example.test",
         preferredUsername: "operator",
         groups: ["service-lasso-operators"],
+        roles: ["operator"],
       },
       createdAt: "2026-05-08T10:00:00Z",
       lastSeenAt: "2026-05-08T10:05:00Z",
     },
   ],
+  zitadelRoleMappings: [
+    {
+      workspaceId: "wks_local_demo",
+      claim: "group",
+      value: "service-lasso-owners",
+      serviceLassoRole: "owner",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "group",
+      value: "service-lasso-admins",
+      serviceLassoRole: "admin",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "group",
+      value: "service-lasso-operators",
+      serviceLassoRole: "operator",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "group",
+      value: "service-lasso-viewers",
+      serviceLassoRole: "viewer",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "role",
+      value: "service-account",
+      serviceLassoRole: "service-account",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "role",
+      value: "backup-restore",
+      serviceLassoRole: "backup-restore-operator",
+    },
+    {
+      workspaceId: "wks_local_demo",
+      claim: "role",
+      value: "file-export",
+      serviceLassoRole: "file-export-operator",
+    },
+  ],
   roles: [
+    {
+      id: "role_local_owner",
+      workspaceId: "wks_local_demo",
+      name: "owner",
+      entitlements: [
+        "workspace:read",
+        "workspace:admin",
+        "secrets-broker-source:read",
+        "secrets-broker-source:write",
+        "secrets-broker-source:use",
+        "secrets-broker:resolve",
+        "workflow:run",
+      ],
+    },
+    {
+      id: "role_local_admin",
+      workspaceId: "wks_local_demo",
+      name: "admin",
+      entitlements: [
+        "workspace:read",
+        "workspace:admin",
+        "secrets-broker-source:read",
+        "secrets-broker-source:write",
+        "secrets-broker-source:use",
+        "secrets-broker:resolve",
+        "workflow:run",
+      ],
+    },
     {
       id: "role_local_operator",
       workspaceId: "wks_local_demo",
@@ -289,6 +380,30 @@ export const examplePlatformFacadeState = {
         "secrets-broker:resolve",
         "workflow:run",
       ],
+    },
+    {
+      id: "role_local_viewer",
+      workspaceId: "wks_local_demo",
+      name: "viewer",
+      entitlements: ["workspace:read", "secrets-broker-source:read"],
+    },
+    {
+      id: "role_local_file_export_operator",
+      workspaceId: "wks_local_demo",
+      name: "file-export-operator",
+      entitlements: ["workspace:read", "secrets-broker-source:read", "secrets-broker-source:use"],
+    },
+    {
+      id: "role_local_backup_restore_operator",
+      workspaceId: "wks_local_demo",
+      name: "backup-restore-operator",
+      entitlements: ["workspace:read", "secrets-broker-source:use", "secrets-broker:resolve"],
+    },
+    {
+      id: "role_local_service_account",
+      workspaceId: "wks_local_demo",
+      name: "service-account",
+      entitlements: ["workspace:read", "secrets-broker:resolve", "workflow:run"],
     },
   ],
   serviceIdentities: [
@@ -518,8 +633,9 @@ export function resolveServiceLassoRequestContext(
       );
     }
 
+    const roleNames = resolveZitadelServiceLassoRoles(request.session, identity, state, workspaceId);
     const entitlements = state.roles
-      .filter((role) => role.workspaceId === workspaceId)
+      .filter((role) => role.workspaceId === workspaceId && roleNames.includes(role.name))
       .flatMap((role) => role.entitlements);
 
     if (entitlements.length === 0) {
@@ -540,9 +656,17 @@ export function resolveServiceLassoRequestContext(
         instanceId: request.instanceId,
         linkedIdentityId: identity.id,
         entitlements: [...new Set(entitlements)],
+        roleNames,
         actor: { kind: "user", id: identity.userId, displayName: user.displayName },
         authMethod: "zitadel-session",
-        audit,
+        audit: safeAudit({
+          ...audit,
+          zitadelIssuer: identity.issuer,
+          zitadelSubject: identity.subject,
+          zitadelGroups: uniqueStrings([...(identity.claims.groups ?? []), ...(request.session.groups ?? [])]),
+          zitadelRoles: uniqueStrings([...(identity.claims.roles ?? []), ...(request.session.roles ?? [])]),
+          serviceLassoRoles: roleNames,
+        }),
       },
     };
   }
@@ -578,11 +702,29 @@ export function resolveServiceLassoRequestContext(
       instanceId: request.instanceId,
       linkedIdentityId: serviceIdentity.id,
       entitlements: [...new Set(serviceIdentity.entitlements)],
+      roleNames: ["service-account"],
       actor: { kind: "service", id: serviceIdentity.serviceId, displayName: serviceIdentity.displayName },
       authMethod: "service-identity",
       audit,
     },
   };
+}
+
+export function resolveZitadelServiceLassoRoles(
+  session: ZitadelSessionContext,
+  identity: LinkedIdentity,
+  state: PlatformFacadeState = examplePlatformFacadeState,
+  workspaceId = identity.workspaceIds[0],
+): PlatformRoleName[] {
+  const groups = uniqueStrings([...(identity.claims.groups ?? []), ...(session.groups ?? [])]);
+  const roles = uniqueStrings([...(identity.claims.roles ?? []), ...(session.roles ?? [])]);
+
+  return uniqueStrings(
+    state.zitadelRoleMappings
+      .filter((mapping) => mapping.workspaceId === workspaceId)
+      .filter((mapping) => mapping.claim === "group" ? groups.includes(mapping.value) : roles.includes(mapping.value))
+      .map((mapping) => mapping.serviceLassoRole),
+  );
 }
 
 export function mapZitadelSessionToPlatformContext(
@@ -610,6 +752,10 @@ function isExpired(expiresAt: string | undefined, now = new Date()): boolean {
   if (!expiresAt) return false;
   const expiry = Date.parse(expiresAt);
   return Number.isFinite(expiry) && expiry <= now.getTime();
+}
+
+function uniqueStrings<T extends string>(values: T[]): T[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
 }
 
 export function authorizePlatformResource(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -964,6 +964,7 @@ function createWorkflowPlatformContext(request: IncomingMessage, workspaceId: st
     instanceId,
     linkedIdentityId,
     entitlements: parseEntitlements(request),
+    roleNames: ["operator"],
     actor: {
       kind: "user",
       id: userId,

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -15,6 +15,7 @@ import {
   providerConnectionMetadataEndpoints,
   readProviderConnectionMetadata,
   resolveServiceLassoRequestContext,
+  resolveZitadelServiceLassoRoles,
   updateProviderConnectionMetadata,
 } from "../dist/platform/facade.js";
 
@@ -39,7 +40,8 @@ test("platform facade fixture defines users workspaces linked identities provide
   assert.equal(examplePlatformFacadeState.workspaces.length, 1);
   assert.equal(examplePlatformFacadeState.linkedIdentities.length, 1);
   assert.equal(examplePlatformFacadeState.providerConnections.length, 1);
-  assert.equal(examplePlatformFacadeState.roles.length, 1);
+  assert.equal(examplePlatformFacadeState.roles.length, 7);
+  assert.equal(examplePlatformFacadeState.zitadelRoleMappings.length, 7);
   assert.equal(examplePlatformFacadeState.serviceIdentities.length, 1);
 
   const connection = examplePlatformFacadeState.providerConnections[0];
@@ -150,6 +152,7 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
   assert.equal(context.instanceId, "inst_local_demo");
   assert.equal(context.actor.kind, "user");
   assert.equal(context.authMethod, "zitadel-session");
+  assert.deepEqual(context.roleNames, ["operator"]);
   assert.deepEqual(context.audit, {
     actorKind: "user",
     actorId: "usr_01hzy9operator",
@@ -157,9 +160,15 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
     instanceId: "inst_local_demo",
     linkedIdentityId: "lid_zitadel_operator",
     authMethod: "zitadel-session",
+    zitadelIssuer: "http://localhost:8080",
+    zitadelSubject: "zitadel-user-operator",
+    zitadelGroups: ["service-lasso-operators"],
+    zitadelRoles: ["operator"],
+    serviceLassoRoles: ["operator"],
   });
   assert.ok(context.entitlements.includes("secrets-broker:resolve"));
   assert.ok(context.entitlements.includes("workflow:run"));
+  assert.equal(context.entitlements.includes("workspace:admin"), false);
 
   assert.equal(
     mapZitadelSessionToPlatformContext({
@@ -168,6 +177,33 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
     }),
     undefined,
   );
+});
+
+test("ZITADEL group and role claims map explicitly to Service Lasso roles", () => {
+  const identity = examplePlatformFacadeState.linkedIdentities[0];
+
+  assert.deepEqual(
+    resolveZitadelServiceLassoRoles(
+      { issuer: identity.issuer, subject: identity.subject, groups: ["service-lasso-admins"], roles: ["backup-restore"] },
+      { ...identity, claims: { groups: [] } },
+      examplePlatformFacadeState,
+      "wks_local_demo",
+    ),
+    ["admin", "backup-restore-operator"],
+  );
+
+  const denied = resolveServiceLassoRequestContext({
+    kind: "zitadel-session",
+    session: { issuer: identity.issuer, subject: identity.subject, groups: ["unmapped-zitadel-group"] },
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+  }, {
+    ...examplePlatformFacadeState,
+    linkedIdentities: [{ ...identity, claims: { groups: [] } }],
+  });
+
+  assert.equal(denied.ok, false);
+  assert.equal(!denied.ok && denied.reason, "unauthorized");
 });
 
 test("request context resolver covers fail-closed session and service identity states", () => {


### PR DESCRIPTION
## Issue
Refs #827

## Summary
- Adds an explicit ZITADEL group/role to Service Lasso role mapping contract.
- Resolves request entitlements only from mapped Service Lasso roles in the active workspace.
- Extends safe audit metadata with ZITADEL issuer/subject/groups/roles and resolved Service Lasso role names.
- Documents the mapping model and adds focused fail-closed tests for unmapped claims.

## Scope
- In scope: platform facade mapping model, fixture roles/mappings, request-context role names, docs, and focused product/workflow facade coverage.
- Out of scope: OIDC/session/callback mechanics, Service Admin UI wiring, full durable action permission rollout, and provider-specific ZITADEL bootstrap behavior.

## Spec / contract / fixture impact
- Updated: `PlatformFacadeState` includes `zitadelRoleMappings`.
- Updated: ZITADEL session contexts may carry safe role claims.
- Updated: request/audit contexts expose resolved Service Lasso role names and safe ZITADEL actor metadata.

## Service Lasso invariant impact
- Invariant: ZITADEL proves identity; Service Lasso decides authorization.
- Preservation proof: raw ZITADEL groups/roles are not entitlements. They must map through workspace-scoped `zitadelRoleMappings`, and unmapped claims fail closed.

## Validation
- PASS `npm ci` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T213025+1000\issue-827-npm-ci.stdout.log`
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T213025+1000\issue-827-npm-build-final.stdout.log`
- PASS `node --test --test-concurrency=1 tests/product-api-facade.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T213025+1000\issue-827-product-api-facade-test.stdout.log`
- PASS `node --test --test-concurrency=1 tests/workflow-platform-api.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T213025+1000\issue-827-workflow-platform-api-test.stdout.log`

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this defines the central ZITADEL-to-Service Lasso permission mapping vocabulary.

## Cleanup
- Branch `fix/827-zitadel-permission-mapping` is pushed. Local issue worktree will remain for review and updated-code demo proof.
