### PR TITLE
#831 document launch setup prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ POST /api/services/:id/recovery/doctor
 
 `POST /api/services/:id/start` and `POST /api/runtime/actions/startAll` use full start semantics: enabled services are installed, configured, non-manual setup steps are reconciled, and then startable services are started in dependency order. Provider-role services in the canonical baseline, including disabled-by-default providers such as `@archive` and supported `@python` artifacts, are still prepared, but they do not require a managed daemon process. Disabled non-provider services, unsupported host artifacts, already-running services, autostart filtering, and truly non-startable services remain explicit skip/blocker cases instead of being forced.
 
+First-run setup is a launch prerequisite. When `GET /api/setup/status` reports
+setup mode, the CLI/API runtime prepares only the setup dependency path
+(`@node`, `@secretsbroker`, and `@serviceadmin`) and skips normal managed
+service starts until the vault owner identity, Owner group, built-in groups, and
+permission catalogue are seeded. Existing workspaces with a ready vault marker
+continue the normal launch path.
+
 ## Use From npm
 
 The public package is:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,6 +41,12 @@ This starts the Service Lasso API and runs the baseline service set from `servic
 
 The API uses port `18090` so it does not collide with the checked-in `@nginx` baseline service on port `18080`.
 
+On a fresh workspace, launch first enters setup mode. The runtime exposes setup
+state at `http://127.0.0.1:18090/api/setup/status` and starts only the setup
+dependencies needed to complete first-run bootstrap before regular managed
+services are started. After setup completes, rerun the same start command to
+continue the normal baseline launch.
+
 Keep this terminal open while you test. Stop it later with `Ctrl+C`.
 
 ## 4. Open the Useful URLs
@@ -48,6 +54,7 @@ Keep this terminal open while you test. Stop it later with `Ctrl+C`.
 | URL | Purpose |
 | --- | --- |
 | `http://127.0.0.1:18090/api/health` | Service Lasso API health |
+| `http://127.0.0.1:18090/api/setup/status` | first-run setup state and blockers |
 | `http://127.0.0.1:18090/api/services` | discovered services and lifecycle state |
 | `http://127.0.0.1:17700/` | Service Admin UI |
 | `http://127.0.0.1:4010/` | Echo Service UI/API |

--- a/docs/reference/first-run-vault-bootstrap-permissions.md
+++ b/docs/reference/first-run-vault-bootstrap-permissions.md
@@ -55,6 +55,40 @@ preparation, manifest discovery, and diagnostics can still run when they are
 safe and non-mutating, but baseline service startup must not proceed until the
 vault owner identity exists.
 
+## Launch prerequisite contract
+
+The normal launch path treats setup as a prerequisite phase before managed
+services are allowed to start. Startup resolves the setup status first, then
+uses that decision for both CLI output and runtime API state:
+
+1. Discover the workspace and service roots.
+2. Read setup status from the configured workspace vault path.
+3. If setup is required, prepare only the setup-capable dependency set:
+   `@node`, `@secretsbroker`, and `@serviceadmin`.
+4. Expose setup mode through `GET /api/setup/status` and show the local setup
+   URL from the runtime host and port when an interactive operator can complete
+   setup.
+5. Accept non-interactive setup inputs only from configured setup sources such
+   as `SERVICE_LASSO_SETUP_TOKEN`, `SERVICE_LASSO_VAULT_PATH`, or mounted
+   secret-provider files.
+6. Seed the vault owner identity, Owner group, built-in groups, and permission
+   catalogue before normal mutating actions are allowed.
+7. Record setup decisions and denials as metadata-only audit/history events.
+8. Re-read setup status after bootstrap; when setup is `not_required`, continue
+   the regular managed service launch set in dependency order.
+
+While setup mode is active, install and config reconciliation may still run for
+services that are safe to prepare, but normal service process start is skipped
+with a setup-mode reason. Existing workspaces with a ready vault marker skip
+setup mode and continue normal launch without the setup dependency restriction.
+
+This split keeps first-run prerequisites visible without granting temporary
+admin authority to every managed service. Secrets Broker is available only for
+the setup boundary until the owner identity, built-in groups, and permission
+catalogue are seeded; after that, regular action permission checks decide which
+actors can install, configure, start, restart, import, restore, or rotate
+workspace resources.
+
 ## Vault bootstrap
 
 The first setup action creates the local vault root state and the initial owner


### PR DESCRIPTION
## Issue
Refs #831

## Summary
- Documented the launch prerequisite contract for first-run setup before normal managed services start.
- Added Quick Start setup-mode guidance and surfaced `/api/setup/status` in the useful URLs list.
- Added README API notes tying setup mode to the setup dependency path and normal launch continuation.

## Scope
- In scope: docs/spec contract for setup prerequisite launch behavior.
- Out of scope: new runtime implementation for remaining #831 acceptance criteria beyond the behavior already covered by existing setup/bootstrap code and tests.

## Spec / contract / fixture impact
- Updated: `docs/reference/first-run-vault-bootstrap-permissions.md`, `docs/quick-start.md`, `README.md`.
- Not required: fixture updates; no service manifest or API schema changed.

## Service Lasso invariant impact
- Invariant: normal managed service launch waits until first-run setup has seeded the owner boundary and permission catalogue.
- Preservation proof: documented setup dependency path and existing setup-mode skip behavior; no runtime behavior changed in this slice.

## Validation
- PASS `npm run build` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260731-234312\issue-831-npm-build-2.stdout.log`.
- PASS `npm run docs:build` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260731-234312\issue-831-docs-build.stdout.log`.
- GAP `node --test tests/bootstrap-start.test.js` timed out after 120s with no stdout/stderr before timeout; evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-a80b-434a-a15a-ce8bc53658ea-20260731-234312\issue-831-bootstrap-start-test.stdout.log`.

## Approval trail
- Required: yes.
- Evidence: Architect review requested for whether this spec slice is sufficient to close #831 or whether the remaining acceptance criteria need implementation follow-up before closure.

## Cleanup
- Branch targets `develop`; local worktree is `C:\projects\service-lasso\.worktrees\service-lasso-831`.