### PR TITLE
#868 adopt verified persisted process owners

### DIFF
--- a/src/runtime/execution/supervisor.ts
+++ b/src/runtime/execution/supervisor.ts
@@ -45,6 +45,15 @@ interface ManagedProcessRecord {
   finalizePromise: Promise<void>;
 }
 
+interface AdoptedProcessRecord {
+  service: DiscoveredService;
+  pid: number;
+  startedAt: string;
+  command: string;
+  stopping: boolean;
+  workspaceRoot: string;
+}
+
 interface StartProcessOptions {
   service: DiscoveredService;
   executionPlan: ProviderExecutionPlan;
@@ -63,8 +72,17 @@ interface StartProcessOptions {
   }) => Promise<void> | void;
 }
 
+interface AdoptManagedProcessOptions {
+  service: DiscoveredService;
+  pid: number;
+  startedAt: string;
+  command: string;
+  workspaceRoot: string;
+}
+
 const managedProcesses = new Map<string, ManagedProcessRecord>();
 const managedProcessFinalizers = new Map<string, Promise<void>>();
+const adoptedProcesses = new Map<string, AdoptedProcessRecord>();
 
 async function prepareRuntimeLogStreams(serviceRoot: string, startedAt: string): Promise<{
   paths: ServiceRuntimeLogPaths;
@@ -109,8 +127,7 @@ async function waitForCommandExit(command: string, args: string[]): Promise<void
   });
 }
 
-async function forceKillManagedProcessTree(child: ChildProcess): Promise<void> {
-  const pid = child.pid;
+async function forceKillProcessTree(pid: number): Promise<void> {
   if (!pid) {
     return;
   }
@@ -121,9 +138,15 @@ async function forceKillManagedProcessTree(child: ChildProcess): Promise<void> {
   }
 
   try {
-    child.kill("SIGKILL");
+    process.kill(pid, "SIGKILL");
   } catch {
     // The process may have exited between the timeout and forced kill.
+  }
+}
+
+async function forceKillManagedProcessTree(child: ChildProcess): Promise<void> {
+  if (child.pid) {
+    await forceKillProcessTree(child.pid);
   }
 }
 
@@ -308,20 +331,62 @@ function buildProcessEnvironment(
 }
 
 export function hasManagedProcess(serviceId: string): boolean {
-  return managedProcesses.has(serviceId);
+  return managedProcesses.has(serviceId) || adoptedProcesses.has(serviceId);
 }
 
 export async function beginManagedProcessStop(serviceId: string): Promise<boolean> {
   const record = managedProcesses.get(serviceId);
-  if (!record) {
-    return false;
+  if (record) {
+    record.stopping = true;
+    if (record.workspaceRoot) {
+      await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopping", undefined, record.child.pid);
+    }
+    return true;
   }
 
-  record.stopping = true;
-  if (record.workspaceRoot) {
-    await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopping", undefined, record.child.pid);
+  const adopted = adoptedProcesses.get(serviceId);
+  if (adopted) {
+    adopted.stopping = true;
+    await transitionProcessOwnership(adopted.workspaceRoot, "service", serviceId, "stopping", undefined, adopted.pid);
+    return true;
   }
-  return true;
+
+  return false;
+}
+
+export async function adoptManagedProcess(options: AdoptManagedProcessOptions): Promise<ManagedProcessHandle> {
+  const { service, pid, startedAt, command, workspaceRoot } = options;
+  const serviceId = service.manifest.id;
+
+  const priorFinalizer = managedProcessFinalizers.get(serviceId);
+  if (priorFinalizer) {
+    await priorFinalizer;
+  }
+
+  if (managedProcesses.has(serviceId) || adoptedProcesses.has(serviceId)) {
+    throw new Error(`Service "${serviceId}" already has a managed process.`);
+  }
+
+  const status = await reconcileRegisteredProcess(workspaceRoot, "service", serviceId);
+  if (status !== "owned") {
+    throw new Error(`Cannot adopt service "${serviceId}" process ${pid}: persisted owner status is ${status}.`);
+  }
+
+  adoptedProcesses.set(serviceId, {
+    service,
+    pid,
+    startedAt,
+    command,
+    stopping: false,
+    workspaceRoot,
+  });
+
+  return {
+    pid,
+    startedAt,
+    command,
+    logs: getServiceRuntimeLogPaths(service.serviceRoot, buildServiceRuntimeLogRunId(startedAt)),
+  };
 }
 
 export async function startManagedProcess(options: StartProcessOptions): Promise<ManagedProcessHandle> {
@@ -344,7 +409,7 @@ export async function startManagedProcess(options: StartProcessOptions): Promise
     await priorFinalizer;
   }
 
-  if (managedProcesses.has(serviceId)) {
+  if (managedProcesses.has(serviceId) || adoptedProcesses.has(serviceId)) {
     throw new Error(`Service "${serviceId}" already has a managed process.`);
   }
   if (workspaceRoot) {
@@ -514,7 +579,7 @@ export async function stopManagedProcess(
 ): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null } | null> {
   const record = managedProcesses.get(serviceId);
   if (!record) {
-    return null;
+    return await stopAdoptedProcess(serviceId, timeoutMs);
   }
 
   await beginManagedProcessStop(serviceId);
@@ -555,13 +620,83 @@ export async function stopManagedProcess(
   return result;
 }
 
+async function waitForAdoptedProcessExit(
+  record: AdoptedProcessRecord,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = await reconcileRegisteredProcess(record.workspaceRoot, "service", record.service.manifest.id);
+    if (status === "not_running" || status === "identity_mismatch") {
+      return true;
+    }
+    if (status === "unknown_owner") {
+      throw new Error(`Cannot verify adopted service "${record.service.manifest.id}" process owner during stop.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+async function stopAdoptedProcess(
+  serviceId: string,
+  timeoutMs: number,
+): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null } | null> {
+  const record = adoptedProcesses.get(serviceId);
+  if (!record) {
+    return null;
+  }
+
+  await beginManagedProcessStop(serviceId);
+  const status = await reconcileRegisteredProcess(record.workspaceRoot, "service", serviceId);
+  if (status === "unknown_owner") {
+    throw new Error(`Cannot stop service "${serviceId}" because its adopted process owner is unverifiable.`);
+  }
+  if (status === "not_running" || status === "identity_mismatch") {
+    adoptedProcesses.delete(serviceId);
+    return { exitCode: 0, signal: null };
+  }
+
+  try {
+    process.kill(record.pid);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      throw error;
+    }
+  }
+
+  const exited = await waitForAdoptedProcessExit(record, timeoutMs);
+  if (!exited) {
+    await forceKillProcessTree(record.pid);
+    await waitForAdoptedProcessExit(record, timeoutMs);
+    adoptedProcesses.delete(serviceId);
+    await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopped", "not_running", record.pid);
+    return { exitCode: null, signal: "SIGKILL" };
+  }
+
+  adoptedProcesses.delete(serviceId);
+  await transitionProcessOwnership(record.workspaceRoot, "service", serviceId, "stopped", "not_running", record.pid);
+  return { exitCode: 0, signal: null };
+}
+
 export async function waitForManagedProcessExit(
   serviceId: string,
   timeoutMs = 5_000,
 ): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null } | null> {
   const record = managedProcesses.get(serviceId);
   if (!record) {
-    return null;
+    const adopted = adoptedProcesses.get(serviceId);
+    if (!adopted) {
+      return null;
+    }
+    await beginManagedProcessStop(serviceId);
+    const exited = await waitForAdoptedProcessExit(adopted, timeoutMs);
+    if (!exited) {
+      return null;
+    }
+    adoptedProcesses.delete(serviceId);
+    await transitionProcessOwnership(adopted.workspaceRoot, "service", serviceId, "stopped", "not_running", adopted.pid);
+    return { exitCode: 0, signal: null };
   }
 
   await beginManagedProcessStop(serviceId);
@@ -599,6 +734,6 @@ export async function waitForManagedProcessExit(
 }
 
 export async function stopAllManagedProcesses(): Promise<void> {
-  const serviceIds = [...managedProcesses.keys()];
+  const serviceIds = [...new Set([...managedProcesses.keys(), ...adoptedProcesses.keys()])];
   await Promise.all(serviceIds.map((serviceId) => stopManagedProcess(serviceId).catch(() => null)));
 }

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -565,6 +565,7 @@ export async function rehydrateLifecycleState(
 ): Promise<ServiceLifecycleState | null> {
   const snapshot = await readStoredState(service.serviceRoot);
   const state = parseLifecycleState(service, snapshot);
+  let rehydratedState = state;
 
   if (state) {
     const serviceId = service.manifest.id;
@@ -641,6 +642,7 @@ export async function rehydrateLifecycleState(
             endpoints: resolveServiceEndpoints(service, state.runtime.ports),
           },
         });
+        rehydratedState = adoptedState;
         await writeServiceState(service, adoptedState);
       }
 
@@ -650,7 +652,7 @@ export async function rehydrateLifecycleState(
     }
   }
 
-  return state;
+  return rehydratedState;
 }
 
 export async function rehydrateDiscoveredServices(

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { resolveServiceEndpoints } from "../operator/endpoints.js";
 import { buildServiceNetwork } from "../operator/network.js";
 import { migrateLegacyProcessOwnership } from "../process/registry.js";
+import type { ProcessInspectorDependencies, ProcessIdentityClassification } from "../process/identity.js";
 import { readStoredState } from "./readState.js";
 import { resolveServiceRootPath } from "./paths.js";
 import { writeServiceState } from "./writeState.js";
@@ -25,6 +26,7 @@ import { writeServiceState } from "./writeState.js";
 export interface RehydrateProcessOwnershipOptions {
   workspaceRoot?: string;
   runtimeInstanceId?: string | null;
+  processInspectorDependencies?: ProcessInspectorDependencies;
 }
 
 interface StoredInstallState {
@@ -559,6 +561,60 @@ function parseLifecycleState(service: DiscoveredService, snapshot: {
   };
 }
 
+function buildBlockedRehydrateState(
+  service: DiscoveredService,
+  state: ServiceLifecycleState,
+  status: ProcessIdentityClassification,
+  pid: number,
+  reason: string,
+): ServiceLifecycleState {
+  const now = new Date().toISOString();
+  const serviceId = service.manifest.id;
+  const message =
+    status === "unknown_owner"
+      ? `Persisted process owner for service "${serviceId}" could not be verified; inspect PID ${pid} and stop the external process before restarting this service.`
+      : `Persisted process owner for service "${serviceId}" was not adopted because ownership verification returned ${status}.`;
+  const attempt: ServiceStartTraceAttempt = {
+    attemptId: `rehydrate-${serviceId}-${now.replace(/[:.]/g, "-")}`,
+    serviceId,
+    action: "start",
+    startedAt: now,
+    finishedAt: now,
+    status: "blocked",
+    events: [{
+      order: 1,
+      phase: "process_spawn",
+      status: "blocked",
+      serviceId,
+      startedAt: now,
+      finishedAt: now,
+      message,
+      metadata: {
+        processOwnerStatus: status,
+        previousPid: pid,
+        reason,
+        nextSafeAction: "Inspect the persisted PID owner and stop the external process before starting a replacement.",
+      },
+    }],
+  };
+
+  return {
+    ...state,
+    running: false,
+    runtime: {
+      ...state.runtime,
+      pid: null,
+      finishedAt: now,
+      exitCode: null,
+      lastTermination: status === "not_running" ? "exited" : state.runtime.lastTermination,
+      startTrace: {
+        current: attempt,
+        history: [...state.runtime.startTrace.history, attempt],
+      },
+    },
+  };
+}
+
 export async function rehydrateLifecycleState(
   service: DiscoveredService,
   options: RehydrateProcessOwnershipOptions = {},
@@ -617,6 +673,7 @@ export async function rehydrateLifecycleState(
         endpoints: network.endpoints
           .filter((endpoint): endpoint is typeof endpoint & { url: string } => typeof endpoint.url === "string")
           .map((endpoint) => ({ name: endpoint.label, url: endpoint.url })),
+        inspectorDependencies: options.processInspectorDependencies,
       });
 
       if (migration.status === "owned") {
@@ -648,6 +705,15 @@ export async function rehydrateLifecycleState(
 
       if (migration.status === "not_running" || migration.status === "identity_mismatch") {
         await writeServiceState(service, nextState);
+      }
+
+      if (migration.status === "unknown_owner") {
+        const blockedState = setLifecycleState(
+          serviceId,
+          buildBlockedRehydrateState(service, nextState, migration.status, legacyRuntime.pid, migration.reason),
+        );
+        rehydratedState = blockedState;
+        await writeServiceState(service, blockedState);
       }
     }
   }

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -585,6 +585,7 @@ export async function rehydrateLifecycleState(
     const legacyRuntime = snapshot.runtime as StoredRuntimeState | null;
     if (
       options.workspaceRoot &&
+      !hasManagedProcess(serviceId) &&
       legacyRuntime?.running === true &&
       typeof legacyRuntime.pid === "number" &&
       Number.isInteger(legacyRuntime.pid) &&

--- a/src/runtime/state/rehydrate.ts
+++ b/src/runtime/state/rehydrate.ts
@@ -1,5 +1,5 @@
 import type { DiscoveredService } from "../../contracts/service.js";
-import { hasManagedProcess } from "../execution/supervisor.js";
+import { adoptManagedProcess, hasManagedProcess } from "../execution/supervisor.js";
 import { getLifecycleState, setLifecycleState } from "../lifecycle/store.js";
 import type {
   LifecycleAction,
@@ -616,6 +616,32 @@ export async function rehydrateLifecycleState(
           .filter((endpoint): endpoint is typeof endpoint & { url: string } => typeof endpoint.url === "string")
           .map((endpoint) => ({ name: endpoint.label, url: endpoint.url })),
       });
+
+      if (migration.status === "owned") {
+        await adoptManagedProcess({
+          service,
+          pid: legacyRuntime.pid,
+          startedAt: legacyRuntime.startedAt,
+          command: legacyRuntime.command,
+          workspaceRoot: options.workspaceRoot,
+        });
+        const adoptedState = setLifecycleState(serviceId, {
+          ...nextState,
+          running: true,
+          runtime: {
+            ...nextState.runtime,
+            pid: legacyRuntime.pid,
+            startedAt: legacyRuntime.startedAt,
+            finishedAt: null,
+            exitCode: null,
+            command: legacyRuntime.command,
+            lastTermination: null,
+            ports: state.runtime.ports,
+            endpoints: resolveServiceEndpoints(service, state.runtime.ports),
+          },
+        });
+        await writeServiceState(service, adoptedState);
+      }
 
       if (migration.status === "not_running" || migration.status === "identity_mismatch") {
         await writeServiceState(service, nextState);

--- a/tests/process-ownership.test.js
+++ b/tests/process-ownership.test.js
@@ -374,6 +374,78 @@ test("rehydration returns adopted running state with retained ports", async () =
   }
 });
 
+test("API restart replaces an adopted persisted process and keeps retained ports", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-adopted-restart-");
+  const { serviceRoot, scriptPath } = await writeExecutableFixtureService(servicesRoot, "adopted-restart-service", {
+    ports: { service: 18093 },
+  });
+  const relativeScriptPath = path.relative(serviceRoot, scriptPath);
+  const child = spawn(process.execPath, [relativeScriptPath], {
+    cwd: serviceRoot,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  let apiServer;
+
+  try {
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    const inspection = await inspectProcess(child.pid);
+    assert.equal(inspection.status, "running");
+
+    const stateRoot = path.join(serviceRoot, ".state");
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(path.join(stateRoot, "install.json"), JSON.stringify({ installed: true }), "utf8");
+    await writeFile(path.join(stateRoot, "config.json"), JSON.stringify({ configured: true }), "utf8");
+    await writeFile(
+      path.join(stateRoot, "runtime.json"),
+      JSON.stringify({
+        running: true,
+        pid: child.pid,
+        startedAt: inspection.identity.createdAt,
+        command: `${process.execPath} ${relativeScriptPath}`,
+        ports: { service: 18093 },
+        lastAction: "start",
+        actionHistory: ["install", "config", "start"],
+      }),
+      "utf8",
+    );
+
+    apiServer = await startApiServer({ port: 0, servicesRoot, workspaceRoot });
+    assert.equal(hasManagedProcess("adopted-restart-service"), true);
+
+    const restart = await postJson(`${apiServer.url}/api/services/adopted-restart-service/restart`);
+
+    assert.equal(restart.response.status, 200);
+    assert.equal(restart.body.action, "restart");
+    assert.equal(restart.body.state.running, true);
+    assert.equal(restart.body.state.runtime.pid > 0, true);
+    assert.notEqual(restart.body.state.runtime.pid, child.pid);
+    assert.deepEqual(restart.body.state.runtime.ports, { service: 18093 });
+    assert.equal(restart.body.state.runtime.endpoints.some((endpoint) => endpoint.port === 18093), true);
+
+    await waitFor(() => child.exitCode !== null || child.signalCode !== null);
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, true);
+    assert.equal(stored.runtime.pid, restart.body.state.runtime.pid);
+    assert.deepEqual(stored.runtime.ports, { service: 18093 });
+
+    const ownership = await findProcessOwnership(workspaceRoot, "service", "adopted-restart-service");
+    assert.equal(ownership.lifecycleState, "running");
+    assert.equal(ownership.pid, restart.body.state.runtime.pid);
+    assert.deepEqual(ownership.allocation.ports, { service: 18093 });
+  } finally {
+    await apiServer?.stop();
+    await stopManagedProcess("adopted-restart-service", 500).catch(() => null);
+    child.kill("SIGKILL");
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("adopted process ownership can be stopped without a ChildProcess handle", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-adopted-process-stop-");

--- a/tests/process-ownership.test.js
+++ b/tests/process-ownership.test.js
@@ -25,7 +25,7 @@ import {
 } from "../dist/runtime/execution/supervisor.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
-import { rehydrateDiscoveredServices } from "../dist/runtime/state/rehydrate.js";
+import { rehydrateDiscoveredServices, rehydrateLifecycleState } from "../dist/runtime/state/rehydrate.js";
 import { readStoredState } from "../dist/runtime/state/readState.js";
 import { makeTempServicesRoot, writeExecutableFixtureService } from "./test-helpers.js";
 
@@ -304,6 +304,71 @@ test("rehydration clears a reused PID without terminating the unrelated live pro
     assert.equal(ownership, null);
   } finally {
     unrelated.kill("SIGKILL");
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("rehydration returns adopted running state with retained ports", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-rehydrate-adopted-state-");
+  const { serviceRoot, scriptPath } = await writeExecutableFixtureService(servicesRoot, "rehydrate-adopted-service", {
+    ports: { service: 18092 },
+  });
+  const relativeScriptPath = path.relative(serviceRoot, scriptPath);
+  const child = spawn(process.execPath, [relativeScriptPath], {
+    cwd: serviceRoot,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    const inspection = await inspectProcess(child.pid);
+    assert.equal(inspection.status, "running");
+
+    const stateRoot = path.join(serviceRoot, ".state");
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(path.join(stateRoot, "install.json"), JSON.stringify({ installed: true }), "utf8");
+    await writeFile(path.join(stateRoot, "config.json"), JSON.stringify({ configured: true }), "utf8");
+    await writeFile(
+      path.join(stateRoot, "runtime.json"),
+      JSON.stringify({
+        running: true,
+        pid: child.pid,
+        startedAt: inspection.identity.createdAt,
+        command: `${process.execPath} ${relativeScriptPath}`,
+        ports: { service: 18092 },
+        lastAction: "start",
+        actionHistory: ["install", "config", "start"],
+      }),
+      "utf8",
+    );
+
+    const [service] = await discoverServices(servicesRoot);
+    const rehydrated = await rehydrateLifecycleState(service, { workspaceRoot });
+
+    assert.equal(rehydrated.running, true);
+    assert.equal(rehydrated.runtime.pid, child.pid);
+    assert.deepEqual(rehydrated.runtime.ports, { service: 18092 });
+    assert.equal(rehydrated.runtime.endpoints.some((endpoint) => endpoint.port === 18092), true);
+    assert.equal(hasManagedProcess("rehydrate-adopted-service"), true);
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, true);
+    assert.equal(stored.runtime.pid, child.pid);
+    assert.deepEqual(stored.runtime.ports, { service: 18092 });
+
+    const ownership = await findProcessOwnership(workspaceRoot, "service", "rehydrate-adopted-service");
+    assert.equal(ownership.lifecycleState, "running");
+    assert.equal(ownership.pid, child.pid);
+    assert.deepEqual(ownership.allocation.ports, { service: 18092 });
+  } finally {
+    await stopManagedProcess("rehydrate-adopted-service", 500).catch(() => null);
+    child.kill("SIGKILL");
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/tests/process-ownership.test.js
+++ b/tests/process-ownership.test.js
@@ -374,6 +374,63 @@ test("rehydration returns adopted running state with retained ports", async () =
   }
 });
 
+test("rehydration records a safe blocker for unverifiable persisted process owners", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-unknown-owner-");
+  const { serviceRoot, scriptPath } = await writeExecutableFixtureService(servicesRoot, "unknown-owner-service");
+  const relativeScriptPath = path.relative(serviceRoot, scriptPath);
+
+  try {
+    const stateRoot = path.join(serviceRoot, ".state");
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(path.join(stateRoot, "install.json"), JSON.stringify({ installed: true }), "utf8");
+    await writeFile(path.join(stateRoot, "config.json"), JSON.stringify({ configured: true }), "utf8");
+    await writeFile(
+      path.join(stateRoot, "runtime.json"),
+      JSON.stringify({
+        running: true,
+        pid: 4242,
+        startedAt: "2026-07-18T02:03:04.000Z",
+        command: `${process.execPath} ${relativeScriptPath}`,
+        ports: { service: 18094 },
+        lastAction: "start",
+        actionHistory: ["install", "config", "start"],
+      }),
+      "utf8",
+    );
+
+    const [service] = await discoverServices(servicesRoot);
+    const rehydrated = await rehydrateLifecycleState(service, {
+      workspaceRoot,
+      processInspectorDependencies: windowsInspector({
+        ProcessId: 4242,
+        CreationDate: null,
+        ExecutablePath: null,
+        CommandLine: null,
+      }),
+    });
+
+    assert.equal(rehydrated.running, false);
+    assert.equal(rehydrated.runtime.pid, null);
+    assert.equal(hasManagedProcess("unknown-owner-service"), false);
+    assert.equal(rehydrated.runtime.startTrace.current.status, "blocked");
+    assert.equal(rehydrated.runtime.startTrace.current.events[0].metadata.processOwnerStatus, "unknown_owner");
+    assert.equal(rehydrated.runtime.startTrace.current.events[0].metadata.previousPid, 4242);
+    assert.match(
+      rehydrated.runtime.startTrace.current.events[0].metadata.nextSafeAction,
+      /Inspect the persisted PID owner/,
+    );
+
+    const stored = await readStoredState(serviceRoot);
+    assert.equal(stored.runtime.running, false);
+    assert.equal(stored.runtime.pid, null);
+    assert.equal(stored.runtime.startTrace.current.status, "blocked");
+  } finally {
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("API restart replaces an adopted persisted process and keeps retained ports", async () => {
   resetLifecycleState();
   const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-adopted-restart-");

--- a/tests/process-ownership.test.js
+++ b/tests/process-ownership.test.js
@@ -18,6 +18,11 @@ import {
   transitionProcessOwnership,
 } from "../dist/runtime/process/registry.js";
 import { startApiServer } from "../dist/server/index.js";
+import {
+  adoptManagedProcess,
+  hasManagedProcess,
+  stopManagedProcess,
+} from "../dist/runtime/execution/supervisor.js";
 import { resetLifecycleState } from "../dist/runtime/lifecycle/store.js";
 import { discoverServices } from "../dist/runtime/discovery/discoverServices.js";
 import { rehydrateDiscoveredServices } from "../dist/runtime/state/rehydrate.js";
@@ -299,6 +304,58 @@ test("rehydration clears a reused PID without terminating the unrelated live pro
     assert.equal(ownership, null);
   } finally {
     unrelated.kill("SIGKILL");
+    resetLifecycleState();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("adopted process ownership can be stopped without a ChildProcess handle", async () => {
+  resetLifecycleState();
+  const { tempRoot, servicesRoot, workspaceRoot } = await makeTempServicesRoot("service-lasso-adopted-process-stop-");
+  const { serviceRoot, scriptPath } = await writeExecutableFixtureService(servicesRoot, "adopted-stop-service");
+  const child = spawn(process.execPath, [path.relative(serviceRoot, scriptPath)], {
+    cwd: serviceRoot,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    const inspection = await inspectProcess(child.pid);
+    assert.equal(inspection.status, "running");
+    const [service] = await discoverServices(servicesRoot);
+    await recordProcessOwnership(workspaceRoot, {
+      ownerType: "service",
+      ownerId: "adopted-stop-service",
+      serviceId: "adopted-stop-service",
+      pid: child.pid,
+      ownerRoot: serviceRoot,
+      lifecycleState: "running",
+      source: "legacy-verified",
+    });
+
+    const handle = await adoptManagedProcess({
+      service,
+      pid: child.pid,
+      startedAt: inspection.identity.createdAt,
+      command: `${process.execPath} ${path.relative(serviceRoot, scriptPath)}`,
+      workspaceRoot,
+    });
+
+    assert.equal(handle.pid, child.pid);
+    assert.equal(hasManagedProcess("adopted-stop-service"), true);
+
+    const stopped = await stopManagedProcess("adopted-stop-service", 500);
+    assert.ok(stopped);
+    assert.equal(hasManagedProcess("adopted-stop-service"), false);
+    const ownership = await findProcessOwnership(workspaceRoot, "service", "adopted-stop-service");
+    assert.equal(ownership.lifecycleState, "stopped");
+    assert.equal(ownership.pid, null);
+  } finally {
+    child.kill("SIGKILL");
     resetLifecycleState();
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Issue
Refs #868

## Summary
- Adds an adopted-process supervisor record path for verified persisted service owners.
- Rehydrates verified legacy runtime ownership as running state instead of clearing it to stopped state.
- Allows stop/stopAll and stop override settlement paths to stop adopted service owners without a Node ChildProcess handle.
- Adds a focused process ownership regression for adopted process stop and registry cleanup.

## Scope
- In scope: first #868 adoption/stop slice for verified persisted owners, safe no-duplicate start guard, registry lifecycle transitions, focused regression coverage.
- Out of scope: full restart/autostart behavior, descendant process-tree guarantees beyond the current stop fallback, and all remaining platform-specific #868 cases.

## Spec / contract / fixture impact
- Updated: rehydrate behavior now restores verified legacy runtime owners to running lifecycle state.
- Updated: supervisor contract now treats adopted owners as managed processes for stop/stopAll decisions.

## Service Lasso invariant impact
- Invariant: a persisted PID is never trusted by PID alone.
- Preservation proof: adoption is only allowed after `reconcileRegisteredProcess(...)` reports `owned`; `unknown_owner` blocks replacement/stop, and identity mismatch clears without terminating unrelated live processes.

## Validation
- PASS `npm run build` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260801T043523Z\issue-868-npm-build-final.result.json`.
- PASS `node --test tests\process-ownership.test.js` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260801T043523Z\issue-868-process-ownership-test-final.result.json`.
- PASS `node --test tests\lifecycle-actions.test.js` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260801T043523Z\issue-868-lifecycle-actions-test.result.json`.
- PASS `git diff --check` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260801T043523Z\issue-868-git-diff-check.result.json`.
- PASS updated-code `npm run build`, `demo-gate`, and `demo-verify-canonical` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-cron-20260801T043523Z\issue-868-demo-proof.result.json`.
- PASS LAN runtime health, Service Admin `/api/dashboard`, and Service Admin `/api/services` probes - evidence `issue-868-final-lan-runtime-health.json`, `issue-868-final-admin-dashboard.json`, and `issue-868-final-admin-services.json` in the same run log.

## Approval trail
- Required: yes.
- Evidence: Architect review requested because #868 is broad lifecycle/process ownership work and this PR lands the first bounded adoption slice rather than the full issue closure.

## Cleanup
- Branch `fix/868-adopt-persisted-processes` targets `develop`.
- Post-review/continuation cleanup: continue remaining #868 acceptance criteria or split follow-up slices as directed, then merge/close only when the full DEV completion gate is satisfied.