### PR TITLE
#834 add service catalog release API

### DIFF
--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -26,4 +26,20 @@ read-only catalog metadata for UI and drift checks.
 This is read-only catalog metadata; it does not change install or start
 behavior.
 
+Core runtime catalog APIs expose the approved catalog and GitHub release-backed
+version choices for Service Admin:
+
+- `GET /api/catalog/packages`: list approved catalog packages. Supports
+  `query`/`q`, `category`, and `tag` filters.
+- `GET /api/catalog/packages/{packageId}`: fetch one approved package entry.
+- `GET /api/catalog/packages/{packageId}/releases`: fetch GitHub Releases for a
+  package repo, select the latest stable default version, and mark the matching
+  service archive asset from the catalog rule.
+
+By default, the runtime reads
+`https://raw.githubusercontent.com/service-lasso/service-catalog/develop/catalog.json`
+and GitHub release metadata from `https://api.github.com`. Operators can point a
+demo or test lane at another approved source with `SERVICE_LASSO_CATALOG_URL`
+and `SERVICE_LASSO_GITHUB_API_BASE_URL`.
+
 <ServiceCatalog />

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -1103,3 +1103,91 @@ export interface ServiceTelemetryPreviewResponse {
 export interface RuntimeTelemetryExportTestResponse {
   exportTest: TelemetryExportTestResult;
 }
+
+export interface ServiceCatalogRepositoryResponse {
+  owner: string;
+  name: string;
+  url: string;
+}
+
+export interface ServiceCatalogVersionPolicyResponse {
+  channel: "stable" | "preview";
+  selector: "latest-semver" | "latest-release";
+  allowPrerelease: boolean;
+}
+
+export interface ServiceCatalogReleaseAssetRuleResponse {
+  namePattern: string;
+  required: boolean;
+}
+
+export interface ServiceCatalogPackageResponse {
+  packageId: string;
+  displayName: string;
+  summary: string;
+  repository: ServiceCatalogRepositoryResponse;
+  category: string;
+  tags: string[];
+  publisher: string;
+  trustStatus: "approved" | "experimental" | "blocked";
+  approved: boolean;
+  defaultVersionPolicy: ServiceCatalogVersionPolicyResponse;
+  releaseAsset: ServiceCatalogReleaseAssetRuleResponse;
+  manifestPath: string;
+}
+
+export interface ServiceCatalogPackagesResponse {
+  catalog: {
+    catalogId: string;
+    schemaVersion: string;
+    updatedAt: string;
+    source: string;
+    packages: ServiceCatalogPackageResponse[];
+    summary: {
+      total: number;
+      approved: number;
+      categories: string[];
+      filtered: number;
+    };
+  };
+}
+
+export interface ServiceCatalogReleaseAssetResponse {
+  name: string;
+  size: number | null;
+  contentType: string | null;
+  downloadUrl: string | null;
+  selected: boolean;
+}
+
+export interface ServiceCatalogReleaseVersionResponse {
+  tag: string;
+  version: string;
+  name: string | null;
+  releaseUrl: string | null;
+  createdAt: string | null;
+  publishedAt: string | null;
+  prerelease: boolean;
+  draft: boolean;
+  notesSummary: string | null;
+  assets: ServiceCatalogReleaseAssetResponse[];
+  selectedAsset: ServiceCatalogReleaseAssetResponse | null;
+  default: boolean;
+}
+
+export interface ServiceCatalogPackageReleasesResponse {
+  package: ServiceCatalogPackageResponse;
+  versions: ServiceCatalogReleaseVersionResponse[];
+  defaultVersion: ServiceCatalogReleaseVersionResponse | null;
+  source: {
+    type: "github-releases";
+    apiBaseUrl: string;
+    repository: string;
+  };
+  summary: {
+    total: number;
+    stable: number;
+    prerelease: number;
+    drafts: number;
+  };
+}

--- a/src/runtime/catalog/service-catalog.ts
+++ b/src/runtime/catalog/service-catalog.ts
@@ -1,0 +1,384 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  ServiceCatalogPackageReleasesResponse,
+  ServiceCatalogPackageResponse,
+  ServiceCatalogPackagesResponse,
+  ServiceCatalogReleaseAssetResponse,
+  ServiceCatalogReleaseVersionResponse,
+  ServiceCatalogVersionPolicyResponse,
+} from "../../contracts/api.js";
+
+export const DEFAULT_SERVICE_CATALOG_URL =
+  "https://raw.githubusercontent.com/service-lasso/service-catalog/develop/catalog.json";
+
+const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
+
+interface ServiceCatalogDocument {
+  schemaVersion?: string;
+  catalogId?: string;
+  updatedAt?: string;
+  defaults?: {
+    publisher?: string;
+    trustStatus?: ServiceCatalogPackageResponse["trustStatus"];
+    versionPolicy?: ServiceCatalogVersionPolicyResponse;
+    releaseAsset?: { namePattern?: string; required?: boolean };
+    manifestPath?: string;
+  };
+  entries?: CatalogEntry[];
+}
+
+interface CatalogEntry {
+  packageId?: string;
+  displayName?: string;
+  summary?: string;
+  repository?: {
+    owner?: string;
+    name?: string;
+    url?: string;
+  };
+  category?: string;
+  tags?: string[];
+  publisher?: string;
+  trustStatus?: ServiceCatalogPackageResponse["trustStatus"];
+  defaultVersionPolicy?: ServiceCatalogVersionPolicyResponse;
+  releaseAsset?: { namePattern?: string; required?: boolean };
+  manifestPath?: string;
+}
+
+interface GitHubReleaseAsset {
+  name?: string;
+  size?: number;
+  content_type?: string | null;
+  browser_download_url?: string | null;
+}
+
+interface GitHubRelease {
+  tag_name?: string;
+  name?: string | null;
+  html_url?: string | null;
+  created_at?: string | null;
+  published_at?: string | null;
+  prerelease?: boolean;
+  draft?: boolean;
+  body?: string | null;
+  assets?: GitHubReleaseAsset[];
+}
+
+export interface ServiceCatalogOptions {
+  catalogUrl?: string;
+  githubApiBaseUrl?: string;
+}
+
+export interface ServiceCatalogPackageQuery extends ServiceCatalogOptions {
+  query?: string | null;
+  category?: string | null;
+  tag?: string | null;
+}
+
+function normalizedCatalogSource(catalogUrl?: string): string {
+  return (catalogUrl?.trim() || process.env.SERVICE_LASSO_CATALOG_URL?.trim() || DEFAULT_SERVICE_CATALOG_URL);
+}
+
+function normalizedGithubApiBaseUrl(githubApiBaseUrl?: string): string {
+  return (githubApiBaseUrl?.trim() || process.env.SERVICE_LASSO_GITHUB_API_BASE_URL?.trim() || DEFAULT_GITHUB_API_BASE_URL)
+    .replace(/\/+$/, "");
+}
+
+function githubHeaders(): Record<string, string> {
+  const token = process.env.GITHUB_TOKEN?.trim() || process.env.GH_TOKEN?.trim();
+  return {
+    accept: "application/vnd.github+json",
+    "user-agent": "service-lasso-core-runtime",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function isHttpSource(source: string): boolean {
+  return /^https?:\/\//i.test(source);
+}
+
+async function readJsonSource(source: string): Promise<unknown> {
+  if (isHttpSource(source)) {
+    const response = await fetch(source, { headers: githubHeaders() });
+    if (!response.ok) {
+      throw new Error(`Catalog source returned ${response.status} ${response.statusText}`.trim());
+    }
+    return await response.json();
+  }
+
+  const filePath = source.startsWith("file:")
+    ? new URL(source)
+    : path.resolve(source);
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Catalog field "${field}" must be a non-empty string.`);
+  }
+  return value;
+}
+
+function normalizePolicy(value: unknown, fallback?: ServiceCatalogVersionPolicyResponse): ServiceCatalogVersionPolicyResponse {
+  const record = value && typeof value === "object" ? value as Record<string, unknown> : {};
+  const channel = record.channel === "preview" ? "preview" : fallback?.channel ?? "stable";
+  const selector = record.selector === "latest-release" ? "latest-release" : fallback?.selector ?? "latest-semver";
+  const allowPrerelease = typeof record.allowPrerelease === "boolean"
+    ? record.allowPrerelease
+    : fallback?.allowPrerelease ?? false;
+  return { channel, selector, allowPrerelease };
+}
+
+function normalizeEntry(entry: CatalogEntry, defaults: ServiceCatalogDocument["defaults"] = {}): ServiceCatalogPackageResponse {
+  const repository = entry.repository ?? {};
+  const publisher = entry.publisher ?? defaults.publisher;
+  const trustStatus = entry.trustStatus ?? defaults.trustStatus ?? "approved";
+  const releaseAsset = entry.releaseAsset ?? defaults.releaseAsset ?? { namePattern: "^.+\\.zip$", required: true };
+
+  return {
+    packageId: requireString(entry.packageId, "entries[].packageId"),
+    displayName: requireString(entry.displayName, "entries[].displayName"),
+    summary: requireString(entry.summary, "entries[].summary"),
+    repository: {
+      owner: requireString(repository.owner, "entries[].repository.owner"),
+      name: requireString(repository.name, "entries[].repository.name"),
+      url: requireString(repository.url, "entries[].repository.url"),
+    },
+    category: requireString(entry.category, "entries[].category"),
+    tags: Array.isArray(entry.tags) ? entry.tags.filter((tag): tag is string => typeof tag === "string") : [],
+    publisher: requireString(publisher, "entries[].publisher"),
+    trustStatus,
+    approved: trustStatus === "approved",
+    defaultVersionPolicy: normalizePolicy(entry.defaultVersionPolicy, normalizePolicy(defaults.versionPolicy)),
+    releaseAsset: {
+      namePattern: requireString(releaseAsset.namePattern, "entries[].releaseAsset.namePattern"),
+      required: releaseAsset.required !== false,
+    },
+    manifestPath: requireString(entry.manifestPath ?? defaults.manifestPath, "entries[].manifestPath"),
+  };
+}
+
+async function loadCatalogDocument(options: ServiceCatalogOptions = {}): Promise<{
+  source: string;
+  document: ServiceCatalogDocument;
+  packages: ServiceCatalogPackageResponse[];
+}> {
+  const source = normalizedCatalogSource(options.catalogUrl);
+  const payload = await readJsonSource(source);
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Catalog source did not return a JSON object.");
+  }
+
+  const document = payload as ServiceCatalogDocument;
+  const entries = Array.isArray(document.entries) ? document.entries : [];
+  if (entries.length === 0) {
+    throw new Error("Catalog source contains no entries.");
+  }
+
+  return {
+    source,
+    document,
+    packages: entries.map((entry) => normalizeEntry(entry, document.defaults)),
+  };
+}
+
+function matchesPackage(pack: ServiceCatalogPackageResponse, input: ServiceCatalogPackageQuery): boolean {
+  const query = input.query?.trim().toLowerCase();
+  const category = input.category?.trim().toLowerCase();
+  const tag = input.tag?.trim().toLowerCase();
+  const haystack = [
+    pack.packageId,
+    pack.displayName,
+    pack.summary,
+    pack.repository.owner,
+    pack.repository.name,
+    pack.category,
+    ...pack.tags,
+  ].join(" ").toLowerCase();
+
+  return (!query || haystack.includes(query))
+    && (!category || pack.category.toLowerCase() === category)
+    && (!tag || pack.tags.some((candidate) => candidate.toLowerCase() === tag));
+}
+
+export async function listServiceCatalogPackages(
+  input: ServiceCatalogPackageQuery = {},
+): Promise<ServiceCatalogPackagesResponse> {
+  const { source, document, packages } = await loadCatalogDocument(input);
+  const filtered = packages.filter((pack) => matchesPackage(pack, input));
+
+  return {
+    catalog: {
+      catalogId: requireString(document.catalogId, "catalogId"),
+      schemaVersion: requireString(document.schemaVersion, "schemaVersion"),
+      updatedAt: requireString(document.updatedAt, "updatedAt"),
+      source,
+      packages: filtered,
+      summary: {
+        total: packages.length,
+        approved: packages.filter((pack) => pack.approved).length,
+        categories: [...new Set(packages.map((pack) => pack.category))].sort(),
+        filtered: filtered.length,
+      },
+    },
+  };
+}
+
+export async function getServiceCatalogPackage(
+  packageId: string,
+  options: ServiceCatalogOptions = {},
+): Promise<ServiceCatalogPackageResponse | null> {
+  const { packages } = await loadCatalogDocument(options);
+  return packages.find((pack) => pack.packageId === packageId) ?? null;
+}
+
+function compareVersionLikeTags(left: string, right: string): number {
+  const tokenize = (tag: string): Array<number | string> =>
+    tag.replace(/^v/i, "").split(/[.-]/g).map((part) => (/^\d+$/.test(part) ? Number(part) : part.toLowerCase()));
+  const leftParts = tokenize(left);
+  const rightParts = tokenize(right);
+  const max = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < max; index += 1) {
+    const leftPart = leftParts[index] ?? 0;
+    const rightPart = rightParts[index] ?? 0;
+    if (typeof leftPart === "number" && typeof rightPart === "number" && leftPart !== rightPart) {
+      return leftPart - rightPart;
+    }
+    const comparison = String(leftPart).localeCompare(String(rightPart));
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}
+
+function selectDefaultRelease(
+  versions: ServiceCatalogReleaseVersionResponse[],
+  policy: ServiceCatalogVersionPolicyResponse,
+): ServiceCatalogReleaseVersionResponse | null {
+  const candidates = policy.allowPrerelease ? versions : versions.filter((release) => !release.prerelease && !release.draft);
+  const selectable = candidates.length > 0 ? candidates : versions.filter((release) => !release.draft);
+  if (selectable.length === 0) return null;
+
+  return [...selectable].sort((left, right) => {
+    if (policy.selector === "latest-semver") {
+      const versionComparison = compareVersionLikeTags(right.tag, left.tag);
+      if (versionComparison !== 0) return versionComparison;
+    }
+
+    return Date.parse(right.publishedAt ?? right.createdAt ?? "") - Date.parse(left.publishedAt ?? left.createdAt ?? "");
+  })[0] ?? null;
+}
+
+function summarizeNotes(body: string | null | undefined): string | null {
+  const normalized = body?.replace(/`[^`]*`/g, "`[redacted]`")
+    .replace(/(token|secret|password|cookie|credential)\s*[:=]\s*\S+/gi, "$1=[redacted]")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^#+\s*/, "").trim())
+    .find((line) => line.length > 0);
+
+  return normalized ? normalized.slice(0, 400) : null;
+}
+
+function buildAssetRule(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return /^$/;
+  }
+}
+
+function toReleaseVersion(
+  release: GitHubRelease,
+  selectedAssetPattern: RegExp,
+  isDefault = false,
+): ServiceCatalogReleaseVersionResponse | null {
+  const tag = release.tag_name;
+  if (typeof tag !== "string" || tag.trim() === "") {
+    return null;
+  }
+
+  const selectedAssetName = (release.assets ?? []).find((asset) =>
+    typeof asset.name === "string" && selectedAssetPattern.test(asset.name),
+  )?.name ?? null;
+  const assets: ServiceCatalogReleaseAssetResponse[] = (release.assets ?? [])
+    .filter((asset): asset is GitHubReleaseAsset & { name: string } => typeof asset.name === "string")
+    .map((asset) => ({
+      name: asset.name,
+      size: typeof asset.size === "number" ? asset.size : null,
+      contentType: typeof asset.content_type === "string" ? asset.content_type : null,
+      downloadUrl: typeof asset.browser_download_url === "string" ? asset.browser_download_url : null,
+      selected: asset.name === selectedAssetName,
+    }));
+
+  return {
+    tag,
+    version: tag,
+    name: typeof release.name === "string" ? release.name : null,
+    releaseUrl: typeof release.html_url === "string" ? release.html_url : null,
+    createdAt: typeof release.created_at === "string" ? release.created_at : null,
+    publishedAt: typeof release.published_at === "string" ? release.published_at : null,
+    prerelease: release.prerelease === true,
+    draft: release.draft === true,
+    notesSummary: summarizeNotes(release.body),
+    assets,
+    selectedAsset: assets.find((asset) => asset.selected) ?? null,
+    default: isDefault,
+  };
+}
+
+async function fetchPackageReleases(pack: ServiceCatalogPackageResponse, apiBaseUrl: string): Promise<GitHubRelease[]> {
+  const repo = `${pack.repository.owner}/${pack.repository.name}`;
+  const response = await fetch(`${apiBaseUrl}/repos/${repo}/releases?per_page=30`, {
+    headers: githubHeaders(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub releases returned ${response.status} ${response.statusText}`.trim());
+  }
+
+  const payload = await response.json();
+  if (!Array.isArray(payload)) {
+    throw new Error("GitHub releases response was not a JSON array.");
+  }
+
+  return payload as GitHubRelease[];
+}
+
+export async function listServiceCatalogPackageReleases(
+  packageId: string,
+  options: ServiceCatalogOptions = {},
+): Promise<ServiceCatalogPackageReleasesResponse> {
+  const pack = await getServiceCatalogPackage(packageId, options);
+  if (!pack) {
+    throw new Error(`Unknown catalog package: ${packageId}.`);
+  }
+
+  const apiBaseUrl = normalizedGithubApiBaseUrl(options.githubApiBaseUrl);
+  const releases = await fetchPackageReleases(pack, apiBaseUrl);
+  const assetRule = buildAssetRule(pack.releaseAsset.namePattern);
+  const versionsWithoutDefault = releases
+    .map((release) => toReleaseVersion(release, assetRule))
+    .filter((release): release is ServiceCatalogReleaseVersionResponse => release !== null);
+  const defaultVersion = selectDefaultRelease(versionsWithoutDefault, pack.defaultVersionPolicy);
+  const versions = versionsWithoutDefault.map((version) => ({
+    ...version,
+    default: defaultVersion?.tag === version.tag,
+  }));
+
+  return {
+    package: pack,
+    versions,
+    defaultVersion: versions.find((version) => version.default) ?? null,
+    source: {
+      type: "github-releases",
+      apiBaseUrl,
+      repository: `${pack.repository.owner}/${pack.repository.name}`,
+    },
+    summary: {
+      total: versions.length,
+      stable: versions.filter((release) => !release.prerelease && !release.draft).length,
+      prerelease: versions.filter((release) => release.prerelease).length,
+      drafts: versions.filter((release) => release.draft).length,
+    },
+  };
+}

--- a/src/runtime/operator/telemetry.ts
+++ b/src/runtime/operator/telemetry.ts
@@ -956,6 +956,7 @@ export function classifyTelemetryRoute(pathname: string): {
   }
 
   const topLevelRoutes = new Set([
+    "catalog",
     "dashboard",
     "dependencies",
     "diagnostics",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -181,6 +181,11 @@ import {
   listServiceUpdateStates,
 } from "../runtime/updates/actions.js";
 import {
+  getServiceCatalogPackage,
+  listServiceCatalogPackageReleases,
+  listServiceCatalogPackages,
+} from "../runtime/catalog/service-catalog.js";
+import {
   assertWorkflowRunFacadeSecretSafe,
   cancelWorkflowFacadeRun,
   exampleWorkflowRunFacadeState,
@@ -225,6 +230,8 @@ export interface ApiServerOptions {
   monitorIntervalMs?: number;
   updateScheduler?: boolean;
   updateSchedulerIntervalMs?: number;
+  serviceCatalogUrl?: string;
+  serviceCatalogGithubApiBaseUrl?: string;
   workflowRunFacadeState?: WorkflowRunFacadeState;
   telemetryExportScheduler?: RuntimeTelemetryExportScheduler | null;
   apiRequestTelemetryState?: ApiRequestTelemetryState;
@@ -242,6 +249,8 @@ interface ApiRouteConfig extends RuntimeConfig {
     monitor: boolean;
     updateScheduler: boolean;
   };
+  serviceCatalogUrl?: string;
+  serviceCatalogGithubApiBaseUrl?: string;
 }
 
 export interface RunningApiServer {
@@ -1682,6 +1691,73 @@ async function routeRequest(
       action: "list",
       services: await listServiceUpdateStates(runtimeModel.registry.list()),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/catalog/packages") {
+    try {
+      writeJson(response, 200, await listServiceCatalogPackages({
+        catalogUrl: config.serviceCatalogUrl,
+        githubApiBaseUrl: config.serviceCatalogGithubApiBaseUrl,
+        query: url.searchParams.get("query") ?? url.searchParams.get("q"),
+        category: url.searchParams.get("category"),
+        tag: url.searchParams.get("tag"),
+      }));
+    } catch (error) {
+      throw new ApiError(
+        "catalog_unavailable",
+        502,
+        error instanceof Error ? error.message : "Service catalog could not be loaded.",
+      );
+    }
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/api/catalog/packages/")) {
+    const pathParts = url.pathname.split("/").filter(Boolean).map((part) => decodeURIComponent(part));
+    const packageId = pathParts[2] === "packages" ? pathParts[3] : "";
+    if (!packageId || pathParts.length < 4 || pathParts.length > 5 || (pathParts.length === 5 && pathParts[4] !== "releases")) {
+      throw new ApiError("invalid_action", 400, "Unknown service catalog route.");
+    }
+
+    if (pathParts.length === 4) {
+      try {
+        const servicePackage = await getServiceCatalogPackage(packageId, {
+          catalogUrl: config.serviceCatalogUrl,
+          githubApiBaseUrl: config.serviceCatalogGithubApiBaseUrl,
+        });
+        if (!servicePackage) {
+          throw new ApiError("not_found", 404, `Unknown catalog package: ${packageId}.`);
+        }
+        writeJson(response, 200, { package: servicePackage });
+      } catch (error) {
+        if (error instanceof ApiError) {
+          throw error;
+        }
+        throw new ApiError(
+          "catalog_unavailable",
+          502,
+          error instanceof Error ? error.message : "Service catalog could not be loaded.",
+        );
+      }
+      return;
+    }
+
+    try {
+      writeJson(response, 200, await listServiceCatalogPackageReleases(packageId, {
+        catalogUrl: config.serviceCatalogUrl,
+        githubApiBaseUrl: config.serviceCatalogGithubApiBaseUrl,
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Service catalog package releases could not be loaded.";
+      throw new ApiError(
+        message.startsWith("Unknown catalog package:")
+          ? "not_found"
+          : "catalog_releases_unavailable",
+        message.startsWith("Unknown catalog package:") ? 404 : 502,
+        message,
+      );
+    }
     return;
   }
 
@@ -3270,6 +3346,8 @@ export function createApiServer(options: ApiServerOptions = {}): Server {
       monitor: options.monitor === true,
       updateScheduler: options.updateScheduler === true,
     },
+    serviceCatalogUrl: options.serviceCatalogUrl,
+    serviceCatalogGithubApiBaseUrl: options.serviceCatalogGithubApiBaseUrl,
   };
   const workflowRunFacadeState = cloneWorkflowRunFacadeState(options.workflowRunFacadeState ?? exampleWorkflowRunFacadeState);
   const apiRequestTelemetryState = options.apiRequestTelemetryState ?? { requests: [], droppedCount: 0 };
@@ -3370,6 +3448,8 @@ export async function startApiServer(options: ApiServerOptions = {}): Promise<Ru
     autostart: options.autostart,
     monitor: options.monitor,
     updateScheduler: options.updateScheduler,
+    serviceCatalogUrl: options.serviceCatalogUrl,
+    serviceCatalogGithubApiBaseUrl: options.serviceCatalogGithubApiBaseUrl,
     telemetryExportScheduler,
     apiRequestTelemetryState,
     workflowRunFacadeState: options.workflowRunFacadeState,

--- a/src/server/routes/runtime.ts
+++ b/src/server/routes/runtime.ts
@@ -56,6 +56,13 @@ const endpointGroups: RuntimeEndpointGroupResponse[] = [
     mutating: true,
   },
   {
+    id: "catalog",
+    label: "Service catalog",
+    methods: ["GET"],
+    pathPrefix: "/api/catalog",
+    mutating: false,
+  },
+  {
     id: "dashboard",
     label: "Dashboard adapter",
     methods: ["GET"],

--- a/tests/api-service-catalog.test.js
+++ b/tests/api-service-catalog.test.js
@@ -1,0 +1,254 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { startApiServer } from "../dist/server/index.js";
+
+async function makeTempRoot() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "service-lasso-catalog-api-"));
+  const servicesRoot = path.join(root, "services");
+  const workspaceRoot = path.join(root, "workspace");
+  await mkdir(servicesRoot, { recursive: true });
+  await mkdir(workspaceRoot, { recursive: true });
+  return { root, servicesRoot, workspaceRoot };
+}
+
+async function writeCatalog(root, entries) {
+  const catalogPath = path.join(root, "catalog.json");
+  await writeFile(
+    catalogPath,
+    JSON.stringify(
+      {
+        schemaVersion: "1.0.0",
+        catalogId: "service-lasso-approved-services",
+        updatedAt: "2026-07-26",
+        defaults: {
+          publisher: "Service Lasso",
+          trustStatus: "approved",
+          versionPolicy: {
+            channel: "stable",
+            selector: "latest-semver",
+            allowPrerelease: false,
+          },
+          releaseAsset: {
+            namePattern: "^.+\\.zip$",
+            required: true,
+          },
+          manifestPath: "service.json",
+        },
+        entries,
+      },
+      null,
+      2,
+    ),
+  );
+  return catalogPath;
+}
+
+async function startFakeGitHubReleaseApi() {
+  const releases = [
+    {
+      tag_name: "v1.3.0-beta.1",
+      name: "Preview",
+      html_url: "https://github.test/service-lasso/lasso-node/releases/v1.3.0-beta.1",
+      created_at: "2026-07-03T00:00:00Z",
+      published_at: "2026-07-03T00:00:00Z",
+      prerelease: true,
+      draft: false,
+      body: "Preview release",
+      assets: [
+        {
+          name: "lasso-node-v1.3.0-beta.1.zip",
+          size: 123,
+          content_type: "application/zip",
+          browser_download_url: "https://downloads.test/lasso-node-v1.3.0-beta.1.zip",
+        },
+      ],
+    },
+    {
+      tag_name: "v1.2.0",
+      name: "Stable",
+      html_url: "https://github.test/service-lasso/lasso-node/releases/v1.2.0",
+      created_at: "2026-07-02T00:00:00Z",
+      published_at: "2026-07-02T00:00:00Z",
+      prerelease: false,
+      draft: false,
+      body: "Stable release with token=should-not-leak",
+      assets: [
+        {
+          name: "lasso-node-v1.2.0.zip",
+          size: 456,
+          content_type: "application/zip",
+          browser_download_url: "https://downloads.test/lasso-node-v1.2.0.zip",
+        },
+        {
+          name: "checksums.txt",
+          size: 32,
+          content_type: "text/plain",
+          browser_download_url: "https://downloads.test/checksums.txt",
+        },
+      ],
+    },
+    {
+      tag_name: "v2.0.0",
+      name: "Draft",
+      html_url: "https://github.test/service-lasso/lasso-node/releases/v2.0.0",
+      created_at: "2026-07-04T00:00:00Z",
+      published_at: "2026-07-04T00:00:00Z",
+      prerelease: false,
+      draft: true,
+      body: "Draft release",
+      assets: [{ name: "lasso-node-v2.0.0.zip" }],
+    },
+  ];
+
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/repos/service-lasso/lasso-node/releases") {
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify(releases));
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end("missing");
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+    stop: async () => {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+test("catalog API lists approved packages with filters", async () => {
+  const { root, servicesRoot, workspaceRoot } = await makeTempRoot();
+  const catalogPath = await writeCatalog(root, [
+    {
+      packageId: "lasso-node",
+      displayName: "Node.js Provider",
+      summary: "Release-backed Node.js provider package.",
+      repository: {
+        owner: "service-lasso",
+        name: "lasso-node",
+        url: "https://github.com/service-lasso/lasso-node",
+      },
+      category: "runtime",
+      tags: ["nodejs", "provider"],
+      defaultVersionPolicy: {
+        channel: "stable",
+        selector: "latest-semver",
+        allowPrerelease: false,
+      },
+      releaseAsset: {
+        namePattern: "^lasso-node-.+\\.zip$",
+        required: true,
+      },
+    },
+    {
+      packageId: "lasso-postgres",
+      displayName: "Postgres",
+      summary: "Database service package.",
+      repository: {
+        owner: "service-lasso",
+        name: "lasso-postgres",
+        url: "https://github.com/service-lasso/lasso-postgres",
+      },
+      category: "database",
+      tags: ["postgres", "storage"],
+      defaultVersionPolicy: {
+        channel: "stable",
+        selector: "latest-semver",
+        allowPrerelease: false,
+      },
+      releaseAsset: {
+        namePattern: "^lasso-postgres-.+\\.zip$",
+        required: true,
+      },
+    },
+  ]);
+  const apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot, serviceCatalogUrl: catalogPath });
+
+  try {
+    const all = await getJson(`${apiServer.url}/api/catalog/packages`);
+    const filtered = await getJson(`${apiServer.url}/api/catalog/packages?category=runtime&tag=provider&q=node`);
+    const detail = await getJson(`${apiServer.url}/api/catalog/packages/lasso-node`);
+
+    assert.equal(all.status, 200);
+    assert.equal(all.body.catalog.summary.total, 2);
+    assert.deepEqual(all.body.catalog.summary.categories, ["database", "runtime"]);
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.catalog.packages.length, 1);
+    assert.equal(filtered.body.catalog.packages[0].packageId, "lasso-node");
+    assert.equal(filtered.body.catalog.packages[0].approved, true);
+    assert.equal(detail.status, 200);
+    assert.equal(detail.body.package.repository.name, "lasso-node");
+  } finally {
+    await apiServer.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog API resolves GitHub release versions and stable default asset", async () => {
+  const { root, servicesRoot, workspaceRoot } = await makeTempRoot();
+  const releaseApi = await startFakeGitHubReleaseApi();
+  const catalogPath = await writeCatalog(root, [
+    {
+      packageId: "lasso-node",
+      displayName: "Node.js Provider",
+      summary: "Release-backed Node.js provider package.",
+      repository: {
+        owner: "service-lasso",
+        name: "lasso-node",
+        url: "https://github.com/service-lasso/lasso-node",
+      },
+      category: "runtime",
+      tags: ["nodejs", "provider"],
+      defaultVersionPolicy: {
+        channel: "stable",
+        selector: "latest-semver",
+        allowPrerelease: false,
+      },
+      releaseAsset: {
+        namePattern: "^lasso-node-.+\\.zip$",
+        required: true,
+      },
+    },
+  ]);
+  const apiServer = await startApiServer({
+    port: 0,
+    servicesRoot,
+    workspaceRoot,
+    serviceCatalogUrl: catalogPath,
+    serviceCatalogGithubApiBaseUrl: releaseApi.baseUrl,
+  });
+
+  try {
+    const response = await getJson(`${apiServer.url}/api/catalog/packages/lasso-node/releases`);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.source.repository, "service-lasso/lasso-node");
+    assert.equal(response.body.summary.total, 3);
+    assert.equal(response.body.summary.stable, 1);
+    assert.equal(response.body.defaultVersion.tag, "v1.2.0");
+    assert.equal(response.body.defaultVersion.selectedAsset.name, "lasso-node-v1.2.0.zip");
+    assert.equal(response.body.defaultVersion.notesSummary, "Stable release with token=[redacted]");
+    assert.equal(response.body.versions.find((version) => version.tag === "v1.3.0-beta.1").default, false);
+  } finally {
+    await apiServer.stop();
+    await releaseApi.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Issue
Closes #834

## Summary
- Adds Service Lasso core catalog contracts and read-only /api/catalog package endpoints.
- Loads the approved service-lasso/service-catalog catalog from the default develop raw URL or an operator/test override.
- Resolves package GitHub Releases, filters stable defaults, summarizes safe release notes, and marks matching archive assets.
- Documents the runtime catalog API and override environment variables.

## Scope
- In scope: catalog package listing/search, package detail, per-package release/version metadata, default version/asset selection, focused API tests.
- Out of scope: Service Admin UI wiring, install flow integration, catalog repo changes, release archive manifest validation during install.

## Spec / contract / fixture impact
- Updated: src/contracts/api.ts with catalog package and release response contracts.
- Added: src/runtime/catalog/service-catalog.ts as the catalog/release resolver.
- Added: 	ests/api-service-catalog.test.js with local catalog and fake GitHub release fixtures.
- Updated: docs/service-catalog.md with runtime endpoint documentation.

## Service Lasso invariant impact
- Invariant: Service Lasso core owns approved catalog and release-version resolution; Service Admin consumes runtime APIs only.
- Preservation proof: catalog source defaults to service-lasso/service-catalog on develop, package records carry pproved, and release notes are summarized with secret-like values redacted.

## Validation
- PASS 
pm ci - evidence C:\projects\service-lasso\.work-agent\logs\20260731T154601Z\issue-834-npm-ci.out.log.
- PASS 
pm run build - evidence C:\projects\service-lasso\.work-agent\logs\20260731T154601Z\issue-834-npm-build-3.out.log.
- PASS 
ode --test --test-concurrency=1 tests/api-service-catalog.test.js - evidence C:\projects\service-lasso\.work-agent\logs\20260731T154601Z\issue-834-api-service-catalog-test-3.out.log.
- PASS 
pm run docs:build - evidence C:\projects\service-lasso\.work-agent\logs\20260731T154601Z\issue-834-docs-build.out.log.
- PASS startup 
pm run build and canonical demo-gate before selection - evidence under C:\projects\service-lasso\.work-agent\logs\20260731T154601Z.

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this adds the approved service catalog API vocabulary and GitHub release resolution contract consumed by Service Admin.

## Cleanup
- Branch ix/834-service-catalog-releases is pushed and targets develop.
- Post-review cleanup: merge to develop, run canonical updated-code demo proof, close #834, and return local checkout to clean develop where possible.
