### PR TITLE
#836 add service archive import CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ node dist/cli.js services import service-lasso/lasso-dagu --tag 2026.5.22-exampl
 
 The import command copies the release `service.json` asset into `services/<service-id>/service.json` and refuses to replace an existing manifest unless `--force` is provided.
 
+Import a local Service Archive upload without enabling or starting it:
+
+```powershell
+node dist/cli.js services import --archive ./downloads/my-service.zip --services-root ./services --dry-run --json
+node dist/cli.js services import --archive ./downloads/my-service.zip --services-root ./services --json
+```
+
+Archive imports stage and inspect the zip before touching `servicesRoot`, require exactly one valid `service.json`, reject unsafe archive paths, copy the archive content into `services/<service-id>/`, rescan discovery, and return a conflict state instead of overwriting an existing service.
+
 Start the baseline services and leave the API running:
 
 ```powershell

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,6 +109,7 @@ function usageText(): string {
     "  service-lasso operator actions defer <actionId> [--until <iso>] [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso operator actions reopen <actionId> [--services-root <path>] [--workspace-root <path>] [--json]",
     "  service-lasso services import <owner/repo> [--tag <tag>] [--services-root <path>] [--dry-run] [--force] [--json]",
+    "  service-lasso services import --archive <path> [--services-root <path>] [--dry-run] [--json]",
     "  service-lasso template check-upgrade <targetServicesRoot> [--core-services-root <path>] [--json]",
     "  service-lasso release verify-manifest <manifestPath> [--assets-root <path>] [--release-version <version>] [--json]",
     "  service-lasso help",
@@ -413,11 +414,9 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
       throw new Error('The "services" command requires one of: import.');
     }
     parsed.serviceCommand = serviceCommand;
-    const repo = remaining.shift();
-    if (!repo || repo.startsWith("-")) {
-      throw new Error('The "services import" command requires an <owner/repo> argument.');
+    if (remaining[0] && !remaining[0].startsWith("-")) {
+      parsed.repo = remaining.shift();
     }
-    parsed.repo = repo;
   }
 
   if (command === "template") {
@@ -532,6 +531,17 @@ function parseCliArgs(argv: string[]): ParsedCliOptions {
           throw new Error("Missing value for --api-base-url.");
         }
         parsed.apiBaseUrl = value;
+        break;
+      }
+      case "--archive": {
+        if (command !== "services" || parsed.serviceCommand !== "import") {
+          throw new Error("--archive is only supported for the services import command.");
+        }
+        const value = remaining.shift();
+        if (!value) {
+          throw new Error("Missing value for --archive.");
+        }
+        parsed.archivePath = value;
         break;
       }
       case "--core-services-root": {
@@ -1132,11 +1142,24 @@ function printImportServiceResult(result: ImportServiceManifestCliResult, asJson
   }
 
   console.log(result.dryRun ? "[service-lasso] service import dry-run completed" : "[service-lasso] service manifest imported");
-  console.log(`- repo: ${result.repo}`);
-  console.log(`- tag: ${result.resolvedTag ?? result.requestedTag ?? "latest"}`);
+  console.log(`- source: ${result.source}`);
+  if (result.repo) {
+    console.log(`- repo: ${result.repo}`);
+    console.log(`- tag: ${result.resolvedTag ?? result.requestedTag ?? "latest"}`);
+  }
+  if (result.archivePath) {
+    console.log(`- archivePath: ${result.archivePath}`);
+  }
   console.log(`- service: ${result.serviceId}`);
+  if (result.version) {
+    console.log(`- version: ${result.version}`);
+  }
   console.log(`- servicesRoot: ${result.servicesRoot}`);
-  console.log(`- targetPath: ${result.targetPath}`);
+  console.log(`- targetPath: ${result.targetPath ?? "none"}`);
+  console.log(`- state: ${result.state}`);
+  if (result.conflict) {
+    console.log(`- conflict: ${result.conflict.kind} ${result.conflict.path}`);
+  }
   console.log(`- wrote: ${result.wrote}`);
   console.log(`- overwritten: ${result.overwritten}`);
 }
@@ -1211,14 +1234,18 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
 
   if (parsed.command === "services" && parsed.serviceCommand === "import") {
     const result = await importServiceManifestFromCli({
-      repo: parsed.repo!,
+      repo: parsed.repo,
       tag: parsed.tag,
       servicesRoot: parsed.servicesRoot,
       apiBaseUrl: parsed.apiBaseUrl,
+      archivePath: parsed.archivePath,
       force: parsed.force,
       dryRun: parsed.dryRun,
     });
     printImportServiceResult(result, parsed.json);
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/runtime/cli/importService.ts
+++ b/src/runtime/cli/importService.ts
@@ -1,5 +1,7 @@
-import { access, mkdir, writeFile } from "node:fs/promises";
+import { access, cp, mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import AdmZip from "adm-zip";
 import type { ServiceManifest } from "../../contracts/service.js";
 import { DEFAULT_SERVICES_ROOT } from "../../contracts/service-root.js";
 import { discoverServices } from "../discovery/discoverServices.js";
@@ -16,25 +18,33 @@ interface GitHubReleaseResponse {
 }
 
 export interface ImportServiceManifestCliOptions {
-  repo: string;
+  repo?: string;
   tag?: string;
   servicesRoot?: string;
   apiBaseUrl?: string;
+  archivePath?: string;
   force?: boolean;
   dryRun?: boolean;
 }
 
 export interface ImportServiceManifestCliResult {
   action: "importService";
-  ok: true;
-  repo: string;
+  ok: boolean;
+  source: "github-release" | "archive";
+  repo: string | null;
   requestedTag: string | null;
   resolvedTag: string | null;
   serviceId: string;
   serviceName: string;
+  version: string | null;
   servicesRoot: string;
-  targetPath: string;
-  manifestAssetUrl: string;
+  targetPath: string | null;
+  targetServiceRoot: string;
+  manifestAssetUrl: string | null;
+  archivePath: string | null;
+  archiveType: "zip" | null;
+  state: "validated" | "imported" | "conflict";
+  conflict: { kind: "target_manifest_exists" | "target_directory_exists"; path: string } | null;
   dryRun: boolean;
   wrote: boolean;
   overwritten: boolean;
@@ -68,6 +78,98 @@ async function pathExists(targetPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function detectArchiveType(archivePath: string): "zip" {
+  if (archivePath.toLowerCase().endsWith(".zip")) {
+    return "zip";
+  }
+
+  throw new Error('The "services import --archive" command currently supports .zip Service Archives.');
+}
+
+function assertSafeArchiveEntry(entryName: string, archivePath: string): string[] {
+  const rawSegments = entryName.replaceAll("\\", "/").split("/");
+  if (rawSegments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`Unsafe archive entry "${entryName}" in ${archivePath}.`);
+  }
+
+  const normalized = path.posix.normalize(rawSegments.join("/"));
+  if (
+    normalized.length === 0 ||
+    normalized === "." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    path.posix.isAbsolute(normalized) ||
+    /^[A-Za-z]:/.test(normalized)
+  ) {
+    throw new Error(`Unsafe archive entry "${entryName}" in ${archivePath}.`);
+  }
+
+  return normalized.split("/").filter(Boolean);
+}
+
+async function extractZipSafely(archivePath: string, destinationPath: string): Promise<void> {
+  await rm(destinationPath, { recursive: true, force: true });
+  await mkdir(destinationPath, { recursive: true });
+
+  const zip = new AdmZip(archivePath);
+  const destinationRoot = path.resolve(destinationPath);
+  for (const entry of zip.getEntries()) {
+    const segments = assertSafeArchiveEntry(entry.entryName, archivePath);
+    const targetPath = path.resolve(destinationRoot, ...segments);
+    if (targetPath !== destinationRoot && !targetPath.startsWith(destinationRoot + path.sep)) {
+      throw new Error(`Unsafe archive entry "${entry.entryName}" in ${archivePath}.`);
+    }
+
+    if (entry.isDirectory) {
+      await mkdir(targetPath, { recursive: true });
+      continue;
+    }
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, entry.getData());
+  }
+}
+
+async function findServiceManifestPaths(root: string): Promise<string[]> {
+  const discovered: string[] = [];
+  async function visit(directory: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+      } else if (entry.isFile() && entry.name === "service.json") {
+        discovered.push(entryPath);
+      }
+    }
+  }
+
+  await visit(root);
+  return discovered;
+}
+
+async function readArchiveManifest(stagingRoot: string, archivePath: string): Promise<{
+  manifest: ServiceManifest;
+  manifestPath: string;
+  contentRoot: string;
+}> {
+  const manifestPaths = await findServiceManifestPaths(stagingRoot);
+  if (manifestPaths.length === 0) {
+    throw new Error(`Service Archive ${archivePath} does not contain service.json.`);
+  }
+  if (manifestPaths.length > 1) {
+    throw new Error(`Service Archive ${archivePath} contains multiple service.json files.`);
+  }
+
+  const manifestPath = manifestPaths[0];
+  const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as unknown;
+  return {
+    manifest: validateServiceManifest(parsed, manifestPath),
+    manifestPath,
+    contentRoot: path.dirname(manifestPath),
+  };
 }
 
 async function fetchReleasedServiceManifest(options: {
@@ -118,10 +220,92 @@ async function fetchReleasedServiceManifest(options: {
 export async function importServiceManifestFromCli(
   options: ImportServiceManifestCliOptions,
 ): Promise<ImportServiceManifestCliResult> {
-  const repo = normalizeRepo(options.repo);
   const servicesRoot = path.resolve(
     options.servicesRoot?.trim() || process.env.SERVICE_LASSO_SERVICES_ROOT || DEFAULT_SERVICES_ROOT,
   );
+  if (options.archivePath) {
+    const sourceArchivePath = path.resolve(options.archivePath);
+    const archiveType = detectArchiveType(sourceArchivePath);
+    const stagingRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-archive-import-"));
+    try {
+      await extractZipSafely(sourceArchivePath, stagingRoot);
+      const { manifest, contentRoot } = await readArchiveManifest(stagingRoot, sourceArchivePath);
+      const serviceRoot = path.join(servicesRoot, manifest.id);
+      const targetPath = path.join(serviceRoot, "service.json");
+      const targetManifestExists = await pathExists(targetPath);
+      const targetRootExists = await pathExists(serviceRoot);
+      const conflict = targetManifestExists
+        ? { kind: "target_manifest_exists" as const, path: targetPath }
+        : targetRootExists
+          ? { kind: "target_directory_exists" as const, path: serviceRoot }
+          : null;
+
+      if (conflict) {
+        return {
+          action: "importService",
+          ok: false,
+          source: "archive",
+          repo: null,
+          requestedTag: null,
+          resolvedTag: null,
+          serviceId: manifest.id,
+          serviceName: manifest.name,
+          version: manifest.version ?? null,
+          servicesRoot,
+          targetPath,
+          targetServiceRoot: serviceRoot,
+          manifestAssetUrl: null,
+          archivePath: sourceArchivePath,
+          archiveType,
+          state: "conflict",
+          conflict,
+          dryRun: options.dryRun === true,
+          wrote: false,
+          overwritten: false,
+        };
+      }
+
+      if (!options.dryRun) {
+        await mkdir(path.dirname(serviceRoot), { recursive: true });
+        await cp(contentRoot, serviceRoot, { recursive: true, errorOnExist: true, force: false });
+        const discovered = await discoverServices(servicesRoot);
+        if (!discovered.some((service) => service.manifest.id === manifest.id && service.manifestPath === targetPath)) {
+          throw new Error(`Imported archive service "${manifest.id}" could not be rediscovered from ${servicesRoot}.`);
+        }
+      }
+
+      return {
+        action: "importService",
+        ok: true,
+        source: "archive",
+        repo: null,
+        requestedTag: null,
+        resolvedTag: null,
+        serviceId: manifest.id,
+        serviceName: manifest.name,
+        version: manifest.version ?? null,
+        servicesRoot,
+        targetPath,
+        targetServiceRoot: serviceRoot,
+        manifestAssetUrl: null,
+        archivePath: sourceArchivePath,
+        archiveType,
+        state: options.dryRun === true ? "validated" : "imported",
+        conflict: null,
+        dryRun: options.dryRun === true,
+        wrote: options.dryRun !== true,
+        overwritten: false,
+      };
+    } finally {
+      await rm(stagingRoot, { recursive: true, force: true });
+    }
+  }
+
+  if (!options.repo) {
+    throw new Error('The "services import" command requires either an <owner/repo> argument or --archive <path>.');
+  }
+
+  const repo = normalizeRepo(options.repo);
   const { manifest, resolvedTag, assetUrl } = await fetchReleasedServiceManifest({
     repo,
     tag: options.tag,
@@ -149,14 +333,21 @@ export async function importServiceManifestFromCli(
   return {
     action: "importService",
     ok: true,
+    source: "github-release",
     repo,
     requestedTag: options.tag ?? null,
     resolvedTag,
     serviceId: manifest.id,
     serviceName: manifest.name,
+    version: manifest.version ?? null,
     servicesRoot,
     targetPath,
+    targetServiceRoot: serviceRoot,
     manifestAssetUrl: assetUrl,
+    archivePath: null,
+    archiveType: null,
+    state: options.dryRun === true ? "validated" : "imported",
+    conflict: null,
     dryRun: options.dryRun === true,
     wrote: options.dryRun !== true,
     overwritten: exists && options.dryRun !== true,

--- a/tests/cli-service-import.test.js
+++ b/tests/cli-service-import.test.js
@@ -5,7 +5,8 @@ import path from "node:path";
 import { createServer } from "node:http";
 import { promisify } from "node:util";
 import { execFile as execFileCallback } from "node:child_process";
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import AdmZip from "adm-zip";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 
 const execFile = promisify(execFileCallback);
@@ -51,6 +52,28 @@ async function makeTempServicesRoot() {
     root,
     servicesRoot: path.join(root, "services"),
   };
+}
+
+function archivedManifest(serviceId = "uploaded-service") {
+  return {
+    id: serviceId,
+    name: "Uploaded Service",
+    description: "Uploaded Service Archive fixture.",
+    version: "2026.8.1-fixture",
+    healthcheck: {
+      type: "process",
+    },
+  };
+}
+
+async function writeServiceArchive(root, entries) {
+  const archivePath = path.join(root, "uploaded-service.zip");
+  const zip = new AdmZip();
+  for (const [entryPath, content] of Object.entries(entries)) {
+    zip.addFile(entryPath, Buffer.isBuffer(content) ? content : Buffer.from(content, "utf8"));
+  }
+  await writeFile(archivePath, zip.toBuffer());
+  return archivePath;
 }
 
 async function startFakeGitHubReleaseServer(manifest) {
@@ -237,6 +260,114 @@ test("services import protects existing manifests unless forced", async () => {
   } finally {
     await firstServer.stop();
     await secondServer.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("services import --archive dry-run validates archive service.json without writing", async () => {
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const archivePath = await writeServiceArchive(root, {
+    "package/service.json": JSON.stringify(archivedManifest(), null, 2),
+    "package/runtime/uploaded-service.mjs": 'console.log("uploaded");\n',
+  });
+  const manifestPath = path.join(servicesRoot, "uploaded-service", "service.json");
+
+  try {
+    const result = await runCli([
+      "services",
+      "import",
+      "--archive",
+      archivePath,
+      "--services-root",
+      servicesRoot,
+      "--dry-run",
+      "--json",
+    ]);
+    const payload = JSON.parse(result.stdout);
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.source, "archive");
+    assert.equal(payload.state, "validated");
+    assert.equal(payload.serviceId, "uploaded-service");
+    assert.equal(payload.version, "2026.8.1-fixture");
+    assert.equal(payload.wrote, false);
+    assert.equal(await exists(manifestPath), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("services import --archive stages, copies, and rediscovers uploaded archive contents", async () => {
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const archivePath = await writeServiceArchive(root, {
+    "package/service.json": JSON.stringify(archivedManifest(), null, 2),
+    "package/runtime/uploaded-service.mjs": 'console.log("uploaded");\n',
+  });
+  const manifestPath = path.join(servicesRoot, "uploaded-service", "service.json");
+  const scriptPath = path.join(servicesRoot, "uploaded-service", "runtime", "uploaded-service.mjs");
+
+  try {
+    const result = await runCli([
+      "services",
+      "import",
+      "--archive",
+      archivePath,
+      "--services-root",
+      servicesRoot,
+      "--json",
+    ]);
+    const payload = JSON.parse(result.stdout);
+    const discovered = await discoverServices(servicesRoot);
+    const written = JSON.parse(await readFile(manifestPath, "utf8"));
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.state, "imported");
+    assert.equal(payload.wrote, true);
+    assert.equal(written.id, "uploaded-service");
+    assert.equal(await readFile(scriptPath, "utf8"), 'console.log("uploaded");\n');
+    assert.equal(discovered.length, 1);
+    assert.equal(discovered[0].manifest.id, "uploaded-service");
+    assert.equal(discovered[0].manifestPath, manifestPath);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("services import --archive returns a conflict state without overwriting existing service", async () => {
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const archivePath = await writeServiceArchive(root, {
+    "service.json": JSON.stringify(archivedManifest(), null, 2),
+  });
+
+  try {
+    await runCli(["services", "import", "--archive", archivePath, "--services-root", servicesRoot, "--json"]);
+    await assert.rejects(
+      runCli(["services", "import", "--archive", archivePath, "--services-root", servicesRoot, "--json"]),
+      (error) => {
+        const payload = JSON.parse(error.stdout);
+        assert.equal(payload.ok, false);
+        assert.equal(payload.state, "conflict");
+        assert.equal(payload.conflict.kind, "target_manifest_exists");
+        return true;
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("services import --archive rejects unsafe archive traversal entries", async () => {
+  const { root, servicesRoot } = await makeTempServicesRoot();
+  const archivePath = await writeServiceArchive(root, {
+    "C:/evil/service.json": JSON.stringify(archivedManifest(), null, 2),
+  });
+
+  try {
+    await assert.rejects(
+      runCli(["services", "import", "--archive", archivePath, "--services-root", servicesRoot, "--json"]),
+      /Unsafe archive entry/,
+    );
+  } finally {
     await rm(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Issue
Closes #836

## Summary
- Adds `services import --archive <path>` for local Service Archive uploads.
- Stages and safely extracts zip archives before touching `servicesRoot`.
- Finds exactly one `service.json`, validates it, copies the archive content into `services/<service-id>/`, and verifies discovery after import.
- Returns conflict metadata without overwriting existing services.
- Documents the archive import CLI flow.

## Scope
- In scope: local zip Service Archive import through the CLI, manifest validation, path traversal rejection, conflict state, discovery rescan, focused tests.
- Out of scope: Service Admin multipart upload UI/API, multi-select catalog add flow, tar/tgz upload support, audit/Inbox event plumbing.

## Spec / contract / fixture impact
- Updated: README CLI usage for Service Archive imports.
- Updated: `ImportServiceManifestCliResult` with source/state/conflict/archive metadata.
- Added: focused zip archive fixtures in `tests/cli-service-import.test.js`.

## Service Lasso invariant impact
- Invariant: `service.json` remains the service manifest source of truth under `services/<service-id>/`.
- Preservation proof: archive import validates exactly one `service.json` before copy, refuses existing target services, rejects unsafe archive paths, and rediscover-checks the copied service.

## Validation
- PASS `npm ci` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T023338+1000\issue-836-npm-ci.stdout.log`.
- PASS `npm run build` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T023338+1000\issue-836-npm-build-final-2.stdout.log`.
- PASS `node --test --test-concurrency=1 tests\cli-service-import.test.js` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T023338+1000\issue-836-cli-service-import-test-final-2.stdout.log`.
- PASS `npm run docs:build` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T023338+1000\issue-836-docs-build-2.stdout.log`.
- PASS startup `npm run build` and canonical `demo-gate` before selection - evidence under `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260801T023338+1000`.

## Approval trail
- Required: yes.
- Evidence: Architect review requested because this adds a new archive import behavior surface and leaves UI/API/audit/Inbox plumbing explicitly out of scope for this slice.

## Cleanup
- Branch `fix/836-import-service-archive` is pushed and targets `develop`.
- Post-review cleanup: merge to `develop`, run updated-code canonical demo proof, close #836, and return local checkout/worktree to clean `develop` where possible.