### PR TITLE
#832 add durable operator Inbox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ GET  /api/services
 GET  /api/services/:id
 GET  /api/runtime
 GET  /api/runtime/capabilities
+GET  /api/operator/inbox
+GET  /api/operator/inbox/counts
+POST /api/operator/inbox/record
+POST /api/operator/inbox/:id/read
+POST /api/operator/inbox/:id/hide
 POST /api/services/:id/install
 POST /api/services/:id/config
 POST /api/services/:id/start

--- a/docs/reference/operator-inbox.md
+++ b/docs/reference/operator-inbox.md
@@ -1,0 +1,71 @@
+# Operator Inbox API
+
+Service Lasso owns the durable operator Inbox. Service Admin and workflow producers should use the runtime APIs below instead of storing Inbox state in the UI.
+
+Inbox records are persisted under the workspace `.state` directory and survive Service Admin refreshes and runtime restarts. Records store safe metadata only. Raw secrets, credentials, provider tokens, cookies, private keys, passwords, bearer tokens, and raw payloads must be excluded or redacted before persistence.
+
+## Item Model
+
+Each item uses the `service-lasso.operator-inbox-item.v1` shape:
+
+- `id`: stable runtime id derived from `dedupeKey`
+- `dedupeKey`: producer-owned key used to upsert recurring notices
+- `title`, `summary`, `details`: bounded human-readable text
+- `type`: `system`, `workflow`, `service`, `update`, `security`, `help`, or `error`
+- `severity`: `info`, `success`, `warning`, `error`, or `critical`
+- `source`: `runtime`, `service`, `workflow`, `updater`, `broker`, `admin-ui`, or `system`
+- `state`: `unread` or `read`
+- `visibility`: `visible` or `hidden`
+- `createdAt`, `updatedAt`, `readAt`, `hiddenAt`
+- `relatedTarget`: optional safe references such as `serviceId`, `workflowId`, `updateId`, `auditId`, `backupExportId`, or `route`
+- `action`: optional action metadata with `label`, `target`, `kind`, and `availability`
+
+## Routes
+
+```text
+GET  /api/operator/inbox
+GET  /api/operator/inbox/:id
+GET  /api/operator/inbox/counts
+POST /api/operator/inbox/record
+POST /api/operator/inbox/:id/read
+POST /api/operator/inbox/:id/unread
+POST /api/operator/inbox/:id/hide
+POST /api/operator/inbox/:id/unhide
+POST /api/operator/inbox/bulk
+```
+
+`GET /api/operator/inbox` supports `filter`, `type`, `state`, `visibility`, `severity`, `source`, `limit`, and `cursor`.
+
+Supported `filter` values are:
+
+- `all`: visible items
+- `unread`: visible unread items
+- `updates`: visible update items
+- `system`: visible system items
+- `workflow`: visible workflow items
+- `service`: visible service items
+- `errors`: visible error or critical items
+- `hidden`: hidden items
+
+`POST /api/operator/inbox/record` upserts an item by `dedupeKey`. Existing read/hidden state is preserved while title, summary, details, severity, target, and action metadata refresh.
+
+`POST /api/operator/inbox/bulk` accepts:
+
+```json
+{
+  "action": "read",
+  "ids": ["inbox-update-core-available"]
+}
+```
+
+Bulk mutation is intentionally limited to `read` and `hide`, so broad UI actions cannot accidentally restore or unread important records.
+
+## Service Admin Contract
+
+Service Admin should use:
+
+- `GET /api/operator/inbox?filter=unread` for unread menus and badges
+- `GET /api/operator/inbox/counts` for header/sidebar counts
+- `POST /api/operator/inbox/:id/read` when an operator opens or acknowledges an item
+- `POST /api/operator/inbox/:id/hide` for dismiss actions that should be restorable
+- `GET /api/operator/inbox?filter=hidden` and `POST /api/operator/inbox/:id/unhide` for restore surfaces

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -208,6 +208,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "reference/operator-inbox",
+          label: "Operator Inbox API",
+        },
+        {
+          type: "doc",
           id: "development/telegram-group-control-plan",
           label: "Telegram Group Control Plan",
         },

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -11,6 +11,10 @@ import type { RuntimeTelemetryPreview, ServiceTelemetryPreview, TelemetryExportT
 import type { ServiceCatalogProvenance } from "./service.js";
 import type { ServiceActionRunState } from "../runtime/actions/runs.js";
 import type { ServiceWorkspaceRegistry } from "../runtime/files/workspace-registry.js";
+import type {
+  OperatorInboxCounts,
+  OperatorInboxItem,
+} from "../runtime/operator/inbox.js";
 
 export interface HealthResponse {
   service: "service-lasso";
@@ -762,6 +766,34 @@ export interface OperatorNotificationsResponse {
     critical: number;
     warning: number;
     info: number;
+  };
+}
+
+export interface OperatorInboxListResponse {
+  inbox: {
+    items: OperatorInboxItem[];
+    pagination: {
+      limit: number;
+      nextCursor: string | null;
+      total: number;
+    };
+  };
+}
+
+export interface OperatorInboxItemResponse {
+  inboxItem: OperatorInboxItem;
+}
+
+export interface OperatorInboxMutationResponse {
+  inbox: {
+    items: OperatorInboxItem[];
+    counts: OperatorInboxCounts;
+  };
+}
+
+export interface OperatorInboxCountsResponse {
+  inbox: {
+    counts: OperatorInboxCounts;
   };
 }
 

--- a/src/runtime/operator/inbox.ts
+++ b/src/runtime/operator/inbox.ts
@@ -1,0 +1,479 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+export const OPERATOR_INBOX_LIMIT = 1000;
+
+export type OperatorInboxType =
+  | "system"
+  | "workflow"
+  | "service"
+  | "update"
+  | "security"
+  | "help"
+  | "error";
+
+export type OperatorInboxSeverity = "info" | "success" | "warning" | "error" | "critical";
+export type OperatorInboxSource = "runtime" | "service" | "workflow" | "updater" | "broker" | "admin-ui" | "system";
+export type OperatorInboxState = "unread" | "read";
+export type OperatorInboxVisibility = "visible" | "hidden";
+export type OperatorInboxActionKind = "link" | "api" | "command";
+export type OperatorInboxActionAvailability = "available" | "disabled" | "expired";
+export type OperatorInboxFilter =
+  | "all"
+  | "unread"
+  | "updates"
+  | "system"
+  | "workflow"
+  | "service"
+  | "errors"
+  | "hidden";
+
+export interface OperatorInboxRelatedTarget {
+  serviceId?: string;
+  workflowId?: string;
+  updateId?: string;
+  auditId?: string;
+  backupExportId?: string;
+  route?: string;
+}
+
+export interface OperatorInboxActionMetadata {
+  label: string;
+  target: string;
+  kind: OperatorInboxActionKind;
+  availability: OperatorInboxActionAvailability;
+}
+
+export interface OperatorInboxItem {
+  id: string;
+  dedupeKey: string;
+  title: string;
+  summary: string;
+  details: string | null;
+  type: OperatorInboxType;
+  severity: OperatorInboxSeverity;
+  source: OperatorInboxSource;
+  state: OperatorInboxState;
+  visibility: OperatorInboxVisibility;
+  createdAt: string;
+  updatedAt: string;
+  readAt: string | null;
+  hiddenAt: string | null;
+  relatedTarget: OperatorInboxRelatedTarget | null;
+  action: OperatorInboxActionMetadata | null;
+}
+
+export interface OperatorInboxStateFile {
+  updatedAt: string;
+  items: OperatorInboxItem[];
+}
+
+export interface OperatorInboxInput {
+  dedupeKey: string;
+  title: string;
+  summary: string;
+  details?: string | null;
+  type: OperatorInboxType;
+  severity: OperatorInboxSeverity;
+  source: OperatorInboxSource;
+  relatedTarget?: OperatorInboxRelatedTarget | null;
+  action?: OperatorInboxActionMetadata | null;
+  observedAt?: string;
+}
+
+export interface OperatorInboxQuery {
+  filter?: OperatorInboxFilter;
+  type?: OperatorInboxType;
+  state?: OperatorInboxState;
+  visibility?: OperatorInboxVisibility;
+  severity?: OperatorInboxSeverity;
+  source?: OperatorInboxSource;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface OperatorInboxListResult {
+  items: OperatorInboxItem[];
+  pagination: {
+    limit: number;
+    nextCursor: string | null;
+    total: number;
+  };
+}
+
+export interface OperatorInboxCounts {
+  total: number;
+  unread: number;
+  read: number;
+  visible: number;
+  hidden: number;
+  byType: Record<OperatorInboxType, number>;
+  bySeverity: Record<OperatorInboxSeverity, number>;
+  bySource: Record<OperatorInboxSource, number>;
+  byFilter: Record<OperatorInboxFilter, number>;
+}
+
+const inboxWriteQueues = new Map<string, Promise<void>>();
+
+const INBOX_TYPES: OperatorInboxType[] = ["system", "workflow", "service", "update", "security", "help", "error"];
+const INBOX_SEVERITIES: OperatorInboxSeverity[] = ["info", "success", "warning", "error", "critical"];
+const INBOX_SOURCES: OperatorInboxSource[] = ["runtime", "service", "workflow", "updater", "broker", "admin-ui", "system"];
+const INBOX_FILTERS: OperatorInboxFilter[] = ["all", "unread", "updates", "system", "workflow", "service", "errors", "hidden"];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function inboxPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".state", "operator-inbox.json");
+}
+
+function stableIdFromDedupeKey(dedupeKey: string): string {
+  const normalized = dedupeKey
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96);
+  return normalized ? "inbox-" + normalized : "inbox-unknown";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function oneOf<T extends string>(value: unknown, values: readonly T[], fallback: T): T {
+  return typeof value === "string" && values.includes(value as T) ? value as T : fallback;
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function sanitizeText(value: string): string {
+  return value
+    .replace(/([\w.-]*(?:password|passwd|secret|token|key|credential|cookie)[\w.-]*\s*[:=]\s*)[^\s,;]+/gi, "$1[redacted]")
+    .replace(/(bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(/(gh[pousr]_[A-Za-z0-9_]+)/g, "[redacted]")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeRelatedTarget(value: unknown): OperatorInboxRelatedTarget | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const target: OperatorInboxRelatedTarget = {};
+  for (const key of ["serviceId", "workflowId", "updateId", "auditId", "backupExportId", "route"] as const) {
+    if (typeof value[key] === "string" && value[key].trim()) {
+      target[key] = sanitizeText(value[key]);
+    }
+  }
+
+  return Object.keys(target).length > 0 ? target : null;
+}
+
+function normalizeAction(value: unknown): OperatorInboxActionMetadata | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const label = sanitizeText(stringOr(value.label, ""));
+  const target = sanitizeText(stringOr(value.target, ""));
+  if (!label || !target) {
+    return null;
+  }
+
+  return {
+    label,
+    target,
+    kind: oneOf(value.kind, ["link", "api", "command"] as const, "link"),
+    availability: oneOf(value.availability, ["available", "disabled", "expired"] as const, "available"),
+  };
+}
+
+function normalizeItem(value: unknown): OperatorInboxItem | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const dedupeKey = sanitizeText(stringOr(value.dedupeKey, ""));
+  if (!dedupeKey) {
+    return null;
+  }
+
+  const observedAt = stringOr(value.updatedAt, nowIso());
+  const state = oneOf(value.state, ["unread", "read"] as const, "unread");
+  const visibility = oneOf(value.visibility, ["visible", "hidden"] as const, "visible");
+  return {
+    id: stringOr(value.id, stableIdFromDedupeKey(dedupeKey)),
+    dedupeKey,
+    title: sanitizeText(stringOr(value.title, "Inbox item")),
+    summary: sanitizeText(stringOr(value.summary, "")),
+    details: stringOrNull(value.details) === null ? null : sanitizeText(stringOr(value.details, "")),
+    type: oneOf(value.type, INBOX_TYPES, "system"),
+    severity: oneOf(value.severity, INBOX_SEVERITIES, "info"),
+    source: oneOf(value.source, INBOX_SOURCES, "runtime"),
+    state,
+    visibility,
+    createdAt: stringOr(value.createdAt, observedAt),
+    updatedAt: observedAt,
+    readAt: state === "read" ? stringOrNull(value.readAt) ?? observedAt : null,
+    hiddenAt: visibility === "hidden" ? stringOrNull(value.hiddenAt) ?? observedAt : null,
+    relatedTarget: normalizeRelatedTarget(value.relatedTarget),
+    action: normalizeAction(value.action),
+  };
+}
+
+export function normalizeOperatorInboxState(input: unknown): OperatorInboxStateFile {
+  if (!isRecord(input)) {
+    return { updatedAt: nowIso(), items: [] };
+  }
+
+  return {
+    updatedAt: stringOr(input.updatedAt, nowIso()),
+    items: Array.isArray(input.items)
+      ? input.items.flatMap((entry) => {
+          const item = normalizeItem(entry);
+          return item ? [item] : [];
+        })
+      : [],
+  };
+}
+
+async function withQueueLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const previous = inboxWriteQueues.get(filePath) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(operation);
+  const settled = next.then(() => undefined, () => undefined);
+  inboxWriteQueues.set(filePath, settled);
+
+  try {
+    return await next;
+  } finally {
+    if (inboxWriteQueues.get(filePath) === settled) {
+      inboxWriteQueues.delete(filePath);
+    }
+  }
+}
+
+export async function readOperatorInbox(workspaceRoot: string): Promise<OperatorInboxStateFile> {
+  try {
+    return normalizeOperatorInboxState(JSON.parse(await readFile(inboxPath(workspaceRoot), "utf8")) as unknown);
+  } catch {
+    return normalizeOperatorInboxState(null);
+  }
+}
+
+async function writeOperatorInboxWithoutQueue(
+  workspaceRoot: string,
+  state: OperatorInboxStateFile,
+): Promise<OperatorInboxStateFile> {
+  const updatedAt = state.updatedAt || nowIso();
+  const nextState: OperatorInboxStateFile = {
+    updatedAt,
+    items: state.items
+      .map((item) => normalizeItem(item))
+      .flatMap((item) => item ? [item] : [])
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, OPERATOR_INBOX_LIMIT),
+  };
+
+  const filePath = inboxPath(workspaceRoot);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(nextState, null, 2));
+  return nextState;
+}
+
+export async function writeOperatorInbox(
+  workspaceRoot: string,
+  state: OperatorInboxStateFile,
+): Promise<OperatorInboxStateFile> {
+  const filePath = inboxPath(workspaceRoot);
+  return await withQueueLock(filePath, () => writeOperatorInboxWithoutQueue(workspaceRoot, state));
+}
+
+export async function upsertOperatorInboxItem(
+  workspaceRoot: string,
+  input: OperatorInboxInput,
+): Promise<OperatorInboxStateFile> {
+  const filePath = inboxPath(workspaceRoot);
+  return await withQueueLock(filePath, async () => {
+    const existing = await readOperatorInbox(workspaceRoot);
+    const observedAt = input.observedAt ?? nowIso();
+    const dedupeKey = sanitizeText(input.dedupeKey);
+    const existingItem = existing.items.find((item) => item.dedupeKey === dedupeKey);
+    const nextItem: OperatorInboxItem = {
+      id: existingItem?.id ?? stableIdFromDedupeKey(dedupeKey),
+      dedupeKey,
+      title: sanitizeText(input.title),
+      summary: sanitizeText(input.summary),
+      details: input.details === undefined || input.details === null ? null : sanitizeText(input.details),
+      type: input.type,
+      severity: input.severity,
+      source: input.source,
+      state: existingItem?.state ?? "unread",
+      visibility: existingItem?.visibility ?? "visible",
+      createdAt: existingItem?.createdAt ?? observedAt,
+      updatedAt: observedAt,
+      readAt: existingItem?.readAt ?? null,
+      hiddenAt: existingItem?.hiddenAt ?? null,
+      relatedTarget: normalizeRelatedTarget(input.relatedTarget ?? null),
+      action: normalizeAction(input.action ?? null),
+    };
+
+    return await writeOperatorInboxWithoutQueue(workspaceRoot, {
+      updatedAt: observedAt,
+      items: [nextItem, ...existing.items.filter((item) => item.id !== nextItem.id)],
+    });
+  });
+}
+
+export async function mutateOperatorInboxItem(
+  workspaceRoot: string,
+  itemId: string,
+  action: "read" | "unread" | "hide" | "unhide",
+  now = nowIso(),
+): Promise<OperatorInboxStateFile> {
+  const filePath = inboxPath(workspaceRoot);
+  return await withQueueLock(filePath, async () => {
+    const existing = await readOperatorInbox(workspaceRoot);
+    let found = false;
+    const items = existing.items.map((item) => {
+      if (item.id !== itemId) {
+        return item;
+      }
+
+      found = true;
+      if (action === "read") {
+        return { ...item, state: "read" as const, updatedAt: now, readAt: now };
+      }
+      if (action === "unread") {
+        return { ...item, state: "unread" as const, updatedAt: now, readAt: null };
+      }
+      if (action === "hide") {
+        return { ...item, visibility: "hidden" as const, updatedAt: now, hiddenAt: now };
+      }
+      return { ...item, visibility: "visible" as const, updatedAt: now, hiddenAt: null };
+    });
+
+    if (!found) {
+      throw new Error("Unknown operator inbox item id: " + itemId + ".");
+    }
+
+    return await writeOperatorInboxWithoutQueue(workspaceRoot, { updatedAt: now, items });
+  });
+}
+
+export async function bulkMutateOperatorInboxItems(
+  workspaceRoot: string,
+  action: "read" | "hide",
+  itemIds: string[],
+  now = nowIso(),
+): Promise<OperatorInboxStateFile> {
+  const filePath = inboxPath(workspaceRoot);
+  return await withQueueLock(filePath, async () => {
+    const existing = await readOperatorInbox(workspaceRoot);
+    const selected = new Set(itemIds);
+    const items = existing.items.map((item) => {
+      if (!selected.has(item.id)) {
+        return item;
+      }
+      if (action === "read") {
+        return { ...item, state: "read" as const, updatedAt: now, readAt: now };
+      }
+      return { ...item, visibility: "hidden" as const, updatedAt: now, hiddenAt: now };
+    });
+    return await writeOperatorInboxWithoutQueue(workspaceRoot, { updatedAt: now, items });
+  });
+}
+
+function matchesFilter(item: OperatorInboxItem, filter: OperatorInboxFilter): boolean {
+  if (filter === "all") {
+    return item.visibility === "visible";
+  }
+  if (filter === "unread") {
+    return item.state === "unread" && item.visibility === "visible";
+  }
+  if (filter === "updates") {
+    return item.type === "update" && item.visibility === "visible";
+  }
+  if (filter === "system") {
+    return item.type === "system" && item.visibility === "visible";
+  }
+  if (filter === "workflow") {
+    return item.type === "workflow" && item.visibility === "visible";
+  }
+  if (filter === "service") {
+    return item.type === "service" && item.visibility === "visible";
+  }
+  if (filter === "errors") {
+    return (item.type === "error" || item.severity === "error" || item.severity === "critical") && item.visibility === "visible";
+  }
+  return item.visibility === "hidden";
+}
+
+export function filterOperatorInboxItems(
+  items: OperatorInboxItem[],
+  query: OperatorInboxQuery = {},
+): OperatorInboxItem[] {
+  const filter = query.filter ?? "all";
+  return items.filter((item) => {
+    return (
+      matchesFilter(item, filter) &&
+      (query.type === undefined || item.type === query.type) &&
+      (query.state === undefined || item.state === query.state) &&
+      (query.visibility === undefined || item.visibility === query.visibility) &&
+      (query.severity === undefined || item.severity === query.severity) &&
+      (query.source === undefined || item.source === query.source)
+    );
+  });
+}
+
+export function listOperatorInboxItems(
+  state: OperatorInboxStateFile,
+  query: OperatorInboxQuery = {},
+): OperatorInboxListResult {
+  const limit = Math.min(Math.max(query.limit ?? 50, 1), 200);
+  const offset = query.cursor ? Math.max(Number.parseInt(query.cursor, 10) || 0, 0) : 0;
+  const filtered = filterOperatorInboxItems(state.items, query);
+  const items = filtered.slice(offset, offset + limit);
+  const nextOffset = offset + items.length;
+  return {
+    items,
+    pagination: {
+      limit,
+      nextCursor: nextOffset < filtered.length ? String(nextOffset) : null,
+      total: filtered.length,
+    },
+  };
+}
+
+export function countOperatorInboxItems(items: OperatorInboxItem[]): OperatorInboxCounts {
+  const counts: OperatorInboxCounts = {
+    total: items.length,
+    unread: items.filter((item) => item.state === "unread").length,
+    read: items.filter((item) => item.state === "read").length,
+    visible: items.filter((item) => item.visibility === "visible").length,
+    hidden: items.filter((item) => item.visibility === "hidden").length,
+    byType: { system: 0, workflow: 0, service: 0, update: 0, security: 0, help: 0, error: 0 },
+    bySeverity: { info: 0, success: 0, warning: 0, error: 0, critical: 0 },
+    bySource: { runtime: 0, service: 0, workflow: 0, updater: 0, broker: 0, "admin-ui": 0, system: 0 },
+    byFilter: { all: 0, unread: 0, updates: 0, system: 0, workflow: 0, service: 0, errors: 0, hidden: 0 },
+  };
+
+  for (const item of items) {
+    counts.byType[item.type] += 1;
+    counts.bySeverity[item.severity] += 1;
+    counts.bySource[item.source] += 1;
+  }
+
+  for (const filter of INBOX_FILTERS) {
+    counts.byFilter[filter] = items.filter((item) => matchesFilter(item, filter)).length;
+  }
+
+  return counts;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -132,6 +132,24 @@ import {
   type OperatorActionMutationInput,
   type OperatorActionQueueState,
 } from "../runtime/operator/action-queue.js";
+import {
+  bulkMutateOperatorInboxItems,
+  countOperatorInboxItems,
+  listOperatorInboxItems,
+  mutateOperatorInboxItem,
+  readOperatorInbox,
+  upsertOperatorInboxItem,
+  type OperatorInboxActionAvailability,
+  type OperatorInboxActionKind,
+  type OperatorInboxFilter,
+  type OperatorInboxInput,
+  type OperatorInboxQuery,
+  type OperatorInboxSeverity,
+  type OperatorInboxSource,
+  type OperatorInboxState,
+  type OperatorInboxType,
+  type OperatorInboxVisibility,
+} from "../runtime/operator/inbox.js";
 import { buildDiagnosticsBundle } from "../runtime/diagnostics/bundle.js";
 import { resolveProviderExecution } from "../runtime/providers/resolveProvider.js";
 import { ensureRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from "../runtime/config.js";
@@ -295,6 +313,144 @@ function parseServiceLogReadType(value: string | null): ServiceLogReadType {
 
 function cloneWorkflowRunFacadeState(state: WorkflowRunFacadeState): WorkflowRunFacadeState {
   return JSON.parse(JSON.stringify(state)) as WorkflowRunFacadeState;
+}
+
+const OPERATOR_INBOX_TYPES = ["system", "workflow", "service", "update", "security", "help", "error"] as const;
+const OPERATOR_INBOX_SEVERITIES = ["info", "success", "warning", "error", "critical"] as const;
+const OPERATOR_INBOX_SOURCES = ["runtime", "service", "workflow", "updater", "broker", "admin-ui", "system"] as const;
+const OPERATOR_INBOX_FILTERS = ["all", "unread", "updates", "system", "workflow", "service", "errors", "hidden"] as const;
+const OPERATOR_INBOX_STATES = ["unread", "read"] as const;
+const OPERATOR_INBOX_VISIBILITIES = ["visible", "hidden"] as const;
+const OPERATOR_INBOX_ACTION_KINDS = ["link", "api", "command"] as const;
+const OPERATOR_INBOX_ACTION_AVAILABILITIES = ["available", "disabled", "expired"] as const;
+
+function parseEnum<T extends string>(
+  name: string,
+  value: unknown,
+  values: readonly T[],
+  options: { required?: boolean } = {},
+): T | undefined {
+  if (value === undefined || value === null || value === "") {
+    if (options.required) {
+      throw new ApiError("invalid_body", 400, `"${name}" must be one of: ${values.join(", ")}.`);
+    }
+    return undefined;
+  }
+  if (typeof value === "string" && values.includes(value as T)) {
+    return value as T;
+  }
+  throw new ApiError("invalid_body", 400, `"${name}" must be one of: ${values.join(", ")}.`);
+}
+
+function parseOperatorInboxQuery(searchParams: URLSearchParams): OperatorInboxQuery {
+  const limit = parseOptionalInteger(searchParams.get("limit"));
+  if (limit !== undefined && limit <= 0) {
+    throw new ApiError("invalid_request", 400, '"limit" must be a positive integer.');
+  }
+
+  return {
+    filter: parseEnum<OperatorInboxFilter>("filter", searchParams.get("filter") ?? undefined, OPERATOR_INBOX_FILTERS),
+    type: parseEnum<OperatorInboxType>("type", searchParams.get("type") ?? undefined, OPERATOR_INBOX_TYPES),
+    state: parseEnum<OperatorInboxState>("state", searchParams.get("state") ?? undefined, OPERATOR_INBOX_STATES),
+    visibility: parseEnum<OperatorInboxVisibility>(
+      "visibility",
+      searchParams.get("visibility") ?? undefined,
+      OPERATOR_INBOX_VISIBILITIES,
+    ),
+    severity: parseEnum<OperatorInboxSeverity>(
+      "severity",
+      searchParams.get("severity") ?? undefined,
+      OPERATOR_INBOX_SEVERITIES,
+    ),
+    source: parseEnum<OperatorInboxSource>("source", searchParams.get("source") ?? undefined, OPERATOR_INBOX_SOURCES),
+    limit,
+    cursor: searchParams.get("cursor") ?? undefined,
+  };
+}
+
+function parseOperatorInboxRecordBody(input: unknown): OperatorInboxInput {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Operator inbox record body must be a JSON object.");
+  }
+  const candidate = input as Record<string, unknown>;
+  if (typeof candidate.dedupeKey !== "string" || !candidate.dedupeKey.trim()) {
+    throw new ApiError("invalid_body", 400, '"dedupeKey" must be a non-empty string.');
+  }
+  if (typeof candidate.title !== "string" || !candidate.title.trim()) {
+    throw new ApiError("invalid_body", 400, '"title" must be a non-empty string.');
+  }
+  if (typeof candidate.summary !== "string") {
+    throw new ApiError("invalid_body", 400, '"summary" must be a string.');
+  }
+  if (candidate.details !== undefined && candidate.details !== null && typeof candidate.details !== "string") {
+    throw new ApiError("invalid_body", 400, '"details" must be a string or null when present.');
+  }
+
+  const action = candidate.action;
+  if (action !== undefined && action !== null && (!action || typeof action !== "object" || Array.isArray(action))) {
+    throw new ApiError("invalid_body", 400, '"action" must be an object or null when present.');
+  }
+  if (action && typeof action === "object" && !Array.isArray(action)) {
+    const actionRecord = action as Record<string, unknown>;
+    parseEnum<OperatorInboxActionKind>("action.kind", actionRecord.kind, OPERATOR_INBOX_ACTION_KINDS, { required: true });
+    parseEnum<OperatorInboxActionAvailability>(
+      "action.availability",
+      actionRecord.availability,
+      OPERATOR_INBOX_ACTION_AVAILABILITIES,
+      { required: true },
+    );
+  }
+
+  return {
+    dedupeKey: candidate.dedupeKey,
+    title: candidate.title,
+    summary: candidate.summary,
+    details: typeof candidate.details === "string" ? candidate.details : null,
+    type: parseEnum<OperatorInboxType>("type", candidate.type, OPERATOR_INBOX_TYPES, { required: true }) ?? "system",
+    severity: parseEnum<OperatorInboxSeverity>("severity", candidate.severity, OPERATOR_INBOX_SEVERITIES, { required: true }) ?? "info",
+    source: parseEnum<OperatorInboxSource>("source", candidate.source, OPERATOR_INBOX_SOURCES, { required: true }) ?? "runtime",
+    relatedTarget: candidate.relatedTarget as OperatorInboxInput["relatedTarget"],
+    action: candidate.action as OperatorInboxInput["action"],
+    observedAt: typeof candidate.observedAt === "string" ? candidate.observedAt : undefined,
+  };
+}
+
+function parseOperatorInboxMutationBody(input: unknown): { now?: string } {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {};
+  }
+  const candidate = input as Record<string, unknown>;
+  if (candidate.now !== undefined && typeof candidate.now !== "string") {
+    throw new ApiError("invalid_body", 400, '"now" must be an ISO timestamp string when present.');
+  }
+  return {
+    now: typeof candidate.now === "string" ? candidate.now : undefined,
+  };
+}
+
+function parseOperatorInboxBulkBody(input: unknown): {
+  action: "read" | "hide";
+  ids: string[];
+  now?: string;
+} {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new ApiError("invalid_body", 400, "Operator inbox bulk body must be a JSON object.");
+  }
+  const candidate = input as Record<string, unknown>;
+  if (candidate.action !== "read" && candidate.action !== "hide") {
+    throw new ApiError("invalid_body", 400, '"action" must be one of: read, hide.');
+  }
+  if (!Array.isArray(candidate.ids) || candidate.ids.some((entry) => typeof entry !== "string" || !entry.trim())) {
+    throw new ApiError("invalid_body", 400, '"ids" must be an array of non-empty strings.');
+  }
+  if (candidate.now !== undefined && typeof candidate.now !== "string") {
+    throw new ApiError("invalid_body", 400, '"now" must be an ISO timestamp string when present.');
+  }
+  return {
+    action: candidate.action,
+    ids: candidate.ids,
+    now: typeof candidate.now === "string" ? candidate.now : undefined,
+  };
 }
 
 function parseOperatorActionRecordBody(input: unknown): OperatorActionInput {
@@ -1733,6 +1889,79 @@ async function routeRequest(
         await buildOperatorNotifications(runtimeModel.discovered, runtimeModel.registry, sharedGlobalEnv),
       ),
     );
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/operator/inbox") {
+    const inbox = await readOperatorInbox(config.workspaceRoot);
+    writeJson(response, 200, {
+      inbox: listOperatorInboxItems(inbox, parseOperatorInboxQuery(url.searchParams)),
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/operator/inbox/counts") {
+    const inbox = await readOperatorInbox(config.workspaceRoot);
+    writeJson(response, 200, {
+      inbox: {
+        counts: countOperatorInboxItems(inbox.items),
+      },
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/api/operator/inbox/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const inboxItemId = decodeURIComponent(pathParts[3] ?? "");
+    const inbox = await readOperatorInbox(config.workspaceRoot);
+    const inboxItem = inbox.items.find((item) => item.id === inboxItemId);
+    if (!inboxItem) {
+      throw new ApiError("inbox_item_not_found", 404, "Unknown operator inbox item id: " + inboxItemId + ".");
+    }
+    writeJson(response, 200, {
+      inboxItem,
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/operator/inbox/record") {
+    const inbox = await upsertOperatorInboxItem(config.workspaceRoot, parseOperatorInboxRecordBody(await readJsonBody(request)));
+    writeJson(response, 200, {
+      inbox: {
+        items: inbox.items,
+        counts: countOperatorInboxItems(inbox.items),
+      },
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/operator/inbox/bulk") {
+    const body = parseOperatorInboxBulkBody(await readJsonBody(request));
+    const inbox = await bulkMutateOperatorInboxItems(config.workspaceRoot, body.action, body.ids, body.now);
+    writeJson(response, 200, {
+      inbox: {
+        items: inbox.items,
+        counts: countOperatorInboxItems(inbox.items),
+      },
+    });
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname.startsWith("/api/operator/inbox/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const inboxItemId = decodeURIComponent(pathParts[3] ?? "");
+    const mutation = pathParts[4];
+    if (!inboxItemId || (mutation !== "read" && mutation !== "unread" && mutation !== "hide" && mutation !== "unhide")) {
+      throw new ApiError("invalid_action", 400, "Unknown operator inbox mutation route.");
+    }
+    const body = parseOperatorInboxMutationBody(await readJsonBody(request));
+    const inbox = await mutateOperatorInboxItem(config.workspaceRoot, inboxItemId, mutation, body.now);
+    writeJson(response, 200, {
+      inbox: {
+        items: inbox.items,
+        counts: countOperatorInboxItems(inbox.items),
+      },
+    });
     return;
   }
 

--- a/tests/operator-inbox.test.js
+++ b/tests/operator-inbox.test.js
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile, rm } from "node:fs/promises";
+import {
+  readOperatorInbox,
+  upsertOperatorInboxItem,
+} from "../dist/runtime/operator/inbox.js";
+import { startApiServer } from "../dist/server/index.js";
+import { makeTempServicesRoot } from "./test-helpers.js";
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+async function postJson(url, body = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+test("operator inbox persists durable items and redacts sensitive fields", async () => {
+  const { tempRoot } = await makeTempServicesRoot("service-lasso-operator-inbox-state-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+
+  try {
+    let inbox = await upsertOperatorInboxItem(workspaceRoot, {
+      dedupeKey: "update:@node:available",
+      title: "Provider update available",
+      summary: "A new provider package is ready without token=ghp_exampleSecret.",
+      details: "Download using Bearer abcdef123456 should never be stored.",
+      type: "update",
+      severity: "info",
+      source: "updater",
+      relatedTarget: {
+        serviceId: "@node",
+        updateId: "2026.8.1",
+        route: "/services/@node/updates?token=ghp_routeSecret",
+      },
+      action: {
+        label: "Install update",
+        target: "/api/services/%40node/update/install",
+        kind: "api",
+        availability: "available",
+      },
+      observedAt: "2026-08-01T00:00:00.000Z",
+    });
+
+    assert.equal(inbox.items.length, 1);
+    assert.equal(inbox.items[0].id, "inbox-update:-node:available");
+    assert.equal(inbox.items[0].state, "unread");
+    assert.equal(inbox.items[0].visibility, "visible");
+
+    const initiallyPersisted = await readFile(path.join(workspaceRoot, ".state", "operator-inbox.json"), "utf8");
+    assert.doesNotMatch(initiallyPersisted, /ghp_exampleSecret|abcdef123456|ghp_routeSecret/);
+    assert.match(initiallyPersisted, /\[redacted\]/);
+
+    inbox = await upsertOperatorInboxItem(workspaceRoot, {
+      dedupeKey: "update:@node:available",
+      title: "Provider update still available",
+      summary: "Safe retry summary.",
+      type: "update",
+      severity: "warning",
+      source: "updater",
+      observedAt: "2026-08-01T00:05:00.000Z",
+    });
+
+    assert.equal(inbox.items.length, 1);
+    assert.equal(inbox.items[0].title, "Provider update still available");
+    assert.equal(inbox.items[0].createdAt, "2026-08-01T00:00:00.000Z");
+    assert.equal(inbox.items[0].updatedAt, "2026-08-01T00:05:00.000Z");
+    assert.equal(inbox.items[0].severity, "warning");
+
+    const persisted = await readFile(path.join(workspaceRoot, ".state", "operator-inbox.json"), "utf8");
+    assert.doesNotMatch(persisted, /ghp_exampleSecret|abcdef123456|ghp_routeSecret/);
+    assert.doesNotMatch(persisted, /\[redacted\]/);
+
+    const reread = await readOperatorInbox(workspaceRoot);
+    assert.equal(reread.items.length, 1);
+    assert.equal(reread.items[0].id, inbox.items[0].id);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("operator inbox API lists filters counts and persists mutations across restart", async () => {
+  const { tempRoot, servicesRoot } = await makeTempServicesRoot("service-lasso-operator-inbox-api-");
+  const workspaceRoot = path.join(tempRoot, "workspace");
+  let apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+  try {
+    const updateRecord = await postJson(apiServer.url + "/api/operator/inbox/record", {
+      dedupeKey: "update:core:available",
+      title: "Runtime update available",
+      summary: "A runtime update is available.",
+      details: "Safe update metadata only.",
+      type: "update",
+      severity: "info",
+      source: "updater",
+      relatedTarget: {
+        updateId: "2026.8.1",
+        route: "/updates",
+      },
+      action: {
+        label: "Review update",
+        target: "/updates",
+        kind: "link",
+        availability: "available",
+      },
+      observedAt: "2026-08-01T00:10:00.000Z",
+    });
+    assert.equal(updateRecord.status, 200);
+    const updateId = updateRecord.body.inbox.items[0].id;
+
+    const securityRecord = await postJson(apiServer.url + "/api/operator/inbox/record", {
+      dedupeKey: "security:remote-auth-required",
+      title: "Remote auth required",
+      summary: "Remote API access is missing trusted identity.",
+      type: "security",
+      severity: "critical",
+      source: "runtime",
+      relatedTarget: {
+        auditId: "audit-1",
+        route: "/security",
+      },
+      observedAt: "2026-08-01T00:11:00.000Z",
+    });
+    assert.equal(securityRecord.status, 200);
+    const securityId = securityRecord.body.inbox.items[0].id;
+
+    let response = await getJson(apiServer.url + "/api/operator/inbox?filter=unread&limit=1");
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.items.length, 1);
+    assert.equal(response.body.inbox.pagination.total, 2);
+    assert.equal(response.body.inbox.pagination.nextCursor, "1");
+
+    response = await getJson(apiServer.url + "/api/operator/inbox?filter=updates");
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body.inbox.items.map((item) => item.id), [updateId]);
+
+    response = await getJson(apiServer.url + "/api/operator/inbox/counts");
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.counts.total, 2);
+    assert.equal(response.body.inbox.counts.unread, 2);
+    assert.equal(response.body.inbox.counts.byFilter.updates, 1);
+    assert.equal(response.body.inbox.counts.byFilter.errors, 1);
+
+    response = await getJson(apiServer.url + "/api/operator/inbox/" + encodeURIComponent(securityId));
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inboxItem.title, "Remote auth required");
+
+    response = await postJson(apiServer.url + "/api/operator/inbox/" + encodeURIComponent(updateId) + "/read", {
+      now: "2026-08-01T00:12:00.000Z",
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.items.find((item) => item.id === updateId).state, "read");
+
+    response = await postJson(apiServer.url + "/api/operator/inbox/bulk", {
+      action: "hide",
+      ids: [securityId],
+      now: "2026-08-01T00:13:00.000Z",
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.counts.hidden, 1);
+
+    await apiServer.stop();
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+
+    response = await getJson(apiServer.url + "/api/operator/inbox/counts");
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.counts.read, 1);
+    assert.equal(response.body.inbox.counts.hidden, 1);
+
+    response = await getJson(apiServer.url + "/api/operator/inbox?filter=hidden");
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body.inbox.items.map((item) => item.id), [securityId]);
+
+    response = await postJson(apiServer.url + "/api/operator/inbox/" + encodeURIComponent(securityId) + "/unhide", {
+      now: "2026-08-01T00:14:00.000Z",
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.items.find((item) => item.id === securityId).visibility, "visible");
+
+    response = await postJson(apiServer.url + "/api/operator/inbox/" + encodeURIComponent(updateId) + "/unread", {
+      now: "2026-08-01T00:15:00.000Z",
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.body.inbox.items.find((item) => item.id === updateId).state, "unread");
+  } finally {
+    await apiServer.stop();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Issue
Refs #832

## Summary
- Adds a Service Lasso-owned durable operator Inbox store under workspace .state.
- Adds runtime APIs to record, list, fetch, count, mark read/unread, hide/unhide, and safely bulk mutate Inbox items.
- Adds contract types, focused persistence/redaction/API tests, and the Operator Inbox reference doc.

## Scope
- In scope: core runtime Inbox model, file-backed persistence, HTTP API surface, filtering/counts/read-hidden mutations, safe metadata redaction, docs.
- Out of scope: Service Admin UI wiring, producer integration from existing notification/update/workflow systems, retention policy, and audit-event wiring for Inbox mutations.

## Spec / contract / fixture impact
- Updated: src/contracts/api.ts with Inbox response contracts.
- Added: src/runtime/operator/inbox.ts as the durable Inbox model/store.
- Added: docs/reference/operator-inbox.md and sidebar/API index entries.

## Service Lasso invariant impact
- Invariant: operator-facing durable messages must persist safe metadata without raw secrets or UI-owned source-of-truth state.
- Preservation proof: the store redacts secret-like values before persistence; tests assert sensitive tokens/passwords do not appear in the persisted Inbox file.

## Validation
- PASS 
pm ci - evidence C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T012047+1000\issue-832-npm-ci.stdout.log.
- PASS 
pm run build - evidence C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T012047+1000\issue-832-npm-build-3.stdout.log.
- PASS 
ode --test --test-concurrency=1 tests/operator-inbox.test.js - evidence C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T012047+1000\issue-832-operator-inbox-test-3.stdout.log.
- PASS 
pm run docs:build - evidence C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T012047+1000\issue-832-docs-build.stdout.log.
- PASS startup 
pm run build and canonical demo-gate before selection - evidence under C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T012047+1000.

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this adds the durable Inbox API vocabulary and mutation contract consumed by Service Admin.

## Cleanup
- Branch ix/832-durable-inbox-api is pushed and targets develop.
- Post-review cleanup: merge to develop, run canonical updated-code demo proof, close #832, and return local checkout to clean develop where possible.