### PR TITLE
#830 add scoped permission grants

### DIFF
--- a/docs/reference/product-api-facade.md
+++ b/docs/reference/product-api-facade.md
@@ -81,6 +81,8 @@ auth state in core.
 | `instanceId` | Local Service Lasso instance boundary. Requests cannot cross instances. |
 | `linkedIdentityId` | ZITADEL linked identity id for user requests, or service identity id for service-authenticated requests. |
 | `entitlements` | Workspace-scoped grants flattened from roles or service identity policy. |
+| `roleIds` / `roleNames` | Role evidence used to match explicit `permission_grants`. |
+| `permissionGrants` | Explicit grants resolved for the actor in this workspace. Empty means default deny for scoped resources. |
 | `actor` | Safe actor descriptor: `kind`, `id`, and display label only. |
 | `authMethod` | `zitadel-session` or `service-identity`. |
 | `audit` | Safe actor/workspace/instance metadata for downstream audit events. |
@@ -142,7 +144,9 @@ Forbidden fields in facade provider connection payloads include `secret`,
 
 ### `roles` and entitlements
 
-Roles are workspace-scoped bundles of entitlements. The first concrete
+Roles are workspace-scoped bundles of coarse entitlements. Entitlements keep
+legacy API boundaries readable, but they do not grant service/action/resource
+access by themselves once scoped grants are present. The first concrete
 entitlements are:
 
 - `workspace:read`
@@ -157,6 +161,71 @@ Secrets Broker resolution requires `secrets-broker:resolve` in the same
 workspace as the requested broker namespace. Workflow/run resolution requires
 `workflow:run`; if a workflow uses provider connection metadata, it also
 requires `secrets-broker-source:use` for each referenced Secrets Broker source metadata record.
+
+### `permission_grants`
+
+Permission grants are the explicit allow list for service/action/resource
+authorization. The default decision is deny: a request context with no matching
+grant is rejected even when the actor has a coarse role label. Adding or
+importing a service registers available actions, but it must not append grants
+to existing non-owner groups.
+
+Each grant records:
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable grant id for audit and review. |
+| `workspaceId` | Workspace boundary for the grant. |
+| `target` | `role`, `actor`, or `service` target id. |
+| `permissionKey` | Permission such as `service:restart`, `secrets-broker:resolve`, `workflow:run`, or owner/root wildcard `*`. |
+| `scope` | Scope type and id. Runtime wildcard `runtime/*` is reserved for owner/root bootstrap. |
+| `constraints` | Optional safe structured limits such as time window or max selected paths. |
+| `createdBy` / `createdAt` | Safe audit metadata for who created the grant and when. |
+| `reason` | Human review note. |
+
+Supported scope types are `runtime`, `workspace`, `service`, `action`,
+`file-source`, `file-path`, `broker-namespace`, `export-destination`, and
+`backup-artifact`. A grant only matches when the workspace, target,
+permission key, and scope match the requested resource, except for the
+owner/root wildcard grant.
+
+```json
+{
+  "id": "grant_postgres_admins_restart_postgres",
+  "workspaceId": "wks_local_demo",
+  "target": { "kind": "role", "id": "role_postgres_admins" },
+  "permissionKey": "service:restart",
+  "scope": { "type": "service", "id": "@postgres" },
+  "createdBy": "usr_01hzy9operator",
+  "createdAt": "2026-05-08T11:00:00Z",
+  "reason": "Postgres Admins may restart only Postgres."
+}
+```
+
+Denied authorization decisions include safe evidence such as
+`missing-entitlement`, `missing-grant`, `workspace-mismatch`, or
+`connection-not-ready`. Allowed decisions include the matched grant id, target,
+permission key, and scope for downstream audit metadata.
+
+### `service_action_permissions`
+
+Services can register available actions and required permission keys in the
+core catalogue/resolved service model:
+
+```json
+{
+  "serviceId": "@serviceadmin",
+  "actionId": "services.restart",
+  "permissionKey": "service:restart",
+  "scopeType": "service",
+  "description": "Restart a managed service through Service Admin.",
+  "registeredAt": "2026-05-08T10:00:00Z"
+}
+```
+
+This registration is catalogue metadata only. It makes the assignment visible
+to Service Admin or automation, but it does not grant the action to any group,
+actor, or service identity.
 
 ## Secrets Broker source metadata API
 

--- a/src/platform/facade.ts
+++ b/src/platform/facade.ts
@@ -11,6 +11,8 @@ export type PlatformEntitlement =
   | "secrets-broker-source:use"
   | "secrets-broker:resolve"
   | "workflow:run";
+export type PlatformPermissionKey = PlatformEntitlement | "service:read" | "service:manage" | "service:start" | "service:stop" | "service:restart" | "service:file-export" | "backup:create" | "backup:restore" | "*" | (string & {});
+export type PlatformPermissionScopeType = "runtime" | "workspace" | "service" | "action" | "file-source" | "file-path" | "broker-namespace" | "export-destination" | "backup-artifact";
 
 export type PlatformActorKind = "user" | "service";
 export type PlatformAuthMethod = "zitadel-session" | "service-identity";
@@ -28,6 +30,35 @@ export type PlatformRole = {
   workspaceId: string;
   name: "owner" | "admin" | "developer" | "operator" | "viewer" | string;
   entitlements: PlatformEntitlement[];
+};
+
+export type PlatformPermissionGrantTarget =
+  | { kind: "role"; id: string }
+  | { kind: "actor"; id: string }
+  | { kind: "service"; id: string };
+
+export type PlatformPermissionGrant = {
+  id: string;
+  workspaceId: string;
+  target: PlatformPermissionGrantTarget;
+  permissionKey: PlatformPermissionKey;
+  scope: {
+    type: PlatformPermissionScopeType;
+    id: string | "*";
+  };
+  constraints?: Record<string, string | number | boolean>;
+  createdBy: string;
+  createdAt: string;
+  reason?: string;
+};
+
+export type PlatformServiceActionPermission = {
+  serviceId: string;
+  actionId: string;
+  permissionKey: PlatformPermissionKey;
+  scopeType: PlatformPermissionScopeType;
+  description: string;
+  registeredAt: string;
 };
 
 export type PlatformServiceIdentity = {
@@ -163,6 +194,9 @@ export type PlatformRequestContext = {
   instanceId: string;
   linkedIdentityId: string;
   entitlements: PlatformEntitlement[];
+  roleIds?: string[];
+  roleNames?: string[];
+  permissionGrants?: PlatformPermissionGrant[];
   actor: {
     kind: PlatformActorKind;
     id: string;
@@ -206,12 +240,30 @@ export type PlatformContextResolution =
 export type AuthorizationResource =
   | { kind: "provider-connection"; connection: ProviderConnectionMetadata }
   | { kind: "secrets-broker-ref"; workspaceId: string; brokerNamespace: string; ref: string }
-  | { kind: "workflow-run"; workspaceId: string; workflowId: string; requiredProviderConnectionIds?: string[] };
+  | { kind: "workflow-run"; workspaceId: string; workflowId: string; requiredProviderConnectionIds?: string[] }
+  | { kind: "service-action"; workspaceId: string; serviceId: string; actionId: string; permissionKey?: PlatformPermissionKey };
+
+export type AuthorizationGrantEvidence = {
+  grantId: string;
+  targetKind: PlatformPermissionGrantTarget["kind"];
+  targetId: string;
+  permissionKey: PlatformPermissionKey;
+  scopeType: PlatformPermissionScopeType;
+  scopeId: string | "*";
+};
+
+export type AuthorizationPermissionRequirement = {
+  permissionKey: PlatformPermissionKey;
+  scopeType: PlatformPermissionScopeType;
+  scopeId: string;
+};
 
 export type AuthorizationDecision = {
   allowed: boolean;
-  reason: "allowed" | "missing-entitlement" | "workspace-mismatch" | "connection-not-ready";
+  reason: "allowed" | "missing-entitlement" | "missing-grant" | "workspace-mismatch" | "connection-not-ready";
   requiredEntitlements: PlatformEntitlement[];
+  requiredPermission: AuthorizationPermissionRequirement;
+  grantEvidence?: AuthorizationGrantEvidence;
 };
 
 export const coreFacadeBoundary = {
@@ -233,6 +285,8 @@ export type PlatformFacadeState = {
   workspaces: PlatformWorkspace[];
   linkedIdentities: LinkedIdentity[];
   roles: PlatformRole[];
+  permissionGrants: PlatformPermissionGrant[];
+  serviceActionPermissions: PlatformServiceActionPermission[];
   serviceIdentities: PlatformServiceIdentity[];
   providerConnections: ProviderConnectionMetadata[];
 };
@@ -289,6 +343,58 @@ export const examplePlatformFacadeState = {
         "secrets-broker:resolve",
         "workflow:run",
       ],
+    },
+  ],
+  permissionGrants: [
+    {
+      id: "grant_operator_workspace_read",
+      workspaceId: "wks_local_demo",
+      target: { kind: "role", id: "role_local_operator" },
+      permissionKey: "workspace:read",
+      scope: { type: "workspace", id: "wks_local_demo" },
+      createdBy: "bootstrap",
+      createdAt: "2026-05-08T10:00:00Z",
+      reason: "Built-in operator workspace visibility.",
+    },
+    {
+      id: "grant_operator_provider_use",
+      workspaceId: "wks_local_demo",
+      target: { kind: "role", id: "role_local_operator" },
+      permissionKey: "secrets-broker-source:use",
+      scope: { type: "broker-namespace", id: "workspaces/local-demo/provider-connections/github" },
+      createdBy: "bootstrap",
+      createdAt: "2026-05-08T10:00:00Z",
+      reason: "Built-in operator can use the demo GitHub metadata source.",
+    },
+    {
+      id: "grant_operator_broker_resolve",
+      workspaceId: "wks_local_demo",
+      target: { kind: "role", id: "role_local_operator" },
+      permissionKey: "secrets-broker:resolve",
+      scope: { type: "broker-namespace", id: "workspaces/local-demo/provider-connections/github" },
+      createdBy: "bootstrap",
+      createdAt: "2026-05-08T10:00:00Z",
+      reason: "Built-in operator can resolve the demo GitHub broker ref.",
+    },
+    {
+      id: "grant_operator_workflow_run",
+      workspaceId: "wks_local_demo",
+      target: { kind: "role", id: "role_local_operator" },
+      permissionKey: "workflow:run",
+      scope: { type: "action", id: "official.core.maintenance/backup-check" },
+      createdBy: "bootstrap",
+      createdAt: "2026-05-08T10:00:00Z",
+      reason: "Built-in operator can run the demo maintenance workflow.",
+    },
+  ],
+  serviceActionPermissions: [
+    {
+      serviceId: "@serviceadmin",
+      actionId: "services.restart",
+      permissionKey: "service:restart",
+      scopeType: "service",
+      description: "Restart a managed service through Service Admin.",
+      registeredAt: "2026-05-08T10:00:00Z",
     },
   ],
   serviceIdentities: [
@@ -518,9 +624,8 @@ export function resolveServiceLassoRequestContext(
       );
     }
 
-    const entitlements = state.roles
-      .filter((role) => role.workspaceId === workspaceId)
-      .flatMap((role) => role.entitlements);
+    const roles = state.roles.filter((role) => role.workspaceId === workspaceId);
+    const entitlements = roles.flatMap((role) => role.entitlements);
 
     if (entitlements.length === 0) {
       return authFailure(
@@ -532,6 +637,8 @@ export function resolveServiceLassoRequestContext(
     }
 
     const audit = safeAudit({ actorKind: "user", actorId: identity.userId, workspaceId, instanceId: request.instanceId, linkedIdentityId: identity.id, authMethod: "zitadel-session" });
+    const roleIds = roles.map((role) => role.id);
+    const roleNames = roles.map((role) => role.name);
     return {
       ok: true,
       context: {
@@ -540,6 +647,9 @@ export function resolveServiceLassoRequestContext(
         instanceId: request.instanceId,
         linkedIdentityId: identity.id,
         entitlements: [...new Set(entitlements)],
+        roleIds,
+        roleNames,
+        permissionGrants: grantsForContext(state.permissionGrants, workspaceId, identity.userId, "user", roleIds, roleNames),
         actor: { kind: "user", id: identity.userId, displayName: user.displayName },
         authMethod: "zitadel-session",
         audit,
@@ -578,6 +688,7 @@ export function resolveServiceLassoRequestContext(
       instanceId: request.instanceId,
       linkedIdentityId: serviceIdentity.id,
       entitlements: [...new Set(serviceIdentity.entitlements)],
+      permissionGrants: grantsForContext(state.permissionGrants, request.workspaceId, serviceIdentity.serviceId, "service", [], []),
       actor: { kind: "service", id: serviceIdentity.serviceId, displayName: serviceIdentity.displayName },
       authMethod: "service-identity",
       audit,
@@ -617,27 +728,117 @@ export function authorizePlatformResource(
   resource: AuthorizationResource,
 ): AuthorizationDecision {
   const requiredEntitlements = requiredEntitlementsForResource(resource);
+  const requiredPermission = requiredPermissionForResource(resource);
   const workspaceId = "connection" in resource ? resource.connection.workspaceId : resource.workspaceId;
 
   if (workspaceId !== context.workspaceId) {
-    return { allowed: false, reason: "workspace-mismatch", requiredEntitlements };
+    return { allowed: false, reason: "workspace-mismatch", requiredEntitlements, requiredPermission };
   }
 
   if (!requiredEntitlements.every((entitlement) => context.entitlements.includes(entitlement))) {
-    return { allowed: false, reason: "missing-entitlement", requiredEntitlements };
+    return { allowed: false, reason: "missing-entitlement", requiredEntitlements, requiredPermission };
   }
 
   if (resource.kind === "provider-connection" && resource.connection.status !== "ready") {
-    return { allowed: false, reason: "connection-not-ready", requiredEntitlements };
+    return { allowed: false, reason: "connection-not-ready", requiredEntitlements, requiredPermission };
   }
 
-  return { allowed: true, reason: "allowed", requiredEntitlements };
+  const grantEvidence = matchingGrantEvidence(context, requiredPermission);
+  if (Array.isArray(context.permissionGrants) && !grantEvidence) {
+    return { allowed: false, reason: "missing-grant", requiredEntitlements, requiredPermission };
+  }
+
+  return { allowed: true, reason: "allowed", requiredEntitlements, requiredPermission, grantEvidence };
 }
 
 function requiredEntitlementsForResource(resource: AuthorizationResource): PlatformEntitlement[] {
   if (resource.kind === "provider-connection") return ["secrets-broker-source:use"];
   if (resource.kind === "secrets-broker-ref") return ["secrets-broker:resolve"];
+  if (resource.kind === "service-action") return ["workspace:read"];
   return ["workflow:run", "secrets-broker-source:use"];
+}
+
+function requiredPermissionForResource(resource: AuthorizationResource): AuthorizationPermissionRequirement {
+  if (resource.kind === "provider-connection") {
+    return {
+      permissionKey: "secrets-broker-source:use",
+      scopeType: "broker-namespace",
+      scopeId: resource.connection.brokerNamespace ?? resource.connection.id,
+    };
+  }
+  if (resource.kind === "secrets-broker-ref") {
+    return {
+      permissionKey: "secrets-broker:resolve",
+      scopeType: "broker-namespace",
+      scopeId: resource.brokerNamespace,
+    };
+  }
+  if (resource.kind === "service-action") {
+    return {
+      permissionKey: resource.permissionKey ?? `service:${resource.actionId}`,
+      scopeType: "service",
+      scopeId: resource.serviceId,
+    };
+  }
+  return {
+    permissionKey: "workflow:run",
+    scopeType: "action",
+    scopeId: resource.workflowId,
+  };
+}
+
+export function registerServiceActionPermission(
+  state: PlatformFacadeState,
+  registration: PlatformServiceActionPermission,
+): PlatformFacadeState {
+  return {
+    ...state,
+    serviceActionPermissions: [
+      ...state.serviceActionPermissions.filter(
+        (candidate) => !(candidate.serviceId === registration.serviceId && candidate.actionId === registration.actionId),
+      ),
+      registration,
+    ],
+    permissionGrants: [...state.permissionGrants],
+  };
+}
+
+function grantsForContext(
+  grants: PlatformPermissionGrant[],
+  workspaceId: string,
+  actorId: string,
+  actorKind: PlatformActorKind,
+  roleIds: string[],
+  roleNames: string[],
+): PlatformPermissionGrant[] {
+  return grants.filter((grant) => {
+    if (grant.workspaceId !== workspaceId) return false;
+    if (grant.target.kind === "actor") return grant.target.id === actorId;
+    if (grant.target.kind === "service") return actorKind === "service" && grant.target.id === actorId;
+    return roleIds.includes(grant.target.id) || roleNames.includes(grant.target.id);
+  });
+}
+
+function matchingGrantEvidence(
+  context: PlatformRequestContext,
+  requiredPermission: NonNullable<AuthorizationDecision["requiredPermission"]>,
+): AuthorizationGrantEvidence | undefined {
+  const grant = context.permissionGrants?.find((candidate) => {
+    if (candidate.permissionKey !== "*" && candidate.permissionKey !== requiredPermission.permissionKey) return false;
+    if (candidate.scope.type === "runtime" && candidate.scope.id === "*") return true;
+    if (candidate.scope.type !== requiredPermission.scopeType) return false;
+    return candidate.scope.id === "*" || candidate.scope.id === requiredPermission.scopeId;
+  });
+
+  if (!grant) return undefined;
+  return {
+    grantId: grant.id,
+    targetKind: grant.target.kind,
+    targetId: grant.target.id,
+    permissionKey: grant.permissionKey,
+    scopeType: grant.scope.type,
+    scopeId: grant.scope.id,
+  };
 }
 
 const secretLikeFieldPattern = /(secret|token|apiKey|api_key|privateKey|private_key|password|credential|recoveryMaterial|recovery_material|keyMaterial|key_material)$/i;

--- a/src/platform/workflowRunFacade.ts
+++ b/src/platform/workflowRunFacade.ts
@@ -9,6 +9,7 @@ export type WorkflowFacadeRunStatus = "queued" | "running" | "succeeded" | "fail
 export type WorkflowFacadeErrorCode =
   | "workspace-mismatch"
   | "missing-entitlement"
+  | "missing-grant"
   | "connection-not-ready"
   | "missing-secret"
   | "secret-denied"
@@ -394,7 +395,7 @@ function denied(code: WorkflowFacadeErrorCode, message: string, action: string):
   return { ok: false, error: { code, message, action } };
 }
 
-function authorizationReasonToFacadeError(reason: "allowed" | "missing-entitlement" | "workspace-mismatch" | "connection-not-ready"): WorkflowFacadeErrorCode {
+function authorizationReasonToFacadeError(reason: "allowed" | "missing-entitlement" | "missing-grant" | "workspace-mismatch" | "connection-not-ready"): WorkflowFacadeErrorCode {
   if (reason === "allowed") return "missing-entitlement";
   return reason;
 }

--- a/tests/product-api-facade.test.js
+++ b/tests/product-api-facade.test.js
@@ -14,6 +14,7 @@ import {
   platformAuditMetadataIncludesSecretMaterial,
   providerConnectionMetadataEndpoints,
   readProviderConnectionMetadata,
+  registerServiceActionPermission,
   resolveServiceLassoRequestContext,
   updateProviderConnectionMetadata,
 } from "../dist/platform/facade.js";
@@ -40,6 +41,8 @@ test("platform facade fixture defines users workspaces linked identities provide
   assert.equal(examplePlatformFacadeState.linkedIdentities.length, 1);
   assert.equal(examplePlatformFacadeState.providerConnections.length, 1);
   assert.equal(examplePlatformFacadeState.roles.length, 1);
+  assert.equal(examplePlatformFacadeState.permissionGrants.length, 4);
+  assert.equal(examplePlatformFacadeState.serviceActionPermissions.length, 1);
   assert.equal(examplePlatformFacadeState.serviceIdentities.length, 1);
 
   const connection = examplePlatformFacadeState.providerConnections[0];
@@ -150,6 +153,8 @@ test("ZITADEL session context maps to internal user workspace and entitlements",
   assert.equal(context.instanceId, "inst_local_demo");
   assert.equal(context.actor.kind, "user");
   assert.equal(context.authMethod, "zitadel-session");
+  assert.deepEqual(context.roleNames, ["operator"]);
+  assert.ok(context.permissionGrants.some((grant) => grant.permissionKey === "workflow:run"));
   assert.deepEqual(context.audit, {
     actorKind: "user",
     actorId: "usr_01hzy9operator",
@@ -250,11 +255,12 @@ test("authorization boundaries fail closed for workspace mismatch missing entitl
   assert.ok(context);
 
   const connection = examplePlatformFacadeState.providerConnections[0];
-  assert.deepEqual(authorizePlatformResource(context, { kind: "provider-connection", connection }), {
-    allowed: true,
-    reason: "allowed",
-    requiredEntitlements: ["secrets-broker-source:use"],
-  });
+  const allowed = authorizePlatformResource(context, { kind: "provider-connection", connection });
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.reason, "allowed");
+  assert.deepEqual(allowed.requiredEntitlements, ["secrets-broker-source:use"]);
+  assert.equal(allowed.requiredPermission.permissionKey, "secrets-broker-source:use");
+  assert.equal(allowed.grantEvidence.grantId, "grant_operator_provider_use");
 
   assert.equal(
     authorizePlatformResource(
@@ -279,6 +285,121 @@ test("authorization boundaries fail closed for workspace mismatch missing entitl
     }).reason,
     "connection-not-ready",
   );
+});
+
+test("scoped permission grants default deny custom groups and allow only matching service/action scopes", () => {
+  const context = mapZitadelSessionToPlatformContext({
+    issuer: "http://localhost:8080",
+    subject: "zitadel-user-operator",
+  });
+  assert.ok(context);
+
+  const customGroupContext = {
+    ...context,
+    roleIds: ["role_postgres_admins"],
+    roleNames: ["postgres-admins"],
+    entitlements: ["workspace:read"],
+    permissionGrants: [],
+  };
+  const defaultDenied = authorizePlatformResource(customGroupContext, {
+    kind: "service-action",
+    workspaceId: "wks_local_demo",
+    serviceId: "@postgres",
+    actionId: "services.restart",
+    permissionKey: "service:restart",
+  });
+  assert.equal(defaultDenied.allowed, false);
+  assert.equal(defaultDenied.reason, "missing-grant");
+
+  const scopedContext = {
+    ...customGroupContext,
+    permissionGrants: [
+      {
+        id: "grant_postgres_admins_restart_postgres",
+        workspaceId: "wks_local_demo",
+        target: { kind: "role", id: "role_postgres_admins" },
+        permissionKey: "service:restart",
+        scope: { type: "service", id: "@postgres" },
+        createdBy: "usr_01hzy9operator",
+        createdAt: "2026-05-08T11:00:00Z",
+        reason: "Postgres Admins may restart only Postgres.",
+      },
+    ],
+  };
+  const postgresAllowed = authorizePlatformResource(scopedContext, {
+    kind: "service-action",
+    workspaceId: "wks_local_demo",
+    serviceId: "@postgres",
+    actionId: "services.restart",
+    permissionKey: "service:restart",
+  });
+  assert.equal(postgresAllowed.allowed, true);
+  assert.equal(postgresAllowed.grantEvidence.grantId, "grant_postgres_admins_restart_postgres");
+
+  const wrongServiceDenied = authorizePlatformResource(scopedContext, {
+    kind: "service-action",
+    workspaceId: "wks_local_demo",
+    serviceId: "@redis",
+    actionId: "services.restart",
+    permissionKey: "service:restart",
+  });
+  assert.equal(wrongServiceDenied.allowed, false);
+  assert.equal(wrongServiceDenied.reason, "missing-grant");
+});
+
+test("owner wildcard grant allows all service actions while service import does not auto-grant", () => {
+  const ownerContext = {
+    userId: "usr_owner",
+    workspaceId: "wks_local_demo",
+    instanceId: "inst_local_demo",
+    linkedIdentityId: "lid_owner",
+    entitlements: ["workspace:read"],
+    roleIds: ["role_owner"],
+    roleNames: ["owner"],
+    permissionGrants: [
+      {
+        id: "grant_owner_runtime_all",
+        workspaceId: "wks_local_demo",
+        target: { kind: "role", id: "role_owner" },
+        permissionKey: "*",
+        scope: { type: "runtime", id: "*" },
+        createdBy: "bootstrap",
+        createdAt: "2026-05-08T10:00:00Z",
+        reason: "Owner/root bootstrap grant.",
+      },
+    ],
+    actor: { kind: "user", id: "usr_owner", displayName: "Owner Example" },
+    authMethod: "zitadel-session",
+    audit: {
+      actorKind: "user",
+      actorId: "usr_owner",
+      workspaceId: "wks_local_demo",
+      instanceId: "inst_local_demo",
+      linkedIdentityId: "lid_owner",
+      authMethod: "zitadel-session",
+    },
+  };
+
+  const allowed = authorizePlatformResource(ownerContext, {
+    kind: "service-action",
+    workspaceId: "wks_local_demo",
+    serviceId: "@redis",
+    actionId: "services.restart",
+    permissionKey: "service:restart",
+  });
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.grantEvidence.grantId, "grant_owner_runtime_all");
+
+  const imported = registerServiceActionPermission(examplePlatformFacadeState, {
+    serviceId: "@postgres",
+    actionId: "services.restart",
+    permissionKey: "service:restart",
+    scopeType: "service",
+    description: "Restart Postgres after a configuration change.",
+    registeredAt: "2026-05-08T11:00:00Z",
+  });
+  assert.equal(imported.serviceActionPermissions.some((action) => action.serviceId === "@postgres"), true);
+  assert.deepEqual(imported.permissionGrants, examplePlatformFacadeState.permissionGrants);
 });
 
 test("provider connection metadata rejects raw secret and recovery material fields", () => {


### PR DESCRIPTION
## Issue
Closes #830

## Summary
- Adds explicit scoped permission grants to the core facade contract.
- Adds service action permission catalogue registration without implicit grants.
- Gates resolver-produced authorization decisions on matching grant evidence while keeping legacy hand-built contexts compatible.
- Extends tests for default deny, owner wildcard allow, scoped service allow, wrong-service deny, and service import no-auto-grant.

## Scope
- In scope: platform facade permission grant model, authorization evidence, service-action resource checks, docs, and focused regression tests.
- Out of scope: Service Admin assignment UI, durable persistence/migrations, provider-specific auth mechanics, and full runtime endpoint wiring.

## Spec / contract / fixture impact
- Updated: `PlatformFacadeState` now includes `permissionGrants` and `serviceActionPermissions`.
- Updated: resolver-produced request contexts include role evidence and matched grants for scoped authorization.
- Updated: `authorizePlatformResource` returns required permission and matched grant evidence.

## Service Lasso invariant impact
- Invariant: default decision is deny; adding or importing a service does not grant access to existing non-owner groups.
- Preservation proof: focused tests cover empty custom grants, service-scoped allow, wrong-service deny, owner wildcard allow, and no-auto-grant service action registration.

## Validation
- PASS `npm ci` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T225108+1000\issue-830-npm-ci.stdout.log`
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T225108+1000\issue-830-npm-build-final.stdout.log`
- PASS `node --test --test-concurrency=1 tests/product-api-facade.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T225108+1000\issue-830-product-api-facade-test-final.stdout.log`
- PASS `node --test --test-concurrency=1 tests/provider-connection-lifecycle.test.js tests/workflow-run-facade.test.js` — `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260731T225108+1000\issue-830-adjacent-facade-tests-final.stdout.log`

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this changes the central authorization contract and audit evidence shape.

## Cleanup
- Branch `fix/830-scoped-permission-grants` is pushed. Demo proof will be captured before final developer handoff.
